### PR TITLE
Add atomic code-generation support for MacOS.

### DIFF
--- a/tools/flang2/flang2exe/expand.h
+++ b/tools/flang2/flang2exe/expand.h
@@ -333,7 +333,7 @@ int get_is_in_atomic_capture(void);
 
 LOGICAL exp_end_atomic(int, int);
 #ifdef PD_IS_ATOMIC
-void exp_atomic_intrinsic(PD_KIND pd, ILM *ilmp, int curilm);
+bool exp_atomic_intrinsic(PD_KIND pd, ILM *ilmp, int curilm);
 #endif
 #endif /* EXPANDER_DECLARE_INTERNAL */
 


### PR DESCRIPTION
There's two major parts to this patch.
1. Refactoring symini_c.n
2. Making expansion of LLVM atomic operations work.

The refactoring turns symini_c.n into platform-suffixed variants:

    symini_c_{linux,osx,win64}.

Each of these symini_c_* files contains two or three lines that select
the keywords (always the same for C/C++), base builtins, and atomics.
E.g., symini_c_linux.n looks like:

    .so ../../../../scc/shared/utils/symtab/keywords.n
    .so base_builtin.n
    .so ../../../../comp.shared/shared/utils/symtab/gnu_atomic_builtin.n

and symini_c_osx.n is similar, except that it includes llvm_atomic_builtin.n
instead of gnu_atomic_builtin.n.

The actual base_builtin.n varies using the usuall symlink tricks, and is
just the old builtin.n with the ".so...atomic_builtin.n" removed.

Expanding the LLVM atomic operations is straightforward, except that
I restructured how ld/st/etc. versus ldkr/stkr/etc.kr are selected.
There's also an odd case that David and I discussed where the LLVM
__atomic_compare_exchange has to lose it's "weak" parameter if it
is passed through to the runtime.

The patch also corrects a bug in the handling of the GNU __atomic_store_1,
__atomic_exchange_1, etc. where two stores or two exchanges were being generated,
because chkblock was being called twice for an ILI expression.

Keywords: OSX atomic codegen