### PR TITLE
fmtread: match uppercase INFINITY

### DIFF
--- a/runtime/flang/fmtread.c
+++ b/runtime/flang/fmtread.c
@@ -2799,7 +2799,7 @@ either_inf_nan_or_error:
                     goto conv_error;
                   w--;
                   c = *p++;
-                  if (c == 'y' || c == 'y') {
+                  if (c == 'y' || c == 'Y') {
                     if (w == 0) {
                       ieee_v.i[0] = 0x0;
                       ieee_v.v.hm = 0x0;


### PR DESCRIPTION
The check for y was done lower case twice instead of both
lower and upper. Change this to both y and Y to match "INFINITY"