### PR TITLE
Fix -Wlogical-not-parentheses compile errors

### DIFF
--- a/tools/flang1/flang1exe/semfin.c
+++ b/tools/flang1/flang1exe/semfin.c
@@ -1455,7 +1455,7 @@ do_equiv(void)
       SOCPTRP(sptr, 0);
     }
     maxa = size = 0;
-    saveflg = sem.savall | (!flg.recursive & 1);
+    saveflg = sem.savall | (!(flg.recursive & 1));
     nmld = vold = dinitd = FALSE;
     for (sptr = psect_base[ps].memlist; sptr != NOSYM; sptr = SYMLKG(sptr)) {
       assert(sptr, "equiv:bsym", 1, 3);

--- a/tools/flang2/flang2exe/ll_write.c
+++ b/tools/flang2/flang2exe/ll_write.c
@@ -423,7 +423,7 @@ ll_write_instruction(FILE *out, struct LL_Instruction_ *inst)
       }
     }
     fprintf(out, ")");
-    if (!inst->flags & IN_MODULE_CALL) {
+    if (!(inst->flags & IN_MODULE_CALL)) {
       add_prototype(inst);
     }
     break;


### PR DESCRIPTION
Those two lines of code are ambiguous, and can result in compile warnings. 