### PR TITLE
Reimplement OpenMP 4.x target teams distribute parallel do simd

### DIFF
--- a/tools/flang1/flang1exe/ast.c
+++ b/tools/flang1/flang1exe/ast.c
@@ -236,7 +236,6 @@ ast_init(void)
     ADD_UPBD(aux.dt_iarray_int, 0) = ADD_UPAST(aux.dt_iarray_int, 0) =
         ADD_EXTNTAST(aux.dt_iarray_int, 0) = astb.bnd.one;
   }
-
 }
 
 void
@@ -719,7 +718,7 @@ mk_binop(int optype, int lop, int rop, DTYPE dtype)
   case OP_LOR:
   case OP_LAND:
     commutable = TRUE;
-    /***** fall through *****/
+  /***** fall through *****/
   default:
     if (A_TYPEG(lop) == A_CNST) {
       ncons = 1;
@@ -733,15 +732,14 @@ mk_binop(int optype, int lop, int rop, DTYPE dtype)
       if (ncons == 1) {
         /*
          * make the left constant the right operand; note that for OP_LOR and
-	 * OP_LAND, 'folding' only examines the right operand.
+         * OP_LAND, 'folding' only examines the right operand.
          */
         tmp = lop;
         lop = rop;
         rop = tmp;
         c2 = c1;
         c1 = 0;
-      }
-      else if (ncons == 0 && lop > rop) {
+      } else if (ncons == 0 && lop > rop) {
         tmp = lop;
         lop = rop;
         rop = tmp;
@@ -1820,7 +1818,8 @@ mk_asd(int *subs, int numdim)
 {
   int i;
   int asd;
-  assert(numdim > 0 && numdim <= MAXSUBS, "mk_subscr: bad numdim", numdim, ERR_Fatal);
+  assert(numdim > 0 && numdim <= MAXSUBS, "mk_subscr: bad numdim", numdim,
+         ERR_Fatal);
   /* search the existing ASDs with the same number of dimensions */
   for (asd = astb.asd.hash[numdim - 1]; asd != 0; asd = ASD_NEXT(asd)) {
     for (i = 0; i < numdim; i++) {
@@ -1857,8 +1856,9 @@ mk_triple(int lb, int ub, int stride)
 {
   int ast;
   ast = hash_triple(A_TRIPLE, lb, ub, stride);
-  A_CALLFGP(ast, (lb ? A_CALLFGG(lb) : 0) | (ub ? A_CALLFGG(ub) : 0) |
-                     (stride ? A_CALLFGG(stride) : 0));
+  A_CALLFGP(ast,
+            (lb ? A_CALLFGG(lb) : 0) | (ub ? A_CALLFGG(ub) : 0) |
+                (stride ? A_CALLFGG(stride) : 0));
   return ast;
 }
 
@@ -1875,8 +1875,9 @@ mk_substr(int chr, int left, int right, DTYPE dtype)
 
   ast = hash_substr(A_SUBSTR, dtype, chr, left, right);
   A_SHAPEP(ast, A_SHAPEG(chr));
-  A_CALLFGP(ast, A_CALLFGG(chr) | (left ? A_CALLFGG(left) : 0) |
-                     (right ? A_CALLFGG(right) : 0));
+  A_CALLFGP(ast,
+            A_CALLFGG(chr) | (left ? A_CALLFGG(left) : 0) |
+                (right ? A_CALLFGG(right) : 0));
   return ast;
 }
 
@@ -3116,7 +3117,7 @@ stride1_triple(int triple)
   return TRUE;
 }
 
-/* contiguous_array_section is a simple 3 state state machine (the 3rd state, 
+/* contiguous_array_section is a simple 3 state state machine (the 3rd state,
  *  FALSE, is implicit).
  *                      |inputs
  *state                |DIM_WHOLE| DIM_TRIPLE           | DIM_ELMNT
@@ -3129,13 +3130,12 @@ contiguous_array_section(int subscr_ast)
 {
   enum { START, TRIPLE_SNGL_ELEM_SEEN } state;
   enum {
-   DIM_WHOLE,   /* ":"  */
-   DIM_TRIPLE,  /* "lb:ub:", no stride allowed */
-   DIM_ELMNT,   /* "indx"   */
-   DONT_CARE, 
+    DIM_WHOLE,  /* ":"  */
+    DIM_TRIPLE, /* "lb:ub:", no stride allowed */
+    DIM_ELMNT,  /* "indx"   */
+    DONT_CARE,
   } tkn;
 
-    
   int asd;
   int ndims, dim;
   int sptr;
@@ -3188,7 +3188,6 @@ contiguous_array_section(int subscr_ast)
   }
   return TRUE;
 }
-
 
 /** \brief Determine if array \a arr_ast covers all extent at dim i
 
@@ -3667,7 +3666,8 @@ insert_stmt_after(int std, int stdafter)
   STD_FINDEX(std) = STD_FINDEX(stdafter);
 }
 
-/* Insert std into STD list before stdbefore; copy lineno and findex from stdbefore
+/* Insert std into STD list before stdbefore; copy lineno and findex from
+ * stdbefore
  * to std. */
 void
 insert_stmt_before(int std, int stdbefore)
@@ -3688,7 +3688,8 @@ remove_stmt(int std)
   int next = STD_NEXT(std);
 #if DEBUG
   if (STD_NEXT(prev) != std || STD_PREV(next) != std) {
-    interr("remove_stmt: corrupt STD or deleting statement twice", std, ERR_Severe);
+    interr("remove_stmt: corrupt STD or deleting statement twice", std,
+           ERR_Severe);
     return;
   }
 #endif
@@ -3738,7 +3739,6 @@ ast_to_comment(int ast)
   par = STD_PAR(std);
   STD_FLAGS(std) = 0;
   STD_PAR(std) = par;
-
 }
 
 int
@@ -4519,7 +4519,7 @@ ast_rewrite(int ast)
     devsrc = ast_rewrite(A_DEVSRCG(ast));
     align = ast_rewrite(A_ALIGNG(ast));
     if (lop != A_LOPG(ast) || src != A_SRCG(ast) || dest != A_DESTG(ast) ||
-        m3 != A_M3G(ast) || start != A_STARTG(ast) || 
+        m3 != A_M3G(ast) || start != A_STARTG(ast) ||
         devsrc != A_DEVSRCG(ast) || align != A_ALIGNG(ast)) {
       astnew = mk_stmt(A_ALLOC, 0);
       A_TKNP(astnew, A_TKNG(ast));
@@ -4955,9 +4955,20 @@ ast_rewrite(int ast)
     dolab = ast_rewrite(A_DOLABG(ast));
     dovar = ast_rewrite(A_DOVARG(ast));
     lastvar = ast_rewrite(A_LASTVALG(ast));
-    m1 = ast_rewrite(A_M1G(ast));
-    m2 = ast_rewrite(A_M2G(ast));
-    m3 = ast_rewrite(A_M3G(ast));
+
+    /* don't rewrite bounds if this is distribute parallel do
+     * unless we combine the distribute and parallel do in
+     * a single loop.
+     */
+    if (A_DISTPARDOG(ast)) {
+      m1 = A_M1G(ast);
+      m2 = A_M2G(ast);
+      m3 = A_M3G(ast);
+    } else {
+      m1 = ast_rewrite(A_M1G(ast));
+      m2 = ast_rewrite(A_M2G(ast));
+      m3 = ast_rewrite(A_M3G(ast));
+    }
     chunk = ast_rewrite(A_CHUNKG(ast));
     if (dolab != A_DOLABG(ast) || dovar != A_DOVARG(ast) || m1 != A_M1G(ast) ||
         lastvar != A_LASTVALG(ast) || m2 != A_M2G(ast) || m3 != A_M3G(ast) ||
@@ -4972,6 +4983,8 @@ ast_rewrite(int ast)
       A_CHUNKP(astnew, chunk);
       A_SCHED_TYPEP(astnew, A_SCHED_TYPEG(ast));
       A_ORDEREDP(astnew, A_ORDEREDG(ast));
+      A_DISTRIBUTEP(astnew, A_DISTRIBUTEG(ast));
+      A_DISTPARDOP(astnew, A_DISTPARDOG(ast));
     }
     break;
   case A_MP_ENDPDO:
@@ -5106,7 +5119,6 @@ ast_clear_repl(int ast)
   }
 
   A_REPLP(ast, 0);
-
 }
 
 static ast_preorder_fn _preorder;

--- a/tools/flang1/flang1exe/lower.h
+++ b/tools/flang1/flang1exe/lower.h
@@ -106,9 +106,11 @@
  *                All of 1.44 + INVOBJINC + PARREF for ST_PROC
  * 17.2        -- 1.46
  *                All of 1.45 + etls + tls, irrspective of target
+ * 17.7        -- 1.47
+ *                All of 1.46 + BPARA
  */
 #define VersionMajor 1
-#define VersionMinor 46
+#define VersionMinor 47
 
 void lower(int);
 void lower_end_contains(void);
@@ -230,6 +232,7 @@ int lower_disable_subscr_chk;
 #define STKMASTER 5
 #define STKTASK 6
 #define STKCANCEL 7
+#define STKDDO 8
 
 void lower_ilm_header(void);
 int plower(char *fmt, ...);

--- a/tools/flang1/flang1exe/mp.h
+++ b/tools/flang1/flang1exe/mp.h
@@ -49,8 +49,8 @@
 #define MP_SCH_INTERLEAVE 0x3
 #define MP_SCH_RUNTIME 0x4
 #define MP_SCH_AUTO 0x5
-#define MP_SCH_DIST_STATIC 0x6       /* use in distribute parallel for */
-#define MP_SCH_DIST_DYNAMIC 0x7      /* use in distribute parallel for */
+#define MP_SCH_DIST_STATIC 0x6  /* use in distribute parallel for */
+#define MP_SCH_DIST_DYNAMIC 0x7 /* use in distribute parallel for */
 
 /* The second byte represents special case flags for static (maskable) */
 #define MP_SCH_SPC_MASK 0x0000FF00
@@ -79,11 +79,31 @@
   0x20 /* Depend is present and has dependence-type INOUT */
 
 typedef enum omp_proc_bind_t {
-    MP_PROC_BIND_FALSE = 0,
-    MP_PROC_BIND_TRUE,
-    MP_PROC_BIND_MASTER,
-    MP_PROC_BIND_CLOSE,
-    MP_PROC_BIND_SPREAD,
+  MP_PROC_BIND_FALSE = 0,
+  MP_PROC_BIND_TRUE,
+  MP_PROC_BIND_MASTER,
+  MP_PROC_BIND_CLOSE,
+  MP_PROC_BIND_SPREAD,
 } omp_proc_bind_t;
+
+typedef enum omp_iftype {
+  IF_DEFAULT = 0,
+  IF_TARGET = 1,
+  IF_TARGETDATA = (1 << 1),
+  IF_TARGETENTERDATA = (1 << 2),
+  IF_TARGETEXITDATA = (1 << 3),
+  IF_TARGETUPDATE = (1 << 4),
+  IF_PARALLEL = (1 << 5),
+  IF_TASK = (1 << 6),
+  IF_TASKLOOP = (1 << 7),
+} omp_iftype;
+
+/* Keep up to date with pgcplus_omp_cancel_type init_omp()*/
+typedef enum omp_canceltype {
+  CANCEL_PARALLEL = 1,
+  CANCEL_FOR = 2,
+  CANCEL_SECTIONS = 3,
+  CANCEL_TASKGROUP = 4,
+} omp_canceltype;
 
 #endif /* __MP_H__ */

--- a/tools/flang1/flang1exe/semant.c
+++ b/tools/flang1/flang1exe/semant.c
@@ -101,7 +101,7 @@ static void fixup_ident_bounds(int);
 
 static int decl_procedure_sym(int sptr, int proc_interf_sptr, int attr);
 static int setup_procedure_sym(int sptr, int proc_interf_sptr, int attr,
-                             char access);
+                               char access);
 static LOGICAL ignore_common_decl(void);
 static void record_func_result(int func_sptr, int func_result_sptr,
                                LOGICAL in_ENTRY);
@@ -253,35 +253,39 @@ static struct {
        ET_B(ET_CONSTANT) | ET_B(ET_ASYNCHRONOUS) | ET_B(ET_PROTECTED) |
        ET_B(ET_TEXTURE) | ET_B(ET_CONTIGUOUS) | ET_B(ET_MANAGED) |
        ET_B(ET_IMPL_MANAGED))},
-    {"external", ~(ET_B(ET_ACCESS) | ET_B(ET_OPTIONAL) | ET_B(ET_BIND) |
-                   ET_B(ET_VALUE) | ET_B(ET_POINTER))},
-    {"intent", ~(ET_B(ET_DIMENSION) | ET_B(ET_OPTIONAL) | ET_B(ET_TARGET) |
-                 ET_B(ET_ALLOCATABLE) | ET_B(ET_BIND) | ET_B(ET_VALUE) |
-                 ET_B(ET_POINTER) | ET_B(ET_VOLATILE) | ET_B(ET_DEVICE) |
-                 ET_B(ET_CONSTANT) | ET_B(ET_PINNED) |
-                 ET_B(ET_SHARED | ET_B(ET_ASYNCHRONOUS) | ET_B(ET_PROTECTED)) |
-                 ET_B(ET_CONTIGUOUS) | ET_B(ET_TEXTURE) | ET_B(ET_MANAGED) |
-                 ET_B(ET_IMPL_MANAGED))},
+    {"external",
+     ~(ET_B(ET_ACCESS) | ET_B(ET_OPTIONAL) | ET_B(ET_BIND) | ET_B(ET_VALUE) |
+       ET_B(ET_POINTER))},
+    {"intent",
+     ~(ET_B(ET_DIMENSION) | ET_B(ET_OPTIONAL) | ET_B(ET_TARGET) |
+       ET_B(ET_ALLOCATABLE) | ET_B(ET_BIND) | ET_B(ET_VALUE) |
+       ET_B(ET_POINTER) | ET_B(ET_VOLATILE) | ET_B(ET_DEVICE) |
+       ET_B(ET_CONSTANT) | ET_B(ET_PINNED) |
+       ET_B(ET_SHARED | ET_B(ET_ASYNCHRONOUS) | ET_B(ET_PROTECTED)) |
+       ET_B(ET_CONTIGUOUS) | ET_B(ET_TEXTURE) | ET_B(ET_MANAGED) |
+       ET_B(ET_IMPL_MANAGED))},
     {"intrinsic", ~(ET_B(ET_ACCESS))},
     {"optional",
      ~(ET_B(ET_DIMENSION) | ET_B(ET_EXTERNAL) | ET_B(ET_INTENT) |
        ET_B(ET_POINTER) | ET_B(ET_SAVE) | ET_B(ET_TARGET) |
        ET_B(ET_ALLOCATABLE) | ET_B(ET_VOLATILE) | ET_B(ET_ASYNCHRONOUS) |
        ET_B(ET_PROTECTED) | ET_B(ET_CONTIGUOUS) | ET_B(ET_MANAGED) |
-       ET_B(ET_VALUE) |
-       ET_B(ET_IMPL_MANAGED) | ET_B(ET_DEVICE))},
-    {"parameter", ~(ET_B(ET_ACCESS) | ET_B(ET_DIMENSION) | ET_B(ET_SAVE) |
-                    ET_B(ET_VALUE) | ET_B(ET_ASYNCHRONOUS))},
-    {"pointer", ~(ET_B(ET_ACCESS) | ET_B(ET_DIMENSION) | ET_B(ET_OPTIONAL) |
-                  ET_B(ET_SAVE) | ET_B(ET_VALUE) | ET_B(ET_BIND) |
-                  ET_B(ET_INTENT) | ET_B(ET_VOLATILE) | ET_B(ET_ASYNCHRONOUS) |
-                  ET_B(ET_PROTECTED) | ET_B(ET_TEXTURE) | ET_B(ET_DEVICE) |
-                  ET_B(ET_CONTIGUOUS) | ET_B(ET_MANAGED) | ET_B(ET_EXTERNAL))},
-    {"save", ~(ET_B(ET_ACCESS) | ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) |
-               ET_B(ET_PARAMETER) | ET_B(ET_POINTER) | ET_B(ET_TARGET) |
-               ET_B(ET_VALUE) | ET_B(ET_VOLATILE) | ET_B(ET_SHARED) |
-               ET_B(ET_ASYNCHRONOUS) | ET_B(ET_PROTECTED) | ET_B(ET_PINNED) |
-               ET_B(ET_TEXTURE) | ET_B(ET_MANAGED) | ET_B(ET_IMPL_MANAGED))},
+       ET_B(ET_VALUE) | ET_B(ET_IMPL_MANAGED) | ET_B(ET_DEVICE))},
+    {"parameter",
+     ~(ET_B(ET_ACCESS) | ET_B(ET_DIMENSION) | ET_B(ET_SAVE) | ET_B(ET_VALUE) |
+       ET_B(ET_ASYNCHRONOUS))},
+    {"pointer",
+     ~(ET_B(ET_ACCESS) | ET_B(ET_DIMENSION) | ET_B(ET_OPTIONAL) |
+       ET_B(ET_SAVE) | ET_B(ET_VALUE) | ET_B(ET_BIND) | ET_B(ET_INTENT) |
+       ET_B(ET_VOLATILE) | ET_B(ET_ASYNCHRONOUS) | ET_B(ET_PROTECTED) |
+       ET_B(ET_TEXTURE) | ET_B(ET_DEVICE) | ET_B(ET_CONTIGUOUS) |
+       ET_B(ET_MANAGED) | ET_B(ET_EXTERNAL))},
+    {"save",
+     ~(ET_B(ET_ACCESS) | ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) |
+       ET_B(ET_PARAMETER) | ET_B(ET_POINTER) | ET_B(ET_TARGET) |
+       ET_B(ET_VALUE) | ET_B(ET_VOLATILE) | ET_B(ET_SHARED) |
+       ET_B(ET_ASYNCHRONOUS) | ET_B(ET_PROTECTED) | ET_B(ET_PINNED) |
+       ET_B(ET_TEXTURE) | ET_B(ET_MANAGED) | ET_B(ET_IMPL_MANAGED))},
     {"target",
      ~(ET_B(ET_ACCESS) | ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) |
        ET_B(ET_INTENT) | ET_B(ET_OPTIONAL) | ET_B(ET_SAVE) | ET_B(ET_VALUE) |
@@ -292,20 +296,21 @@ static struct {
      ~(ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) | ET_B(ET_POINTER) |
        ET_B(ET_TARGET) | ET_B(ET_VALUE) | ET_B(ET_VOLATILE) |
        ET_B(ET_ASYNCHRONOUS) | ET_B(ET_PROTECTED))},
-    {"static", ~(ET_B(ET_ACCESS) | ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) |
-                 ET_B(ET_POINTER) | ET_B(ET_SAVE) | ET_B(ET_TARGET) |
-                 ET_B(ET_BIND) | ET_B(ET_VALUE) | ET_B(ET_VOLATILE) |
-                 ET_B(ET_ASYNCHRONOUS) | ET_B(ET_PROTECTED))},
-    {"bind", ~(ET_B(ET_ACCESS) | ET_B(ET_DIMENSION) | ET_B(ET_EXTERNAL) |
-               ET_B(ET_INTENT) | ET_B(ET_POINTER) | ET_B(ET_TARGET) |
-               ET_B(ET_STATIC) | ET_B(ET_VOLATILE) | ET_B(ET_ASYNCHRONOUS) |
-               ET_B(ET_PROTECTED) | ET_B(ET_CONTIGUOUS))},
+    {"static",
+     ~(ET_B(ET_ACCESS) | ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) |
+       ET_B(ET_POINTER) | ET_B(ET_SAVE) | ET_B(ET_TARGET) | ET_B(ET_BIND) |
+       ET_B(ET_VALUE) | ET_B(ET_VOLATILE) | ET_B(ET_ASYNCHRONOUS) |
+       ET_B(ET_PROTECTED))},
+    {"bind",
+     ~(ET_B(ET_ACCESS) | ET_B(ET_DIMENSION) | ET_B(ET_EXTERNAL) |
+       ET_B(ET_INTENT) | ET_B(ET_POINTER) | ET_B(ET_TARGET) | ET_B(ET_STATIC) |
+       ET_B(ET_VOLATILE) | ET_B(ET_ASYNCHRONOUS) | ET_B(ET_PROTECTED) |
+       ET_B(ET_CONTIGUOUS))},
     {"value",
      ~(ET_B(ET_ACCESS) | ET_B(ET_DIMENSION) | ET_B(ET_EXTERNAL) |
        ET_B(ET_INTENT) | ET_B(ET_PARAMETER) | ET_B(ET_POINTER) | ET_B(ET_SAVE) |
        ET_B(ET_TARGET) | ET_B(ET_STATIC) | ET_B(ET_ASYNCHRONOUS) |
-       ET_B(ET_OPTIONAL) |
-       ET_B(ET_PROTECTED) | ET_B(ET_CONTIGUOUS))},
+       ET_B(ET_OPTIONAL) | ET_B(ET_PROTECTED) | ET_B(ET_CONTIGUOUS))},
     {"volatile",
      ~(ET_B(ET_ACCESS) | ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) |
        ET_B(ET_INTENT) | ET_B(ET_OPTIONAL) | ET_B(ET_POINTER) | ET_B(ET_SAVE) |
@@ -314,15 +319,18 @@ static struct {
        ET_B(ET_SHARED) | ET_B(ET_CONTIGUOUS))},
     {"pass", ~(0)},
     {"nopass", ~(0)},
-    {"device", ~(ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) | ET_B(ET_INTENT) |
-                 ET_B(ET_VOLATILE) | ET_B(ET_ACCESS) | ET_B(ET_TARGET) |
-                 ET_B(ET_POINTER) | ET_B(ET_TEXTURE) | ET_B(ET_CONTIGUOUS) |
-                 ET_B(ET_OPTIONAL) | ET_B(ET_IMPL_MANAGED))},
-    {"pinned", ~(ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) | ET_B(ET_INTENT) |
-                 ET_B(ET_SAVE) | ET_B(ET_TARGET) | ET_B(ET_ACCESS) |
-                 ET_B(ET_CONTIGUOUS) | ET_B(ET_IMPL_MANAGED))},
-    {"shared", ~(ET_B(ET_DIMENSION) | ET_B(ET_SAVE) | ET_B(ET_INTENT) |
-                 ET_B(ET_VOLATILE))},
+    {"device",
+     ~(ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) | ET_B(ET_INTENT) |
+       ET_B(ET_VOLATILE) | ET_B(ET_ACCESS) | ET_B(ET_TARGET) |
+       ET_B(ET_POINTER) | ET_B(ET_TEXTURE) | ET_B(ET_CONTIGUOUS) |
+       ET_B(ET_OPTIONAL) | ET_B(ET_IMPL_MANAGED))},
+    {"pinned",
+     ~(ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) | ET_B(ET_INTENT) |
+       ET_B(ET_SAVE) | ET_B(ET_TARGET) | ET_B(ET_ACCESS) | ET_B(ET_CONTIGUOUS) |
+       ET_B(ET_IMPL_MANAGED))},
+    {"shared",
+     ~(ET_B(ET_DIMENSION) | ET_B(ET_SAVE) | ET_B(ET_INTENT) |
+       ET_B(ET_VOLATILE))},
     {"constant", ~(ET_B(ET_DIMENSION) | ET_B(ET_INTENT) | ET_B(ET_ACCESS))},
     {"protected",
      ~(ET_B(ET_ACCESS) | ET_B(ET_ALLOCATABLE) | ET_B(ET_DIMENSION) |
@@ -336,8 +344,9 @@ static struct {
        ET_B(ET_POINTER) | ET_B(ET_SAVE) | ET_B(ET_TARGET) | ET_B(ET_AUTOMATIC) |
        ET_B(ET_STATIC) | ET_B(ET_BIND) | ET_B(ET_VALUE) | ET_B(ET_VOLATILE) |
        ET_B(ET_PROTECTED) | ET_B(ET_IMPL_MANAGED))},
-    {"texture", ~(ET_B(ET_DIMENSION) | ET_B(ET_INTENT) | ET_B(ET_POINTER) |
-                  ET_B(ET_DEVICE) | ET_B(ET_SAVE))},
+    {"texture",
+     ~(ET_B(ET_DIMENSION) | ET_B(ET_INTENT) | ET_B(ET_POINTER) |
+       ET_B(ET_DEVICE) | ET_B(ET_SAVE))},
     {"kind", 0},       /* 'no' field not used, so make it 0 */
     {"len", 0},        /* 'no' field not used, so make it 0 */
     {"contiguous", 0}, /* 'no' field not used, so make it 0 */
@@ -523,7 +532,8 @@ semant_init(int noparse)
     sem.target = 0;
     sem.teams = 0;
     sem.expect_do = FALSE;
-    sem.expect_simdloop = FALSE;
+    sem.expect_simd_do = FALSE;
+    sem.expect_dist_do = FALSE;
     sem.expect_acc_do = 0;
     sem.expect_cuf_do = 0;
     sem.close_pdo = FALSE;
@@ -626,7 +636,6 @@ semant_init(int noparse)
     if (gbl.internal)
       restore_host_state(4);
   }
-
 }
 
 static int
@@ -682,9 +691,9 @@ reloc_byvalue_parameters()
       } else
         byval_default = BYVALDEFAULT(thesub);
       if (PASSBYVALG(psptr) && OPTARGG(psptr)) {
-	/* an address is passed for optional value arguments as if call by
-	 * reference, but the address is of a temp
-	 */
+        /* an address is passed for optional value arguments as if call by
+         * reference, but the address is of a temp
+         */
         continue;
       }
       if ((byval_default || PASSBYVALG(psptr)) && (!PASSBYREFG(psptr)) &&
@@ -896,8 +905,8 @@ semant1(int rednum, SST *top)
         restored = 1;
       }
     }
-    if (sem.expect_do || sem.expect_acc_do || sem.expect_simdloop ||
-        (sem.expect_cuf_do && XBIT(137, 0x20000))) {
+    if (sem.expect_do || sem.expect_acc_do || sem.expect_simd_do ||
+        sem.expect_dist_do || (sem.expect_cuf_do && XBIT(137, 0x20000))) {
       int stt;
       stt = sem.tkntyp;
       if (stt == TK_NAMED_CONSTRUCT)
@@ -943,7 +952,7 @@ semant1(int rednum, SST *top)
           break;
         case DI_PDO:
           if (DI_ISSIMD(sem.doif_depth))
-            p = "OMP DOSIMD";
+            p = "OMP DO SIMD";
           else
             p = "OMP DO";
           sem.doif_depth--; /* remove PDO from stack */
@@ -959,6 +968,7 @@ semant1(int rednum, SST *top)
           p = "OMP SIMD";
           par_pop_scope();
           break;
+
         case DI_DISTRIBUTE:
           sem.doif_depth--; /* remove from DISTRIBUTE stack */
           p = "OMP DISTRIBUTE";
@@ -969,30 +979,28 @@ semant1(int rednum, SST *top)
           p = "OMP TARGET PARALLEL DO";
           par_pop_scope();
           break;
-        case DI_TARGTEAMSDIST:
-          sem.doif_depth--; /* remove from stack */
-          p = "OMP TARGET TEAMS DISTRIBUTE";
-          par_pop_scope();
-          break;
-        case DI_TARGTEAMSDISTPARDO:
-          sem.doif_depth--; /* remove from stack */
-          p = "OMP TARGET TEAMS DISTRIBUTE PARALLEL DO";
-          par_pop_scope();
-          break;
-        case DI_TEAMSDIST:
-          sem.doif_depth--; /* remove from stack */
-          p = "OMP TEAMS DISTRIBUTE";
-          par_pop_scope();
-          break;
-        case DI_TEAMSDISTPARDO:
-          sem.doif_depth--; /* remove from stack */
-          p = "OMP TEAMS DISTRIBUTE PARALLEL DO";
-          par_pop_scope();
-          break;
         case DI_DISTPARDO:
           sem.doif_depth--; /* remove from stack */
           p = "OMP DISTRIBUTE PARALLEL DO";
           par_pop_scope();
+
+          if (scn.stmtyp == TK_MP_ENDTEAMS) {
+            /* distribute parallel do */
+            break;
+          } else if (scn.stmtyp == TK_MP_ENDTARGET) {
+            /* teams distribute parallel do */
+            par_pop_scope();
+          } else if (DI_ID(sem.doif_depth) == DI_TEAMS) {
+            /* if the previous stack id is DI_TEAMS
+             * and scn.stmtyp != TK_MP_ENDTEAMS, then
+             * this is target teams distribute parallel do
+             * constrct: pop teams and target as we manually
+             * add stack for those.
+             */
+            par_pop_scope();
+            par_pop_scope();
+          }
+
           break;
         case DI_DOACROSS:
           p = "DOACROSS";
@@ -1013,7 +1021,8 @@ semant1(int rednum, SST *top)
         }
         error(155, 3, gbl.lineno, "DO loop expected after", p);
         sem.expect_do = FALSE;
-        sem.expect_simdloop = FALSE;
+        sem.expect_simd_do = FALSE;
+        sem.expect_dist_do = FALSE;
         sem.expect_acc_do = 0;
         sem.expect_cuf_do = 0;
         sem.collapse = sem.collapse_depth = 0;
@@ -1037,13 +1046,7 @@ semant1(int rednum, SST *top)
       sem.close_pdo = FALSE;
       switch (DI_ID(sem.doif_depth)) {
       case DI_PDO:
-        if (DI_ISSIMD(sem.doif_depth)) {
-          if (scn.stmtyp != TK_MP_ENDDOSIMD) {
-            ast = mk_stmt(A_MP_BARRIER, 0);
-            (void)add_stmt(ast);
-            sem.doif_depth--; /* pop DOIF stack */
-          }
-        } else if (scn.stmtyp != TK_MP_ENDPDO) {
+        if (scn.stmtyp != TK_MP_ENDPDO) {
           ast = mk_stmt(A_MP_BARRIER, 0);
           (void)add_stmt(ast);
           sem.doif_depth--; /* pop DOIF stack */
@@ -1056,73 +1059,58 @@ semant1(int rednum, SST *top)
         }
         /* else ENDDISTRIBUTE pops the stack */
         break;
+      case DI_TEAMSDIST:
+        if (scn.stmtyp != TK_MP_ENDTEAMSDIST) {
+          sem.doif_depth--; /* pop DOIF stack */
+          end_teams();
+        }
+        /* else ENDTEAMSDIST pops the stack */
+        break;
+      case DI_TARGTEAMSDIST:
+        if (scn.stmtyp != TK_MP_ENDTARGTEAMSDIST) {
+          sem.doif_depth--; /* pop DOIF stack */
+          end_teams();
+          end_target();
+        }
+        /* else ENDTEAMSDIST pops the stack */
+        break;
       case DI_TARGPARDO:
-        if (DI_ISSIMD(sem.doif_depth)) {
-          if (scn.stmtyp != TK_MP_ENDTARGPARDOSIMD) {
-            ast = mk_stmt(A_MP_BARRIER, 0);
-            (void)add_stmt(ast);
-            sem.doif_depth--; /* pop DOIF stack */
-          }
-        } else if (scn.stmtyp != TK_MP_ENDTARGPARDO) {
+        if (scn.stmtyp != TK_MP_ENDTARGPARDO) {
           ast = mk_stmt(A_MP_BARRIER, 0);
           (void)add_stmt(ast);
           sem.doif_depth--; /* pop DOIF stack */
+          end_target();
         }
         /* else ENDTARGPARDO[SIMD] pops the stack */
         break;
-      case DI_TARGTEAMSDIST:
-        if (DI_ISSIMD(sem.doif_depth)) {
-          if (scn.stmtyp != TK_MP_ENDTARGTEAMSDISTSIMD) {
-            sem.doif_depth--; /* pop DOIF stack */
-          }
-        } else if (scn.stmtyp != TK_MP_ENDTARGTEAMSDIST) {
-          sem.doif_depth--; /* pop DOIF stack */
-        }
-        /* else ENDTARGTEAMSDIST[SIMD] pops the stack */
-        break;
-      case DI_TARGTEAMSDISTPARDO:
-        if (DI_ISSIMD(sem.doif_depth)) {
-          if (scn.stmtyp != TK_MP_ENDTARGTEAMSDISTPARDOSIMD) {
-            sem.doif_depth--; /* pop DOIF stack */
-          }
-        } else if (scn.stmtyp != TK_MP_ENDTARGTEAMSDISTPARDO) {
-          sem.doif_depth--; /* pop DOIF stack */
-        }
-        /* else ENDTARGTEAMSDISTPARDO[SIMD] pops the stack */
-        break;
-      case DI_TEAMSDIST:
-        if (DI_ISSIMD(sem.doif_depth)) {
-          if (scn.stmtyp != TK_MP_ENDTEAMSDISTSIMD) {
-            sem.doif_depth--; /* pop DOIF stack */
-          }
-        } else if (scn.stmtyp != TK_MP_ENDTEAMSDIST) {
-          sem.doif_depth--; /* pop DOIF stack */
-        }
-        /* else ENDTEAMSDIST[SIMD] pops the stack */
-        break;
+
       case DI_TEAMSDISTPARDO:
-        if (DI_ISSIMD(sem.doif_depth)) {
-          if (scn.stmtyp != TK_MP_ENDTEAMSDISTPARDOSIMD) {
-            sem.doif_depth--; /* pop DOIF stack */
-          }
-        } else if (scn.stmtyp != TK_MP_ENDTEAMSDISTPARDO) {
+        if (scn.stmtyp != TK_MP_ENDTEAMSDISTPARDO &&
+            scn.stmtyp != TK_MP_ENDTEAMSDISTPARDOSIMD) {
           sem.doif_depth--; /* pop DOIF stack */
+          end_teams();
         }
         /* else ENDTEAMSDISTPARDO[SIMD] pops the stack */
         break;
+      case DI_TARGTEAMSDISTPARDO:
+        if (scn.stmtyp != TK_MP_ENDTARGTEAMSDISTPARDO &&
+            scn.stmtyp != TK_MP_ENDTARGTEAMSDISTPARDOSIMD) {
+          sem.doif_depth--; /* pop DOIF stack */
+          end_teams();
+          end_target();
+        }
+        /* else ENDTARGTEAMSDISTPARDO[SIMD] pops the stack */
+        break;
       case DI_DISTPARDO:
-        if (DI_ISSIMD(sem.doif_depth)) {
-          if (scn.stmtyp != TK_MP_ENDDISTPARDOSIMD) {
-            sem.doif_depth--; /* pop DOIF stack */
-          }
-        } else if (scn.stmtyp != TK_MP_ENDDISTPARDO) {
+        if (scn.stmtyp != TK_MP_ENDDISTPARDO &&
+            scn.stmtyp != TK_MP_ENDDISTPARDOSIMD) {
           sem.doif_depth--; /* pop DOIF stack */
         }
-        /* else ENDDISTPARDO[SIMD] pops the stack */
         break;
       case DI_TARGETSIMD:
         if (scn.stmtyp != TK_MP_ENDTARGSIMD) {
           sem.doif_depth--; /* pop DOIF stack */
+          end_target();
         }
         /* else ENDTARGETSIMD pops the stack */
         break;
@@ -1139,10 +1127,7 @@ semant1(int rednum, SST *top)
         sem.doif_depth--; /* pop DOIF stack */
         break;
       case DI_PARDO:
-        if (DI_ISSIMD(sem.doif_depth)) {
-          if (scn.stmtyp != TK_MP_ENDPARDOSIMD)
-            sem.doif_depth--; /* pop DOIF stack */
-        } else if (scn.stmtyp != TK_MP_ENDPARDO) {
+        if (scn.stmtyp != TK_MP_ENDPARDO) {
           sem.doif_depth--; /* pop DOIF stack */
           /* else ENDPARDO pops the stack */
         }
@@ -1489,7 +1474,7 @@ semant1(int rednum, SST *top)
          * Note that scan has set 'scn.end_program_unit to TRUE'.
          */
         if (sem.end_host_labno && sem.which_pass) {
-          int labsym = getsymf(".L%05ld", (long) sem.end_host_labno);
+          int labsym = getsymf(".L%05ld", (long)sem.end_host_labno);
           /*
            * If a label was present on the end statement of the
            * host subprogram, need to define & emit the label now.
@@ -1602,9 +1587,6 @@ semant1(int rednum, SST *top)
           case DI_TARGETSIMD:
           case DI_SIMD:
           case DI_DISTRIBUTE:
-          case DI_TARGTEAMSDIST:
-          case DI_TARGTEAMSDISTPARDO:
-          case DI_TEAMSDISTPARDO:
           case DI_DISTPARDO:
           case DI_DOACROSS:
           case DI_PARDO:
@@ -1869,7 +1851,7 @@ semant1(int rednum, SST *top)
       *(aux.dpdsc_base + (aux.dpdsc_avl++)) = sptr;
     }
     /* Set parameter count
-     * 
+     *
      * For procedure pointer symbols it should go into dtype, for old style
      * procedure symbols use PARAMCT attribute.
      *
@@ -2855,10 +2837,10 @@ semant1(int rednum, SST *top)
         LOGICAL was_declared = DCLDG(itemp->t.sptr);
         /* External pointer should come out the same as procedure(T) pointer */
         sptr = decl_procedure_sym(itemp->t.sptr, proc_interf_sptr,
-                                 (entity_attr.exist | ET_B(ET_POINTER)));
+                                  (entity_attr.exist | ET_B(ET_POINTER)));
         sptr = setup_procedure_sym(itemp->t.sptr, proc_interf_sptr,
-                                 (entity_attr.exist | ET_B(ET_POINTER)),
-                                 entity_attr.access);
+                                   (entity_attr.exist | ET_B(ET_POINTER)),
+                                   entity_attr.access);
         DCLDP(sptr, was_declared);
       } else {
         /* Use simple approach when we can't argue that this needs to be a
@@ -3179,7 +3161,8 @@ semant1(int rednum, SST *top)
     name_prefix_char = 'm';
   union_map:
     stype = ST_MEMBER;
-    sptr = declref(getsymf("%c@%05ld", name_prefix_char, (long) dtype), stype, 'r');
+    sptr =
+        declref(getsymf("%c@%05ld", name_prefix_char, (long)dtype), stype, 'r');
 #if DEBUG
     assert(STYPEG(sptr) == stype,
            scn.stmtyp == TK_UNION ? "UNION: bad stype" : "MAP: bad stype", sptr,
@@ -4810,19 +4793,18 @@ semant1(int rednum, SST *top)
         /* data type for ident has already been specified */
         if (DDTG(DTYPEG(sptr)) == dtype)
           error(119, 2, gbl.lineno, SYMNAME(sptr), CNULL);
-	else if (DTY(DTYPEG(sptr)) == TY_PTR && 
-	         DTY(DTY(DTYPEG(sptr)+1)) == TY_PROC &&
-	         DTY(DTY(DTYPEG(sptr)+1)+1) == DT_NONE &&
-	         DTY(DTY(DTYPEG(sptr)+1)+2) == 0) {
-	  /* ptr to procedure, return dtype is DT_NONE, no interface; just
-	   * update the return dtype (no longer assume it's a pointer to a
-	   * subroutine.
-	   */
-	   DTY(DTY(DTYPEG(sptr)+1)+1) = dtype;
-	}
-        else {
+        else if (DTY(DTYPEG(sptr)) == TY_PTR &&
+                 DTY(DTY(DTYPEG(sptr) + 1)) == TY_PROC &&
+                 DTY(DTY(DTYPEG(sptr) + 1) + 1) == DT_NONE &&
+                 DTY(DTY(DTYPEG(sptr) + 1) + 2) == 0) {
+          /* ptr to procedure, return dtype is DT_NONE, no interface; just
+           * update the return dtype (no longer assume it's a pointer to a
+           * subroutine.
+           */
+          DTY(DTY(DTYPEG(sptr) + 1) + 1) = dtype;
+        } else {
           error(37, 3, gbl.lineno, SYMNAME(sptr), CNULL);
-	}
+        }
       }
       break; /* to avoid setting symbol table entry's stype field */
     }
@@ -4972,8 +4954,7 @@ semant1(int rednum, SST *top)
     stype = ST_ARRAY;
     dtype = SST_DTYPEG(RHS(4));
     ad = AD_DPTR(dtype);
-    if (AD_ASSUMSZ(ad) || AD_ADJARR(ad) || AD_DEFER(ad) ||
-        sem.interface)
+    if (AD_ASSUMSZ(ad) || AD_ADJARR(ad) || AD_DEFER(ad) || sem.interface)
       sem.dinit_count = -1;
     else
       sem.dinit_count = ad_val_of(sym_of_ast(AD_NUMELM(AD_DPTR(dtype))));
@@ -7075,15 +7056,14 @@ semant1(int rednum, SST *top)
         /* Generate proper procedure symbol */
         sptr = insert_sym(sptr);
         sptr = setup_procedure_sym(sptr, proc_interf_sptr, ET_B(ET_POINTER),
-                                 entity_attr.access);
+                                   entity_attr.access);
         SST_SYMP(RHS(1), sptr);
         /* Restore "declared" flag */
         DCLDP(sptr, declared);
       }
       if (sem.contiguous)
         CONTIGATTRP(sptr, 1);
-      if (DTYG(DTYPEG(sptr)) == TY_DERIVED &&
-          XBIT(58, 0x40000)) {
+      if (DTYG(DTYPEG(sptr)) == TY_DERIVED && XBIT(58, 0x40000)) {
         F90POINTERP(sptr, TRUE);
       }
       if (DTY(DTYPEG(sptr)) == TY_ARRAY) {
@@ -7171,8 +7151,7 @@ semant1(int rednum, SST *top)
       if (SCG(sptr) != SC_DUMMY)
         ALLOCP(sptr, 1);
       POINTERP(sptr, TRUE);
-      if (DTYG(DTYPEG(sptr)) == TY_DERIVED &&
-          XBIT(58, 0x40000)) {
+      if (DTYG(DTYPEG(sptr)) == TY_DERIVED && XBIT(58, 0x40000)) {
         F90POINTERP(sptr, TRUE);
       }
       if (SDSCG(sptr) == 0 && !F90POINTERG(sptr)) {
@@ -7185,8 +7164,7 @@ semant1(int rednum, SST *top)
     else {
       ALLOCP(sptr, 1);
       ALLOCATTRP(sptr, 1);
-      if (DTYG(DTYPEG(sptr)) == TY_DERIVED &&
-          XBIT(58, 0x40000)) {
+      if (DTYG(DTYPEG(sptr)) == TY_DERIVED && XBIT(58, 0x40000)) {
         F90POINTERP(sptr, TRUE);
       }
     }
@@ -8069,8 +8047,8 @@ semant1(int rednum, SST *top)
         }
         /* Produce procedure symbol based on attributes */
         sptr = decl_procedure_sym(sptr, 0, entity_attr.exist);
-        sptr = setup_procedure_sym(sptr, 0, entity_attr.exist,
-                                 entity_attr.access);
+        sptr =
+            setup_procedure_sym(sptr, 0, entity_attr.exist, entity_attr.access);
         if (!TYPDG(sptr)) {
 #ifdef EXTRP
           EXTRP(sptr, sem.extrinsic);
@@ -8122,8 +8100,7 @@ semant1(int rednum, SST *top)
         POINTERP(sptr, TRUE);
         if (sem.contiguous)
           CONTIGATTRP(sptr, 1);
-        if (DTYG(DTYPEG(sptr)) == TY_DERIVED &&
-            XBIT(58, 0x40000)) {
+        if (DTYG(DTYPEG(sptr)) == TY_DERIVED && XBIT(58, 0x40000)) {
           F90POINTERP(sptr, TRUE);
         }
         if (is_array) {
@@ -8605,8 +8582,7 @@ semant1(int rednum, SST *top)
     dtype = SST_DTYPEG(RHS(4));
     dtypeset = 1;
     ad = AD_DPTR(dtype);
-    if (AD_ASSUMSZ(ad) || AD_ADJARR(ad) || AD_DEFER(ad) ||
-        sem.interface)
+    if (AD_ASSUMSZ(ad) || AD_ADJARR(ad) || AD_DEFER(ad) || sem.interface)
       sem.dinit_count = -1;
     else
       sem.dinit_count = ad_val_of(sym_of_ast(AD_NUMELM(ad)));
@@ -9240,8 +9216,9 @@ semant1(int rednum, SST *top)
     }
     if (i && sem.defined_io_type && i != sem.defined_io_type) {
       char *name_cpy;
-      name_cpy = getitem(0, strlen(SYMNAME(SST_SYMG(RHS(1)))) +
-                                strlen(SYMNAME(SST_SYMG(RHS(3)))) + 1);
+      name_cpy = getitem(0,
+                         strlen(SYMNAME(SST_SYMG(RHS(1)))) +
+                             strlen(SYMNAME(SST_SYMG(RHS(3)))) + 1);
       sprintf(name_cpy, "%s(%s)", SYMNAME(SST_SYMG(RHS(1))),
               SYMNAME(SST_SYMG(RHS(3))));
       error(155, 3, gbl.lineno,
@@ -9637,10 +9614,9 @@ semant1(int rednum, SST *top)
     init_use_stmts();
     if (XBIT(68, 0x1)) {
       /* Append "_la" to the names of some modules. */
-      static const char *names[] = {
-        "ieee_exceptions", "ieee_arithmetic", "cudafor",
-        "openacc", "accel_lib", NULL
-      };
+      static const char *names[] = {"ieee_exceptions", "ieee_arithmetic",
+                                    "cudafor",         "openacc",
+                                    "accel_lib",       NULL};
       int j;
       for (j = 0; names[j]; ++j) {
         if (strcmp(SYMNAME(sptr), names[j]) == 0) {
@@ -10562,8 +10538,8 @@ semant1(int rednum, SST *top)
         attr |= ET_B(ET_POINTER);
       }
       sptr = decl_procedure_sym(sptr, proc_interf_sptr, attr);
-      sptr = setup_procedure_sym(sptr, proc_interf_sptr, attr,
-                               entity_attr.access);
+      sptr =
+          setup_procedure_sym(sptr, proc_interf_sptr, attr, entity_attr.access);
     }
 
     /* Error while creating proc symbol */
@@ -11644,7 +11620,6 @@ gen_dinit(int sptr, SST *stkptr)
     }
     sem.dinit_error = FALSE;
   }
-
 }
 
 static void
@@ -14714,7 +14689,8 @@ replace_sdsc_in_bounds(int sdsc, ADSC *ad, int i)
   }
 }
 
-/* If there is an ID node in the ast tree that matches the name of this descriptor,
+/* If there is an ID node in the ast tree that matches the name of this
+   descriptor,
    replace it with the sdsc symbol.  Return 0 if unchanged.
  */
 static int
@@ -14724,8 +14700,8 @@ replace_sdsc_in_ast(int sdsc, int ast)
   switch (A_TYPEG(ast)) {
   case A_ID:
     sptr = A_SPTRG(ast);
-    if (DESCARRAYG(sptr) && sdsc != sptr
-        && strcmp(SYMNAME(sdsc), SYMNAME(sptr)) == 0) {
+    if (DESCARRAYG(sptr) && sdsc != sptr &&
+        strcmp(SYMNAME(sdsc), SYMNAME(sptr)) == 0) {
       return mk_id(sdsc);
     }
     break;
@@ -14734,7 +14710,7 @@ replace_sdsc_in_ast(int sdsc, int ast)
     rop = replace_sdsc_in_ast(sdsc, A_ROPG(ast));
     if (lop != 0 || rop != 0) {
       return mk_binop(A_OPTYPEG(ast), lop != 0 ? lop : A_LOPG(ast),
-        rop != 0 ? rop : A_ROPG(ast), A_DTYPEG(ast));
+                      rop != 0 ? rop : A_ROPG(ast), A_DTYPEG(ast));
     }
     break;
   case A_SUBSCR:
@@ -15243,7 +15219,8 @@ get_parameterized_dt(DTYPE dtype)
   DTYPE new_dtype;
   ACL *ict;
 
-  assert(DTY(dtype) == TY_DERIVED, "expected TY_DERIVED", DTY(dtype), ERR_Fatal);
+  assert(DTY(dtype) == TY_DERIVED, "expected TY_DERIVED", DTY(dtype),
+         ERR_Fatal);
 
   tag = DTY(dtype + 3);
   sptr = get_next_sym(SYMNAME(tag), "pt");
@@ -15351,8 +15328,8 @@ match_memname(int sptr, int mem)
 static LOGICAL
 is_pdt_dtype(DTYPE dtype)
 {
-  return DTY(dtype) == TY_DERIVED
-    && strstr(SYMNAME(DTY(dtype + 3)), "$pt") != 0;
+  return DTY(dtype) == TY_DERIVED &&
+         strstr(SYMNAME(DTY(dtype + 3)), "$pt") != 0;
 }
 
 /** \brief allow other source files to check whether we're processing a
@@ -15421,7 +15398,8 @@ getCref()
  *  \return symbol type index, zero on error
  */
 static int
-get_procedure_stype(int attr) {
+get_procedure_stype(int attr)
+{
   if (attr & ET_B(ET_POINTER)) {
     if (!INSIDE_STRUCT) {
       return ST_VAR;
@@ -15449,7 +15427,8 @@ get_procedure_stype(int attr) {
  *  \return symbol table index for created symbol
  */
 static int
-decl_procedure_sym(int sptr, int proc_interf_sptr, int attr) {
+decl_procedure_sym(int sptr, int proc_interf_sptr, int attr)
+{
   /* First get expected symbol type */
   int stype = get_procedure_stype(attr);
 
@@ -15558,8 +15537,7 @@ setup_procedure_sym(int sptr, int proc_interf_sptr, int attr, char access)
   if (stype == ST_PROC) {
     if (proc_interf_sptr && (!gbl.currsub || SCG(sptr))) {
       defer_iface(proc_interf_sptr, 0, sptr, 0);
-    }
-    else if (scn.stmtyp == TK_PROCEDURE)
+    } else if (scn.stmtyp == TK_PROCEDURE)
       /* have a procedure without an interface, i.e.,
        *   procedure() [...] :: foo
        * Assume 'subroutine'
@@ -15578,8 +15556,7 @@ setup_procedure_sym(int sptr, int proc_interf_sptr, int attr, char access)
     if (proc_interf_sptr) {
       DTY(dtype + 2) = proc_interf_sptr; /* Set interface */
       defer_iface(proc_interf_sptr, dtype, 0, sptr);
-    }
-    else if (sem.gdtype == -1)
+    } else if (sem.gdtype == -1)
       /*
        * Have procedure( ), pointer [...] :: foo k
        * If a type appears as the interface name, sem.gdtype will be set to

--- a/tools/flang1/flang1exe/semant.h
+++ b/tools/flang1/flang1exe/semant.h
@@ -107,6 +107,21 @@ typedef struct xyyz {
 } ITEM;
 #define ITEM_END ((ITEM *)1)
 
+typedef enum LOOPTYPE { 
+  LP_PDO = 1,         	/* omp do */
+  LP_PARDO,           	/* parallel do */
+  LP_DISTRIBUTE,        /* distribute loop: distribute construct */
+  LP_DIST_TEAMS,        /* distribute loop: teams distribute construct */
+  LP_DIST_TARGTEAMS,    /* distribute loop: target teams distribute construct */
+  LP_DISTPARDO,       	/* distribute loop: distribute parallel do ... */
+  LP_DISTPARDO_TEAMS,  	/* distribute loop: teams distribute parallel do ... */
+  LP_DISTPARDO_TARGTEAMS,  	/* distribute loop: target teams dist... */
+  LP_PARDO_OTHER        /* parallel do: created for any distribute parallel do 
+                         *              construct.
+                         */
+ 
+}distlooptype;
+
 typedef struct {
   int index_var; /* do index variable */
   int init_expr;
@@ -119,6 +134,7 @@ typedef struct {
                     */
   char prev_dovar; /* DOVAR flag of index variable before it's entered */
   LOGICAL nodepchk;
+  int distloop;    /* LOOPTYPE */
 
 } DOINFO;
 
@@ -320,20 +336,23 @@ typedef struct {/* DO-IF stack entries */
 #define DI_TASKGROUP 40
 #define DI_TASKLOOP 41
 #define DI_TARGET 42
-#define DI_TARGETDATA 43
-#define DI_TARGETUPDATE 44
-#define DI_DISTRIBUTE 45
-#define DI_TEAMS 46
-#define DI_DECLTARGET 47
-#define DI_TARGETSIMD 48
-#define DI_ASSOC 49
-#define DI_TARGPARDO 50
-#define DI_TARGTEAMSDIST 51
-#define DI_TARGTEAMSDISTPARDO 52
-#define DI_TEAMSDIST 53
-#define DI_TEAMSDISTPARDO 54
-#define DI_DISTPARDO 55
-#define DI_MAXID 56
+#define DI_TARGETENTERDATA 43
+#define DI_TARGETEXITDATA 44
+#define DI_TARGETDATA 45
+#define DI_TARGETUPDATE 46
+#define DI_DISTRIBUTE 47
+#define DI_TEAMS 48
+#define DI_DECLTARGET 49
+#define DI_ASSOC 50
+#define DI_DISTPARDO 51
+#define DI_TARGPARDO 52
+#define DI_TARGETSIMD 53
+#define DI_TARGTEAMSDIST 54
+#define DI_TEAMSDIST 55
+#define DI_TARGTEAMSDISTPARDO 56
+#define DI_TEAMSDISTPARDO 57
+#define DI_MAXID 58
+
 /*   NOTE: the DI_ID value cannot be greater than 63 (SEE DI_NEST ...)  **/
 
 #define DI_SCH_STATIC 0
@@ -1264,7 +1283,10 @@ typedef struct {
                       * the parallel region is closed when the
                       * DO loop is closed.
                       */
-  LOGICAL expect_simdloop; /* next statement after SIMD construct
+  LOGICAL expect_simd_do;  /* next statement after SIMD construct
+                            * to be a DO.
+                            */
+  LOGICAL expect_dist_do;  /* next statement after SIMD construct
                             * to be a DO.
                             */
   int target;              /* use for OpenMP target */
@@ -1424,6 +1446,7 @@ void end_contained(void);
 
 /* semsmp.c */
 int emit_epar(void);
+int emit_etarget(void);
 void is_dovar_sptr(int);
 void clear_no_scope_sptr(void);
 void add_no_scope_sptr(int, int, int);
@@ -1433,7 +1456,8 @@ void check_no_scope_sptr(void);
 void parstuff_init(void);
 int emit_bcs_ecs(int);
 void end_parallel_clause(int);
-void end_combine_constructs(int);
+extern void end_teams();
+extern void end_target();
 void add_assign_firstprivate(int, int);
 void accel_end_dir(int, LOGICAL);
 void add_non_private(int);
@@ -1454,7 +1478,8 @@ int emit_epar(void);
 int emit_bcs_ecs(int);
 int is_sptr_in_shared_list(int);
 void end_parallel_clause(int);
-void end_combine_constructs(int);
+extern void end_teams();
+extern void end_target();
 int find_outer_sym(int);
 void add_assign_firstprivate(int, int);
 void add_non_private(int);

--- a/tools/flang1/utils/prstab/gram.txt
+++ b/tools/flang1/utils/prstab/gram.txt
@@ -1676,7 +1676,7 @@
 	       IS_DEVICE_PTR ( <ident list> ) |
 	       DEFAULTMAP ( <id name> : <id name> ) |
 	       <motion clause> |
-	       DIST_SCHEDULE ( <id name> <opt chunk> ) |
+	       DIST_SCHEDULE ( <id name> <opt distchunk> ) |
 	       GRAINSIZE ( <expression> ) |
 	       NUM_TASKS ( <expression> ) |
 	       PRIORITY ( <expression> ) |
@@ -1713,6 +1713,9 @@
 <opt chunk> ::= |
 		, <expression>
 
+<opt distchunk> ::= |
+		, <expression>
+
 <reduction> ::= <reduc op> : <pflsr list> |
 		<pflsr list>
 
@@ -1725,7 +1728,9 @@
 	       <ident>
 
 <par ifclause> ::= IF ( <expression> ) |
-                   IF ( <id name> : <expression> )
+                   IF ( <id name> : <expression> ) |
+                   IF ( <id name> <id name> : <expression> ) |
+                   IF ( <id name> <id name> <id name> : <expression> )
 
 <opt par ifclause> ::= |
                        <opt comma> <par ifclause>

--- a/tools/flang2/flang2exe/kmpcutil.c
+++ b/tools/flang2/flang2exe/kmpcutil.c
@@ -126,8 +126,8 @@ static const struct kmpc_api_entry_t kmpc_api_calls[] = {
         [KMPC_API_DIST_DISPATCH_INIT] =
             {"__kmpc_dist_dispatch_init_%d%s", 0, DT_VOID_NONE,
              KMPC_FLAG_STR_FMT}, /*4,4u,8,8u are possible*/
-        [KMPC_API_PUSH_PROC_BIND] = {"__kmpc_push_proc_bind", 0,
-                                         DT_VOID_NONE, 0},
+        [KMPC_API_PUSH_PROC_BIND] = {"__kmpc_push_proc_bind", 0, DT_VOID_NONE,
+                                     0},
 };
 
 #define KMPC_NAME(_api) kmpc_api_calls[KMPC_CHK(_api)].name
@@ -404,7 +404,7 @@ mk_kmpc_api_call(int kmpc_api, int n_args, int *arg_dtypes, int *arg_ilis, ...)
   update_acc_with_fn(fn_sptr);
   ilix = ll_ad_outlined_func2(ret_opc, IL_JSR, fn_sptr, n_args, arg_ilis);
 
-/* Create the GJSR */
+  /* Create the GJSR */
   for (i = n_args - 1; i >= 0; --i) /* Reverse the order */
     garg_ilis[i] = arg_ilis[n_args - 1 - i];
   gargs = ll_make_outlined_garg(n_args, garg_ilis, arg_dtypes);
@@ -476,8 +476,6 @@ KMPC_GENERIC_P_I(ll_make_kmpc_task_wait, KMPC_API_TASK_WAIT)
 KMPC_GENERIC_P_I(ll_make_kmpc_taskgroup, KMPC_API_TASKGROUP)
 KMPC_GENERIC_P_I(ll_make_kmpc_end_taskgroup, KMPC_API_END_TASKGROUP)
 
-
-
 /* Generic routine that returns a jsr to __kmpc_<api_name>
  * This is for all kmpc function calls that look like
  * void api_func(ident *, global_tid, kmp_int32).
@@ -495,16 +493,17 @@ ll_make_kmpc_generic_ptr_2int(int kmpc_api, int argili)
   return mk_kmpc_api_call(kmpc_api, 3, arg_types, args);
 }
 
-#define KMPC_GENERIC_P_2I(_fn, _api, argili)   \
-  int _fn(int argili)                                \
-  {                                            \
+#define KMPC_GENERIC_P_2I(_fn, _api, argili)            \
+  int _fn(int argili)                                   \
+  {                                                     \
     return ll_make_kmpc_generic_ptr_2int(_api, argili); \
   }
 KMPC_GENERIC_P_2I(ll_make_kmpc_push_proc_bind, KMPC_API_PUSH_PROC_BIND, argili)
-KMPC_GENERIC_P_2I(ll_make_kmpc_push_num_threads, KMPC_API_PUSH_NUM_THREADS, argili)
+KMPC_GENERIC_P_2I(ll_make_kmpc_push_num_threads, KMPC_API_PUSH_NUM_THREADS,
+                  argili)
 KMPC_GENERIC_P_2I(ll_make_kmpc_cancel, KMPC_API_CANCEL, argili)
-KMPC_GENERIC_P_2I(ll_make_kmpc_cancellationpoint, KMPC_API_CANCELLATIONPOINT, argili)
-
+KMPC_GENERIC_P_2I(ll_make_kmpc_cancellationpoint, KMPC_API_CANCELLATIONPOINT,
+                  argili)
 
 /* arglist is 1 containing the uplevel pointer */
 int
@@ -730,7 +729,6 @@ ll_make_kmpc_task_arg(int base, int sptr, int scope_sptr, int flags_sptr,
   return base;
 }
 
-
 /* Return an sptr to the allocated task object:  __kmp_omp_task_alloc()
  * base:        sptr for storing return value from __kmpc_omp_task_alloc.
  * sptr:        sptr representing the outlined function that is the task.
@@ -749,9 +747,8 @@ ll_make_kmpc_taskloop_arg(int base, int sptr, int scope_sptr, int flags_sptr,
       arg_types[11] = {DT_CPTR, DT_INT, DT_CPTR, DT_INT,  DT_CPTR, DT_CPTR,
                        DT_INT8, DT_INT, DT_INT,  DT_INT8, DT_CPTR};
 
-
-   return 0;
-//  return base;
+  return 0;
+  //  return base;
 }
 
 /* Return a JSR ili to __kpmc_omp_task.
@@ -852,6 +849,10 @@ mp_sched_to_kmpc_sched(int sched)
 
   /* distribute scheduling */
   case SCHED_PREFIX(DIST_STATIC) | MP_SCH_ATTR_CHUNKED:
+    return KMP_DISTRIBUTE_STATIC_CHUNKED;
+
+  case SCHED_PREFIX(DIST_STATIC) | MP_SCH_ATTR_CHUNKED | MP_SCH_BLK_CYC:
+  case SCHED_PREFIX(DIST_STATIC) | MP_SCH_ATTR_CHUNKED | MP_SCH_CHUNK_1:
     return KMP_DISTRIBUTE_STATIC_CHUNKED;
 
   default:

--- a/tools/flang2/flang2exe/mp.h
+++ b/tools/flang2/flang2exe/mp.h
@@ -49,8 +49,8 @@
 #define MP_SCH_INTERLEAVE 0x3
 #define MP_SCH_RUNTIME 0x4
 #define MP_SCH_AUTO 0x5
-#define MP_SCH_DIST_STATIC 0x6       /* use in distribute parallel for */
-#define MP_SCH_DIST_DYNAMIC 0x7      /* use in distribute parallel for */
+#define MP_SCH_DIST_STATIC 0x6  /* use in distribute parallel for */
+#define MP_SCH_DIST_DYNAMIC 0x7 /* use in distribute parallel for */
 
 /* The second byte represents special case flags for static (maskable) */
 #define MP_SCH_SPC_MASK 0x0000FF00
@@ -79,11 +79,31 @@
   0x20 /* Depend is present and has dependence-type INOUT */
 
 typedef enum omp_proc_bind_t {
-    MP_PROC_BIND_FALSE = 0,
-    MP_PROC_BIND_TRUE,
-    MP_PROC_BIND_MASTER,
-    MP_PROC_BIND_CLOSE,
-    MP_PROC_BIND_SPREAD,
+  MP_PROC_BIND_FALSE = 0,
+  MP_PROC_BIND_TRUE,
+  MP_PROC_BIND_MASTER,
+  MP_PROC_BIND_CLOSE,
+  MP_PROC_BIND_SPREAD,
 } omp_proc_bind_t;
+
+typedef enum omp_iftype {
+  IF_DEFAULT = 0,
+  IF_TARGET = 1,
+  IF_TARGETDATA = (1 << 1),
+  IF_TARGETENTERDATA = (1 << 2),
+  IF_TARGETEXITDATA = (1 << 3),
+  IF_TARGETUPDATE = (1 << 4),
+  IF_PARALLEL = (1 << 5),
+  IF_TASK = (1 << 6),
+  IF_TASKLOOP = (1 << 7),
+} omp_iftype;
+
+/* Keep up to date with pgcplus_omp_cancel_type init_omp()*/
+typedef enum omp_canceltype {
+  CANCEL_PARALLEL = 1,
+  CANCEL_FOR = 2,
+  CANCEL_SECTIONS = 3,
+  CANCEL_TASKGROUP = 4,
+} omp_canceltype;
 
 #endif /* __MP_H__ */

--- a/tools/flang2/flang2exe/outliner.c
+++ b/tools/flang2/flang2exe/outliner.c
@@ -1025,10 +1025,10 @@ load_uplevel_args_for_region(int uplevel, int base, int count,
 
     based = 0;
     if (!sptr && !lensptr) {
-      /* We put a placeholder in the front end for character 
-       * len(CLENG) after its character sptr for assumed len 
+      /* We put a placeholder in the front end for character
+       * len(CLENG) after its character sptr for assumed len
        * or deferred char because CLENG may not be set
-       * until later in the backend.  We shouldn't have a 
+       * until later in the backend.  We shouldn't have a
        * problem for fixed len char because we
        * can get its len from DTY(dtype+1).
        */
@@ -1041,12 +1041,11 @@ load_uplevel_args_for_region(int uplevel, int base, int count,
  * member should be placed.
  */
 
-    if (!lensptr && (DT_ASSNCHAR == DDTG(DTYPEG(sptr)) ||
-                     DT_ASSCHAR == DDTG(DTYPEG(sptr)) ||
-                     DT_DEFERNCHAR == DDTG(DTYPEG(sptr)) ||
-                     DT_DEFERCHAR == DDTG(DTYPEG(sptr))  ||
-                     DTY(DTYPEG(sptr)) == TY_CHAR)
-       ) {
+    if (!lensptr &&
+        (DT_ASSNCHAR == DDTG(DTYPEG(sptr)) ||
+         DT_ASSCHAR == DDTG(DTYPEG(sptr)) ||
+         DT_DEFERNCHAR == DDTG(DTYPEG(sptr)) ||
+         DT_DEFERCHAR == DDTG(DTYPEG(sptr)) || DTY(DTYPEG(sptr)) == TY_CHAR)) {
       lensptr = CLENG(sptr);
     }
 
@@ -1055,10 +1054,14 @@ load_uplevel_args_for_region(int uplevel, int base, int count,
       byval = 1;
       sptr = lensptr;
     } else if (SCG(sptr) == SC_DUMMY) {
+      int asym = mk_argasym(sptr);
+      int anme = addnme(NT_VAR, asym, 0, (INT)0);
       val = mk_address(sptr);
+      val = ad2ili(IL_LDA, val, anme);
+
     } else if (SCG(sptr) == SC_BASED && MIDNUMG(sptr)) {
       /* for adjustable len char the $p does not have
-       * clen field so we need to reference it from 
+       * clen field so we need to reference it from
        * the SC_BASED
        */
       based = sptr;
@@ -1068,12 +1071,19 @@ load_uplevel_args_for_region(int uplevel, int base, int count,
       offset += size_of(DT_CPTR);
       continue;
 #endif
-    } else 
-    if (THREADG(sptr)) {
-    /* 
-     * special handle for copyin threadprivate var - we put it in uplevel structure
-     * so that we get master threadprivate copy and pass down to its team.
-     */ 
+      if (SCG(sptr) == SC_DUMMY) {
+        int asym = mk_argasym(sptr);
+        int anme = addnme(NT_VAR, asym, 0, (INT)0);
+        val = mk_address(sptr);
+        val = ad2ili(IL_LDA, val, anme);
+      }
+    } else
+        if (THREADG(sptr)) {
+      /*
+       * special handle for copyin threadprivate var - we put it in uplevel
+       * structure
+       * so that we get master threadprivate copy and pass down to its team.
+       */
       int sym = getThreadPrivateTp(sptr);
       val = llGetThreadprivateAddr(sym);
     } else
@@ -1136,9 +1146,8 @@ load_uplevel_args_for_region(int uplevel, int base, int count,
       } else
       {
         PARREFLOADP(sptr, 1);
-/* prevent optimizer to remove store instruction */
-        if (SCG(sptr) != SC_DUMMY)
-          ADDRTKNP(sptr, 1);
+        /* prevent optimizer to remove store instruction */
+        ADDRTKNP(sptr, 1);
       }
       if (lensptr && byval) {
         if (CHARLEN_64BIT) {

--- a/tools/flang2/flang2exe/upper.h
+++ b/tools/flang2/flang2exe/upper.h
@@ -106,9 +106,11 @@
  *                All of 1.44 + INVOBJINC + PARREF for ST_PROC
  * 17.2        -- 1.46
  *                All of 1.45 + etls + tls, irrspective of target
+ * 17.7        -- 1.47
+ *                All of 1.4r + BPARA
  */
 #define VersionMajor 1
-#define VersionMinor 46
+#define VersionMinor 47
 
 void upper(int);
 void upper_assign_addresses(void);


### PR DESCRIPTION
Includes patch from CL131256 that fixes warning from Clang.

Results from automated review below. The use of "we" here is acceptable.

Check commit message...
    * simd is still ignore unless it is a standalone simd but we still
    * We now create 2 separate for distribute parallel do to avoid
      kmpc runtime bug if we were to create just a single loop.
    outliner.c: When loading dummy argument address, we need to do IL_LDA
    	because we are loading from address constant(.C0xxx)
    	If we don't do this, the optimizer will think that its
    	iteration because this is a distribute part, we
    semant.c: This is the only place thata we really need to use
    	no need to have OMP END ... and we need those DI
    	so that we can close its regions.  If we really
    	need to use more DI_ , we can probably change
           	At closing the loop, if the current loop we are closing is
    	Then we close the next loop (which is distributed loop).
Git status...
    # On branch CL131144
    nothing to commit, working directory clean
Bad .orig or .rej files...
Bad strings...