### PR TITLE
Install prefix docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The latest LLVM version we support is 3.9
 
 The command-line examples provided below will install everything into the default system location.
 
-To specify a custom install location, add `-DCMAKE_INSTALL_PREFIX=/some/directory` to each of the CMake commands given below.
+To specify a custom install location, add `-DCMAKE_INSTALL_PREFIX=<INSTALL_PREFIX>` to each of the CMake commands given below.
 
 When using a custom install location, you must make sure that the bin directory is on your PATH when building and running flang.
 
@@ -52,6 +52,8 @@ Flang is developed outside of the llvm source tree.
    make
    sudo make install
    ```
+   
+   If you use `CMAKE_INSTALL_PREFIX` in Step 1 and `<INSTALL_PREFIX>/bin` is not in your path, you need to add `-DLLVM_CONFIG==<INSTALL_PREFIX>` when invoking CMake, otherwise you will encounter an error related to `LLVMConfig.cmake` not being found.
 
 3. Build and install openmp-llvm (3.9)
    ```

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Flang is developed outside of the llvm source tree.
    make
    sudo make install
    ```
+   
+   If you use `CMAKE_INSTALL_PREFIX` in Step 1 and `<INSTALL_PREFIX>/bin` is not in your path, you need to add `-DLLVM_CONFIG==<INSTALL_PREFIX>` and set the explicit paths for the compilers (i.e. ` -DCMAKE_CXX_COMPILER=<INSTALL_PREFIX>/bin/clang++ -DCMAKE_C_COMPILER=<INSTALL_PREFIX>/bin/clang -DCMAKE_Fortran_COMPILER=<INSTALL_PREFIX>/bin/flang`) when invoking CMake, otherwise you will encounter errors.
 
 [llvm-cmake]: http://llvm.org/releases/3.9.0/docs/CMake.html
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Flang is developed outside of the llvm source tree.
    sudo make install
    ```
    
-   If you use `CMAKE_INSTALL_PREFIX` in Step 1 and `<INSTALL_PREFIX>/bin` is not in your path, you need to add `-DLLVM_CONFIG==<INSTALL_PREFIX>` when invoking CMake, otherwise you will encounter an error related to `LLVMConfig.cmake` not being found.
+   If you use `CMAKE_INSTALL_PREFIX` in Step 1 and `<INSTALL_PREFIX>/bin` is not in your path, you need to add `-DLLVM_CONFIG=<INSTALL_PREFIX>` when invoking CMake, otherwise you will encounter an error related to `LLVMConfig.cmake` not being found.
 
 3. Build and install openmp-llvm (3.9)
    ```
@@ -78,7 +78,7 @@ Flang is developed outside of the llvm source tree.
    sudo make install
    ```
    
-   If you use `CMAKE_INSTALL_PREFIX` in Step 1 and `<INSTALL_PREFIX>/bin` is not in your path, you need to add `-DLLVM_CONFIG==<INSTALL_PREFIX>` and set the explicit paths for the compilers (i.e. ` -DCMAKE_CXX_COMPILER=<INSTALL_PREFIX>/bin/clang++ -DCMAKE_C_COMPILER=<INSTALL_PREFIX>/bin/clang -DCMAKE_Fortran_COMPILER=<INSTALL_PREFIX>/bin/flang`) when invoking CMake, otherwise you will encounter errors.
+   If you use `CMAKE_INSTALL_PREFIX` in Step 1 and `<INSTALL_PREFIX>/bin` is not in your path, you need to add `-DLLVM_CONFIG=<INSTALL_PREFIX>` and set the explicit paths for the compilers (i.e. ` -DCMAKE_CXX_COMPILER=<INSTALL_PREFIX>/bin/clang++ -DCMAKE_C_COMPILER=<INSTALL_PREFIX>/bin/clang -DCMAKE_Fortran_COMPILER=<INSTALL_PREFIX>/bin/flang`) when invoking CMake, otherwise you will encounter errors.
 
 [llvm-cmake]: http://llvm.org/releases/3.9.0/docs/CMake.html
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Flang is developed outside of the llvm source tree.
    sudo make install
    ```
    
-   If you use `CMAKE_INSTALL_PREFIX` in Step 1 and `<INSTALL_PREFIX>/bin` is not in your path, you need to add `-DLLVM_CONFIG=<INSTALL_PREFIX>` when invoking CMake, otherwise you will encounter an error related to `LLVMConfig.cmake` not being found.
+   If you use `CMAKE_INSTALL_PREFIX` in Step 1 and `<INSTALL_PREFIX>/bin` is not in your path, you need to add `-DLLVM_CONFIG=<INSTALL_PREFIX>/bin/llvm-config` when invoking CMake, otherwise you will encounter an error related to `LLVMConfig.cmake` not being found.
 
 3. Build and install openmp-llvm (3.9)
    ```
@@ -78,7 +78,7 @@ Flang is developed outside of the llvm source tree.
    sudo make install
    ```
    
-   If you use `CMAKE_INSTALL_PREFIX` in Step 1 and `<INSTALL_PREFIX>/bin` is not in your path, you need to add `-DLLVM_CONFIG=<INSTALL_PREFIX>` and set the explicit paths for the compilers (i.e. ` -DCMAKE_CXX_COMPILER=<INSTALL_PREFIX>/bin/clang++ -DCMAKE_C_COMPILER=<INSTALL_PREFIX>/bin/clang -DCMAKE_Fortran_COMPILER=<INSTALL_PREFIX>/bin/flang`) when invoking CMake, otherwise you will encounter errors.
+   If you use `CMAKE_INSTALL_PREFIX` in Step 1 and `<INSTALL_PREFIX>/bin` is not in your path, you need to add `-DLLVM_CONFIG=<INSTALL_PREFIX>/bin/llvm-config` and set the explicit paths for the compilers (i.e. ` -DCMAKE_CXX_COMPILER=<INSTALL_PREFIX>/bin/clang++ -DCMAKE_C_COMPILER=<INSTALL_PREFIX>/bin/clang -DCMAKE_Fortran_COMPILER=<INSTALL_PREFIX>/bin/flang`) when invoking CMake, otherwise you will encounter errors.
 
 [llvm-cmake]: http://llvm.org/releases/3.9.0/docs/CMake.html
 


### PR DESCRIPTION
The documentation was incomplete for the case where the user is installing to a location that is not in the default path list.