### PR TITLE
cmake: allow dropping -Werror from c flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,10 @@ endif()
 # Add appropriate flags for GCC
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+  option(WITH_WERROR "Compile with '-Werror' C compiler flag" ON)
+  if (WITH_WERROR)
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+  endif ()
 endif ()
 
 if (APPLE)


### PR DESCRIPTION
cmake: allow dropping -Werror from c flags

gcc-7.1.0 generates a couple of warnings when compiling flang, so
allow to drop '-Werror' from the c flags. It is anyhow a bad idea
to enforce that flag as it is unclear what future compiler
versions will warn about.

Signed-off-by: Christoph Junghans <junghans@lanl.gov>