### PR TITLE
flang1, flang2: larger buffers, to hold longer filenames

### DIFF
--- a/tools/flang1/flang1exe/astout.c
+++ b/tools/flang1/flang1exe/astout.c
@@ -49,10 +49,10 @@ static int continuations = 0; /* number of continuation lines */
 
 static int indent; /* number of indentation levels */
 
-#define CARDB_SIZE 300 /* make it large enough */
+#define CARDB_SIZE 2100 /* make it large enough */
 static char lbuff[CARDB_SIZE];
 
-#define MAX_FNAME_LEN 258
+#define MAX_FNAME_LEN 2050
 static LOGICAL ast_is_comment = FALSE;
 static LOGICAL op_space = TRUE;
 

--- a/tools/flang1/flang1exe/exterf.c
+++ b/tools/flang1/flang1exe/exterf.c
@@ -99,7 +99,7 @@ static LOGICAL for_contained = FALSE;
 static LOGICAL exporting_module = FALSE;
 static lzhandle *outlz;
 static int exportmode = 0;
-#define MAX_FNAME_LEN 258
+#define MAX_FNAME_LEN 2050
 
 static int out_platform = MOD_ANY;
 

--- a/tools/flang1/flang1exe/fpp.c
+++ b/tools/flang1/flang1exe/fpp.c
@@ -196,7 +196,7 @@ static char ctable[256] = {
 #define FORMALMAX 31
 #define ARGST 0xFE
 /* * * * * MAX_FNAME_LEN MUST be less than scan.c:CARDB_SIZE * * * * */
-#define MAX_FNAME_LEN 258
+#define MAX_FNAME_LEN 2050
 #define MAXINC 20
 #define MACSTK_MAX 100
 

--- a/tools/flang1/flang1exe/gbldefs.h
+++ b/tools/flang1/flang1exe/gbldefs.h
@@ -71,7 +71,7 @@
 #define MAXIDLEN 163
 
 /*  should replace local MAX_FNAME_LENs with: */
-#define MAX_FILENAME_LEN 256
+#define MAX_FILENAME_LEN 2048
 
 /* maximum number of array subscripts */
 #define MAXSUBS 7

--- a/tools/flang1/flang1exe/inliner.c
+++ b/tools/flang1/flang1exe/inliner.c
@@ -68,7 +68,7 @@
 #define INLINER_VERSION 14
 
 #define MAX_INLINE_NAME 42
-#define MAX_FNAME_LEN 256
+#define MAX_FNAME_LEN 2048
 #define TOC_HEADER_FMT "Inliner TOC V.%d"
 #define TOC_ENTRY_FMT "%s %s %s %s"
 #define MODNAME_FMT "i%d.e"

--- a/tools/flang1/flang1exe/interf.c
+++ b/tools/flang1/flang1exe/interf.c
@@ -71,7 +71,7 @@ static int HOST_OLDSCOPE = 0, HOST_NEWSCOPE = 0;
 static char **modinclist = NULL;
 static int modinclistsize = 0, modinclistavl = 0;
 
-#define MAX_FNAME_LEN 258
+#define MAX_FNAME_LEN 2050
 #define MOD_SUFFIX ".mod"
 
 /** \brief 'interface' initialization, called once per compilation

--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -947,7 +947,7 @@ open_module(int use)
     if (strcmp(SYMNAME(usedb.base[module_id].module), name) == 0)
       return module_id;
 
-#define MAX_FNAME_LEN 258
+#define MAX_FNAME_LEN 2050
 
   use_fd = NULL;
   fullname = getitem(8, MAX_FNAME_LEN + 1);

--- a/tools/flang1/flang1exe/scan.c
+++ b/tools/flang1/flang1exe/scan.c
@@ -108,11 +108,11 @@ extern LOGICAL fpp_;
 
 /* for KANJI, the 2 following limits are effectively halved */
 #define MAX_COLS 264
-#define CARDB_SIZE 270
+#define CARDB_SIZE 2100
 
 #define INIT_LPS 21
 #define MAX_IDEPTH 20
-#define MAXFNAME 200
+#define MAXFNAME 2048
 
 /*   define pseudo-characters - integer values equivalent
      to non-printing characters are used:  */

--- a/tools/flang2/flang2exe/gbldefs.h
+++ b/tools/flang2/flang2exe/gbldefs.h
@@ -63,7 +63,7 @@
 #define MAXIDLEN 163
 
 /*  should replace local MAX_FNAME_LENs with: */
-#define MAX_FILENAME_LEN 256
+#define MAX_FILENAME_LEN 2048
 
 typedef int8_t INT8;
 typedef int16_t INT16;


### PR DESCRIPTION
It's not uncommon for Linux systems to have complex directory trees with long paths (e.g. when things are kept on NFS). In such a case, 258-chars MAX_FNAME_LEN is too small: it is used when combining paths as given by -I or -J flags with imported module names. We could easily cause compiler to malfunction with buffer that small.
