### PR TITLE
Pull 2017-08-08T16-48 Recent NVIDIA Changes

### DIFF
--- a/tools/flang1/flang1exe/exterf.c
+++ b/tools/flang1/flang1exe/exterf.c
@@ -42,6 +42,7 @@
 #include "dpm_out.h"
 
 #define MOD_CMN_IDX(a, c) (((a) << 1) | (c))
+#define COMPILER_OWNED_MODULE XBIT(58,0x100000)
 
 /* ------------------------------------------------------------------ */
 /* ----------------------- Export Utilities ------------------------- */
@@ -195,6 +196,8 @@ export_header(FILE *fd, char *export_name, int compress)
   if (XBIT(68, 0x1)) {
     out_platform = out_platform | MOD_LA;
   }
+  if (COMPILER_OWNED_MODULE)
+    out_platform = out_platform | MOD_PG;
 
   fprintf(fd, "V%d :0x%x %s\n", IVSN, out_platform, export_name);
   fprintf(fd, "%d %s S%d %d\n", (unsigned)strlen(gbl.src_file), gbl.src_file,

--- a/tools/flang1/flang1exe/interf.c
+++ b/tools/flang1/flang1exe/interf.c
@@ -1391,16 +1391,20 @@ import_header_only(FILE *fd, char *file_name, int import_which)
     }
 
     in_platform = get_num(16);
-    if (curr_platform != in_platform) {
-      if ((curr_platform | MOD_I8 | MOD_R8 | MOD_LA) !=
-          (in_platform | MOD_I8 | MOD_R8 | MOD_LA)) {
-        error(4, 3, gbl.lineno, import_incompatible_msg, import_file_name);
-        error(4, 0, gbl.lineno,
-              "Compile source file with the same compiler options",
-              import_sourcename);
-        return NULL;
+#if DO_MODULE_OPTION_CHECK
+    if (ivsn >= IVSN && curr_platform != in_platform) {
+      if (!(in_platform & MOD_PG)) {
+        if ((curr_platform | MOD_I8 | MOD_R8 | MOD_PG) != 
+            (in_platform | MOD_I8 | MOD_R8 | MOD_PG)) {
+          error(4, 3, gbl.lineno, import_incompatible_msg, import_file_name);
+          error(4, 0, gbl.lineno,
+                "Compile source file with the same compiler options",
+                import_sourcename);
+          return NULL;
+        }
       }
     }
+#endif
   }
   get_string(import_name);
 

--- a/tools/flang1/flang1exe/interf.h
+++ b/tools/flang1/flang1exe/interf.h
@@ -105,9 +105,10 @@ void ipa_export_close(void);                 /* exterf.c */
 #define MOD_I8  0x8  /* -i8 */
 #define MOD_R8  0x10 /* -r8 */
 #define MOD_LA  0x20 /* -Mlarge_arrays */
+#define MOD_PG  0x40 /* compilers' own module files */
 
 #undef IVSN
-#define IVSN 31
+#define IVSN 32
 #undef IVSN_24
 #define IVSN_24 24
 #undef IVSN_27
@@ -137,6 +138,8 @@ void ipa_export_close(void);                 /* exterf.c */
  *     30 - Add more 1 AST field, w18; used to record the 'end label' of
  *          various MP ASTs such as PARALLEL/PDO/TASK/SECTIONS.
  *     31 - Add MP_ATOMICxxx for atomic operations
+ *     32 - add compiler own module files flag into platform flag. 
+ *          It is set if it is compiler module file.
  */
 
 /*

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -1921,7 +1921,7 @@ Valid only if the output is f77 (-x 49 0x80).
 Fortran - for the compiler-created module commons,
 do not prepend an underscore.
 .XB 0x100000:
-AVAILABLE
+Compiler owned module.
 .XB 0x200000:
 AVAILABLE
 .XB 0x400000:


### PR DESCRIPTION
Improve module file consistency checks.

For now, this check is disabled using an ifdef macro (DO_MODULE_OPTION_CHECK).
The goal of the consistency check is to make sure we are not mixing modules
that are compiled with and without certain compiler flags like
-Mlarge_arrays.

The consistency checks do not yet work with libraries that are portable
across all compiler flag-sets. So, the checks are disabled for now.