### PR TITLE
Pull 2018-02-08T12-20 Recent NVIDIA Changes

### DIFF
--- a/tools/flang1/flang1exe/semsmp.c
+++ b/tools/flang1/flang1exe/semsmp.c
@@ -575,6 +575,7 @@ semsmp(int rednum, SST *top)
    *	<declare simd> ::= <declare simd begin> <opt par list>
    */
   case DECLARE_SIMD1:
+    apply_nodepchk(gbl.lineno, 2);
     break;
 
   /* ------------------------------------------------------------------ */
@@ -1425,6 +1426,7 @@ semsmp(int rednum, SST *top)
    *	<mp stmt> ::= <taskloopsimd begin> <opt par list> |
    */
   case MP_STMT36:
+    apply_nodepchk(gbl.lineno, 1);
     goto share_taskloop;
     break;
   /*
@@ -1470,6 +1472,7 @@ semsmp(int rednum, SST *top)
     get_stblk_uplevel_sptr();
     begin_parallel_clause(sem.doif_depth);
     DI_ISSIMD(sem.doif_depth) = TRUE;
+    apply_nodepchk(gbl.lineno, 1);
 
     SST_ASTP(LHS, 0);
     break;
@@ -1499,6 +1502,7 @@ semsmp(int rednum, SST *top)
     par_push_scope(TRUE);
     begin_parallel_clause(sem.doif_depth);
     SST_ASTP(LHS, 0);
+    apply_nodepchk(gbl.lineno, 1);
     break;
   /*
    *	<mp stmt> ::= <mp endsimd> |
@@ -1711,6 +1715,7 @@ semsmp(int rednum, SST *top)
     doif = SST_CVALG(RHS(1));
     sem.expect_do = TRUE;
     do_bdistribute(doif);
+    apply_nodepchk(gbl.lineno, 1);
     SST_ASTP(LHS, 0);
     break;
   /*
@@ -1766,6 +1771,7 @@ semsmp(int rednum, SST *top)
     begin_parallel_clause(sem.doif_depth);
     DI_ISSIMD(sem.doif_depth) = TRUE;
     SST_ASTP(LHS, 0);
+    apply_nodepchk(gbl.lineno, 1);
     break;
   /*
    *	<mp stmt> ::= <mp endpardosimd> |
@@ -1898,6 +1904,7 @@ semsmp(int rednum, SST *top)
     sem.expect_simd_do = TRUE;
     par_push_scope(TRUE);
     begin_parallel_clause(sem.doif_depth);
+    apply_nodepchk(gbl.lineno, 1);
     SST_ASTP(LHS, 0);
 
     break;
@@ -8339,6 +8346,10 @@ begin_combine_constructs(BIGINT64 construct)
 
   has_team = FALSE;
   save_clauses();
+
+  if (BT_SIMD & construct) {
+    apply_nodepchk(gbl.lineno, 1);
+  }
 
   if (BT_TARGET & construct) {
     do_btarget(sem.doif_depth);

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -2231,7 +2231,8 @@ Unconditionally generate prtcnt.
 Execute tasks immediately 
 .XB 0x80000:
 In the outliner used for KPMC openmp regions, when filling the argument
-structure, fill in the struct members for the NME entries.
+.XB 0x100000:
+Enable nodepchk for simd construct/clause.
 
 .XF "70-79:"
 RESERVED FOR ALTERNATE CODE GENERATION

--- a/tools/flang2/flang2exe/bih.h
+++ b/tools/flang2/flang2exe/bih.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ typedef struct {
       unsigned innermost : 1; /* bih is the head of an innermost loop*/
       unsigned mexits : 1;    /* bih is the head of a loop with > 1 exit*/
       unsigned ozcr : 1;      /* bih is optimizer pro-/epi- logue (temp) */
+
       unsigned par : 1;       /* bih belongs to a parallel region */
       unsigned cs : 1;        /* bih is a critical section */
       unsigned streg : 1;     /* block contains stores of globally assigned
@@ -60,12 +61,13 @@ typedef struct {
                                * NOT YET SET
                                */
       unsigned UNUSED1 : 1;   /* AVAILABLE */
-      unsigned UNUSED2 : 1;   /* AVAILABLE */
+      unsigned nodepchk : 1;  /* nodepchk - use by llvm bridge */
       unsigned enlab : 1;     /* this bih contains entry debug label */
       unsigned parloop : 1;   /* bih is the head of a parallel loop; the loop
                                * is parallelized by vpar() or is specified by
                                * the user as a PDO.
                                */
+
       unsigned parsect : 1;   /* bih belongs to a parallel section */
       unsigned ujres : 1;     /* bih contains ujresidual start & count info */
       unsigned simd : 1;       /* bih contains simd code */
@@ -96,6 +98,7 @@ typedef struct {
       unsigned mark : 1;
       unsigned task : 1;       /* bih belongs to a task */
       unsigned resid : 1;      /* bih is the head of a residual loop */
+
       unsigned vcand : 1;      /* bih is the head of a vector candidate loop */
       unsigned accel : 1;      /* bih is head of an accelerator region */
       unsigned endaccel : 1;   /* bih is tail of an accelerator region */
@@ -104,6 +107,7 @@ typedef struct {
       unsigned endaccdata : 1; /* bih is tail of an accelerator data region */
       unsigned mark2 : 1;
       unsigned mark3 : 1;
+
       unsigned kernel : 1;     /* bih is head of a cuda kernel */
       unsigned endkernel : 1;  /* bih is tail of a cuda kernel */
       unsigned useful : 1;     /* bih contains useful work */
@@ -181,6 +185,7 @@ typedef struct {
 #define BIH_CS(i) bihb.stg_base[i].flags.bits.cs
 #define BIH_STREG(i) bihb.stg_base[i].flags.bits.streg
 #define BIH_VPAR(i) bihb.stg_base[i].flags.bits.vpar
+#define BIH_NODEPCHK(i) bihb.stg_base[i].flags.bits.nodepchk
 #define BIH_MARK(i) bihb.stg_base[i].flags2.bits.mark
 #define BIH_MARK2(i) bihb.stg_base[i].flags2.bits.mark2
 #define BIH_MARK3(i) bihb.stg_base[i].flags2.bits.mark3

--- a/tools/flang2/flang2exe/bihutil.c
+++ b/tools/flang2/flang2exe/bihutil.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,6 +233,7 @@ merge_bih_flags(int to_bih, int fm_bih)
   BIH_ASM(to_bih) = BIH_ASM(to_bih) | BIH_ASM(fm_bih);
   BIH_LDVOL(to_bih) = BIH_LDVOL(to_bih) | BIH_LDVOL(fm_bih);
   BIH_STVOL(to_bih) = BIH_STVOL(to_bih) | BIH_STVOL(fm_bih);
+  BIH_NODEPCHK(to_bih) = BIH_NODEPCHK(to_bih) | BIH_NODEPCHK(fm_bih);
 
   if (BIH_TAIL(fm_bih))
     BIH_TAIL(to_bih) = 1;

--- a/tools/flang2/flang2exe/main.c
+++ b/tools/flang2/flang2exe/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1997-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -319,7 +319,13 @@ llvm_restart:
     dmp_dtype();
   if (gbl.rutype != RU_BDATA) {
     cuda_emu_end();
-    direct_rou_end();
+      /* TDB: make it look better!*/
+      if (!flg.smp)
+        direct_rou_end();
+      else if (!ll_has_more_outlined())
+        direct_rou_end();
+      else if (!ALLOW_NODEPCHK_SIMD)
+        direct_rou_end();
   }
   if (!flg.smp || !ll_has_more_outlined())
   {

--- a/tools/flang2/flang2exe/mwd.c
+++ b/tools/flang2/flang2exe/mwd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2000-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -4859,6 +4859,7 @@ db(int block)
   putbit("kernel", BIH_KERNEL(block));
   putbit("endkernel", BIH_ENDKERNEL(block));
   putbit("midiom", BIH_MIDIOM(block));
+  putbit("nodepchk", BIH_NODEPCHK(block));
   putline();
 #ifdef BIH_FINDEX
   if (BIH_FINDEX(block) || BIH_FTAG(block)) {

--- a/tools/flang2/flang2exe/outliner.c
+++ b/tools/flang2/flang2exe/outliner.c
@@ -604,6 +604,11 @@ static const KMPC_ST_TYPE taskdupSig[3] = {
     {.dtype = DT_INT, .byval = TRUE}, 
 };
 
+extern void
+setOutlinedPragma(int func_sptr, int saved)
+{
+}
+
 static int
 makeOutlinedFunc(int stblk_sptr, int scope_sptr, LOGICAL is_task, LOGICAL istaskdup)
 {

--- a/tools/flang2/flang2exe/outliner.h
+++ b/tools/flang2/flang2exe/outliner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,4 +85,5 @@ extern void start_taskdup(int, int );
 extern void stop_taskdup(int, int );
 extern void finish_taskdup_routine(int, int, INT);
 
+extern void setOutlinedPragma(int, int);
 #endif /* __OUTLINER_H__ */

--- a/tools/shared/pgifeat.h
+++ b/tools/shared/pgifeat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,11 @@
  */
 #define XBIT_NOUNIFORM XBIT(15,0x200)
 
+/*
+ * Enable nodepchk similar to loop pragma/directive for OpenMP simd
+ */
 #define TARGET_KMPC
+#define ALLOW_NODEPCHK_SIMD (!XBIT(69,0x100000))
 
 /*
  * Strict adherence to OpenACC standard.

--- a/tools/shared/pragma.c
+++ b/tools/shared/pragma.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1486,6 +1486,37 @@ void
 rouprg_enter(void)
 {
   load_dirset(&direct.rou_begin);
+}
+
+/*
+ * Create a carry forward loop pragma because simd pragma is processed
+ * before enter the loop.
+ * Note: perhaps try the direct.loop flags later?
+ */
+void
+apply_nodepchk(int dir_lineno, int dir_scope)
+{
+  int index, diroff;
+  DIRSET* tempdir;
+  if (!ALLOW_NODEPCHK_SIMD)
+    return;
+  direct.loop_flag = TRUE;
+  direct.carry_fwd = TRUE;
+  lineno = dir_lineno;
+  scope = dir_scope;
+  switch (scope) {
+  case S_LOOP:
+      currdir = &direct.loop;
+      break;
+  case S_ROUTINE:
+      currdir = &direct.rou;
+      break;
+  case S_GLOBAL:
+  case S_NONE:
+      return;
+  }
+
+  assn(DIR_OFFSET(currdir, depchk), FALSE);
 }
 
 /*

--- a/tools/shared/pragma.h
+++ b/tools/shared/pragma.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007-2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2007-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,3 +175,5 @@ typedef enum {
 
 /* Ignore data movement pragmas */
 #define ACC_DATAMOVEMENT_DISABLED XBIT(195, 0x400)
+
+void apply_nodepchk(int dir_lineno, int dir_scope);


### PR DESCRIPTION
Apply nodepchk to a loop/routine as a pragma nodepchk for simd
clause or simd construct. Since the host function has
information about nodepcheck, need to propagate the info to
outlined function when it was created because we lose sptr of
host function when we expand outlined function.