### PR TITLE
Changes for module variables debug

### DIFF
--- a/test/f90_correct/debug_module_mixed_type_variables.f90
+++ b/test/f90_correct/debug_module_mixed_type_variables.f90
@@ -1,0 +1,36 @@
+! REQUIRES: llvm5
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+module mixed_type_vars
+logical(kind=1) :: var1 = .TRUE.
+integer :: var2 = 19
+double precision :: var3 = 3.14
+character(len=5) :: var4 = "hello"
+contains
+subroutine check_val()
+end subroutine
+end module
+
+program main
+use mixed_type_vars
+call check_val()
+end program
+
+! //CHECK: @_mixed_type_vars_9_ = global %struct_mixed_type_vars_9_ <{ [5 x i8] {{.*}} !dbg ![[DBG_VAR4_GVEXP:[0-9]+]]
+! //CHECK: @_mixed_type_vars_10_ = global %struct_mixed_type_vars_10_ <{ [8 x i8] {{.*}} !dbg ![[DBG_VAR3_GVEXP:[0-9]+]]
+! //CHECK: @_mixed_type_vars_8_ = global %struct_mixed_type_vars_8_ <{ [8 x i8] {{.*}} !dbg ![[DBG_VAR1_GVEXP:[0-9]+]], !dbg ![[DBG_VAR2_GVEXP:[0-9]+]]
+
+! //CHECK: ![[DBG_VAR4_GVEXP]] = !DIGlobalVariableExpression(var: ![[DBG_VAR4:[0-9]+]], expr: ![[DBG_VAR1_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR4]] = distinct !DIGlobalVariable(name: "var4", linkageName: "_mixed_type_vars_9_", scope: ![[SCOPE:[0-9]+]], {{.*}}, type: ![[VAR4_TYPE:[0-9]+]]
+! //CHECK: ![[SCOPE]] = !DIModule({{.*}}, name: "mixed_type_vars"{{.*}}
+! //CHECK: ![[VAR4_TYPE]] = !DIBasicType({{.*}}name: "character", size: 40, align: 8, encoding: DW_ATE_signed)
+! //CHECK: ![[DBG_VAR1_EXP]] = !DIExpression({{.*}})
+! //CHECK: ![[DBG_VAR3_GVEXP]] = !DIGlobalVariableExpression(var: ![[DBG_VAR3:[0-9]+]], expr: ![[DBG_VAR1_EXP]])
+! //CHECK: ![[DBG_VAR3]] = distinct !DIGlobalVariable(name: "var3", linkageName: "_mixed_type_vars_10_", scope: ![[SCOPE]], {{.*}}, type: ![[VAR3_TYPE:[0-9]+]]
+! //CHECK: ![[VAR3_TYPE]] = !DIBasicType(name: "double precision", size: 64, align: 64, encoding: DW_ATE_float)
+! //CHECK: ![[DBG_VAR1_GVEXP]] = !DIGlobalVariableExpression(var: ![[DBG_VAR1:[0-9]+]], expr: ![[DBG_VAR1_EXP]])
+! //CHECK: ![[DBG_VAR1]] = distinct !DIGlobalVariable(name: "var1", linkageName: "_mixed_type_vars_8_", scope: ![[SCOPE]], {{.*}}, type: ![[VAR1_TYPE:[0-9]+]]
+! //CHECK: ![[VAR1_TYPE]] = !DIBasicType(name: "logical*1", size: 8, align: 8, encoding: DW_ATE_boolean)
+! //CHECK: ![[DBG_VAR2_GVEXP]] = !DIGlobalVariableExpression(var: ![[DBG_VAR2:[0-9]+]], expr: ![[DBG_VAR2_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR2]] = distinct !DIGlobalVariable(name: "var2", linkageName: "_mixed_type_vars_8_", scope: ![[SCOPE]], {{.*}}, type: ![[VAR2_TYPE:[0-9]+]]
+! //CHECK: ![[VAR2_TYPE]] = !DIBasicType(name: "integer", size: 32, align: 32, encoding: DW_ATE_signed)
+! //CHECK: ![[DBG_VAR2_EXP]] = !DIExpression({{.*}}4{{.*}})

--- a/test/f90_correct/debug_module_variables_empty_type.f90
+++ b/test/f90_correct/debug_module_variables_empty_type.f90
@@ -1,0 +1,16 @@
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+module vars
+type empty
+end type empty
+
+type(empty) :: nothing
+end module vars
+
+! //CHECK: @_vars_0_ = common global %struct_vars_0_ zeroinitializer, align 64, !dbg ![[DBG_VAR1_GVEXP:[0-9]+]]
+! //CHECK: ![[DBG_VAR1_GVEXP]] = !DIGlobalVariableExpression(var: ![[DBG_VAR1:[0-9]+]], expr: ![[DBG_VAR1_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR1]] = distinct !DIGlobalVariable(name: "nothing", linkageName: "_vars_0_", scope: ![[SCOPE:[0-9]+]], {{.*}}, type: ![[DBG_VAR1_TYPE:[0-9]+]]
+! //CHECK: ![[SCOPE]] = !DIModule({{.*}}, name: "vars"
+! //CHECK: ![[DBG_VAR1_TYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "empty", {{.*}}, elements: ![[DBG_VAR1_ELEMENTS:[0-9]+]])
+! //CHECK: ![[DBG_VAR1_ELEMENTS]] = !{}
+! //CHECK: ![[DBG_VAR1_EXP]] = !DIExpression({{.*}})

--- a/test/f90_correct/debug_module_variables_misc.f90
+++ b/test/f90_correct/debug_module_variables_misc.f90
@@ -1,0 +1,53 @@
+! REQUIRES: llvm5
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+module mod_vars1
+  type outpatch_list
+    integer :: patch_val
+    integer, allocatable, dimension(:) :: patch_list
+  end type outpatch_list
+  integer, parameter :: ndims = 2
+  integer :: val1 = 20
+end module
+
+module mod_vars2
+  use mod_vars1
+  type(outpatch_list) :: outpatch_table
+  integer, allocatable, dimension(:)   :: patch_count
+  integer, dimension(ndims) :: dims
+  integer :: val2
+  contains
+  function check_flang()
+    print *, dims
+    check_flang = val1
+  end function
+end module
+
+program main
+use mod_vars2
+print *,check_flang()
+end program
+
+! //CHECK: @_mod_vars1_8_ = global %struct_mod_vars1_8_ {{.*}} !dbg ![[DBG_VAL1_GVEXP:[0-9]+]]
+! //CHECK: @_mod_vars2_0_ = global %struct_mod_vars2_0_ zeroinitializer, {{.*}} !dbg ![[DBG_PATCH_COUNT_GVEXP:[0-9]+]], !dbg ![[DBG_PATCH_TABLE_GVEXP:[0-9]+]], !dbg !31, !dbg ![[DBG_DIMS_GVEXP:[0-9]+]], !dbg ![[DBG_VAL2_GVEXP:[0-9]+]]
+
+! //CHECK: ![[MODULE_SCOPE1:[0-9]+]] = !DIModule({{.*}}, name: "mod_vars1"
+! //CHECK: ![[DBG_PATCH_TABLE_TYPE:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "outpatch_list",
+! //CHECK: ![[DBG_VAL1_TYPE:[0-9]+]] = !DIBasicType(name: "integer", size: 32, align: 32, encoding: DW_ATE_signed)
+! //CHECK: ![[DBG_PATCH_COUNT_TYPE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[DBG_VAL1_TYPE]], size: 64, align: 64)
+! //CHECK: ![[DBG_VAL1_GVEXP]] = !DIGlobalVariableExpression(var: ![[DBG_VAL1:[0-9]+]], expr: ![[DBG_VAL1_VEXP:[0-9]+]])
+! //CHECK: ![[DBG_VAL1]] = distinct !DIGlobalVariable(name: "val1", linkageName: "_mod_vars1_8_", scope: ![[MODULE_SCOPE1]], {{.*}}, type: ![[DBG_VAL1_TYPE]],
+! //CHECK: ![[DBG_VAL1_VEXP:[0-9]+]] = !DIExpression({{.*}}96{{.*}})
+! //CHECK: ![[DBG_PATCH_COUNT_GVEXP]] = !DIGlobalVariableExpression(var: ![[DBG_PATCH_COUNT:[0-9]+]], expr: ![[DBG_PATCH_COUNT_VEXP:[0-9]+]])
+! //CHECK: ![[DBG_PATCH_COUNT]] = distinct !DIGlobalVariable(name: "patch_count{{.*}}", linkageName: "_mod_vars2_0_", scope: ![[MODULE_SCOPE2:[0-9]+]], {{.*}}, type: ![[DBG_PATCH_COUNT_TYPE]],
+! //CHECK: ![[MODULE_SCOPE2]] = !DIModule({{.*}}, name: "mod_vars2"
+! //CHECK: ![[DBG_PATCH_COUNT_VEXP]] = !DIExpression({{.*}}16{{.*}})
+! //CHECK: ![[DBG_PATCH_TABLE_GVEXP]] = !DIGlobalVariableExpression(var: ![[DBG_PATCH_TABLE:[0-9]+]], expr: ![[DBG_PATCH_TABLE_VEXP:[0-9]+]])
+! //CHECK: ![[DBG_PATCH_TABLE]] = distinct !DIGlobalVariable(name: "outpatch_table", linkageName: "_mod_vars2_0_", scope: ![[MODULE_SCOPE2]], {{.*}}, type: ![[DBG_PATCH_TABLE_TYPE]],
+! //CHECK: ![[DBG_PATCH_TABLE_VEXP]] = !DIExpression({{.*}}88{{.*}})
+! //CHECK: ![[DBG_DIMS_GVEXP]] = !DIGlobalVariableExpression(var: ![[DBG_DIMS:[0-9]+]], expr: ![[DBG_DIMS_VEXP:[0-9]+]])
+! //CHECK: ![[DBG_DIMS]] = distinct !DIGlobalVariable(name: "dims", linkageName: "_mod_vars2_0_", scope: ![[MODULE_SCOPE2]], {{.*}}, type: ![[DBG_DIMS_TYPE:[0-9]+]],
+! //CHECK: ![[DBG_DIMS_TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: ![[DBG_VAL1_TYPE]], size: 64, align: 32,
+! //CHECK: ![[DBG_DIMS_VEXP]] = !DIExpression({{.*}}192{{.*}})
+! //CHECK: ![[DBG_VAL2_GVEXP]] = !DIGlobalVariableExpression(var: ![[DBG_VAL2:[0-9]+]], expr: ![[DBG_VAL2_VEXP:[0-9]+]])
+! //CHECK: ![[DBG_VAL2]] = distinct !DIGlobalVariable(name: "val2", linkageName: "_mod_vars2_0_", scope: ![[MODULE_SCOPE2]], {{.*}}, type: ![[DBG_VAL1_TYPE]],
+! //CHECK: ![[DBG_VAL2_VEXP]] = !DIExpression({{.*}}200{{.*}})

--- a/test/f90_correct/debug_module_variables_mixed.f90
+++ b/test/f90_correct/debug_module_variables_mixed.f90
@@ -1,0 +1,34 @@
+! REQUIRES: llvm5
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+module mixed_vars
+integer :: var1 = 17
+integer :: var2
+integer :: var3 = 37
+integer :: var4
+contains
+subroutine change_val()
+var2 = 27
+var4 = 47
+end subroutine
+end module
+
+program hello
+use mixed_vars
+call change_val()
+end program hello
+
+! //CHECK: @_mixed_vars_8_ = global %struct_mixed_vars_8_ <{ [8 x i8] {{.*}} !dbg ![[DBG_VAR1_GVEXP:[0-9]+]], !dbg ![[DBG_VAR3_GVEXP:[0-9]+]]
+! //CHECK: @_mixed_vars_0_ = common global %struct_mixed_vars_0_ zeroinitializer, {{.*}} !dbg ![[DBG_VAR2_GVEXP:[0-9]+]], !dbg ![[DBG_VAR4_GVEXP:[0-9]+]]
+
+! //CHECK: ![[DBG_VAR1_GVEXP:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG_VAR1:[0-9]+]], expr: ![[DBG_VAR1_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR1]] = distinct !DIGlobalVariable(name: "var1", linkageName: "_mixed_vars_8_", scope: ![[SCOPE:[0-9]+]],
+! //CHECK: ![[SCOPE]] = !DIModule({{.*}}, name: "mixed_vars"
+! //CHECK: ![[DBG_VAR1_EXP]] = !DIExpression({{.*}})
+! //CHECK: ![[DBG_VAR3_GVEXP:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG_VAR3:[0-9]+]], expr: ![[DBG_VAR3_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR3]] = distinct !DIGlobalVariable(name: "var3", linkageName: "_mixed_vars_8_", scope: ![[SCOPE]],
+! //CHECK: ![[DBG_VAR3_EXP]] = !DIExpression({{.*}}4{{.*}})
+
+! //CHECK: ![[DBG_VAR2_GVEXP:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG_VAR2:[0-9]+]], expr: ![[DBG_VAR1_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR2]] = distinct !DIGlobalVariable(name: "var2", linkageName: "_mixed_vars_0_", scope: ![[SCOPE:[0-9]+]],
+! //CHECK: ![[DBG_VAR4_GVEXP:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG_VAR4:[0-9]+]], expr: ![[DBG_VAR2_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR4]] = distinct !DIGlobalVariable(name: "var4", linkageName: "_mixed_vars_0_", scope: ![[SCOPE]],

--- a/test/f90_correct/debug_module_variables_with_init.f90
+++ b/test/f90_correct/debug_module_variables_with_init.f90
@@ -1,0 +1,20 @@
+! REQUIRES: llvm5
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+module init_vars
+integer :: var1 = 37
+integer :: var2 = 47
+end module
+
+program hello
+use init_vars
+print *, var1
+end program hello
+
+! //CHECK: @_init_vars_8_ = global %struct_init_vars_8_ <{ [8 x i8] {{.*}} !dbg ![[DBG_VAR1_GVEXP:[0-9]+]], !dbg ![[DBG_VAR2_GVEXP:[0-9]+]]
+! //CHECK: ![[DBG_VAR1_GVEXP:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG_VAR1:[0-9]+]], expr: ![[DBG_VAR1_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR1]] = distinct !DIGlobalVariable(name: "var1", linkageName: "_init_vars_8_", scope: ![[SCOPE:[0-9]+]],
+! //CHECK: ![[SCOPE]] = !DIModule({{.*}}, name: "init_vars"
+! //CHECK: ![[DBG_VAR1_EXP]] = !DIExpression({{.*}})
+! //CHECK: ![[DBG_VAR2_GVEXP:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG_VAR2:[0-9]+]], expr: ![[DBG_VAR2_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR2]] = distinct !DIGlobalVariable(name: "var2", linkageName: "_init_vars_8_", scope: ![[SCOPE]],
+! //CHECK: ![[DBG_VAR2_EXP]] = !DIExpression({{.*}}4{{.*}})

--- a/test/f90_correct/debug_module_variables_without_init.f90
+++ b/test/f90_correct/debug_module_variables_without_init.f90
@@ -1,0 +1,20 @@
+! REQUIRES: llvm5
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+module no_init_vars
+integer :: var1
+integer :: var2
+end module
+
+program hello
+use no_init_vars
+print *, var1
+end program hello
+
+! //CHECK: @_no_init_vars_0_ = common global %struct_no_init_vars_0_ zeroinitializer, {{.*}} !dbg ![[DBG_VAR1_GVEXP:[0-9]+]], !dbg ![[DBG_VAR2_GVEXP:[0-9]+]]
+! //CHECK: ![[DBG_VAR1_GVEXP:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG_VAR1:[0-9]+]], expr: ![[DBG_VAR1_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR1]] = distinct !DIGlobalVariable(name: "var1", linkageName: "_no_init_vars_0_", scope: ![[SCOPE:[0-9]+]],
+! //CHECK: ![[SCOPE]] = !DIModule({{.*}}, name: "no_init_vars"
+! //CHECK: ![[DBG_VAR1_EXP]] = !DIExpression({{.*}})
+! //CHECK: ![[DBG_VAR2_GVEXP:[0-9]+]] = !DIGlobalVariableExpression(var: ![[DBG_VAR2:[0-9]+]], expr: ![[DBG_VAR2_EXP:[0-9]+]])
+! //CHECK: ![[DBG_VAR2]] = distinct !DIGlobalVariable(name: "var2", linkageName: "_no_init_vars_0_", scope: ![[SCOPE]],
+! //CHECK: ![[DBG_VAR2_EXP]] = !DIExpression({{.*}}4{{.*}})

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -195,6 +195,12 @@ config.clang = inferClang(config.environment['PATH']).replace('\\', '/')
 if not lit_config.quiet:
     lit_config.note('using flang: %r' % config.flang)
 
+llvm_version_str = subprocess.check_output([ config.clang, '--version' ])
+match = re.match(r'clang\s+version\s+(\S+)\s+[\s\S]+', llvm_version_str)
+llvm_version = int(match.group(1).split('.')[0])
+if llvm_version >= 5:
+    config.available_features.add('llvm5')
+
 # Plugins (loadable modules)
 # TODO: This should be supplied by Makefile or autoconf.
 if sys.platform in ['win32', 'cygwin']:

--- a/tools/flang2/flang2exe/ll_structure.c
+++ b/tools/flang2/flang2exe/ll_structure.c
@@ -2033,7 +2033,8 @@ ll_get_md_node(LLVMModuleRef module, enum LL_MDClass mdclass,
    \param sptr    The key to be added
    \param mdnode  The value to be added
 
-   If the key, \p sptr, is already in the map, the map is unaltered.
+   If the key, \p sptr, is already in the map, the value in the map
+   is replaced. Replacement became necessary for module variables.
  */
 void
 ll_add_global_debug(LLVMModuleRef module, int sptr, LL_MDRef mdnode)
@@ -2044,6 +2045,8 @@ ll_add_global_debug(LLVMModuleRef module, int sptr, LL_MDRef mdnode)
 
   if (!hashmap_lookup(module->globalDebugMap, key, &oldval))
     hashmap_insert(module->globalDebugMap, key, value);
+  else
+    hashmap_replace(module->globalDebugMap, key, &value);
 }
 
 LL_MDRef

--- a/tools/flang2/flang2exe/llassem.h
+++ b/tools/flang2/flang2exe/llassem.h
@@ -36,6 +36,13 @@ struct argdtlist {
   DTLIST *next;
 };
 
+typedef struct dbglist DBGLIST;
+
+struct dbglist {
+  LL_MDRef md;
+  DBGLIST *next;
+};
+
 typedef struct uplevelpair {
   int oldsptr; /* sptr from ilm file */
   int newsptr; /* newsptr - from symbolxref[oldsptr] */
@@ -119,6 +126,7 @@ void hostsym_is_refd(int sptr);
 #define AG_TYPENMPTR(s) agb.s_base[s].type_nmptr
 #define AG_OLDNMPTR(s) agb.s_base[s].old_nmptr
 #define AG_TYPEDESC(s) agb.s_base[s].typedesc /* Boolean */
+#define AG_DEBUG(s) agb.s_base[s].debug /* Boolean */
 #define AG_STYPE(s) agb.s_base[s].stype
 #define AG_RET_LLTYPE(s) agb.s_base[s].ret_lltype
 #define AG_LLTYPE(s) agb.s_base[s].lltype
@@ -148,6 +156,7 @@ void hostsym_is_refd(int sptr);
 #define AG_ARGDTLIST(s) agb.s_base[s].argdtlist
 #define AG_ARGDTLIST_LENGTH(s) agb.s_base[s].n_argdtlist
 #define AG_ARGDTLIST_IS_VALID(s) agb.s_base[s].argdtlist_is_set
+#define AG_CMBLK_MEM_LIST(s) agb.s_base[s].cmblk_mem_list
 
 #define FPTR_HASHLK(s) fptr_local.s_base[s].hashlk
 #define FPTR_IFACENMPTR(s) fptr_local.s_base[s].ifacenmptr
@@ -180,6 +189,7 @@ typedef struct {
   int dtypesc;     /**< dtype scope */
   int n_argdtlist; /**< Number of items in argdtlist */
   LOGICAL argdtlist_is_set; /**< Argdtlist has built, perhaps with 0 args */
+  LOGICAL debug;            /**< is debug generated? */
   char stype;               /**< ST_ of global */
   char sc;                  /**< SC_ of global */
   char alloc;               /**< ALLOCATABLE flag */
@@ -187,6 +197,7 @@ typedef struct {
   LL_Type *lltype;          /**< LLVM representation of the ag symbol */
   LL_Type *ret_lltype;      /**< If this is a func this is the return type */
   DTLIST *argdtlist;        /**< linked listed of argument lltype */
+  DBGLIST *cmblk_mem_list;  /**< linked listed of members (only debug) of a common block */
   int uplevel_avl;
   int uplevel_sz;
   UPLEVEL_PAIR *uplist;  /**< uplevel list for internal procecure */

--- a/tools/flang2/flang2exe/lldebug.h
+++ b/tools/flang2/flang2exe/lldebug.h
@@ -137,7 +137,7 @@ LL_MDRef lldbg_emit_param_variable(LL_DebugInfo *db, int sptr, int findex,
    have a pointer type.
  */
 void lldbg_emit_global_variable(LL_DebugInfo *db, int sptr, ISZ_T off, 
-                                int findex, LL_Value *var_ptr);
+                                int findex, LL_Value *var_ptr, LL_MDRef module, char *linkage_name);
 
 /**
    \brief Emit empty expression mdnode
@@ -209,5 +209,7 @@ void write_metadata_defs(LL_DebugInfo *db);
 char *get_llvm_mips_sname(int sptr);
 
 void lldbg_cleanup_missing_bounds(LL_DebugInfo *db, int findex);
+
+LL_MDRef lldbg_get_current_module_mdnode();
 
 #endif /* LLDEBUG_H__ */

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -529,6 +529,8 @@ void write_struct_defs(void);
  * them to llutil.c */
 void process_sptr(SPTR);
 void set_llvm_sptr_name(OPERAND *);
+void generate_module_variables_debug_cmem(int sptr, int cmsym, LOGICAL init);
+void print_module_variables_debug_cmem(int sptr, LOGICAL init);
 #ifdef DT_INT /* Use DT_INT to detect whether DTYPE is defined. */
 int get_return_dtype(DTYPE, unsigned int *, unsigned int);
 int is_struct_kind(DTYPE, LOGICAL, LOGICAL);


### PR DESCRIPTION
This patch contains the changes for enabling module variables debug.

test/f90_correct/debug_module_mixed_type_variables.f90
test/f90_correct/debug_module_variables_empty_type.f90
test/f90_correct/debug_module_variables_misc.f90
test/f90_correct/debug_module_variables_mixed.f90
test/f90_correct/debug_module_variables_with_init.f90
test/f90_correct/debug_module_variables_without_init.f90
test/lit.cfg : only run the tests for > llvm5.0 
tools/flang2/flang2exe/cgmain.c : New functions to generate and print module variables debug.
tools/flang2/flang2exe/ll_structure.c
tools/flang2/flang2exe/llassem.c : Calls to generate and print module variables debug for with and without initialisation
tools/flang2/flang2exe/llassem.h
tools/flang2/flang2exe/lldebug.c : Create global variable with module as scope, utility function to get the mdnode of the current module.
tools/flang2/flang2exe/lldebug.h
tools/flang2/flang2exe/llutil.h