### PR TITLE
Pull 2018-03-02T07-55 Recent NVIDIA Changes

### DIFF
--- a/runtime/flang/allo.c
+++ b/runtime/flang/allo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1995-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -626,18 +626,31 @@ I8(ftn_allocated)(char *area)
 }
 
 __LOG_T
-ENTF90(ALLOCATED, allocated)
-(char *area) { return I8(__fort_allocated)(area) ? GET_DIST_TRUE_LOG : 0; }
-
-__LOG8_T
-ENTF90(KALLOCATED, kallocated)
-(char *area)
+ENTF90(ALLOCATED, allocated)(char *area)
 {
+  return I8(__fort_allocated)(area) ? GET_DIST_TRUE_LOG : 0;
+}
 
-  /* 
-   * -i8 variant of ALLOCATED
-   */
+/* ALLOCATED_LHS is identical to ALLOCATED but used to indicate
+ * that it is being used to test the LHS in an allocatable assignment
+ * in an OpenACC compute region or OpenACC routine. */
+__LOG_T
+ENTF90(ALLOCATED_LHS, allocated_lhs)(char *area)
+{
+  return I8(__fort_allocated)(area) ? GET_DIST_TRUE_LOG : 0;
+}
 
+/* -i8 variant of ALLOCATED */
+__LOG8_T
+ENTF90(KALLOCATED, kallocated)(char *area)
+{
+  return (__LOG8_T)I8(__fort_allocated)(area) ? GET_DIST_TRUE_LOG : 0;
+}
+
+/* -i8 variant of ALLOCATED_LHS */
+__LOG8_T
+ENTF90(KALLOCATED_LHS, kallocated_lhs)(char *area)
+{
   return (__LOG8_T)I8(__fort_allocated)(area) ? GET_DIST_TRUE_LOG : 0;
 }
 

--- a/tools/flang1/flang1exe/ast.c
+++ b/tools/flang1/flang1exe/ast.c
@@ -3763,18 +3763,17 @@ move_stmts_after(int std, int stdafter)
 void
 ast_to_comment(int ast)
 {
-  int newast;
-  int std;
-  int par;
+  int std = A_STDG(ast);
+  int par = STD_PAR(std);
+  int accel = STD_ACCEL(std);
+  int newast = mk_stmt(A_COMMENT, 0);
 
-  newast = mk_stmt(A_COMMENT, 0);
   A_LOPP(newast, ast);
-  std = A_STDG(ast);
   STD_AST(std) = newast;
   A_STDP(newast, std);
-  par = STD_PAR(std);
   STD_FLAGS(std) = 0;
   STD_PAR(std) = par;
+  STD_ACCEL(std) = accel;
 }
 
 int

--- a/tools/flang1/flang1exe/astout.c
+++ b/tools/flang1/flang1exe/astout.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994-2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1994-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -807,11 +807,16 @@ print_ast(int ast)
     }
     break;
   case A_INTR:
+    optype = A_OPTYPEG(ast);
     if (ast_is_comment) {
-      put_call(ast, 0, NULL, 0);
+      if (A_ISASSIGNLHSG(ast)) {
+        assert(optype == I_ALLOCATED, "unexpected ISASSIGNLHS", ast, ERR_Fatal);
+        put_call(ast, 0, "allocated_lhs", 0);
+      } else {
+        put_call(ast, 0, NULL, 0);
+      }
       break;
     }
-    optype = A_OPTYPEG(ast);
     if ((sym = EXTSYMG(intast_sym[optype]))) {
       put_call(ast, 0, SYMNAME(sym), 0);
       break;
@@ -1601,6 +1606,8 @@ print_ast(int ast)
     }
     if (A_FIRSTALLOCG(ast))
       put_string(", firstalloc");
+    if (A_DALLOCMEMG(ast))
+      put_string(", dallocmem");
     if (A_DEVSRCG(ast)) {
       put_string(", devsrc=");
       print_ast(A_DEVSRCG(ast));

--- a/tools/flang1/flang1exe/func.c
+++ b/tools/flang1/flang1exe/func.c
@@ -3941,7 +3941,7 @@ rewrite_calls(void)
         }
         sptr_lhs = memsym_of_ast(A_SRCG(ast));
         if (allocatable_member(sptr_lhs)) {
-          rewrite_deallocate(A_SRCG(ast), std);
+          rewrite_deallocate(A_SRCG(ast), false, std);
           if (!ALLOCG(sptr_lhs) && !ALLOCATTRG(sptr_lhs) &&
               !POINTERG(sptr_lhs)) {
             /* Has allocatable members but item itself is not

--- a/tools/flang1/flang1exe/lowerexp.c
+++ b/tools/flang1/flang1exe/lowerexp.c
@@ -3726,10 +3726,8 @@ lower_intrinsic(int ast)
     break;
 
   case I_ALLOCATED:
-    {
-      ilm =
-          f90_function(mkRteRtnNm(RTE_allocated), stb.user.dt_log, args, nargs);
-    }
+    rtlRtn = RTE_allocated;
+    ilm = f90_function(mkRteRtnNm(rtlRtn), stb.user.dt_log, args, nargs);
     break;
 
   case I_PRESENT:

--- a/tools/flang1/flang1exe/transfrm.h
+++ b/tools/flang1/flang1exe/transfrm.h
@@ -46,7 +46,7 @@ LOGICAL is_array_type(int sptr);
 int mk_conformable_test(int dest, int src, int optype);
 int mk_allocate(int ast);
 int mk_deallocate(int ast);
-void rewrite_deallocate(int ast, int std);
+void rewrite_deallocate(int ast, bool is_assign_lhs, int std);
 void gen_dealloc_if_allocated(int ast, int std);
 
 #endif /* FE_TRANSFRM_H */

--- a/tools/flang1/utils/ast/ast.n
+++ b/tools/flang1/utils/ast/ast.n
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+.\" * Copyright (c) 1994-2018, NVIDIA CORPORATION.  All rights reserved.
 .\" *
 .\" * Licensed under the Apache License, Version 2.0 (the "License");
 .\" * you may not use this file except in compliance with the License.
@@ -630,6 +630,10 @@ Flags
 .FL CALLFG
 Set if a reference to a function appears in any of the arguments
 to the intrinisc.
+.lp
+.FL ISASSIGNLHS f7
+Set if this is a "allocated(x)" check generated for the LHS of an allocatable
+assignment in an OpenACC compute region or an OpenACC routine.
 .lp
 .ul
 Other Fields

--- a/tools/shared/rtlRtns.c
+++ b/tools/shared/rtlRtns.c
@@ -47,6 +47,7 @@ FtnRteRtn ftnRtlRtns[] = {
     {"alloc04m", "", TRUE, ""},
     {"alloc04p", "", TRUE, ""},
     {"allocated", "", TRUE, "k"},
+    {"allocated_lhs", "", TRUE, "k"},
     {"amodulev", "", FALSE, ""},
     {"amodulov", "", FALSE, ""},
     {"auto_alloc", "", TRUE, ""},

--- a/tools/shared/rtlRtns.h
+++ b/tools/shared/rtlRtns.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2016-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ typedef enum {
   RTE_alloc04m,
   RTE_alloc04p,
   RTE_allocated,
+  RTE_allocated_lhs,
   RTE_amodulev,
   RTE_amodulov,
   RTE_auto_alloc,


### PR DESCRIPTION
Support -Mallocatable=03 in device code

Generate RTE_allocated_lhs() when testing if the LHS of an allocatable
assignment is allocated when inside atarget compute region or in a routine
compiled for the device. This is equivalent to RTE_allocated() but allows the
accelerator code generator and runtime to provide special handling for this
case.

This is implemented by adding the ISASSIGNLHS flag to the I_ALLOCATED ast in
these circumstances. gen_allocated_check() and rewrite_deallocate() have a new
argument to indicate when the check is for the destination of an allocatable
assignment.

To correctly identify an assignment with STD_ACCEL set, the flag must be
preserved when it is commented out by ast_to_comment(). Otherwise, if
gen_allocated_check() occurs right before that STD, we wouldn't recognize it
as being in a compute region.

The code in lowerexp.c for lowering I_ALLOCATED was simplified but the only
functional change is to use the new routine when ISASSIGNLHS is set.

Rewrite the final gen_allocated_check() in rewrite_allocatable_assignment()
so that it is not associated with the next STD. It could be from the next
line, resulting in an incorrect line number or STD_ACCEL flag.