### PR TITLE
AArch64: fix for failing ieee17 test case: Introduce correct values for Rounding Mode selection

### DIFF
--- a/runtime/flang/ieee_arithmetic.F95
+++ b/runtime/flang/ieee_arithmetic.F95
@@ -43,8 +43,13 @@ module IEEE_ARITHMETIC
 
 #ifdef TARGET_LINUX_ARM
   integer, private, parameter :: FE_TONEAREST  = 0
+#ifdef TARGET_LLVM_ARM64
+  integer, private, parameter :: FE_DOWNWARD   = X'00800000'
+  integer, private, parameter :: FE_UPWARD     = X'00400000'
+#else
   integer, private, parameter :: FE_DOWNWARD   = X'00400000'
   integer, private, parameter :: FE_UPWARD     = X'00800000'
+#endif
   integer, private, parameter :: FE_TOWARDZERO = X'00c00000'
 #else
 #ifdef TARGET_LINUX_POWER


### PR DESCRIPTION
This patch fixes a bug causing ieee17 test case to fail,
as described in bug report #263. It introduces correct values
for flags contrilling Rounding Mode selection on AArch64.

The valid values for Rounding Mode control field for AArch64 (bits
[23:22] of FPCR register) are listed here:

http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0488d/CIHCACFF.html