### PR TITLE
Fix test for default ieee mode

### DIFF
--- a/test/f90_correct/ieee_mode.f90
+++ b/test/f90_correct/ieee_mode.f90
@@ -16,5 +16,5 @@
 
 ! RUN: %flang -c -Knoieee %s -v 2>&1 | grep flang2 | grep "-ieee 0"
 ! RUN: %flang -c -Kieee %s -v 2>&1 | grep flang2 | grep "-ieee 1"
-! RUN: %flang -c %s -v 2>&1 | grep flang2 | grep "-ieee 1"
+! RUN: %flang -c %s -v 2>&1 | grep flang2 | grep "-ieee 0"
 


### PR DESCRIPTION
This was detected by failure of the following test.
https://github.com/flang-compiler/flang/blob/master/test/f90_correct/ieee_mode.f90