### PR TITLE
Pull 2018-04-24T04-55 Recent NVIDIA Changes

### DIFF
--- a/runtime/libpgmath/lib/common/cdexp.c
+++ b/runtime/libpgmath/lib/common/cdexp.c
@@ -19,3 +19,16 @@
 
 /* For X86-64 architectures, cdexp is defined in fastmath.s */
 
+#if (! defined (TARGET_X8664) && ! defined(LINUX8664))
+ZMPLXFUNC_Z(__mth_i_cdexp)
+{
+  ZMPLXARGS_Z;
+  double x, y, z;
+  x = exp(real);
+  __mth_dsincos(imag, &z, &y);
+  y *= x;
+  z *= x;
+  ZRETURN_D_D(y, z); /* should leave y & z in appropriate
+                  * registers */
+}
+#endif

--- a/runtime/libpgmath/lib/common/dispatch.c
+++ b/runtime/libpgmath/lib/common/dispatch.c
@@ -1269,7 +1269,13 @@ __math_dispatch_init()
       fputs("waiting for __math_dispatch\n", stderr);
     }
     while (false == __math_dispatch_is_init) {
+#if     defined(TARGET_X8664)
       __asm__("pause");
+#elif   defined(TARGET_LINUX_POWER)
+      __asm__("yield");     // or   27,27,27
+#else
+#error  Unknown processor architecture
+#endif
     }
   }
 }

--- a/runtime/libpgmath/lib/common/log/gdlog2.c
+++ b/runtime/libpgmath/lib/common/log/gdlog2.c
@@ -34,7 +34,9 @@ __gz_log_1(double complex x)
   return (clog(x));
 }
 
+#ifdef  TARGET_X8664
 #define clog    __mth_i_cdlog_c99
+#endif
 
 vcd1_t
 __gz_log_1v(vcd1_t x)

--- a/runtime/libpgmath/lib/common/log/gdlog4.c
+++ b/runtime/libpgmath/lib/common/log/gdlog4.c
@@ -28,7 +28,9 @@ __gd_log_4m(vrd4_t x, vid4_t mask)
   return (__ZGVyM4v__mth_i_vr8(x, mask, __mth_i_dlog));
 }
 
+#ifdef  TARGET_X8664
 #define clog    __mth_i_cdlog_c99
+#endif
 
 vcd2_t
 __gz_log_2(vcd2_t x)

--- a/runtime/libpgmath/lib/common/log/gdlog8.c
+++ b/runtime/libpgmath/lib/common/log/gdlog8.c
@@ -28,7 +28,9 @@ __gd_log_8m(vrd8_t x, vid8_t mask)
   return (__ZGVzM8v__mth_i_vr8(x, mask, __mth_i_dlog));
 }
 
+#ifdef  TARGET_X8664
 #define clog    __mth_i_cdlog_c99
+#endif
 
 vcd4_t
 __gz_log_4(vcd4_t x)

--- a/runtime/libpgmath/lib/common/misc.h
+++ b/runtime/libpgmath/lib/common/misc.h
@@ -210,6 +210,10 @@ typedef struct {
 #define CONST
 #define EXPORT __declspec(dllexport)
 
+#if (defined(__GNUC__) || defined(__CLANG__)) && (defined(__i386__) || defined(__x86_64__))
+#include <x86intrin.h>
+#endif
+
 #define INFINITYf ((float)INFINITY)
 #define NANf ((float)NAN)
 #define INFINITYl ((long double)INFINITY)

--- a/runtime/libpgmath/lib/common/mthdecls.h
+++ b/runtime/libpgmath/lib/common/mthdecls.h
@@ -352,7 +352,11 @@ float __builtin_cimagf(float complex);
 #define FABSF fabs
 #define FLOORF floorf
 #define FMODF fmodf
+#ifdef __PGI_TOOLS14
+#define HYPOTF _hypot
+#else
 #define HYPOTF hypotf
+#endif
 #define ERFF erff
 #define ERFCF erfcf
 #define GAMMAF tgammaf
@@ -532,8 +536,18 @@ double __mth_i_dbessel_y1(double arg);
 double __mth_i_dbessel_yn(int n, double arg);
 double __f90_dbessel_yn(int n1, int n, double d);
 
+#if	! defined (TARGET_X8664) && ! defined(LINUX8664)
+/*
+ * See explanation below for rationale behind the two flavors of __mth_sincos.
+ */
+static inline void __mth_sincos(float angle, float *s, float *c)
+        __attribute__((always_inline));
+static inline void __mth_dsincos(double angle, double *s, double *c)
+        __attribute__((always_inline));
+#else	/* ! defined (TARGET_X8664) && ! defined(LINUX8664) */
 void __mth_sincos(float, float *, float *);
 void __mth_dsincos(double, double *, double *);
+#endif	/* ! defined (TARGET_X8664) && ! defined(LINUX8664) */
 
 FLTDECL_C(__mth_i_cabs);
 CMPLXDECL_C(__mth_i_cacos);

--- a/runtime/libpgmath/lib/common/p_dpowi.c
+++ b/runtime/libpgmath/lib/common/p_dpowi.c
@@ -31,7 +31,9 @@
  * as a temporary workaround to get higher precision multiplies.
  */
 
+#if	defined (TARGET_LINUX_POWER) || defined (LINUX8664) || defined (TARGET_X8664)
 #define	__float128	long double
+#endif
 
 double
 __pmth_i_dpowk(double x8, long long i8)

--- a/runtime/libpgmath/lib/common/pgstdinit.h
+++ b/runtime/libpgmath/lib/common/pgstdinit.h
@@ -47,8 +47,14 @@ typedef unsigned size_t;
 /* declarations in runtime must match declarations in MS msvcrt.dll
  * to achieve consistent DLL linkage.
  */
+#if defined(_DLL) && (defined(TARGET_WIN) || defined(WIN64) || defined(WIN32))
+#define environ _environ
+#define WIN_CDECL __cdecl
+#define WIN_MSVCRT_IMP extern __declspec(dllimport)
+#else
 #define WIN_CDECL
 #define WIN_MSVCRT_IMP extern
+#endif
 
 #ifndef NULL
 #define NULL 0
@@ -164,8 +170,15 @@ typedef long seekoffx_t;
 
 /* some conversions */
 
+#if defined(C90)
+extern long double strtold();
+extern char *_Lecvt();
+#define __io_strtod(p, ep) strtold(p, ep)
+#define __io_ecvt(v, n, d, s, r) _Lecvt(v, n, d, s)
+#else
 #define __io_strtod(p, ep) __fortio_strtod(p, ep)
 #define __io_ecvt(v, n, d, s, r) __fortio_ecvt(v, n, d, s, r)
+#endif
 #define __io_fcvt(v, n, sf, d, s, r) __fortio_fcvt(v, n, sf, d, s, r)
 
 /* and defines for other routines */

--- a/runtime/libpgmath/lib/common/sincosf.c
+++ b/runtime/libpgmath/lib/common/sincosf.c
@@ -15,7 +15,9 @@
  *
  */
 
+#ifdef  TARGET_X8664
 #error  Single precision - generic sincos() will not work on X86-64 systems.
+#endif
 
 #include "mthdecls.h"
 

--- a/runtime/libpgmath/lib/ppc64le/builtin.c
+++ b/runtime/libpgmath/lib/ppc64le/builtin.c
@@ -101,6 +101,7 @@ __builtin_tan(double a)
   return d;
 }
 
+#if defined(TARGET_X8664)
 float
 __builtin_truncf(float a)
 {
@@ -114,6 +115,7 @@ __builtin_trunc(double a)
   double d = __builtin_trunc(a);
   return d;
 }
+#endif
 
 float
 __builtin_acosf(float a)

--- a/runtime/libpgmath/lib/x86_64/cpuid8664.h
+++ b/runtime/libpgmath/lib/x86_64/cpuid8664.h
@@ -22,6 +22,10 @@
 #include <stdint.h>
 #include <cpuid.h>
 
+#if	! defined(TARGET_X8664)
+#error	To use cpuid8664.h CPP macro TARGET_X8664 must be defined.
+#endif
+
 /*
  * Define some interesting fields in the extended control register[0].
  * Currently xcr[0] only defines bits in the lower 32-bits of the 64-bit

--- a/runtime/libpgmath/lib/x86_64/libm_inlines_amd.h
+++ b/runtime/libpgmath/lib/x86_64/libm_inlines_amd.h
@@ -232,6 +232,7 @@ restorePrecision(unsigned int cwold)
 {
 #if defined(linux)
 /* There is no precision control on Hammer */
+#elif defined(INTERIX86)
 #elif defined(TARGET_OSX_X86)
 #else
 #error Unknown machine
@@ -311,6 +312,10 @@ get_fpsw_inline(void)
   unsigned int sw;
   asm volatile("STMXCSR %0" : "=m"(sw));
   return sw;
+#elif defined(INTERIX86)
+  unsigned int sw;
+  asm volatile("STMXCSR %0" : "=m"(sw));
+  return sw;
 #else
 #error Unknown machine
 #endif
@@ -325,6 +330,9 @@ set_fpsw_inline(unsigned int sw)
 #if defined(TARGET_WIN)
   _mm_setcsr(sw);
 #elif defined(linux)
+  /* Set the current floating-point control/status word */
+  asm volatile("LDMXCSR %0" : : "m"(sw));
+#elif defined(INTERIX86)
   /* Set the current floating-point control/status word */
   asm volatile("LDMXCSR %0" : : "m"(sw));
 #else
@@ -345,6 +353,13 @@ clear_fpsw_inline(void)
           AMD_F_INVALID);
   _mm_setcsr(cw);
 #elif defined(linux)
+  unsigned int cw;
+  /* Get the current floating-point control/status word */
+  asm volatile("STMXCSR %0" : "=m"(cw));
+  cw &= ~(AMD_F_INEXACT | AMD_F_UNDERFLOW | AMD_F_OVERFLOW | AMD_F_DIVBYZERO |
+          AMD_F_INVALID);
+  asm volatile("LDMXCSR %0" : : "m"(cw));
+#elif defined(INTERIX86)
   unsigned int cw;
   /* Get the current floating-point control/status word */
   asm volatile("STMXCSR %0" : "=m"(cw));

--- a/runtime/libpgmath/lib/x86_64/mthdecls.h
+++ b/runtime/libpgmath/lib/x86_64/mthdecls.h
@@ -352,7 +352,11 @@ float __builtin_cimagf(float complex);
 #define FABSF fabs
 #define FLOORF floorf
 #define FMODF fmodf
+#ifdef __PGI_TOOLS14
+#define HYPOTF _hypot
+#else
 #define HYPOTF hypotf
+#endif
 #define ERFF erff
 #define ERFCF erfcf
 #define GAMMAF tgammaf
@@ -532,8 +536,18 @@ double __mth_i_dbessel_y1(double arg);
 double __mth_i_dbessel_yn(int n, double arg);
 double __f90_dbessel_yn(int n1, int n, double d);
 
+#if	! defined (TARGET_X8664) && ! defined(LINUX8664)
+/*
+ * See explanation below for rationale behind the two flavors of __mth_sincos.
+ */
+static inline void __mth_sincos(float angle, float *s, float *c)
+        __attribute__((always_inline));
+static inline void __mth_dsincos(double angle, double *s, double *c)
+        __attribute__((always_inline));
+#else	/* ! defined (TARGET_X8664) && ! defined(LINUX8664) */
 void __mth_sincos(float, float *, float *);
 void __mth_dsincos(double, double *, double *);
+#endif	/* ! defined (TARGET_X8664) && ! defined(LINUX8664) */
 
 FLTDECL_C(__mth_i_cabs);
 CMPLXDECL_C(__mth_i_cacos);


### PR DESCRIPTION
libpgmath improvements.
Put back some of the target specific #ifdef pre-processor conditions in
libpgmath. This allows libpgmath to be built on multiple targets.