### PR TITLE
runtime: remove locks around malloc()/free() in mpmalloc.c for glibc-…

### DIFF
--- a/runtime/flangrti/mpmalloc.c
+++ b/runtime/flangrti/mpmalloc.c
@@ -17,18 +17,28 @@
 
 /* mp-safe wrappers for malloc, etc. */
 
+#ifdef TARGET_LINUX
+#include <features.h>
+#endif
+
 #include <stdlib.h>
 #include "llcrit.h"
+#ifndef __GNU_LIBRARY__
 MP_SEMAPHORE(static, sem);
+#endif
 
 void *
 _mp_malloc(size_t n)
 {
   void *p;
 
+#ifndef __GNU_LIBRARY__
   _mp_p(&sem);
+#endif
   p = malloc(n);
+#ifndef __GNU_LIBRARY__
   _mp_v(&sem);
+#endif
   return (p);
 }
 
@@ -37,9 +47,13 @@ _mp_calloc(size_t n, size_t t)
 {
   void *p;
 
+#ifndef __GNU_LIBRARY__
   _mp_p(&sem);
+#endif
   p = calloc(n, t);
+#ifndef __GNU_LIBRARY__
   _mp_v(&sem);
+#endif
   return (p);
 }
 
@@ -48,9 +62,13 @@ _mp_realloc(void *p, size_t n)
 {
   void *q;
 
+#ifndef __GNU_LIBRARY__
   _mp_p(&sem);
+#endif
   q = realloc(p, n);
+#ifndef __GNU_LIBRARY__
   _mp_v(&sem);
+#endif
   return (q);
 }
 
@@ -59,7 +77,11 @@ _mp_free(void *p)
 {
   if (p == 0)
     return;
+#ifndef __GNU_LIBRARY__
   _mp_p(&sem);
+#endif
   free(p);
+#ifndef __GNU_LIBRARY__
   _mp_v(&sem);
+#endif
 }


### PR DESCRIPTION
…based systems

This is due to following statement in the glibc manual:

    To  avoid  corruption in multithreaded applications,
    mutexes are used internally to protect the memory-management
    data structures employed by these functions. In a multithreaded
    application in which threads simultaneously allocate and free
    memory, there could be contention for these mutexes. To scalably
    handle memory allocation in multithreaded applications,
    glibc creates additional memory  allocation arenas if mutex
    contention is detected.  Each arena is a large region of memory
    that is internally allocated by the system (using brk(2)
    or mmap(2)), and managed with its own mutexes.

Having locks around them in the flang runtime library
can ruin optimization effort when tcmalloc is preloaded
to replace standard malloc()/free() implementation with the one
optimized for reducing lock contention.