### PR TITLE
Always SAVE module variables

### DIFF
--- a/test/f90_correct/savemod.f90
+++ b/test/f90_correct/savemod.f90
@@ -1,0 +1,8 @@
+! RUN: %flang %s -S -emit-llvm -o - | FileCheck %s
+
+module somemod
+  integer, allocatable :: something(:)
+end module somemod
+
+! CHECK: %struct.BSS1
+! CHECK: @.BSS1 = internal global %struct.BSS1 zeroinitializer

--- a/tools/flang1/flang1exe/semant.c
+++ b/tools/flang1/flang1exe/semant.c
@@ -1979,6 +1979,7 @@ semant1(int rednum, SST *top)
    *	<prog title> ::= MODULE <id> |
    */
   case PROG_TITLE6:
+    sem.savall = TRUE;
     sem.submod_sym = 0;
     sptr = begin_module(SST_SYMG(RHS(2)));
     sptr1 = NOSYM;


### PR DESCRIPTION
Something that other compilers always do, e.g. https://software.intel.com/en-us/forums/intel-visual-fortran-compiler-for-windows/topic/275783

> On the practical side, our implementation always saves module variables

This is to address bug #468 