### PR TITLE
Pull 2018-05-17T14-36 Recent NVIDIA Changes

### DIFF
--- a/tools/flang1/flang1exe/dpm_out.c
+++ b/tools/flang1/flang1exe/dpm_out.c
@@ -1639,10 +1639,7 @@ prepare_for_astout(void)
       int encl = ENCLFUNCG(sptr);
       int sdsc = SDSCG(sptr);
       if (sdsc && !PARREFG(sdsc) && DESCUSEDG(sptr)) {
-        if (encl)
-          set_parref_flag(sptr, sptr, PARUPLEVELG(encl));
-        else
-          set_parref_flag2(sptr, 0, 0);
+        set_parref_flag2(sptr, 0, 0);
       }
     }
   }


### PR DESCRIPTION
Fix a bug in prepare_for_astout() of dpm_out.c.

ENCLFUNC of a module variable can be module symbol and, therefore, cannot be
used to get the paruplevel symbol.  Always call set_parref_flag2 to add to
the uplevel structure.