### PR TITLE
Pull 2018-05-18T14-08 Recent NVIDIA Changes

### DIFF
--- a/include/replaced-scutil.h
+++ b/include/replaced-scutil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2016-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,15 @@
  * limitations under the License.
  *
  */
+
+#ifndef SCUTIL_H_
+#define SCUTIL_H_
+
 #include "legacy-folding-api.h"
 #include "legacy-ints.h"
 #include "legacy-util-api.h"
+#include "universal.h"
+
+#endif
+
+

--- a/include/scutil.h
+++ b/include/scutil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2016-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,15 @@
  * limitations under the License.
  *
  */
+
+#ifndef SCUTIL_H_
+#define SCUTIL_H_
+
 #include "legacy-folding-api.h"
 #include "legacy-ints.h"
 #include "legacy-util-api.h"
+#include "universal.h"
+
+#endif
+
+

--- a/include/universal.h
+++ b/include/universal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2016-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
  * \brief Declarations common across all programs for all hosts and targets.
  */
 
-#ifndef INCLUDEGUARD_UNIVERSAL_DEFS_H
-#define INCLUDEGUARD_UNIVERSAL_DEFS_H
+#ifndef UNIVERSAL_DEFS_H_
+#define UNIVERSAL_DEFS_H_
 
 #ifdef __cplusplus
 
@@ -32,7 +32,7 @@
 #define HAVE_INLINE 1
 #endif
 
-#else
+#else // !__cplusplus
 
 #define BEGIN_DECL_WITH_C_LINKAGE
 #define END_DECL_WITH_C_LINKAGE
@@ -58,4 +58,4 @@ typedef char bool;
 
 #endif /* __cplusplus */
 
-#endif /* INCLUDEGUARD_UNIVERSAL_DEFS_H */
+#endif /* UNIVERSAL_DEFS_H_ */

--- a/tools/flang1/flang1exe/extern.h
+++ b/tools/flang1/flang1exe/extern.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1994-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -166,7 +166,7 @@ LOGICAL pta_conflict(int ptrstdx, int ptrsptr, int targetstdx, int targetsptr,
                      int targetpointer, int targettarget);     /* pointsto.c */
 int pta_target(int ptrstdx, int ptrsptr, int *ptag, int *pid); /* pointsto.c */
 LOGICAL pta_aligned(int ptrstdx, int ptrsptr);                 /* pointsto.c */
-LOGICAL pta_stride1(int ptrstdx, int ptrsptr);                 /* pointsto.c */
+bool pta_stride1(int ptrstdx, int ptrsptr);                 /* pointsto.c */
 
 struct arg_gbl {
   int std;

--- a/tools/flang1/flang1exe/func.c
+++ b/tools/flang1/flang1exe/func.c
@@ -3682,7 +3682,7 @@ allocate_lhs_if_needed(int lhs, int rhs, int std)
 }
 
 void
-rewrite_asn(int ast, int std, LOGICAL flag, int lc)
+rewrite_asn(int ast, int std, bool flag, int lc)
 {
   int rhs, lhs;
   int args;

--- a/tools/flang1/flang1exe/gbldefs.h
+++ b/tools/flang1/flang1exe/gbldefs.h
@@ -26,6 +26,7 @@
 #define FE_GBLDEFS_H
 
 #include <stdint.h>
+#include "universal.h"
 #include "platform.h"
 #include "pgifeat.h"
 #include <scutil.h>
@@ -168,7 +169,7 @@ void *get_getitem_p(int);
 void free_getitem_p(void);
 
 char *mkfname(char *, char *, char *); /* from miscutil.c: */
-LOGICAL is_xflag_bit(int);
+bool is_xflag_bit(int);
 void set_xflag(int, INT);
 void set_yflag(int, INT);
 void bzero(void *, size_t);

--- a/tools/flang1/flang1exe/global.h
+++ b/tools/flang1/flang1exe/global.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1994-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
  * limitations under the License.
  *
  */
+
+#ifndef GLOBAL_H_
+#define GLOBAL_H_
 
 /** \file global.h
     \brief Fortran global variables and flags.
@@ -218,3 +221,5 @@ typedef struct {
 } FLG;
 
 extern FLG flg;
+
+#endif

--- a/tools/flang1/flang1exe/optimize.h
+++ b/tools/flang1/flang1exe/optimize.h
@@ -799,7 +799,7 @@ void bv_intersect3(BV *a, BV *b, BV *c, UINT len);
 void optimize_alloc(void);                     /* commopt.c */
 void points_to_anal(void);                     /* pointsto.c */
 void fini_points_to_all(void);                 /* pointsto.c */
-LOGICAL pta_stride1(int ptrstdx, int ptrsptr); /* pointsto.c */
+bool pta_stride1(int ptrstdx, int ptrsptr); /* pointsto.c */
 void pstride_analysis(void);                   /* pstride.c */
 void fini_pstride_analysis(void);              /* pstride.c */
 void call_analyze(void);                       /* rest.c */

--- a/tools/flang1/flang1exe/pointsto.c
+++ b/tools/flang1/flang1exe/pointsto.c
@@ -960,7 +960,7 @@ is_source_nonlocal(int psdx)
  * if this is an LHS reference, make sure it has a slot number
  */
 static void
-add_psd(int tpdx, int type, int parent, int sym, LOGICAL lhs)
+add_psd(int tpdx, int type, int parent, int sym, bool lhs)
 {
   int val, psdx, t;
 
@@ -1009,7 +1009,7 @@ add_psd(int tpdx, int type, int parent, int sym, LOGICAL lhs)
  * make sure all dependent (parent) pointer source descriptors are also built.
  */
 static void
-build_psd(int tdsx, LOGICAL lhs)
+build_psd(int tdsx, bool lhs)
 {
   int subtds;
   if (TLINK(tdsx))
@@ -1320,7 +1320,7 @@ make_assignment(int v, int iltx, int lhstds, int rhstds, int add, int stride)
     fprintf(gbl.dbgfil, " (stride=%d)\n", stride);
   }
 #endif
-  build_psd(lhstds, TRUE);
+  build_psd(lhstds, true);
   lhspsdx = TLINK(lhstds);
   asx = 0;
   switch (TTYPE(rhstds)) {
@@ -1382,7 +1382,7 @@ make_assignment(int v, int iltx, int lhstds, int rhstds, int add, int stride)
     break;
   default:
     /* indirect or otherwise; need dataflow analysis */
-    build_psd(rhstds, FALSE);
+    build_psd(rhstds, false);
     rhspsdx = TLINK(rhstds);
 
     asx = STG_NEXT(as);
@@ -1619,7 +1619,7 @@ make_init_assignment(int v, int sourcesptr, int stars, int targettype,
   while (stars-- > 0) {
     lhstds = make_address(0, TT_IND, 0, lhstds);
   }
-  build_psd(lhstds, TRUE);
+  build_psd(lhstds, true);
   lhspsdx = TLINK(lhstds);
   asx = 0;
   /* get PTE for RHS */
@@ -3194,7 +3194,7 @@ putstdpta(int stdx)
 
 #endif /* } debug */
 
-static LOGICAL
+static bool
 different_pta(int pta1, int pta2)
 {
   int p1, p2;
@@ -3341,7 +3341,7 @@ set_std_pta(int stdx, int change)
 #define TRACEFLAG 10
 #define TRACEBIT 0x1000000
 
-LOGICAL
+bool
 pta_conflict(int ptrstdx, int ptrsptr, int targetstdx, int targetsptr,
              int targetpointer, int targettarget)
 {
@@ -3804,7 +3804,7 @@ pta_conflict(int ptrstdx, int ptrsptr, int targetstdx, int targetsptr,
  *  unk  - unknown
  *         unaligned
  */
-LOGICAL
+bool
 pta_aligned(int ptrstdx, int ptrsptr)
 {
   int ptrsrc, ptrpte, sptr;
@@ -3870,7 +3870,7 @@ pta_aligned(int ptrstdx, int ptrsptr)
  *  for instance that it can be passed directly to an assumed-shape argument
  *  without copying to a temp
  */
-LOGICAL
+bool
 pta_stride1(int ptrstdx, int ptrsptr)
 {
   int ptrsrc, ptrpte;

--- a/tools/flang1/flang1exe/symacc.c
+++ b/tools/flang1/flang1exe/symacc.c
@@ -32,12 +32,8 @@
 
 /* FIXME: This file is compiled with different gbldefs.h included
    depending on in which part of the build it is recompiled. */
-#include "scutil.h"
-#include "gbldefs.h"
-#include "global.h"
+#include "symacc.h"
 #include "error.h"
-#include "sharedefs.h"
-#include "symtab.h"
 #include <stdarg.h>
 
 #ifndef STANDARD_MAXIDLEN
@@ -104,7 +100,6 @@ realloc_sym_storage()
 
 /**
    \brief Look up symbol with indicated name.
-
    \return If there is already such a symbol, the pointer to the
    existing symbol table entry; or 0 if a symbol doesn't exist.
    \param name is a symbol name.

--- a/tools/flang1/flang1exe/symacc.h
+++ b/tools/flang1/flang1exe/symacc.h
@@ -15,6 +15,16 @@
  *
  */
 
+#ifndef SYMACC_H_
+#define SYMACC_H_
+
+#include "scutil.h"
+#include "gbldefs.h"
+#include "global.h"
+struct SYM;
+#include "symtab.h"
+#include "sharedefs.h"
+
 /**
  * \file
  * \brief Various definitions for symacc.
@@ -59,7 +69,7 @@ public:
 #define INDEX_BY(T, Index) T *
 #endif
 
-#if defined(__cplusplus) && !defined(HACK_EAS)
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -102,7 +112,7 @@ void realloc_sym_storage();
 
 /*  symbol table typedef declarations */
 
-typedef struct {
+typedef struct SYM {
   SYMTYPE stype : 8;
   SC_KIND sc : 8;
   unsigned b3 : 8;
@@ -265,6 +275,8 @@ void symini_errfatal(int n);
 void symini_error(int n, int s, int l, const char *c1, const char *c2);
 void symini_interr(const char *txt, int val, int sev);
 
-#if defined(__cplusplus) && !defined(HACK_EAS)
+#if defined(__cplusplus)
 }
 #endif
+
+#endif // SYMACC_H_

--- a/tools/flang1/utils/symtab/symtab.in.h
+++ b/tools/flang1/utils/symtab/symtab.in.h
@@ -15,6 +15,9 @@
  *
  */
 
+#ifndef SYMTAB_H_
+#define SYMTAB_H_
+
 /**
  *  \file
  *  \brief symtab.h - symbol tab definitions for Fortran
@@ -411,7 +414,7 @@ LOGICAL is_arg_in_entry(int, int);
 int resolve_sym_aliases(int);
 LOGICAL is_procedure_ptr(int);
 void proc_arginfo(int, int *, int *, int *);
-void dup_sym(int, SYM *);
+void dup_sym(int, struct SYM *);
 int insert_dup_sym(int);
 int get_align_desc(int, int);
 void dump_align(FILE*, int);
@@ -457,21 +460,14 @@ void dmp_socs(int sptr, FILE *file);
  * \brief flag defintions for cmp_interfaces_strict()
  */
 typedef enum CMP_INTERFACE_FLAGS {
-
   IGNORE_IFACE_NAMES = 0x0, /**< ignore the symbol names sym1 & sym2, but make
                                  sure arguments have same stypes and names. */
-                            
   CMP_IFACE_NAMES = 0x1, /**< make sure sym1 and sym2 have the same symbol 
-                              name. */
-                            
+                              name. */                          
   IGNORE_ARG_NAMES = 0x2, /**< ignore the argument names. */   
-
   RELAX_STYPE_CHK = 0x4, /**< relax stype check on arguments. */
-
   CMP_OPTARG = 0x8, /**< make sure sym1 and sym2 OPTARG fields are identical. */
-
   RELAX_INTENT_CHK = 0x10, /**< relax intent check on arguments. */
-
   RELAX_POINTER_CHK = 0x20, /**< relax pointer check on arguments. */
 
   RELAX_PURE_CHK_1 = 0x40, /**< relax pure check on argument #1 of
@@ -480,5 +476,8 @@ typedef enum CMP_INTERFACE_FLAGS {
                                 cmp_interfaces_strict() function */
 } cmp_interface_flags;
 
-bool compatible_characteristics(int psptr, int psptr2, cmp_interface_flags flag);
+bool compatible_characteristics(int psptr, int psptr2,
+                                cmp_interface_flags flag);
 bool cmp_interfaces_strict(SPTR sym1, SPTR sym2, cmp_interface_flags flag);
+
+#endif // SYMTAB_H_

--- a/tools/flang2/flang2exe/aarch64-Linux/machreg.h
+++ b/tools/flang2/flang2exe/aarch64-Linux/machreg.h
@@ -15,6 +15,11 @@
  *
  */
 
+#ifndef MACHREG_H_
+#define MACHREG_H_
+
+#include "gbldefs.h"
+
 extern const int scratch_regs[];
 
 /* Define registers for x86-32.
@@ -350,12 +355,14 @@ extern RGSETB rgsetb;
 
 /*****  External Function Declarations  *****/
 
-extern int mr_getnext(int rtype);
-extern int mr_getreg(int rtype);
-extern int mr_get_rgset();
-extern int mr_gindex(int rtype, int regno);
-extern void mr_end();
-extern void mr_init();
-extern void mr_reset_frglobals();
-extern void mr_reset(int rtype);
-extern void mr_reset_numglobals(int);
+ int mr_getnext(int rtype);
+ int mr_getreg(int rtype);
+ int mr_get_rgset();
+ int mr_gindex(int rtype, int regno);
+ void mr_end();
+ void mr_init();
+ void mr_reset_frglobals();
+ void mr_reset(int rtype);
+ void mr_reset_numglobals(int);
+
+#endif

--- a/tools/flang2/flang2exe/assem.h
+++ b/tools/flang2/flang2exe/assem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2002-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,9 @@ extern int get_private_size(void);
 
 extern void add_init_routine(char *initroutine);
 /* Create a .init section to call an initialization function */
+
+void create_static_base(int name);
+void hostsym_is_refd(int);
 
 #define STR_SEC 0
 #define RO_SEC 1

--- a/tools/flang2/flang2exe/bih.h
+++ b/tools/flang2/flang2exe/bih.h
@@ -15,8 +15,8 @@
  *
  */
 
-#if !defined(BIH_H__)
-#define BIH_H__
+#ifndef BIH_H_
+#define BIH_H_
 
 /**
    \file
@@ -241,22 +241,6 @@ typedef struct {
 
 extern BIHB bihb;
 
-/* declare external functions from bihutil.c */
+#include "bihutil.h"
 
-extern void bih_init(void);
-extern int addbih(int);
-extern int addbih_inherit(int);
-extern void delbih(int);
-extern int merge_bih(int);
-extern void merge_blks(int, int);
-extern void merge_rgset(int, int, LOGICAL);
-extern void dump_blocks(FILE *, int, char *, int);
-extern void dump_one_block(FILE *, int, char *);
-void merge_bih_flags(int to_bih, int fm_bih);
-void unsplit(void);
-LOGICAL any_asm(void);
-void split_extended(void);
-extern int addbih(int);
-extern int addnewbih(int, int, int);
-
-#endif /* BIH_H__ */
+#endif /* BIH_H_ */

--- a/tools/flang2/flang2exe/bihutil.c
+++ b/tools/flang2/flang2exe/bihutil.c
@@ -19,7 +19,7 @@
  * \brief C and Fortran BIH utility module
  */
 
-#include "gbldefs.h"
+#include "bihutil.h"
 #include "error.h"
 #include "global.h"
 #include "symtab.h"
@@ -344,7 +344,7 @@ merge_bih(int curbih)
 
   wrilts(curbih);
 
-  merge_rgset(curbih, nextbih, FALSE);
+  merge_rgset(curbih, nextbih, false);
 
   /* remove the block from the BIH list  */
 
@@ -387,7 +387,7 @@ merge_blks(int b1, int b2)
 
 /* BIH_RGSET(tobih) U= BIH_RGSET(frombih) */
 void
-merge_rgset(int tobih, int frombih, LOGICAL reuse_to)
+merge_rgset(int tobih, int frombih, bool reuse_to)
 {
   if (BIH_RGSET(tobih) != BIH_RGSET(frombih)) {
     if (!BIH_RGSET(tobih))

--- a/tools/flang2/flang2exe/bihutil.h
+++ b/tools/flang2/flang2exe/bihutil.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef BIHUTIL_H_
+#define BIHUTIL_H_
+
+#include "gbldefs.h"
+#include <stdio.h>
+
+/**
+   \brief ...
+ */
+bool any_asm(void);
+
+/**
+   \brief ...
+ */
+int addbih(int after);
+
+/**
+   \brief ...
+ */
+int addnewbih(int after, int flags, int fih);
+
+/**
+   \brief ...
+ */
+int exp_addbih(int after);
+
+/**
+   \brief ...
+ */
+int merge_bih(int curbih);
+
+/**
+   \brief ...
+ */
+void bih_cleanup(void);
+
+/**
+   \brief ...
+ */
+void bih_init(void);
+
+/**
+   \brief ...
+ */
+void *ccff_bih_info(int msgtype, char *msgid, int bihx, const char *message,
+                    ...);
+
+/**
+   \brief ...
+ */
+void delbih(int bihx);
+
+/**
+   \brief ...
+ */
+void dump_blocks(FILE *ff, int bih, char *fmt, int fihflag);
+
+/**
+   \brief ...
+ */
+void dump_one_block(FILE *ff, int bih, char *fmt);
+
+/**
+   \brief ...
+ */
+void merge_bih_flags(int to_bih, int fm_bih);
+
+/**
+   \brief ...
+ */
+void merge_blks(int b1, int b2);
+
+/**
+   \brief ...
+ */
+void merge_rgset(int tobih, int frombih, bool reuse_to);
+
+/**
+   \brief ...
+ */
+void split_extended(void);
+
+/**
+   \brief ...
+ */
+void *subccff_bih_info(void *xparent, int msgtype, char *msgid, int bihx,
+                       const char *message, ...);
+
+/**
+   \brief ...
+ */
+void unsplit(void);
+
+#endif

--- a/tools/flang2/flang2exe/cgllvm.h
+++ b/tools/flang2/flang2exe/cgllvm.h
@@ -146,14 +146,13 @@ LL_Type *maybe_fixup_x86_abi_return(LL_Type *sig);
 /* ll_ftn.c */
 void store_llvm_localfptr(void);
 void stb_process_routine_parameters(void);
-LOGICAL has_multiple_entries(int sptr);
 int get_entries_argnum(void);
 void get_local_overlap_size(void);
 void write_master_entry_routine(void);
 char *get_llvm_ifacenm(int sptr);
 int get_iface_sptr(int sptr);
 int is_iso_cptr(int d_dtype);
-extern void ll_process_routine_parameters(int sptr);
+ void ll_process_routine_parameters(int sptr);
 void fix_llvm_fptriface(void);
 char *get_entret_arg_name(void);
 

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef CGMAIN_H_
+#define CGMAIN_H_
+
+#include "gbldefs.h"
+#include "global.h"
+#include "symtab.h"
+#include "ili.h"
+#include "cgllvm.h"
+#include "ll_structure.h"
+
+/**
+   \brief ...
+ */
+bool currsub_is_sret(void);
+
+/**
+   \brief ...
+ */
+bool is_cg_llvm_init(void);
+
+/**
+   \brief ...
+ */
+bool ll_check_struct_return(DTYPE dtype);
+
+/**
+   \brief ...
+ */
+bool strict_match(LL_Type *ty1, LL_Type *ty2);
+
+/**
+   \brief ...
+ */
+char *dtype_struct_name(int dtype);
+
+/**
+   \brief ...
+ */
+char *gen_llvm_vconstant(const char *ctype, int sptr, int tdtype, int flags);
+
+/**
+   \brief ...
+ */
+char *get_label_name(int sptr);
+
+/**
+   \brief ...
+ */
+char *get_llvm_mips_sname(int sptr);
+
+/**
+   \brief ...
+ */
+char *get_llvm_sname(int sptr);
+
+/**
+   \brief ...
+ */
+char *match_names(MATCH_Kind match_val);
+
+/**
+   \brief ...
+ */
+const char *char_type(int dtype, int sptr);
+
+/**
+   \brief ...
+ */
+DTYPE msz_dtype(MSZ msz);
+
+/**
+   \brief ...
+ */
+INSTR_LIST *llvm_info_last_instr(void);
+
+/**
+   \brief ...
+ */
+INSTR_LIST *mk_store_instr(OPERAND *val, OPERAND *addr);
+
+/**
+   \brief ...
+ */
+int cg_get_type(int n, int v1, int v2);
+
+/**
+   \brief ...
+ */
+int find_pointer_to_function(int ilix);
+
+/**
+   \brief ...
+ */
+int match_llvm_types(LL_Type *ty1, LL_Type *ty2);
+
+/**
+   \brief ...
+ */
+int need_ptr(int sptr, int sc, int sdtype);
+
+/**
+   \brief ...
+ */
+LL_Type *maybe_fixup_x86_abi_return(LL_Type *sig);
+
+/**
+   \brief ...
+ */
+OPERAND *gen_address_operand(int addr_op, int nme, bool lda,
+                             LL_Type *llt_expected, MSZ msz);
+
+/**
+   \brief ...
+ */
+OPERAND *gen_call_as_llvm_instr(int sptr, int ilix);
+
+/**
+   \brief ...
+ */
+OPERAND *gen_call_to_builtin(int ilix, char *fname, OPERAND *params,
+                             LL_Type *return_ll_type, INSTR_LIST *Call_Instr,
+                             int i_name);
+
+/**
+   \brief ...
+ */
+OPERAND *gen_llvm_expr(int ilix, LL_Type *expected_type);
+
+/**
+   \brief ...
+ */
+OPERAND *mk_alloca_instr(LL_Type *ptrTy);
+
+/**
+   \brief ...
+ */
+TMPS *gen_extract_insert(int i_name, LL_Type *struct_type, TMPS *tmp,
+                         LL_Type *tmp_type, TMPS *tmp2, LL_Type *tmp2_type,
+                         int index);
+
+/**
+   \brief ...
+ */
+void build_routine_and_parameter_entries(SPTR func_sptr, LL_ABI_Info *abi,
+                                         LL_Module *module);
+
+/**
+   \brief ...
+ */
+void cg_fetch_clen_parampos(SPTR *len, int *param, SPTR sptr);
+
+/**
+   \brief ...
+ */
+void cg_llvm_end(void);
+
+/**
+   \brief ...
+ */
+void cg_llvm_fnend(void);
+
+/**
+   \brief ...
+ */
+void cg_llvm_init(void);
+
+/**
+   \brief ...
+ */
+void clear_deletable_flags(int ilix);
+
+/**
+   \brief ...
+ */
+void dump_type_for_debug(LL_Type *ll_type);
+
+/**
+   \brief ...
+ */
+void llvm_ctor_add(const char *name);
+
+/**
+   \brief ...
+ */
+void llvm_ctor_add_with_priority(const char *name, int priority);
+
+/**
+   \brief ...
+ */
+void llvm_dtor_add(const char *name);
+
+/**
+   \brief ...
+ */
+void llvm_dtor_add_with_priority(const char *name, int priority);
+
+/**
+   \brief ...
+ */
+void llvmResetSname(int sptr);
+
+/**
+   \brief ...
+ */
+void llvm_write_ctors(void);
+
+/**
+   \brief ...
+ */
+void print_personality(void);
+
+/**
+   \brief ...
+ */
+void print_tmp_name(TMPS *t);
+
+/**
+   \brief ...
+ */
+void process_formal_arguments(LL_ABI_Info *abi);
+
+/**
+   \brief ...
+ */
+void process_global_lifetime_debug(void);
+
+/**
+   \brief ...
+ */
+void process_sptr(SPTR sptr);
+
+/**
+   \brief ...
+ */
+void reset_expr_id(void);
+
+/**
+   \brief ...
+ */
+void schedule(void);
+
+/**
+   \brief ...
+ */
+void set_llvm_sptr_name(OPERAND *operand);
+
+/**
+   \brief ...
+ */
+void update_external_function_declarations(const char *name, char *decl,
+                                           unsigned flags);
+
+/**
+   \brief ...
+ */
+void write_external_function_declarations(int first_time);
+
+#endif

--- a/tools/flang2/flang2exe/dinitutl.c
+++ b/tools/flang2/flang2exe/dinitutl.c
@@ -19,10 +19,7 @@
  * \brief SCFTN data initialization file utilities.
  */
 
-#include "gbldefs.h"
-#include "error.h"
-#include "global.h"
-#include "dinit.h"
+#include "dinitutl.h"
 #include "ilm.h"
 #include "symtab.h"
 
@@ -61,10 +58,11 @@ dinit_put(int dtype, ISZ_T conval)
     mode = 'w';
   } else if (mode == ' ') {
     if ((df = tmpf("b")) == NULL)
-      errfatal(5);
+      errfatal(F_0005_Unable_to_open_temporary_file);
     mode = 'w';
   } else if (mode != 'w') {
-    error(10, 4, 0, "(data init file)", CNULL);
+    error(F_0010_File_write_error_occurred_OP1, ERR_Fatal, 0,
+          "(data init file)", CNULL);
   }
 
   t.dtype = dtype;
@@ -74,7 +72,8 @@ dinit_put(int dtype, ISZ_T conval)
 
   n = fwrite((char *)&t, sizeof(t), 1, df);
   if (n != 1)
-    error(10, 4, 0, "(data init file)", CNULL);
+    error(F_0010_File_write_error_occurred_OP1, ERR_Fatal, 0,
+          "(data init file)", CNULL);
 }
 
 /*
@@ -260,9 +259,8 @@ dinit_restore(void)
   }
 } /* dinit_restore */
 
-LOGICAL
-df_is_open()
+bool
+df_is_open(void)
 {
   return (df != NULL);
 }
-

--- a/tools/flang2/flang2exe/dinitutl.h
+++ b/tools/flang2/flang2exe/dinitutl.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef DINITUTL_H_
+#define DINITUTL_H_
+
+#include "gbldefs.h"
+#include "error.h"
+#include "global.h"
+#include "dinit.h"
+
+/**
+   \brief ...
+ */
+bool df_is_open(void);
+
+/**
+   \brief ...
+ */
+DREC *dinit_read(void);
+
+/**
+   \brief ...
+ */
+long dinit_ftell(void);
+
+/**
+   \brief ...
+ */
+void dinit_end(void);
+
+/**
+   \brief ...
+ */
+void dinit_fseek(long off);
+
+/**
+   \brief ...
+ */
+void dinit_fskip(long off);
+
+/**
+   \brief ...
+ */
+void dinit_init(void);
+
+/**
+   \brief ...
+ */
+void dinit_put(int dtype, ISZ_T conval);
+
+/**
+   \brief ...
+ */
+void dinit_put_string(ISZ_T len, char *str);
+
+/**
+   \brief ...
+ */
+void dinit_read_string(ISZ_T len, char *str);
+
+/**
+   \brief ...
+ */
+void dinit_restore(void);
+
+/**
+   \brief ...
+ */
+void dinit_save(void);
+
+#endif

--- a/tools/flang2/flang2exe/dtypeutl.c
+++ b/tools/flang2/flang2exe/dtypeutl.c
@@ -28,7 +28,7 @@ static int size_sym = 0;
  * are mirrored from the front end */
 struct visit_list {
   DTYPE dtype;
-  LOGICAL is_active;
+  bool is_active;
   struct visit_list *next;
 };
 

--- a/tools/flang2/flang2exe/exp_ftn.h
+++ b/tools/flang2/flang2exe/exp_ftn.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef EXP_FTN_H_
+#define EXP_FTN_H_
+
+#include "gbldefs.h"
+#include "error.h"
+#include "global.h"
+#include "symtab.h"
+#include "expand.h"
+
+/**
+   \brief ...
+ */
+int create_array_ref(int nmex, int sptr, DTYPE dtype, int nsubs, int *subs,
+                     int ilix, int sdscilix, int inline_flag, int *pnme);
+
+/**
+   \brief ...
+ */
+int exp_get_sdsc_len(int s, int base, int basenm);
+
+/**
+   \brief ...
+ */
+int get_sdsc_element(int sdsc, int indx, int membase, int membase_nme);
+
+/**
+   \brief ...
+ */
+SPTR frte_func(SPTR (*pf)(const char *), const char *root);
+
+/**
+   \brief ...
+ */
+void exp_ac(ILM_OP opc, ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void exp_array(ILM_OP opc, ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void exp_bran(ILM_OP opc, ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void exp_misc(ILM_OP opc, ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void exp_restore_mxcsr(void);
+
+#endif // EXP_FTN_H_

--- a/tools/flang2/flang2exe/exp_fvec.c
+++ b/tools/flang2/flang2exe/exp_fvec.c
@@ -15,6 +15,7 @@
  *
  */
 
+#include "exp_fvec.h"
 #include "gbldefs.h"
 #include "error.h"
 #include "global.h"

--- a/tools/flang2/flang2exe/exp_fvec.h
+++ b/tools/flang2/flang2exe/exp_fvec.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef EXP_FVEC_H_
+#define EXP_FVEC_H_
+
+/**
+   \brief ...
+ */
+void eval_fvec(int ilmx);
+
+/**
+   \brief ...
+ */
+void fin_fvec(void);
+
+/**
+   \brief ...
+ */
+void init_fvec(void);
+
+#endif // EXP_FVEC_H_

--- a/tools/flang2/flang2exe/exp_rte.h
+++ b/tools/flang2/flang2exe/exp_rte.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef F_EXP_RTE_H_
+#define F_EXP_RTE_H_
+
+#include "gbldefs.h"
+#include "global.h"
+#include "symtab.h"
+#include "expand.h"
+
+/**
+   \brief ...
+ */
+bool bindC_function_return_struct_in_registers(int func_sym);
+
+/**
+   \brief ...
+ */
+int charaddr(int sym);
+
+/**
+   \brief ...
+ */
+int charlen(int sym);
+
+/**
+   \brief ...
+ */
+int exp_alloca(ILM *ilmp);
+
+/**
+   \brief ...
+ */
+int gen_arg_ili(void);
+
+/**
+   \brief ...
+ */
+int getdumlen(void);
+
+/**
+   \brief ...
+ */
+int gethost_dumlen(int arg, ISZ_T address);
+
+/**
+   \brief ...
+ */
+int is_passbyval_dummy(int sptr);
+
+/**
+   \brief ...
+ */
+int needlen(int sym, int func);
+
+/**
+   \brief ...
+ */
+void add_arg_ili(int ilix, int nme, int dtype);
+
+/**
+   \brief ...
+ */
+void chk_terminal_func(int entbih, int exitbih);
+
+/**
+   \brief ...
+ */
+void end_arg_ili(void);
+
+/**
+   \brief ...
+ */
+void exp_agoto(ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void expand_smove(int destilm, int srcilm, DTYPE dtype);
+
+/**
+   \brief ...
+ */
+void exp_build_agoto(int *tab, int mx);
+
+/**
+   \brief ...
+ */
+void exp_call(ILM_OP opc, ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void exp_cgoto(ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void exp_end(ILM *ilmp, int curilm, bool is_func);
+
+/**
+   \brief ...
+ */
+void exp_fstring(ILM_OP opc, ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void exp_header(int sym);
+
+/**
+   \brief ...
+ */
+void exp_qjsr(char *ext, int res_dtype, ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void exp_remove_gsmove(void);
+
+/**
+   \brief ...
+ */
+void exp_reset_argregs(int ir, int fr);
+
+/**
+   \brief ...
+ */
+void exp_szero(ILM *ilmp, int curilm, int to, int from, int dtype);
+
+/**
+   \brief ...
+ */
+void exp_zqjsr(char *ext, int res_dtype, ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void init_arg_ili(int n);
+
+#endif

--- a/tools/flang2/flang2exe/expatomics.h
+++ b/tools/flang2/flang2exe/expatomics.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef EXPATOMICS_H_
+#define EXPATOMICS_H_
+
+#include "gbldefs.h"
+#include "symtab.h"
+#include "expand.h"
+#include "ili.h"
+
+/**
+   \brief ...
+ */
+bool exp_end_atomic(int store, int curilm);
+
+/**
+   \brief ...
+ */
+ILI_OP get_atomic_update_opcode(int current_ili);
+
+/**
+   \brief ...
+ */
+int create_atomic_capture_seq(int update_ili, int read_ili, int capture_first);
+
+/**
+   \brief ...
+ */
+int create_atomic_read_seq(int store_ili);
+
+/**
+   \brief ...
+ */
+int create_atomic_seq(int store_ili);
+
+/**
+   \brief ...
+ */
+int create_atomic_write_seq(int store_ili);
+
+/**
+   \brief ...
+ */
+int exp_mp_atomic_read(ILM *ilmp);
+
+/**
+   \brief ...
+ */
+int get_atomic_capture_created(void);
+
+/**
+   \brief ...
+ */
+int get_atomic_function_ex(ILI_OP opcode);
+
+/**
+   \brief ...
+ */
+int get_atomic_function(ILI_OP opcode);
+
+/**
+   \brief ...
+ */
+int get_atomic_read_opcode(int current_ili);
+
+/**
+   \brief ...
+ */
+int get_atomic_store_created(void);
+
+/**
+   \brief ...
+ */
+int get_atomic_write_opcode(int current_ili);
+
+/**
+   \brief ...
+ */
+int get_capture_read_ili(void);
+
+/**
+   \brief ...
+ */
+int get_capture_update_ili(void);
+
+/**
+   \brief ...
+ */
+int get_is_in_atomic_capture(void);
+
+/**
+   \brief ...
+ */
+int get_is_in_atomic_read(void);
+
+/**
+   \brief ...
+ */
+int get_is_in_atomic(void);
+
+/**
+   \brief ...
+ */
+int get_is_in_atomic_write(void);
+
+/**
+   \brief ...
+ */
+void exp_mp_atomic_capture(ILM *ilmp);
+
+/**
+   \brief ...
+ */
+void exp_mp_atomic_update(ILM *ilmp);
+
+/**
+   \brief ...
+ */
+void exp_mp_atomic_write(ILM *ilmp);
+
+/**
+   \brief ...
+ */
+void set_atomic_capture_created(int x);
+
+/**
+   \brief ...
+ */
+void set_atomic_store_created(int x);
+
+/**
+   \brief ...
+ */
+void set_capture_read_ili(int x);
+
+/**
+   \brief ...
+ */
+void set_capture_update_ili(int x);
+
+/**
+   \brief ...
+ */
+void set_is_in_atomic_capture(int x);
+
+/**
+   \brief ...
+ */
+void set_is_in_atomic(int x);
+
+/**
+   \brief ...
+ */
+void set_is_in_atomic_read(int x);
+
+/**
+   \brief ...
+ */
+void set_is_in_atomic_write(int x);
+
+#endif

--- a/tools/flang2/flang2exe/expreg.c
+++ b/tools/flang2/flang2exe/expreg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 /** \file
  * \brief Register allocation performed by the expander at opt level 1
  */
+
+#include "expreg.h"
 #include "gbldefs.h"
 #include "error.h"
 #include "global.h"

--- a/tools/flang2/flang2exe/expreg.h
+++ b/tools/flang2/flang2exe/expreg.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef EXPREG_H_
+#define EXPREG_H_
+
+/**
+   \brief ...
+ */
+void exp_rcand(int ilix, int nmex);
+
+/**
+   \brief ...
+ */
+void reg_assign1(void);
+
+#endif

--- a/tools/flang2/flang2exe/expsmp.h
+++ b/tools/flang2/flang2exe/expsmp.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef EXPSMP_H_
+#define EXPSMP_H_
+
+#include "gbldefs.h"
+#include "error.h"
+#include "global.h"
+#include "symtab.h"
+#include "expand.h"
+#include "llmputil.h"
+
+/**
+   \brief ...
+ */
+int add_mp_barrier2(void);
+
+/**
+   \brief ...
+ */
+int add_mp_lcpu(void);
+
+/**
+   \brief ...
+ */
+int add_mp_ncpus3(void);
+
+/**
+   \brief ...
+ */
+int add_mp_ncpus(void);
+
+/**
+   \brief ...
+ */
+int add_mp_penter(int ispar);
+
+/**
+   \brief ...
+ */
+int add_mp_pexit(void);
+
+/**
+   \brief ...
+ */
+int add_mp_p(int semaphore);
+
+/**
+   \brief ...
+ */
+int add_mp_v(int semaphore);
+
+/**
+   \brief ...
+ */
+int get_threadprivate_origsize(int sym);
+
+/**
+   \brief ...
+ */
+int lcpu_temp(int sc);
+
+/**
+   \brief ...
+ */
+int llTaskAllocSptr(void);
+
+/**
+   \brief ...
+ */
+int _make_mp_get_threadprivate(int data_ili, int size_ili, int cache_ili);
+
+/**
+   \brief ...
+ */
+int ncpus_temp(int sc);
+
+/**
+   \brief ...
+ */
+LLTask *llGetTask(int scope);
+
+/**
+   \brief ...
+ */
+void clear_tplnk(void);
+
+/**
+   \brief ...
+ */
+void exp_mp_func_prologue(void);
+
+/**
+   \brief ...
+ */
+void exp_smp_fini(void);
+
+/**
+   \brief ...
+ */
+void exp_smp(ILM_OP opc, ILM *ilmp, int curilm);
+
+/**
+   \brief ...
+ */
+void exp_smp_init(void);
+
+/**
+   \brief ...
+ */
+void section_create_endblock(int endLabel);
+
+LLTask* llGetTask(int scope);
+
+#endif // EXPSMP_H_

--- a/tools/flang2/flang2exe/exputil.c
+++ b/tools/flang2/flang2exe/exputil.c
@@ -19,15 +19,14 @@
  * \brief Expander utility routines
  */
 
-#include "gbldefs.h"
-#include "error.h"
-#include "global.h"
-#include "symtab.h"
+#include "exputil.h"
+#include "expreg.h"
 #include "dinit.h"
 #include "ilm.h"
 #include "ilmtp.h"
 #include "fih.h"
 #include "ili.h"
+#include "iliutil.h"
 #define EXPANDER_DECLARE_INTERNAL
 #include "expand.h"
 #include "machar.h"
@@ -180,7 +179,7 @@ flsh_saveili(void)
   int savefg;  /* save for the ilt call flag	 */
   char ldvol;  /* save for the ilt ldvol flag	 */
   char stvol;  /* save for the ilt stvol flag	 */
-  char qjsrfg; /* save for the ilt qjsrfg flag	 */
+  bool qjsrfg; /* save for the ilt qjsrfg flag	 */
 
   if (expb.flags.bits.waitlbl) {
 
@@ -223,7 +222,7 @@ flsh_saveili(void)
     iltb.callfg = 0;
     iltb.ldvol = 0;
     iltb.stvol = 0;
-    iltb.qjsrfg = 0;
+    iltb.qjsrfg = false;
     expb.curilt = addilt(expb.curilt, expb.saveili);
     iltb.callfg = savefg;
     iltb.ldvol = ldvol;
@@ -455,7 +454,7 @@ check_ilm(int ilmx, int ilix)
      * leader block may not yet be created
      */
     if (!iltb.qjsrfg && qjsr_in(ilix)) {
-      iltb.qjsrfg = 1;
+      iltb.qjsrfg = true;
       if (EXPDBG(8, 2))
         fprintf(gbl.dbgfil, "check_ilm - qjsr_in(%d)\n", ilix);
     }
@@ -545,7 +544,8 @@ check_ilm(int ilmx, int ilix)
        * from above (see the lines after "break_out:"), otherwise
        * it's across block boundaries.
        */
-      int save_iltb_callfg, save_iltb_ldvol, save_iltb_stvol, save_iltb_qjsrfg;
+      int save_iltb_callfg, save_iltb_ldvol, save_iltb_stvol;
+      bool save_iltb_qjsrfg;
 
     conv_pseudo_st:
       /* JHM (8 Dec 2011) bug-fix:

--- a/tools/flang2/flang2exe/exputil.h
+++ b/tools/flang2/flang2exe/exputil.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef EXPUTIL_H_
+#define EXPUTIL_H_
+
+#include "gbldefs.h"
+#include "global.h"
+#include "symtab.h"
+
+/**
+   \brief ...
+ */
+int access_swtab_base_label(int base_label, int sptr, int flag);
+
+/**
+   \brief ...
+ */
+int access_swtab_case_label(int case_label, int *case_val, int sptr, int flag);
+
+/**
+   \brief ...
+ */
+int add_reg_arg_ili(int arglist, int argili, int nmex, DTYPE dtype);
+
+/**
+   \brief ...
+ */
+int check_ilm(int ilmx, int ilix);
+
+/**
+   \brief ...
+ */
+int find_argasym(int sptr);
+
+/**
+   \brief ...
+ */
+int get_byval_local(int argsptr);
+
+/**
+   \brief ...
+ */
+int mk_argasym(int sptr);
+
+/**
+   \brief ...
+ */
+int mk_impsym(int sptr);
+
+/**
+   \brief ...
+ */
+int mk_swlist(INT n, SWEL *swhdr, int doinit);
+
+/**
+   \brief ...
+ */
+int mk_swtab(INT n, SWEL *swhdr, int deflab, int doinit);
+
+/**
+   \brief ...
+ */
+int mk_swtab_ll(INT n, SWEL *swhdr, int deflab, int doinit);
+
+/**
+   \brief ...
+ */
+SPTR mkfunc_cncall(const char *nmptr);
+
+/**
+   \brief ...
+ */
+SPTR mkfunc_sflags(const char *nmptr, const char *flags);
+
+/**
+   \brief ...
+ */
+void chk_block(int newili);
+
+/**
+   \brief ...
+ */
+void chk_block_suppress_throw(int newili);
+
+/**
+   \brief ...
+ */
+void cr_block(void);
+
+/**
+   \brief ...
+ */
+void exp_add_copy(int lhssptr, int rhssptr);
+
+/**
+   \brief ...
+ */
+void expdumpilms(void);
+
+/**
+   \brief ...
+ */
+void flsh_block(void);
+
+/**
+   \brief ...
+ */
+void mkarglist(int cnt, int dt);
+
+/**
+   \brief ...
+ */
+void put_funccount(void);
+
+/**
+   \brief ...
+ */
+void wr_block(void);
+
+#endif

--- a/tools/flang2/flang2exe/gbldefs.h
+++ b/tools/flang2/flang2exe/gbldefs.h
@@ -85,11 +85,11 @@ typedef BIGINT BV;
 
 /* ETLS/TLS threadprivate features */
 
-typedef int LOGICAL;
+typedef bool LOGICAL;
 #undef TRUE
-#define TRUE 1
+#define TRUE true
 #undef FALSE
-#define FALSE 0
+#define FALSE false
 
 /*
  * Define truth values for Fortran.  The negate operation is dependent
@@ -173,7 +173,6 @@ typedef enum RUTYPE {
  void free_getitem_p(void);
 
  char *mkfname(char *, char *, char *); /* from miscutil.c: */
- LOGICAL is_xflag_bit(int);
  void set_xflag(int, INT);
  void set_yflag(int, INT);
  void bzero(void *, size_t);

--- a/tools/flang2/flang2exe/ili-rewrite.h
+++ b/tools/flang2/flang2exe/ili-rewrite.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,22 +73,23 @@ typedef struct ILI_coordinates ILI_coordinates;
  */
 typedef int (*ILI_visitor)(const ILI_coordinates *at);
 
-/* ILI rewriting driver.  Returns TRUE if any change occurs.
- *
- * The traversal is in block sequence order, with the ILTs being
- * visited in forward order within each block.
- *
- * The void *visitor_context is passed to the visitation callback as
- * at->context.
- *
- * Set the "context_insensitive" flag to TRUE for faster processing
- * when the rewriting visitor is known to not be sensitive to the context
- * (i.e., it always maps ILI 'x' to the same 'y' in any statement).
- */
-LOGICAL visit_ilis(ILI_visitor visitor, void *visitor_context,
-                   LOGICAL context_insensitive);
+/**
+   \brief ILI rewriting driver.  Returns TRUE if any change occurs.
 
-/* Visitation context structure passed to callbacks.*/
+   The traversal is in block sequence order, with the ILTs being visited in
+   forward order within each block.
+
+   The void *visitor_context is passed to the visitation callback as
+   at->context.
+
+   Set the "context_insensitive" flag to TRUE for faster processing when the
+   rewriting visitor is known to not be sensitive to the context (i.e., it
+   always maps ILI 'x' to the same 'y' in any statement).
+ */
+bool visit_ilis(ILI_visitor visitor, void *visitor_context,
+                   bool context_insensitive);
+
+/** \brief Visitation context structure passed to callbacks.*/
 struct ILI_coordinates {
   ILI_visitor visitor;
   void *context;    /* callback's own state */
@@ -97,31 +98,40 @@ struct ILI_coordinates {
   int bih, ilt; /* position of statement containing this ILI instance */
   const ILI_coordinates *parent; /* null if ILI is root expression of ILT */
   int parent_opnd;           /* ILI_OPND(parent->ili,parent_opnd) links here */
-  LOGICAL this_ili_improved; /* this ILI improved when operands updated */
-  LOGICAL has_cse;           /* operand trees contain JSR and/or CSE */
+  bool this_ili_improved; /* this ILI improved when operands updated */
+  bool has_cse;           /* operand trees contain JSR and/or CSE */
 };
 
-/* Utility for callbacks: given an ILI index, create a new ILI in which
- * one operand has been replaced.
+/**
+   \brief Utility for callbacks: given an ILI index, create a new ILI in which
+   one operand has been replaced.
  */
 int update_ili_operand(int ili, int opnd_index, int new_opnd);
 
-/* Collects the set of ILT root expression ILIs. */
+/**
+   \brief Collects the set of ILT root expression ILIs.
+ */
 void collect_root_ilis(fastset *root_ilis);
 
-/* Collects the set of live ILIs. */
-void collect_live_ilis(fastset *live_ilis);
-
-/* ILI tree scanning in preorder with a callback.
- * A true return from the callback causes the scan to immediately
- * return TRUE.  Does not descend into IL_CSExx operands; recurse
- * thither from the visitor if that's what you really want.
+/**
+   \brief Collects the set of live ILIs.
  */
-typedef LOGICAL (*ILI_tree_scan_visitor)(void *visitor_context, int ili);
-LOGICAL scan_ili_tree(ILI_tree_scan_visitor visitor, void *visitor_context,
-                      int ili);
+void collect_live_ilis(fastset *live);
 
-/* Collects the set of ILIs in an ILI expression tree. */
-void collect_tree_ilis(fastset *tree_ilis, int ili, LOGICAL scan_cses);
+typedef bool (*ILI_tree_scan_visitor)(void *visitor_context, int ili);
+
+/**
+   \brief Collects the set of ILIs in an ILI expression tree.
+ */
+void collect_tree_ilis(fastset *tree_ilis, int ili, bool scan_cses);
+
+/**
+   \brief ILI tree scanning in preorder with a callback.
+   A true return from the callback causes the scan to immediately return TRUE.
+   Does not descend into IL_CSExx operands; recurse thither from the visitor if
+   that's what you really want.
+ */
+bool scan_ili_tree(ILI_tree_scan_visitor visitor, void *visitor_context,
+                   int ili);
 
 #endif /* ILI_REWRITE_H_ */

--- a/tools/flang2/flang2exe/ili.h
+++ b/tools/flang2/flang2exe/ili.h
@@ -453,88 +453,13 @@ typedef struct {
 extern ILIB ilib;
 extern ILIINFO ilis[];
 
-#if DEBUG
-void ddilitree(int i, int flag);
-#endif
-
-char* dump_msz(MSZ ms);
-
 /* ---------------------------------------------------------------------- */
 
 #ifndef ILITP_UTIL
-extern LOGICAL share_proc_ili; /* defd in iliutil.c */
-extern LOGICAL share_qjsr_ili; /* defd in iliutil.c */
+extern bool share_proc_ili; /* defd in iliutil.c */
+extern bool share_qjsr_ili; /* defd in iliutil.c */
 
 /*  declare external functions iliutil.c, unless building ilitp utility prog */
-void ili_init(void);
-int ili_traverse(int (*)(int), int);
-void ili_visit(int, int);
-void ili_unvisit(void);
-void prilitree(int i); /* iliutil.c */
-void garbage_collect(void (*mark_function)(int));
-
-int jsrsearch(int);
-int qjsrsearch(int);
-
-int addili(ILI *);
-int get_ili_ns(ILI *);
-int ad1ili(ILI_OP, int);
-int ad2ili(ILI_OP, int, int);
-int ad3ili(ILI_OP, int, int, int);
-int ad4ili(ILI_OP, int, int, int, int);
-int ad5ili(ILI_OP, int, int, int, int, int);
-int ad_cse(int);
-int has_cse(int ilix);
-int ad_icon(INT);
-int ad_kcon(INT, INT);
-int ad_kconi(ISZ_T);
-int ad_aconi(ISZ_T);
-int ad_acon(int, ISZ_T);
-int ad_aconk(INT, INT);
-int ad_load(int);
-int ad_free(int);
-ILI_OP ldopc_from_stopc(ILI_OP);
-ISZ_T get_isz_conili(int);
-
-int ili_opnd(int, int);
-int mk_address(int);
-int compute_address(int);
-
-int sel_icnst(ISZ_T, int);
-int sel_iconv(int, int);
-int sel_decr(int, int);
-int sel_aconv(int);
-
-int is_argili_opcode(ILI_OP);
-int is_cseili_opcode(ILI_OP);
-int is_freeili_opcode(ILI_OP);
-int is_mvili_opcode(ILI_OP);
-int is_rgdfili_opcode(ILI_OP);
-int is_daili_opcode(ILI_OP);
-int is_dfrili_opcode(ILI_OP);
-int is_integer_comparison_opcode(ILI_OP);  /* includes conditional jumps */
-int is_floating_comparison_opcode(ILI_OP); /* ditto */
-int is_unsigned_opcode(ILI_OP);            /* ditto */
-
-int ili_get_vect_arg_count(int);
-DTYPE ili_get_vect_dtype(int);
-
-int ili_subscript(int);
-int ili_isdeleted(int);
-int ili_throw_label(int);
-int uikmove(int);
-int ikmove(int);
-int kimove(int);
-void initcallargs(int count);
-void addcallarg(int ili, int nme, int dtype);
-int gencallargs(void);
-char *gnr_math(char *, int, int, char *, int);
-char *fast_math(char *, int, int, char *);
-char *relaxed_math(char *, int, int, char *);
-int mkfunc_avx(char *, int);
-void rm_smove(void);
-
-void dump_ili(FILE *, int);
 
 #define XBIT_NEW_MATH_NAMES XBIT(164, 0x800000)
 
@@ -548,86 +473,12 @@ void dump_ili(FILE *, int);
 
 #define XBIT_VECTORABI_FOR_SCALAR XBIT(26,2)
 
-/* Complements a relation; also known as negation or inversion.
- *  complement_int_cc(CC_LT) -> CC_GE
- *  complement_ieee_cc(CC_LT) -> CC_NOTLT
- */
-CC_RELATION complement_int_cc(CC_RELATION cc);
-CC_RELATION complement_ieee_cc(CC_RELATION cc);
-
-/* Commutes a relation to correspond to an exchange of its operands.
- *  commute_cc(CC_LT) -> CC_GT
- */
-CC_RELATION commute_cc(CC_RELATION cc);
-
-/* Reduces a comparison of two operands whose result is compared with zero
- * into a single comparison of the two operands.
- *  combine_*_ccs(CC_x, CC_NE or CC_GT) -> CC_x
- *  combine_*_ccs(CC_x, CC_EQ or CC_LE) -> complement_*_cc(CC_x)
- *  combine_*_ccs(CC_x, CC_LT or CC_GE) -> 0
- */
-CC_RELATION combine_int_ccs(CC_RELATION binary_cc, CC_RELATION zero_cc);
-CC_RELATION combine_ieee_ccs(CC_RELATION binary_cc, CC_RELATION zero_cc);
-
-/* Predicate: if two operands were equal, would that satisfy a condition? */
-bool cc_includes_equality(CC_RELATION cc);
-
-/* Predicate: are two condition codes complements of each other? */
-bool ccs_are_complementary(CC_RELATION cc1, CC_RELATION cc2);
-
-int ll_ad_outlined_func(ILI_OP, ILI_OP, char *, int, int, int, int);
-
-#ifdef DEBUG
-void dmpili(void);
-void dmpilitree(int i);
-void _ddilitree(int i, int flag);
-#endif
-
-MSZ mem_size(TY_KIND ty);
-int rewr_ili_nme(int tree, int oldili, int newili, int oldnme, int newnme,
-                 int douse, int dodef);
-extern int rewr_ili(int, int, int);
-extern void rewr_cln_ili(void);
-
-/* iliutil.h */
-int find_ili(int tree, int it);
-int genretvalue(int ilix, ILI_OP resultopc);
-
 /*****  ILT, BIH, NME  declarations  *****/
 #include "ilt.h"
 #include "bih.h"
 #include "nme.h"
-LOGICAL qjsr_in(int ilix);
-int alt_qjsr(int ilix);
-LOGICAL find_ili(int tree, int it);
-LOGICAL is_llvm_local_private(int sptr);
-int mk_charlen_parref_sptr(int);
 
 /***** Atomic Operation Encodings *****/
-int atomic_encode(MSZ msz, SYNC_SCOPE scope, ATOMIC_ORIGIN origin);
-int atomic_encode_rmw(MSZ msz, SYNC_SCOPE scope, ATOMIC_ORIGIN origin,
-                      ATOMIC_RMW_OP op);
-MEMORY_ORDER memory_order(int ilix);
-ATOMIC_INFO atomic_info(int ilix);
-LOGICAL is_omp_atomic_ld(int);
-LOGICAL is_omp_atomic_st(int);
-
-ATOMIC_INFO atomic_decode(int encoding);
-int atomic_info_index(ILI_OP opc);
-
-/* compare-exchange requires 8 inputs.  To avoid having to allow 8-operand ILI
-   operations, it's broken into 2 ILIs, an IL_CMPXCHGx on top of an
-   IL_CMPXCHG_DST.  Clients should avoid creating or referencing the 
-   IL_CMPXCHG_DST instruction directly, and instead use the interfaces below.*/
-
-bool cmpxchg_is_weak(int ilix);
-int cmpxchg_loc(int ilix);
-int ilstckind(ILI_OP _1, int _2);
-int ad_cmpxchg(ILI_OP opc, int ilix_val, int ilix_loc, int nme,
-               int stc_atomic_info, int ilix_comparand, int ilix_is_weak,
-               int ilix_sucess, int ilix_failure);
-
-CMPXCHG_MEMORY_ORDER cmpxchg_memory_order(int ilix);
 
 /* Extract MSZ from an int that is a MSZ operand or an encoded ATOMIC_INFO.
    This functionality is handy for extracting the MSZ from an instruction
@@ -640,14 +491,8 @@ CMPXCHG_MEMORY_ORDER cmpxchg_memory_order(int ilix);
 /* Get MSZ of an IL_ST, IL_STSP, IL_STDP, or IL_ATOMICSTx instruction */
 #define ILI_MSZ_OF_ST(ilix) (ILI_MSZ_FROM_STC(ILI_OPND((ilix), 4)))
 
-int imul_const_ili(ISZ_T valconst, int valilix);
-int imul_ili_ili(int leftx, int rightx);
-int iadd_const_ili(ISZ_T valconst, int valilix);
-int iadd_ili_ili(int leftx, int rightx);
-int isub_ili_ili(int leftx, int rightx);
-int idiv_ili_const(int valilix, ISZ_T valconst);
-int idiv_ili_ili(int leftx, int rightx);
-int imax_ili_ili(int leftx, int rightx);
-int imin_ili_ili(int leftx, int rightx);
-#endif /* !defined(ILITP_UTIL) */
+#include "iliutil.h"
+
+#endif /* !ILITP_UTIL */
+
 #endif /* ILI_H_ */

--- a/tools/flang2/flang2exe/iliutil.h
+++ b/tools/flang2/flang2exe/iliutil.h
@@ -1,0 +1,677 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef ILIUTIL_H_
+#define ILIUTIL_H_
+
+#include "gbldefs.h"
+#include "error.h"
+#include "global.h"
+#include "symtab.h"
+#include "ilm.h"
+#include "ilmtp.h"
+#include "ili.h"
+#include "mth.h"
+
+/* exported variables */
+
+extern bool share_proc_ili;
+extern bool share_qjsr_ili;
+
+/* exported functions */
+
+/**
+   \brief ...
+ */
+ATOMIC_INFO atomic_decode(int encoding);
+
+/**
+   \brief ...
+ */
+ATOMIC_INFO atomic_info(int ilix);
+
+/**
+   \brief ...
+ */
+BIGINT get_isz_conili(int ili);
+
+/**
+   \brief ...
+ */
+bool cc_includes_equality(CC_RELATION cc);
+
+/**
+   \brief ...
+ */
+bool ccs_are_complementary(CC_RELATION cc1, CC_RELATION cc2);
+
+/**
+   \brief ...
+ */
+bool cmpxchg_is_weak(int ilix);
+
+/**
+   \brief ...
+ */
+bool _find_ili(int ilix, int find_this);
+
+/**
+   \brief ...
+ */
+bool find_ili(int tree, int it);
+
+/**
+   \brief ...
+ */
+bool func_in(int ilix);
+
+/**
+   \brief ...
+ */
+bool is_floating_comparison_opcode(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+bool is_integer_comparison_opcode(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+bool is_llvm_local(int sptr, int funcsptr);
+
+/**
+   \brief ...
+ */
+bool is_llvm_local_private(int sptr);
+
+/**
+   \brief ...
+ */
+bool is_omp_atomic_ld(int ilix);
+
+/**
+   \brief ...
+ */
+bool is_omp_atomic_st(int ilix);
+
+/**
+   \brief ...
+ */
+bool is_unsigned_opcode(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+bool qjsr_in(int ilix);
+
+/**
+   \brief ...
+ */
+CC_RELATION combine_ieee_ccs(CC_RELATION binary_cc, CC_RELATION zero_cc);
+
+/**
+   \brief ...
+ */
+CC_RELATION combine_int_ccs(CC_RELATION binary_cc, CC_RELATION zero_cc);
+
+/**
+   \brief ...
+ */
+CC_RELATION commute_cc(CC_RELATION cc);
+
+/**
+   \brief ...
+ */
+CC_RELATION complement_ieee_cc(CC_RELATION cc);
+
+/**
+   \brief ...
+ */
+CC_RELATION complement_int_cc(CC_RELATION cc);
+
+/**
+   \brief ...
+ */
+char *dump_msz(MSZ ms);
+
+/**
+   \brief ...
+ */
+char *fast_math(char *root, int widthc, int typec, char *oldname);
+
+/**
+   \brief ...
+ */
+char *gnr_math(char *root, int widthc, int typec, char *oldname, int masked);
+
+/**
+   \brief ...
+ */
+char *make_math(MTH_FN fn, SPTR *fptr, int vectlen, bool mask, DTYPE res_dt, int nargs, int arg1_dt_, ...);
+
+/**
+   \brief ...
+ */
+char *make_math_name(MTH_FN fn, int vectlen, bool mask, DTYPE res_dt);
+
+/**
+   \brief ...
+ */
+char *make_math_name_vabi(MTH_FN fn, int vectlen, bool mask, DTYPE res_dt);
+
+/**
+   \brief ...
+ */
+char *relaxed_math(char *root, int widthc, int typec, char *oldname);
+
+/**
+   \brief ...
+ */
+char *scond(int c);
+
+/**
+   \brief ...
+ */
+CMPXCHG_MEMORY_ORDER cmpxchg_memory_order(int ilix);
+
+/**
+   \brief ...
+ */
+DTYPE ili_get_vect_dtype(int ilix);
+
+/**
+   \brief ...
+ */
+ILI_OP ldopc_from_stopc(ILI_OP stopc);
+
+/**
+   \brief ...
+ */
+int ad1ili(ILI_OP opc, int opn1);
+
+/**
+   \brief ...
+ */
+int ad2func_kint(ILI_OP opc, char *name, int opn1, int opn2);
+
+/**
+   \brief ...
+ */
+int ad2ili(ILI_OP opc, int opn1, int opn2);
+
+/**
+   \brief ...
+ */
+int ad3ili(ILI_OP opc, int opn1, int opn2, int opn3);
+
+/**
+   \brief ...
+ */
+int ad4ili(ILI_OP opc, int opn1, int opn2, int opn3, int opn4);
+
+/**
+   \brief ...
+ */
+int ad5ili(ILI_OP opc, int opn1, int opn2, int opn3, int opn4, int opn5);
+
+/**
+   \brief ...
+ */
+int ad_aconi(BIGINT val);
+
+/**
+   \brief ...
+ */
+int ad_acon(int sym, BIGINT val);
+
+/**
+   \brief ...
+ */
+int ad_aconk(INT m32, INT l32);
+
+/**
+   \brief ...
+ */
+int ad_cmpxchg(ILI_OP opc, int ilix_val, int ilix_loc, int nme, int stc_atomic_info, int ilix_comparand, int ilix_is_weak, int ilix_success, int ilix_failure);
+
+/**
+   \brief ...
+ */
+int ad_cse(int ilix);
+
+/**
+   \brief ...
+ */
+int addili(ILI *ilip);
+
+/**
+   \brief ...
+ */
+int ad_free(int ilix);
+
+/**
+   \brief ...
+ */
+int ad_icon(INT val);
+
+/**
+   \brief ...
+ */
+int ad_kconi(BIGINT v);
+
+/**
+   \brief ...
+ */
+int ad_kcon(INT m32, INT l32);
+
+/**
+   \brief ...
+ */
+int ad_load(int stx);
+
+/**
+   \brief ...
+ */
+int alt_qjsr(int ilix);
+
+/**
+   \brief ...
+ */
+int atomic_encode(MSZ msz, SYNC_SCOPE scope, ATOMIC_ORIGIN origin);
+
+/**
+   \brief ...
+ */
+int atomic_encode_rmw(MSZ msz, SYNC_SCOPE scope, ATOMIC_ORIGIN origin, ATOMIC_RMW_OP op);
+
+/**
+   \brief ...
+ */
+int atomic_info_index(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+int cmpxchg_loc(int ilix);
+
+/**
+   \brief ...
+ */
+int compl_br(int ilix, int lbl);
+
+/**
+   \brief ...
+ */
+int compute_address(int sptr);
+
+/**
+   \brief ...
+ */
+int gencallargs(void);
+
+/**
+   \brief ...
+ */
+int genregcallargs(void);
+
+/**
+   \brief ...
+ */
+int genretvalue(int ilix, ILI_OP resultopc);
+
+/**
+   \brief ...
+ */
+int get_ili_ns(ILI *ilip);
+
+/**
+   \brief ...
+ */
+int get_rewr_new_nme(int nmex);
+
+/**
+   \brief ...
+ */
+int has_cse(int ilix);
+
+/**
+   \brief ...
+ */
+int iadd_const_ili(BIGINT valconst, int valilix);
+
+/**
+   \brief ...
+ */
+int iadd_ili_ili(int leftx, int rightx);
+
+/**
+   \brief ...
+ */
+int idiv_ili_const(int valilix, BIGINT valconst);
+
+/**
+   \brief ...
+ */
+int idiv_ili_ili(int leftx, int rightx);
+
+/**
+   \brief ...
+ */
+int ikmove(int ilix);
+
+/**
+   \brief ...
+ */
+int ili_get_vect_arg_count(int ilix);
+
+/**
+   \brief ...
+ */
+int ili_isdeleted(int ili);
+
+/**
+   \brief ...
+ */
+int ili_opnd(int ilix, int n);
+
+/**
+   \brief ...
+ */
+int ili_subscript(int sub);
+
+/**
+   \brief ...
+ */
+int ili_throw_label(int ilix);
+
+/**
+   \brief ...
+ */
+int ili_traverse(int (*visit_f)(int), int ilix);
+
+/**
+   \brief ...
+ */
+int ilstckind(ILI_OP opc, int opnum);
+
+/**
+   \brief ...
+ */
+int imax_ili_ili(int leftx, int rightx);
+
+/**
+   \brief ...
+ */
+int imin_ili_ili(int leftx, int rightx);
+
+/**
+   \brief ...
+ */
+int imul_const_ili(BIGINT valconst, int valilix);
+
+/**
+   \brief ...
+ */
+int imul_ili_ili(int leftx, int rightx);
+
+/**
+   \brief ...
+ */
+int is_argili_opcode(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+int is_cseili_opcode(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+int is_daili_opcode(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+int is_dfrili_opcode(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+int is_freeili_opcode(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+int is_mvili_opcode(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+int is_rgdfili_opcode(ILI_OP opc);
+
+/**
+   \brief ...
+ */
+int isub_ili_ili(int leftx, int rightx);
+
+/**
+   \brief ...
+ */
+int jsrsearch(int ilix);
+
+/**
+   \brief ...
+ */
+int kimove(int ilix);
+
+/**
+   \brief ...
+ */
+int ll_ad_outlined_func(ILI_OP result_opc, ILI_OP call_opc, char *func_name, int narg, int arg1, int arg2, int arg3);
+
+/**
+   \brief ...
+ */
+int mk_address(int sptr);
+
+/**
+   \brief ...
+ */
+int mk_charlen_parref_sptr(int sptr);
+
+/**
+   \brief ...
+ */
+int mkfunc_avx(char *nmptr, int avxp);
+
+/**
+   \brief ...
+ */
+int qjsrsearch(int ilix);
+
+/**
+   \brief ...
+ */
+int rewr_ili(int tree, int old, int New);
+
+/**
+   \brief ...
+ */
+int rewr_ili_nme(int tree, int oldili, int newili, int oldnme, int newnme, int douse, int dodef);
+
+/**
+   \brief ...
+ */
+int save_rewr_count(void);
+
+/**
+   \brief ...
+ */
+int sel_aconv(int ili);
+
+/**
+   \brief ...
+ */
+int sel_decr(int ili, int isi8);
+
+/**
+   \brief ...
+ */
+int sel_icnst(BIGINT val, int isi8);
+
+/**
+   \brief ...
+ */
+int sel_iconv(int ili, int isi8);
+
+/**
+   \brief ...
+ */
+int simplified_cmp_ili(int cmp_ili);
+
+/**
+   \brief ...
+ */
+int uikmove(int ilix);
+
+/**
+   \brief ...
+ */
+MEMORY_ORDER memory_order(int ilix);
+
+/**
+   \brief ...
+ */
+MSZ mem_size(TY_KIND ty);
+
+/**
+   \brief ...
+ */
+void addcallarg(int ili, int nme, int dtype);
+
+/**
+   \brief ...
+ */
+void choose_multiplier_64(int N, UINT64 dd, int prec);
+
+/**
+   \brief ...
+ */
+void choose_multiplier(int N, unsigned dd, int prec);
+
+/**
+   \brief ...
+ */
+void _ddilitree(int i, int flag);
+
+/**
+   \brief ...
+ */
+void ddilitree(int i, int flag);
+
+/**
+   \brief ...
+ */
+void dmpilitree(int i);
+
+/**
+   \brief ...
+ */
+void dmpili(void);
+
+/**
+   \brief ...
+ */
+void dump_atomic_info(FILE *f, ATOMIC_INFO info);
+
+/**
+   \brief ...
+ */
+void dump_ili(FILE *f, int i);
+
+/**
+   \brief ...
+ */
+void garbage_collect(void (*mark_function)(int));
+
+/**
+   \brief ...
+ */
+void ili_cleanup(void);
+
+/**
+   \brief ...
+ */
+void ili_init(void);
+
+/**
+   \brief ...
+ */
+void ili_unvisit(void);
+
+/**
+   \brief ...
+ */
+void ili_visit(int ilix, int v);
+
+/**
+   \brief ...
+ */
+void initcallargs(int count);
+
+/**
+   \brief ...
+ */
+void inline_mulh(void);
+
+/**
+   \brief ...
+ */
+void ldst_msz(DTYPE dtype, ILI_OP *ld, ILI_OP *st, MSZ *siz);
+
+/**
+   \brief ...
+ */
+void llmk_math_name(char *buff, int fn, int vectlen, bool mask, DTYPE res_dt);
+
+/**
+   \brief ...
+ */
+void prilitree(int i);
+
+/**
+   \brief ...
+ */
+void restore_rewr_count(int c);
+
+/**
+   \brief ...
+ */
+void rewr_cln_ili(void);
+
+/**
+   \brief ...
+ */
+void rewr_these_ili(int oldili, int newili);
+
+/**
+   \brief ...
+ */
+void rewr_these_ili_nme(int oldili, int newili, int oldnme, int newnme);
+
+#endif // ILIUTIL_H_

--- a/tools/flang2/flang2exe/ilm.h
+++ b/tools/flang2/flang2exe/ilm.h
@@ -15,6 +15,9 @@
  *
  */
 
+#ifndef ILM_H_
+#define ILM_H_
+
 /* ***  ILM Area  *****/
 
 /* ILM_T is defined in gbldefs.h */
@@ -145,40 +148,7 @@ extern char *ilmaux[];  /*  defined in ilmtpdf.h  */
 #define BYVALDEFAULT(func) \
   (!(PASSBYREFG(func)) && (PASSBYVALG(func) | STDCALLG(func) | CFUNCG(func)))
 
-void SaveGilms(FILE *fil);
-void RestoreGilms(FILE *fil);
-void init_global_ilm_position(void);
-void reset_global_ilm_position(void);
-void addlabel(int sptr);
-void init_global_ilm_mode(void);
-int rdgilms(int mode);
-
-#ifdef ST_UNKNOWN /* Use ST_UNKNOWN to detect if SYMTYPE is defined. */
-
-/** If a function returning a value of type ret_type needs
-    to have a pointer to a temporary for possible use as
-    as return slot, return the SYMTYPE for that temporary.
-    Otherwise return ST_UNKNOWN.
-
-    The result is a property of ILM, not the ABI. */
-SYMTYPE
-ilm_symtype_of_return_slot(DTYPE ret_type);
-
-/** Determine if the ILM performs a call and the call has a
-    pointer to a return slot.  If so, return the operand index
-    of the slot.  Otherwise return 0.  Returns 0 for non-call ILMs. */
-int ilm_return_slot_index(ILM_T *ilmp);
-
-#endif
-
 #ifdef N_ILM /* Use N_ILM to detect whether ILM_OP is defined */
-/** Return index of callee for given operation, which must have type IMTY_PROC.
-    index+k is the index for the kth argument.
-    index-1 is the index of the dtype for the function signature if there is
-   one.
-  */
-int ilm_callee_index(ILM_OP opc);
-
 /** Check that ilmptr is plausibly a valid ILM index, and issue internal error
     with text if it is not.  Active only in DEBUG mode. */
 #define ASSERT_IS_LNK(ilmptr, text)                                   \
@@ -188,6 +158,10 @@ int ilm_callee_index(ILM_OP opc);
 
 #define ASSERT_IS_LABEL(labelptr, text) \
   DEBUG_ASSERT(STYPEG(labelptr) == ST_LABEL, (text))
+#endif // N_ILM
+
+#ifndef ILMTOOLBUILD
+#include "ilmutil.h"
 #endif
 
-void set_gilmb_mode(int mode);
+#endif // ILM_H_

--- a/tools/flang2/flang2exe/ilmutil.c
+++ b/tools/flang2/flang2exe/ilmutil.c
@@ -36,10 +36,8 @@
  *     int rdilms()            - read in an ILM block
  */
 
-#include "gbldefs.h"
+#include "ilmutil.h"
 #include "error.h"
-#include "global.h"
-#include "symtab.h"
 #include "ilmtp.h"
 #include "ilm.h"
 #include "fih.h"
@@ -611,7 +609,7 @@ reloc_ilms(ILM_T *p)
       varpart = 0;
       opnd = 1;
     }
-    for (; TRUE; opnd++) {
+    for (;; opnd++) {
       if (noprs == 0) {
         if ((varpart--) == 0)
           break;
@@ -918,7 +916,7 @@ _dumponeilm(ILM_T *ilm_base, int i, int check)
         fprintf(gbl.dbgfil, "<-BAD ARG COUNT");
       }
     }
-  } while (TRUE);
+  } while (true);
   if (pr) {
     char *s;
     switch (opc) {

--- a/tools/flang2/flang2exe/ilmutil.h
+++ b/tools/flang2/flang2exe/ilmutil.h
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef ILMUTIL_H_
+#define ILMUTIL_H_
+
+#include "gbldefs.h"
+#include "symtab.h"
+#include "ilmtp.h"
+
+/**
+   \brief ...
+ */
+ILM_T *save_ilms0(void *area);
+
+/**
+   \brief ...
+ */
+ILM_T *save_ilms(int area);
+
+/**
+   \brief ...
+ */
+int ad1ilm(int opc);
+
+/**
+   \brief ...
+ */
+int ad2ilm(int opc, int opr1);
+
+/**
+   \brief ...
+ */
+int ad3ilm(int opc, int opr1, int opr2);
+
+/**
+   \brief ...
+ */
+int ad4ilm(int opc, int opr1, int opr2, int opr3);
+
+/**
+   \brief ...
+ */
+int ad5ilm(int opc, int opr1, int opr2, int opr3, int opr4);
+
+/**
+   \brief ...
+ */
+int adNilm(int n, int opc, ...);
+
+/**
+   \brief ...
+ */
+int count_ilms(void);
+
+/**
+   \brief ...
+ */
+int _dumponeilm(ILM_T *ilm_base, int i, int check);
+
+/**
+   \brief ...
+ */
+int get_entry(void);
+
+/**
+   \brief FIXME
+   \return index of callee for given operation, which must have type IMTY_PROC.
+   index+k is the index for the kth argument.  index-1 is the index of the dtype
+   for the function signature if there is one.
+ */
+int ilm_callee_index(ILM_OP opc);
+
+/**
+   \brief Determine if the ILM performs a call and the call has a pointer to a
+   return slot.  If so, return the operand index of the slot.  Otherwise return
+   0.  Returns 0 for non-call ILMs.
+ */
+int ilm_return_slot_index(ILM_T *ilmp);
+
+/**
+   \brief ...
+ */
+int rdgilms(int mode);
+
+/**
+   \brief ...
+ */
+int rdilms(void);
+
+/**
+   \brief ...
+ */
+long get_ilmpos(void);
+
+/**
+   \brief ...
+ */
+long get_ilmstart(void);
+
+#ifdef ST_UNKNOWN /* Use ST_UNKNOWN to detect if SYMTYPE is defined. */
+/**
+   \brief If a function returning a value of type ret_type needs to have a
+   pointer to a temporary for possible use as as return slot, return the SYMTYPE
+   for that temporary.  Otherwise return ST_UNKNOWN.
+
+   The result is a property of ILM, not the ABI.
+ */
+SYMTYPE ilm_symtype_of_return_slot(DTYPE ret_type);
+#endif
+
+/**
+   \brief ...
+ */
+void add_ilms(ILM_T *p);
+
+/**
+   \brief ...
+ */
+void addlabel(int sptr);
+
+/**
+   \brief ...
+ */
+void dmpilms(void);
+
+/**
+   \brief ...
+ */
+void _dumpilms(ILM_T *ilm_base, int check);
+
+/**
+   \brief ...
+ */
+void dumpilms(void);
+
+/**
+   \brief ...
+ */
+void dumpilmtree(int ilmptr);
+
+/**
+   \brief ...
+ */
+void dumpilmtrees(void);
+
+/**
+   \brief ...
+ */
+void dumpsingleilm(ILM_T *ilm_base, int i);
+
+/**
+   \brief ...
+ */
+void fini_ilm(void);
+
+/**
+   \brief ...
+ */
+void fini_next_gilm(void);
+
+/**
+   \brief ...
+ */
+void gwrilms(int nilms);
+
+/**
+   \brief ...
+ */
+void init_global_ilm_mode(void);
+
+/**
+   \brief ...
+ */
+void init_global_ilm_position(void);
+
+/**
+   \brief ...
+ */
+void init_ilm(int ilmsize);
+
+/**
+   \brief ...
+ */
+void init_next_gilm(void);
+
+/**
+   \brief ...
+ */
+void mkbranch(int ilmptr, int truelb, int flag);
+
+/**
+   \brief ...
+ */
+void reloc_ilms(ILM_T *p);
+
+/**
+   \brief ...
+ */
+void reset_global_ilm_position(void);
+
+/**
+   \brief ...
+ */
+void restartilms(void);
+
+/**
+   \brief ...
+ */
+void RestoreGilms(FILE *fil);
+
+/**
+   \brief ...
+ */
+void rewindilms(void);
+
+/**
+   \brief ...
+ */
+void SaveGilms(FILE *fil);
+
+/**
+   \brief ...
+ */
+void set_gilmb_mode(int mode);
+
+/**
+   \brief ...
+ */
+void set_ilmpos(long pos);
+
+/**
+   \brief ...
+ */
+void set_ilmstart(int start);
+
+/**
+   \brief ...
+ */
+void swap_next_gilm(void);
+
+/**
+   \brief ...
+ */
+void wrilms(int linenum);
+
+#endif // ILMUTIL_H_

--- a/tools/flang2/flang2exe/ilt.h
+++ b/tools/flang2/flang2exe/ilt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  *
  */
 
-#if !defined(ILT_H__)
-#define ILT_H__
+#ifndef ILT_H_
+#define ILT_H_
 
 /** \file
  * \brief ILT data structures and definitions
@@ -67,7 +67,7 @@ typedef struct {
   int callfg;
   char ldvol;   /* Volatile load flag */
   char stvol;   /* Volatile store flag */
-  char qjsrfg;  /* QJSR flag */
+  bool qjsrfg;  /* QJSR flag */
   char privtmp; /* private temp state; DEBUG-only dmpilt() sets */
 } ILTB;
 
@@ -104,18 +104,6 @@ typedef struct {
 
 extern ILTB iltb;
 
-/*  declare external functions iltutil.c */
-void ilt_init(void);
-void ilt_cleanup(void);
-int addilt(int, int);
-#define adjust_can_throw(iltx) ((void)iltx)
+#include "iltutil.h"
 
-void delilt(int);
-void unlnkilt(int, int, LOGICAL);
-void moveilt(int, int);
-void wrilts(int);
-void rdilts(int);
-void dump_ilt(FILE *ff, int bihx); // dump ILT to a file
-void dmpilt(int bihx); // Synonym to dump_ilt, but outputs to global debug file
-
-#endif // ILT_H__
+#endif // ILT_H_

--- a/tools/flang2/flang2exe/iltutil.c
+++ b/tools/flang2/flang2exe/iltutil.c
@@ -19,7 +19,7 @@
  * \brief ILT utility module
  */
 
-#include "gbldefs.h"
+#include "iltutil.h"
 #include "error.h"
 #include "global.h"
 #include "symtab.h" /* prerequisite for expand.h and ili.h */
@@ -96,7 +96,7 @@ addilt(int after, int ilix)
   iltb.callfg = 0;
   iltb.ldvol = 0;
   iltb.stvol = 0;
-  iltb.qjsrfg = 0;
+  iltb.qjsrfg = false;
   return (i);
 }
 
@@ -125,10 +125,10 @@ delilt(int iltx)
  *
  * \param iltx    ilt to be deleted
  * \param bihx    bih of block from which ilt is deleted (0 => read)
- * \param reuse   TRUE if ilt is to be reused
+ * \param reuse   true if ilt is to be reused
  */
 void
-unlnkilt(int iltx, int bihx, LOGICAL reuse)
+unlnkilt(int iltx, int bihx, bool reuse)
 {
   int i, j;
 

--- a/tools/flang2/flang2exe/iltutil.h
+++ b/tools/flang2/flang2exe/iltutil.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef ILTUTIL_H_
+#define ILTUTIL_H_
+
+#include "gbldefs.h"
+#include <stdio.h>
+
+/**
+   \brief ...
+ */
+int addilt(int after, int ilix);
+
+/**
+   \brief ...
+ */
+int reduce_ilt(int iltx, int ilix);
+
+/**
+   \brief ...
+ */
+void *ccff_ilt_info(int msgtype, char *msgid, int iltx, int bihx, const char *message, ...);
+
+/**
+   \brief ...
+ */
+void delilt(int iltx);
+
+/**
+   \brief ...
+ */
+void dmpilt(int bihx);
+
+/**
+   \brief ...
+ */
+void dump_ilt(FILE *ff, int bihx);
+
+/**
+   \brief ...
+ */
+void ilt_cleanup(void);
+
+/**
+   \brief ...
+ */
+void ilt_init(void);
+
+/**
+   \brief ...
+ */
+void moveilt(int iltx, int before);
+
+/**
+   \brief ...
+ */
+void rdilts(int bihx);
+
+/**
+   \brief ...
+ */
+void relnkilt(int iltx, int bihx);
+
+/**
+   \brief ...
+ */
+void *subccff_ilt_info(void *xparent, int msgtype, char *msgid, int iltx, int bihx, const char *message, ...);
+
+/**
+   \brief ...
+ */
+void unlnkilt(int iltx, int bihx, bool reuse);
+
+/**
+   \brief ...
+ */
+void wrilts(int bihx);
+
+#endif // ILTUTIL_H_

--- a/tools/flang2/flang2exe/kmpcutil.c
+++ b/tools/flang2/flang2exe/kmpcutil.c
@@ -21,16 +21,17 @@
  *
  */
 
-#include "gbldefs.h"
+#define _GNU_SOURCE // for vasprintf()
+#include <stdio.h>
+#undef _GNU_SOURCE
+#include "kmpcutil.h"
 #include "error.h"
-#include "global.h"
-#include "symtab.h"
 #include "semant.h"
 #include "ilmtp.h"
 #include "ilm.h"
 #include "ili.h"
 #include "expand.h"
-#include "kmpcutil.h"
+#include "exputil.h"
 #include "outliner.h"
 #include "machreg.h"
 #include "mp.h"
@@ -975,10 +976,10 @@ mp_sched_to_kmpc_sched(int sched)
 }
 
 /* Returns 'true' if this dtype is to be treated as a signed value */
-static LOGICAL
+static bool
 is_signed(int dtype)
 {
-  return TRUE;
+  return true;
 }
 
 /* Return a JSR ili to __kmpc_for_static_init_<size><signed|unsigned>

--- a/tools/flang2/flang2exe/kmpcutil.h
+++ b/tools/flang2/flang2exe/kmpcutil.h
@@ -15,12 +15,16 @@
  *
  */
 
+#ifndef KMPC_RUNTIME_H_
+#define KMPC_RUNTIME_H_
+
+#include "gbldefs.h"
+#include "global.h"
+#include "symtab.h"
+
 /** \file
  * \brief Various definitions for the kmpc runtime
  */
-
-#ifndef __KMP_RUNTIME_H__
-#define __KMP_RUNTIME_H__
 
 /* KMPC Task Flags
  * See KMPC's kmp.h struct kmp_tasking_flags
@@ -104,60 +108,6 @@ typedef struct any_kmpc_struct {
   int psptr;
 } KMPC_ST_TYPE;
 
-extern int ll_make_kmpc_dispatch_next(int, int, int, int, int);
-extern int ll_make_kmpc_dispatch_init(const loop_args_t *);
-extern int ll_make_kmpc_dispatch_fini(int);
-extern int ll_make_kmpc_fork_call(int, int, int *, RegionType);
-extern int ll_make_kmpc_for_static_init(const loop_args_t *);
-extern int ll_make_kmpc_for_static_init_args(int, int *);
-extern int ll_make_kmpc_barrier(void);
-extern int ll_make_kmpc_cancel_barrier(void);
-extern int ll_make_kmpc_master(void);
-extern int ll_make_kmpc_end_master(void);
-extern int ll_make_kmpc_flush(void);
-extern int ll_make_kmpc_single(void);
-extern int ll_make_kmpc_ordered(void);
-extern int ll_make_kmpc_end_single(void);
-extern int ll_make_kmpc_end_serialized_parallel(void);
-extern int ll_make_kmpc_end_ordered(void);
-extern int ll_make_kmpc_for_static_fini(void);
-extern int ll_make_kmpc_task(int);
-extern int ll_make_kmpc_task_arg(int, int, int, int, int);
-extern int ll_make_kmpc_task_begin_if0(int);
-extern int ll_make_kmpc_task_complete_if0(int);
-extern int ll_make_kmpc_task_wait(void);
-extern int ll_make_kmpc_task_yield(void);
-extern int ll_make_kmpc_threadprivate_cached(int, int, int);
-extern int ll_make_kmpc_threadprivate(int, int);
-extern int ll_make_kmpc_global_thread_num(void);
-extern int ll_make_kmpc_global_num_threads(void);
-extern int ll_make_kmpc_bound_thread_num(void);
-extern int ll_make_kmpc_bound_num_threads(void);
-extern int ll_make_kmpc_push_num_threads(int);
-extern int ll_make_kmpc_serialized_parallel(void);
-extern int ll_make_kmpc_critical(int);
-extern int ll_make_kmpc_end_critical(int);
-extern int ll_make_kmpc_copyprivate(int, int, int);
-extern int ll_make_kmpc_cancel(int);
-extern int ll_make_kmpc_cancellationpoint(int);
-extern int ll_make_kmpc_struct_type(int, char *, KMPC_ST_TYPE *);
-extern int ll_make_kmpc_taskgroup(void);
-extern int ll_make_kmpc_end_taskgroup(void);
-extern int ll_make_kmpc_push_num_teams(int, int);
-extern int ll_make_kmpc_fork_teams(int, int, int *);
-extern int ll_make_kmpc_dist_for_static_init(const loop_args_t *);
-extern int ll_make_kmpc_dist_dispatch_init(const loop_args_t *);
-extern int ll_make_kmpc_push_proc_bind(int);
-extern int ll_make_kmpc_atomic_rd(int, int, char*, char*);
-extern int ll_make_kmpc_atomic_wr(int, int, char*);
-int ll_make_kmpc_taskloop(int*);
-
-extern void reset_kmpc_ident_dtype();
-extern int mp_to_kmpc_tasking_flags(int);
-
-/* Given a MP_ or DI_ schedule type and return the KMPC equivalent */
-extern kmpc_sched_e mp_sched_to_kmpc_sched(int sched);
-
 /* KMPC API macros and structs */
 enum {
   KMPC_API_BAD,
@@ -213,4 +163,275 @@ enum {
   KMPC_API_N_ENTRIES /* <-- Always last */
 };
 
-#endif /* __KMP_RUNTIME_H__ */
+/**
+   \brief ...
+ */
+int ll_make_kmpc_atomic_read(int *opnd, DTYPE dtype);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_atomic_write(int *opnd, DTYPE dtype);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_barrier(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_bound_num_threads(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_bound_thread_num(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_cancel_barrier(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_cancel(int argili);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_cancellationpoint(int argili);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_copyprivate(int array_sptr, int single_ili, int copyfunc_acon);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_critical(int sem);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_dispatch_fini(int dtype);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_dispatch_init(const loop_args_t *inargs);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_dispatch_next(int lower, int upper, int stride, int last, int dtype);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_dist_dispatch_init(const loop_args_t *inargs);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_dist_for_static_init(const loop_args_t *inargs);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_end_critical(int sem);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_end_master(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_end_ordered(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_end_serialized_parallel(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_end_single(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_end_taskgroup(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_flush(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_fork_call(int sptr, int argc, int *arglist, RegionType rt);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_fork_teams(int sptr, int argc, int *arglist);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_for_static_fini(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_for_static_init_args(int dtype, int *inargs);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_for_static_init(const loop_args_t *inargs);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_global_num_threads(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_global_thread_num(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_master(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_omp_wait_deps(const loop_args_t *inargs);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_ordered(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_push_num_teams(int nteams_ili, int thread_limit_ili);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_push_num_threads(int argili);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_push_proc_bind(int argili);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_serialized_parallel(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_single(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_struct_type(int count, char *name, KMPC_ST_TYPE *meminfo);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_task_arg(int base, int sptr, int scope_sptr, int flags_sptr, int uplevel_ili);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_task_begin_if0(int task_sptr);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_task_complete_if0(int task_sptr);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_taskgroup(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_task(int task_sptr);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_taskloop(int *inargs);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_task_wait(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_task_with_deps(const loop_args_t *inargs);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_task_yield(void);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_threadprivate_cached(int data_ili, int size_ili, int cache_ili);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_threadprivate(int data_ili, int size_ili);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_threadprivate_register(int data_ili, int ctor_ili, int cctor_ili, int dtor_ili);
+
+/**
+   \brief ...
+ */
+int ll_make_kmpc_threadprivate_register_vec(int data_ili, int ctor_ili, int cctor_ili, int dtor_ili, int size_ili);
+
+/**
+   \brief ...
+ */
+int mp_to_kmpc_tasking_flags(const int mp);
+
+/**
+   \brief Given a MP_ or DI_ schedule type and return the KMPC equivalent
+ */
+kmpc_sched_e mp_sched_to_kmpc_sched(int sched);
+
+/**
+   \brief ...
+ */
+void reset_kmpc_ident_dtype(void);
+
+
+#endif /* KMPC_RUNTIME_H_ */

--- a/tools/flang2/flang2exe/listing.c
+++ b/tools/flang2/flang2exe/listing.c
@@ -19,6 +19,7 @@
    \brief Fortran source listing file module.
  */
 
+#include "listing.h"
 #include "gbldefs.h"
 #include "global.h"
 #include "version.h"

--- a/tools/flang2/flang2exe/listing.h
+++ b/tools/flang2/flang2exe/listing.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef LISTING_H_
+#define LISTING_H_
+
+#include <stdio.h>
+
+/**
+   \brief ...
+ */
+void list_init(FILE *fd);
+
+/**
+   \brief ...
+ */
+void list_line(char *txt);
+
+/**
+   \brief ...
+ */
+void list_page(void);
+
+#endif // LISTING_H_

--- a/tools/flang2/flang2exe/ll_builder.h
+++ b/tools/flang2/flang2exe/ll_builder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,13 @@
  *
  */
 
-/*
- * ll_builder.h
- *
- * Convenience functions for constructing LLVM IR.
- */
-
 #ifndef LL_BUILDER_H_
 #define LL_BUILDER_H_
+
+/**
+   \file
+   \brief Convenience functions for constructing LLVM IR.
+ */
 
 #include "ll_structure.h"
 #include "llutil.h"
@@ -86,5 +85,86 @@ void llmd_set_class(LLMD_Builder, enum LL_MDClass);
 LL_MDRef llmd_finish(LLMD_Builder);
 
 LL_MDRef ll_finish_variable(LLMD_Builder, LL_MDRef);
+
+/**
+   \brief ...
+ */
+LLMD_Builder llmd_init(LL_Module *module);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_finish_variable(LLMD_Builder mdb, LL_MDRef fwd);
+
+/**
+   \brief ...
+ */
+LL_MDRef llmd_finish(LLMD_Builder mdb);
+
+/**
+   \brief ...
+ */
+unsigned llmd_get_nelems(LLMD_Builder mdb);
+
+/**
+   \brief ...
+ */
+void llmd_add_i1(LLMD_Builder mdb, int value);
+
+/**
+   \brief ...
+ */
+void llmd_add_i32(LLMD_Builder mdb, int value);
+
+/**
+   \brief ...
+ */
+void llmd_add_i64(LLMD_Builder mdb, long long value);
+
+/**
+   \brief ...
+ */
+void llmd_add_i64_lsb_msb(LLMD_Builder mdb, unsigned lsb, unsigned msb);
+
+/**
+   \brief ...
+ */
+void llmd_add_INT64(LLMD_Builder mdb, INT64 value);
+
+/**
+   \brief ...
+ */
+void llmd_add_md(LLMD_Builder mdb, LL_MDRef mdnode);
+
+/**
+   \brief ...
+ */
+void llmd_add_null(LLMD_Builder mdb);
+
+/**
+   \brief ...
+ */
+void llmd_add_string(LLMD_Builder mdb, const char *value);
+
+/**
+   \brief ...
+ */
+void llmd_add_value(LLMD_Builder mdb, LL_Value *value);
+
+/**
+   \brief ...
+ */
+void llmd_reverse(LLMD_Builder mdb);
+
+/**
+   \brief ...
+ */
+void llmd_set_class(LLMD_Builder mdb, enum LL_MDClass mdclass);
+
+/**
+   \brief ...
+ */
+void llmd_set_distinct(LLMD_Builder mdb);
+
 
 #endif /* LL_BUILDER_H_ */

--- a/tools/flang2/flang2exe/ll_ftn.h
+++ b/tools/flang2/flang2exe/ll_ftn.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef LL_FTN_H_
+#define LL_FTN_H_
+
+#include "gbldefs.h"
+#include "ll_structure.h"
+
+/**
+   \brief ...
+ */
+ISZ_T get_socptr_offset(int sptr);
+
+/**
+   \brief ...
+ */
+bool has_multiple_entries(int sptr);
+
+/**
+   \brief ...
+ */
+bool is_fastcall(int ilix);
+
+/**
+   \brief ...
+ */
+char *get_entret_arg_name(void);
+
+/**
+   \brief ...
+ */
+char *get_llvm_ifacenm(int sptr);
+
+/**
+   \brief ...
+ */
+char *get_local_overlap_var(void);
+
+/**
+   \brief ...
+ */
+int get_entries_argnum(void);
+
+/**
+   \brief ...
+ */
+int get_iface_sptr(int sptr);
+
+/**
+   \brief ...
+ */
+int get_master_sptr(void);
+
+/**
+   \brief ...
+ */
+int get_return_type(int func_sptr);
+
+/**
+   \brief ...
+ */
+int is_iso_cptr(int d_dtype);
+
+/**
+   \brief ...
+ */
+int mk_charlen_address(int sptr);
+
+/**
+   \brief ...
+ */
+LL_Type *get_ftn_lltype(int sptr);
+
+/**
+   \brief ...
+ */
+LL_Type *get_local_overlap_vartype(void);
+
+/**
+   \brief ...
+ */
+void assign_array_lltype(int dtype, int size, int sptr);
+
+/**
+   \brief ...
+ */
+void fix_llvm_fptriface(void);
+
+/**
+   \brief ...
+ */
+void get_local_overlap_size(void);
+
+/**
+   \brief ...
+ */
+void ll_process_routine_parameters(int func_sptr);
+
+/**
+   \brief ...
+ */
+void print_entry_subroutine(LL_Module *module);
+
+/**
+   \brief ...
+ */
+void reset_equiv_var(void);
+
+/**
+   \brief ...
+ */
+void reset_master_sptr(void);
+
+/**
+   \brief ...
+ */
+void stb_process_routine_parameters(void);
+
+/**
+   \brief ...
+ */
+void store_llvm_localfptr(void);
+
+/**
+   \brief ...
+ */
+void write_llvm_lltype(int sptr);
+
+/**
+   \brief ...
+ */
+void write_local_overlap(void);
+
+/**
+   \brief ...
+ */
+void write_master_entry_routine(void);
+
+#endif // LL_FTN_H_

--- a/tools/flang2/flang2exe/ll_structure.c
+++ b/tools/flang2/flang2exe/ll_structure.c
@@ -209,18 +209,18 @@ types_equal(hash_key_t key_a, hash_key_t key_b)
   unsigned i, n;
 
   if (a->data_type != b->data_type)
-    return FALSE;
+    return false;
   if (a->flags != b->flags)
-    return FALSE;
+    return false;
   if (a->addrspace != b->addrspace)
-    return FALSE;
+    return false;
   if (a->sub_elements != b->sub_elements)
-    return FALSE;
+    return false;
 
   n = get_num_subtypes(a);
   for (i = 0; i != n; i++)
     if (a->sub_types[i] != b->sub_types[i])
-      return FALSE;
+      return false;
 
   /* FIXME: We really shouldn't be adding named structs to the uniquing
    * tables, but at the moment we may be creating multiple versions of a
@@ -232,7 +232,7 @@ types_equal(hash_key_t key_a, hash_key_t key_b)
   if (a->data_type == LL_STRUCT && (a->flags & LL_TYPE_IS_NAMED_STRUCT))
     return a->str == b->str;
 
-  return TRUE;
+  return true;
 }
 
 static const hash_functions_t types_hash_functions = {types_hash, types_equal};
@@ -347,13 +347,13 @@ mdnode_equal(hash_key_t key_a, hash_key_t key_b)
   unsigned i;
 
   if (a->num_elems != b->num_elems)
-    return FALSE;
+    return false;
 
   for (i = 0; i < a->num_elems; i++)
     if (a->elem[i] != b->elem[i])
-      return FALSE;
+      return false;
 
-  return TRUE;
+  return true;
 }
 
 static const hash_functions_t mdnode_hash_functions = {mdnode_hash,
@@ -1282,7 +1282,7 @@ ll_named_struct_type_exists(LLVMModuleRef module, int id,
 /**
    \brief Create a new named struct type in the module.
 
-   Type can be uniquely named if parameter unique is set to TRUE
+   Type can be uniquely named if parameter unique is set to true
 
    If id is positive, the new struct type is associated with the id so it can be
    retrieved with ll_get_struct_type(). Usually, the TY_STRUCT dtype is used as
@@ -1301,7 +1301,7 @@ ll_named_struct_type_exists(LLVMModuleRef module, int id,
    The type name may be modified to ensure its uniqueness.
  */
 LL_Type *
-ll_create_named_struct_type(LLVMModuleRef module, int id, LOGICAL unique,
+ll_create_named_struct_type(LLVMModuleRef module, int id, bool unique,
                             const char *format, ...)
 {
   va_list ap;
@@ -1356,7 +1356,7 @@ ll_remove_struct_type(LLVMModuleRef module, int struct_id)
    The id must be positive.
 
    If no named struct type has been created with that id, NULL is returned. If
-   required is TRUE, an internal compiler error is signaled instead of returning
+   required is true, an internal compiler error is signaled instead of returning
    NULL.
  */
 LL_Type *
@@ -1896,7 +1896,7 @@ alloc_mdnode(LLVMModuleRef module, enum LL_MDClass mdclass,
   node->num_elems = nelems;
   node->mdclass = mdclass;
   node->is_distinct = is_distinct;
-  node->is_flexible = FALSE;
+  node->is_flexible = false;
   memcpy(node->elem, elems, nelems * sizeof(LL_MDRef));
 
   /* Check for bitfield overflow. */
@@ -1933,8 +1933,8 @@ alloc_flexible_mdnode(LLVMModuleRef module, const LL_MDRef *elems,
   node = (LL_MDNode*) malloc(sizeof(LL_MDNode) + size * sizeof(LL_MDRef));
   node->num_elems = nelems;
   node->mdclass = LL_PlainMDNode;
-  node->is_distinct = FALSE;
-  node->is_flexible = TRUE;
+  node->is_distinct = false;
+  node->is_flexible = true;
   if (nelems)
     memcpy(node->elem, elems, nelems * sizeof(LL_MDRef));
 
@@ -2013,7 +2013,7 @@ LL_MDRef
 ll_get_md_node(LLVMModuleRef module, enum LL_MDClass mdclass,
                const LL_MDRef *elems, unsigned nelems)
 {
-  LL_MDNode *node = alloc_mdnode(module, mdclass, elems, nelems, FALSE);
+  LL_MDNode *node = alloc_mdnode(module, mdclass, elems, nelems, false);
   LL_MDRef mdref = LL_MDREF_INITIALIZER(MDRef_Node, 0);
   hash_data_t oldval;
   unsigned mdnum;
@@ -2069,7 +2069,7 @@ LL_MDRef
 ll_create_distinct_md_node(LLVMModuleRef module, enum LL_MDClass mdclass,
                            const LL_MDRef *elems, unsigned nelems)
 {
-  LL_MDNode *node = alloc_mdnode(module, mdclass, elems, nelems, TRUE);
+  LL_MDNode *node = alloc_mdnode(module, mdclass, elems, nelems, true);
   LL_MDRef md = LL_MDREF_INITIALIZER(MDRef_Node, insert_mdnode(module, node));
   return md;
 }
@@ -2454,13 +2454,13 @@ ll_proto_get_abi(const char *fnname)
 /**
    \brief Set the flag "function has body"
    \param fnname       a key (function name)
-   \param has_defined  TRUE iff \p fnname is a definition
+   \param has_defined  true iff \p fnname is a definition
 
    Sets the bit representing the information that the body of the function
    represented by \p fnname is defined.
  */
 void
-ll_proto_set_defined_body(const char *fnname, LOGICAL has_defined)
+ll_proto_set_defined_body(const char *fnname, bool has_defined)
 {
   LL_FnProto *proto = NULL;
 
@@ -2470,7 +2470,7 @@ ll_proto_set_defined_body(const char *fnname, LOGICAL has_defined)
   proto->has_defined_body = has_defined;
 }
 
-LOGICAL
+bool
 ll_proto_has_defined_body(const char *fnname)
 {
   LL_FnProto *proto = NULL;
@@ -2484,13 +2484,13 @@ ll_proto_has_defined_body(const char *fnname)
 /**
    \brief Set the flag "function is weak"
    \param fnname       a key (function name)
-   \param is_weak      TRUE iff \p fnname is weak
+   \param is_weak      true iff \p fnname is weak
 
    Sets the bit representing the information that the function
    represented by \p fnname is weak.
  */
 void
-ll_proto_set_weak(const char *fnname, LOGICAL is_weak)
+ll_proto_set_weak(const char *fnname, bool is_weak)
 {
   LL_FnProto *proto = NULL;
 
@@ -2500,7 +2500,7 @@ ll_proto_set_weak(const char *fnname, LOGICAL is_weak)
   proto->is_weak = is_weak;
 }
 
-LOGICAL
+bool
 ll_proto_is_weak(const char *fnname)
 {
   LL_FnProto *proto = NULL;

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -905,10 +905,6 @@ LL_FnProto *ll_proto_add(const char *fnname, struct LL_ABI_Info_ *abi);
 LL_FnProto *ll_proto_add_sptr(int sptr, struct LL_ABI_Info_ *abi);
 void ll_proto_set_abi(const char *fnname, struct LL_ABI_Info_ *abi);
 struct LL_ABI_Info_ *ll_proto_get_abi(const char *fnname);
-void ll_proto_set_defined_body(const char *fnname, LOGICAL has_defined);
-LOGICAL ll_proto_has_defined_body(const char *fnname);
-void ll_proto_set_weak(const char *fnname, LOGICAL is_weak);
-LOGICAL ll_proto_is_weak(const char *fnname);
 void ll_proto_set_intrinsic(const char *fnname, const char *intrinsic_decl_str);
 
 /**
@@ -934,8 +930,6 @@ void ll_create_sym(struct LL_Symbols_ *, int, LL_Value *);
 
 LL_Value *ll_named_struct_type_exists(LLVMModuleRef module, int id,
                                       const char *format, ...);
-LL_Type *ll_create_named_struct_type(LLVMModuleRef, int id, LOGICAL unique,
-                                     const char *format, ...);
 void ll_remove_struct_type(LLVMModuleRef, int id);
 LL_Type *ll_get_struct_type(LLVMModuleRef, int id, int required);
 void ll_set_struct_body(LL_Type *ctype, LL_Type *const *elements,
@@ -1091,5 +1085,534 @@ llObjtodbgGet(LL_ObjToDbgListIter *iter)
 
 void llObjtodbgPush(LL_ObjToDbgList *odl, LL_MDRef md);
 void llObjtodbgFree(LL_ObjToDbgList *ods);
+
+/**
+   \brief ...
+ */
+ISZ_T ll_type_bytes(LL_Type *type);
+
+/**
+   \brief ...
+ */
+ISZ_T ll_type_bytes_unchecked(LL_Type *type);
+
+/**
+   \brief ...
+ */
+bool ll_proto_has_defined_body(const char *fnname);
+
+/**
+   \brief ...
+ */
+bool ll_proto_is_weak(const char *fnname);
+
+/**
+   \brief ...
+ */
+const char *ll_create_local_name(LL_Function *function, const char *format, ...);
+
+/**
+   \brief ...
+ */
+const char *ll_get_calling_conv_str(enum LL_CallConv cc);
+
+/**
+   \brief ...
+ */
+const char *ll_get_str_type_for_basic_type(enum LL_BaseDataType type);
+
+/**
+   \brief ...
+ */
+const char *ll_proto_key(int func_sptr);
+
+/**
+   \brief ...
+ */
+int is_module_var(LLVMModuleRef module, LL_Value *modvar);
+
+/**
+   \brief ...
+ */
+int ll_create_module_var(LLVMModuleRef module, LL_Value *modvar);
+
+/**
+   \brief ...
+ */
+int ll_get_pointer_addrspace(LL_Type *ptr);
+
+/**
+   \brief ...
+ */
+int ll_type_is_fp(LL_Type *ty);
+
+/**
+   \brief ...
+ */
+int ll_type_is_mem_seq(LL_Type *ty);
+
+/**
+   \brief ...
+ */
+int ll_type_is_pointer_to_function(LL_Type *ty);
+
+/**
+   \brief ...
+ */
+LL_FnProto *ll_proto_add(const char *fnname, struct LL_ABI_Info_ *abi);
+
+/**
+   \brief ...
+ */
+LL_FnProto *ll_proto_add_sptr(int func_sptr, struct LL_ABI_Info_ *abi);
+
+/**
+   \brief ...
+ */
+LL_Function *ll_create_function_from_type(LL_Type *func_type, const char *name);
+
+/**
+   \brief ...
+ */
+LL_IRVersion get_llvm_version(void);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_create_distinct_md_node(LLVMModuleRef module, enum LL_MDClass mdclass, const LL_MDRef *elems, unsigned nelems);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_create_flexible_md_node(LLVMModuleRef module);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_get_global_debug(LLVMModuleRef module, int sptr);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_get_md_i1(int value);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_get_md_i32(LLVMModuleRef module, int value);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_get_md_i64(LLVMModuleRef module, long long value);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_get_md_node(LLVMModuleRef module, enum LL_MDClass mdclass, const LL_MDRef *elems, unsigned nelems);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_get_md_rawstring(LLVMModuleRef module, const void *rawstr, size_t length);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_get_md_string(LLVMModuleRef module, const char *str);
+
+/**
+   \brief ...
+ */
+LL_MDRef ll_get_md_value(LLVMModuleRef module, LL_Value *value);
+
+/**
+   \brief ...
+ */
+LL_Object *ll_create_global_alias(LL_Value *aliasee_ptr, const char *format, ...);
+
+/**
+   \brief ...
+ */
+LL_Object *ll_create_global_object_with_type(LL_Type *type, int addrspace, const char *format, ...);
+
+/**
+   \brief ...
+ */
+LL_Object *ll_create_local_object(LL_Function *function, LL_Type *type, unsigned align_bytes, const char *format, ...);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_create_anon_struct_type(LLVMModuleRef module, LL_Type *elements[], unsigned num_elements, bool is_packed);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_create_basic_type(LLVMModuleRef module, enum LL_BaseDataType type, int addrspace);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_create_function_type(LLVMModuleRef module, LL_Type *args[], unsigned num_args, int is_varargs);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_create_int_type(LLVMModuleRef module, unsigned bits);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_create_named_struct_type(LLVMModuleRef module, int id, bool unique,
+                                     const char *format, ...);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_get_addrspace_type(LL_Type *type, int addrspace);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_get_array_type(LL_Type *type, BIGUINT64 num_elements, int addrspace);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_get_pointer_type(LL_Type *type);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_get_struct_type(LLVMModuleRef module, int struct_id, int required);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_get_vector_type(LL_Type *type, unsigned num_elements);
+
+/**
+   \brief ...
+ */
+LL_Type *ll_type_array_elety(LL_Type *ty);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_create_array_value_from_type(LLVMModuleRef module, LL_Type *type,
+                                          const char *data, int addrspace);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_create_array_value(LLVMModuleRef module, enum LL_BaseDataType type, const char *data, BIGUINT64 num_elements, int addrspace);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_create_basic_value(LLVMModuleRef module, enum LL_BaseDataType type, const char *data, int addrspace);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_create_metadata_value(LLVMModuleRef module, LL_MDRef mdref);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_create_metadata_wrapper(LLVMModuleRef module, LL_Value *towrap);
+
+/**
+   \brief ...
+ */
+LL_Value **ll_create_operands(LLVMModuleRef module, int num_operands);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_create_pointer_value_from_type(
+    LLVMModuleRef module, LL_Type *type, const char *data, int addrspace);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_create_pointer_value(
+    LLVMModuleRef module, enum LL_BaseDataType type, const char *data,
+    int addrspace);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_create_value_from_type(LLVMModuleRef module, LL_Type *type,
+                                    const char *data);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_create_value(LLVMModuleRef module, enum LL_BaseDataType type, const char *data);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_get_const_addrspacecast(LLVMModuleRef module, LL_Value *value, LL_Type *type);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_get_const_bitcast(LLVMModuleRef module, LL_Value *value, LL_Type *type);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_get_const_gep(LLVMModuleRef module, LL_Value *ptr, unsigned num_idx, ...);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_get_const_int(LLVMModuleRef module, unsigned bits, long long value);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_get_function_local(struct LL_Function_ *function, int index);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_get_function_pointer(LLVMModuleRef module, LL_Function *function);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_get_global_pointer(const char *name, LL_Type *type);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_get_sym(struct LL_Symbols_ *symbol_table, int index);
+
+/**
+   \brief ...
+ */
+LL_Value *ll_named_struct_type_exists(LLVMModuleRef module, int id, const char *format, ...);
+
+/**
+   \brief ...
+ */
+LLVMModuleRef ll_create_module(const char *module_name, const char *target_triple, enum LL_IRVersion llvm_ir_version);
+
+/**
+   \brief ...
+ */
+struct LL_ABI_Info_ *ll_proto_get_abi(const char *fnname);
+
+/**
+   \brief ...
+ */
+struct LL_BasicBlock_ *ll_create_basic_block(struct LL_Function_ *function, const char *name);
+
+/**
+   \brief ...
+ */
+struct LL_Function_ *ll_create_function(LLVMModuleRef module, const char *name, LL_Type *return_type, int is_kernel, int launch_bounds, const char *calling_convention, enum LL_LinkageType linkage);
+
+/**
+   \brief ...
+ */
+struct LL_Instruction_ *ll_create_empty_instruction(struct LL_BasicBlock_ *bb, enum LL_Op op, int num_operands);
+
+/**
+   \brief ...
+ */
+struct LL_Instruction_ *ll_create_instruction(struct LL_BasicBlock_ *bb, enum LL_Op op, LL_Value **operands, int num_operands);
+
+/**
+   \brief ...
+ */
+struct LL_Symbols_ *ll_create_sym_table(int num_symbols);
+
+/**
+   \brief ...
+ */
+unsigned ll_feature_dwarf_version(const LL_IRFeatures *feature);
+
+/**
+   \brief ...
+ */
+unsigned ll_reserve_md_node(LLVMModuleRef module);
+
+/**
+   \brief ...
+ */
+unsigned ll_type_int_bits(LL_Type *type);
+
+/**
+   \brief ...
+ */
+void ll_add_global_debug(LLVMModuleRef module, int sptr, LL_MDRef mdnode);
+
+/**
+   \brief ...
+ */
+void ll_append_llvm_used(LLVMModuleRef module, LL_Value *ptr);
+
+/**
+   \brief ...
+ */
+void ll_create_module_extern_func_ref(LLVMModuleRef module, LL_Value *new_ref);
+
+/**
+   \brief ...
+ */
+void ll_create_sym(struct LL_Symbols_ *symbol_table, int index, LL_Value *new_value);
+
+/**
+   \brief ...
+ */
+void ll_destroy_function(struct LL_Function_ *function);
+
+/**
+   \brief ...
+ */
+void ll_destroy_mem(struct LL_ManagedMallocs_ *current);
+
+/**
+   \brief ...
+ */
+void ll_destroy_module(LLVMModuleRef module);
+
+/**
+   \brief ...
+ */
+void ll_destroy_sym_table(struct LL_Symbols_ *sym_tab);
+
+/**
+   \brief ...
+ */
+void ll_extend_md_node(LLVMModuleRef module, LL_MDRef flexnode, LL_MDRef elem);
+
+/**
+   \brief ...
+ */
+void ll_extend_named_md_node(LLVMModuleRef module, enum LL_MDName name,
+                             LL_MDRef elem);
+
+/**
+   \brief ...
+ */
+void llObjtodbgFree(LL_ObjToDbgList *ods);
+
+/**
+   \brief ...
+ */
+void llObjtodbgPush(LL_ObjToDbgList *odl, LL_MDRef md);
+
+/**
+   \brief ...
+ */
+void ll_proto_dump(void);
+
+/**
+   \brief ...
+ */
+void ll_proto_init(void);
+
+/**
+   \brief ...
+ */
+void ll_proto_iterate(LL_FnProto_Handler callback);
+
+/**
+   \brief ...
+ */
+void ll_proto_set_abi(const char *fnname, struct LL_ABI_Info_ *abi);
+
+/**
+   \brief ...
+ */
+void ll_proto_set_defined_body(const char *fnname, bool has_defined);
+
+/**
+   \brief ...
+ */
+void ll_proto_set_intrinsic(const char *fnname, const char *intrinsic_decl_str);
+
+/**
+   \brief ...
+ */
+void ll_proto_set_weak(const char *fnname, bool is_weak);
+
+/**
+   \brief ...
+ */
+void ll_remove_struct_type(LLVMModuleRef module, int struct_id);
+
+/**
+   \brief ...
+ */
+void ll_reset_module_functions(LLVMModuleRef module);
+
+/**
+   \brief ...
+ */
+void ll_reset_module_types(LLVMModuleRef module);
+
+/**
+   \brief ...
+ */
+void ll_set_function_argument(struct LL_Function_ *function, int index,
+                              LL_Value *argument);
+
+/**
+   \brief ...
+ */
+void ll_set_function_local(struct LL_Function_ *function, LL_Value *local);
+
+/**
+   \brief ...
+ */
+void ll_set_function_num_arguments(struct LL_Function_ *function, int num_args);
+
+/**
+   \brief ...
+ */
+void ll_set_md_node(LLVMModuleRef module, unsigned mdNum, LL_MDNode *node);
+
+/**
+   \brief ...
+ */
+void ll_set_named_md_node(LLVMModuleRef module, enum LL_MDName name,
+                          const LL_MDRef *elems, unsigned nelems);
+
+/**
+   \brief ...
+ */
+void ll_set_struct_body(LL_Type *ctype, LL_Type *const *elements,
+                        unsigned *const offsets, char *const pads,
+                        unsigned num_elements, int is_packed);
+
+/**
+   \brief ...
+ */
+void ll_set_struct_element(LL_Type *ctype, unsigned elem_index,
+                           LL_Type *elem_type);
+
+/**
+   \brief ...
+ */
+void ll_unique_func_ref(LLVMModuleRef module);
+
+/**
+   \brief ...
+ */
+void ll_update_extern_func_refs(LLVMModuleRef module,
+                                struct LL_Function_ *function);
+
+/**
+   \brief ...
+ */
+void ll_update_md_node(LLVMModuleRef module, LL_MDRef node_to_update,
+                       unsigned elem_index, LL_MDRef elem);
 
 #endif

--- a/tools/flang2/flang2exe/ll_write.h
+++ b/tools/flang2/flang2exe/ll_write.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2014-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,22 +19,81 @@
 #define LL_WRITE_H_
 
 #include <stdio.h>
-
 #include "ll_structure.h"
 
-void ll_write_module(FILE *, LLVMModuleRef);
-void ll_write_module_header(FILE *out, LLVMModuleRef module);
-void ll_write_function(FILE *, struct LL_Function_ *, LLVMModuleRef module);
-void ll_write_basicblock(FILE *, struct LL_Function_ *,
-                         struct LL_BasicBlock_ *, LLVMModuleRef module);
-void ll_write_instruction(FILE *, struct LL_Instruction_ *, LLVMModuleRef module);
-void ll_write_function_signature(FILE *, struct LL_Function_ *);
-void ll_write_global_var_signature(FILE *, LL_Value *);
-void ll_write_user_structs(FILE *out, LLVMModuleRef module);
-void ll_write_llvm_used(FILE *out, LLVMModuleRef module);
+/**
+   \brief ...
+ */
+void ll_write_basicblock(FILE *out, LL_Function *function, LL_BasicBlock *block,
+                         LL_Module *module);
+
+/**
+   \brief ...
+ */
+void ll_write_function(FILE *out, LL_Function *function, LL_Module *module);
+
+/**
+   \brief ...
+ */
+void ll_write_function_signature(FILE *out, struct LL_Function_ *function);
+
+/**
+   \brief ...
+ */
 void ll_write_global_objects(FILE *out, LLVMModuleRef module);
-void ll_write_local_objects(FILE *out, struct LL_Function_ *function);
+
+/**
+   \brief ...
+ */
+void ll_write_global_var_signature(FILE *out, LL_Value *variable);
+
+/**
+   \brief ...
+ */
+void ll_write_instruction(FILE *out, struct LL_Instruction_ *inst,
+                          LL_Module *module);
+
+/**
+   \brief ...
+ */
+void ll_write_llvm_used(FILE *out, LLVMModuleRef module);
+
+/**
+   \brief ...
+ */
+void ll_write_local_objects(FILE *out, LL_Function *function);
+
+/**
+   \brief ...
+ */
 void ll_write_metadata(FILE *out, LLVMModuleRef module);
-void ll_write_object_dbg_references(FILE *, LL_Module *, LL_ObjToDbgList *);
+
+/**
+   \brief ...
+ */
+void ll_write_module(FILE *out, LL_Module *module);
+
+/**
+   \brief ...
+ */
+void ll_write_module_header(FILE *out, LLVMModuleRef module);
+
+/**
+   \brief ...
+ */
+void ll_write_object_dbg_references(FILE *out, LL_Module *m,
+                                    LL_ObjToDbgList *ods);
+
+/**
+   \brief ...
+ */
+void ll_write_user_structs(FILE *out, LLVMModuleRef module);
+
+/**
+   \brief ...
+ */
+void write_mdref(FILE *out, LL_Module *module, LL_MDRef rmdref,
+                 int omit_metadata_type);
+
 
 #endif

--- a/tools/flang2/flang2exe/llassem.h
+++ b/tools/flang2/flang2exe/llassem.h
@@ -18,6 +18,9 @@
 #ifndef LLASSEM_H_
 #define LLASSEM_H_
 
+#include "gbldefs.h"
+#include "global.h"
+#include "symtab.h"
 #include "llutil.h"
 
 typedef struct argdtlist DTLIST;
@@ -77,10 +80,8 @@ extern int master_sptr;
 char *get_string_constant(int);
 char *get_local_overlap_var(void);
 int get_ag_argdtlist_length(int gblsym);
-LOGICAL get_byval_from_argdtlist(const char *argdtlist);
 int get_sptr_from_argdtlist(char *argdtlist);
 int get_sptr_uplevel_address(int sptr);
-LOGICAL is_llvmag_entry(int gblsym);
 void set_llvmag_entry(int gblsym);
 void set_ag_argdtlist_is_valid(int gblsym);
 void llvm_funcptr_store(int sptr, char *ag_name);
@@ -178,7 +179,7 @@ typedef struct {
                       bss area (only for AGL ag-local) */
   int dtypesc;     /**< dtype scope */
   int n_argdtlist; /**< Number of items in argdtlist */
-  LOGICAL argdtlist_is_set; /**< Argdtlist has built, perhaps with 0 args */
+  bool argdtlist_is_set; /**< Argdtlist has built, perhaps with 0 args */
   char stype;               /**< ST_ of global */
   char sc;                  /**< SC_ of global */
   char alloc;               /**< ALLOCATABLE flag */
@@ -375,9 +376,414 @@ int get_master_sptr(void);
 int generic_dummy_dtype(void);
 LL_Type *make_generic_dummy_lltype(void);
 void set_llvm_iface_oldname(int, char *);
-LL_ABI_Info *process_ll_abi_func_ftn(int, LOGICAL);
 LL_Type *get_local_overlap_vartype(void);
 LL_ObjToDbgList **llassem_get_objtodbg_list(SPTR sptr);
 void ll_process_routine_parameters(int sptr);
+
+/**
+   \brief ...
+ */
+bool get_byval_from_argdtlist(const char *argdtlist);
+
+/**
+   \brief ...
+ */
+bool has_typedef_ag(int gblsym);
+
+/**
+   \brief ...
+ */
+bool is_llvmag_entry(int gblsym);
+
+/**
+   \brief ...
+ */
+bool is_llvmag_iface(int gblsym);
+
+/**
+   \brief ...
+ */
+bool is_typedesc_defd(int sptr);
+
+/**
+   \brief ...
+ */
+char *getaddrdebug(int sptr);
+
+/**
+   \brief ...
+ */
+char *get_ag_name(int gblsym);
+
+/**
+   \brief ...
+ */
+char *get_ag_typename(int gblsym);
+
+/**
+   \brief ...
+ */
+char *get_argdtlist(int gblsym);
+
+/**
+   \brief ...
+ */
+char *getextfuncname(int sptr);
+
+/**
+   \brief ...
+ */
+char *get_llvm_name(int sptr);
+
+/**
+   \brief ...
+ */
+char *get_main_progname(void);
+
+/**
+   \brief ...
+ */
+char *get_next_argdtlist(char *argdtlist);
+
+/**
+   \brief ...
+ */
+char *getsname(int sptr);
+
+/**
+   \brief ...
+ */
+char *get_string_constant(int sptr);
+
+/**
+   \brief ...
+ */
+DTYPE get_ftn_typedesc_dtype(SPTR sptr);
+
+/**
+   \brief ...
+ */
+int add_ag_typename(int gblsym, char *typeName);
+
+/**
+   \brief ...
+ */
+int find_ag(const char *ag_name);
+
+/**
+   \brief ...
+ */
+int find_funcptr_name(int sptr);
+
+/**
+   \brief ...
+ */
+int get_ag_argdtlist_length(int gblsym);
+
+/**
+   \brief ...
+ */
+int get_ag(int sptr);
+
+/**
+   \brief ...
+ */
+int get_bss_addr(void);
+
+/**
+   \brief ...
+ */
+int get_dummy_ag(int sptr);
+
+/**
+   \brief ...
+ */
+int get_hollerith_size(int sptr);
+
+/**
+   \brief ...
+ */
+int get_intrin_ag(char *ag_name, int dtype);
+
+/**
+   \brief ...
+ */
+int get_llvm_funcptr_ag(int sptr, char *ag_name);
+
+/**
+   \brief ...
+ */
+int get_private_size(void);
+
+/**
+   \brief ...
+ */
+int get_sptr_from_argdtlist(char *argdtlist);
+
+/**
+   \brief ...
+ */
+int get_sptr_uplevel_address(int sptr);
+
+/**
+   \brief ...
+ */
+int get_stack_size(void);
+
+/**
+   \brief ...
+ */
+int get_typedef_ag(char *ag_name, char *typeName);
+
+/**
+   \brief ...
+ */
+int get_uplevel_address_size(void);
+
+/**
+   \brief ...
+ */
+int has_valid_ag_argdtlist(int gblsym);
+
+/**
+   \brief ...
+ */
+int is_cache_aligned(int syma);
+
+/**
+   \brief ...
+ */
+int ll_shallow_copy_uplevel(int hostsptr, int olsptr);
+
+/**
+   \brief ...
+ */
+int local_funcptr_sptr_to_gblsym(int sptr);
+
+/**
+   \brief ...
+ */
+int make_uplevel_arg_struct(void);
+
+/**
+   \brief ...
+ */
+int runtime_32_byte_alignment(int acon_sptr);
+
+/**
+   \brief ...
+ */
+int runtime_alignment(int syma);
+
+/**
+   \brief ...
+ */
+LL_ObjToDbgList **llassem_get_objtodbg_list(SPTR sptr);
+
+/**
+   \brief ...
+ */
+LL_Type *get_ag_lltype(int gblsym);
+
+/**
+   \brief ...
+ */
+LL_Type *get_ag_return_lltype(int gblsym);
+
+/**
+   \brief ...
+ */
+LL_Type *get_lltype_from_argdtlist(char *argdtlist);
+
+/**
+   \brief ...
+ */
+unsigned align_of_var(SPTR sptr);
+
+/**
+   \brief ...
+ */
+void addag_llvm_argdtlist(int gblsym, int arg_num, int arg_sptr, LL_Type *lltype);
+
+/**
+   \brief ...
+ */
+void add_aguplevel_oldsptr(void);
+
+/**
+   \brief ...
+ */
+void _add_llvm_uplevel_symbol(int oldsptr);
+
+/**
+   \brief ...
+ */
+void add_uplevel_to_host(int *ptr, int cnt);
+
+/**
+   \brief ...
+ */
+void arg_is_refd(int sptr);
+
+/**
+   \brief ...
+ */
+void assem_begin_func(int sptr);
+
+/**
+   \brief ...
+ */
+void assemble_end(void);
+
+/**
+   \brief ...
+ */
+void assemble_init(int argc, char *argv[], char *cmdline);
+
+/**
+   \brief ...
+ */
+void assemble(void);
+
+/**
+   \brief ...
+ */
+void assem_data(void);
+
+/**
+   \brief ...
+ */
+void assem_dinit(void);
+
+/**
+   \brief ...
+ */
+void assem_emit_align(int n);
+
+/**
+   \brief ...
+ */
+void assem_emit_file_line(int findex, int lineno);
+
+/**
+   \brief ...
+ */
+void assem_emit_line(int findex, int lineno);
+
+/**
+   \brief ...
+ */
+void assem_end(void);
+
+/**
+   \brief ...
+ */
+void assem_init(void);
+
+/**
+   \brief ...
+ */
+void assem_put_linux_trace(int sptr);
+
+/**
+   \brief ...
+ */
+void create_static_base(int num);
+
+/**
+   \brief ...
+ */
+void create_static_name(char *name, int usestatic, int num);
+
+/**
+   \brief ...
+ */
+void deleteag_llvm_argdtlist(int gblsym);
+
+/**
+   \brief ...
+ */
+void fix_equiv_locals(int loc_list, ISZ_T loc_addr);
+
+/**
+   \brief ...
+ */
+void fix_equiv_statics(int loc_list, ISZ_T loc_addr, bool dinitflg);
+
+/**
+   \brief ...
+ */
+void fix_private_sym(int sptr);
+
+/**
+   \brief ...
+ */
+void _fixup_llvm_uplevel_symbol(void);
+
+/**
+   \brief ...
+ */
+void hostsym_is_refd(int sptr);
+
+/**
+   \brief ...
+ */
+void llvm_funcptr_store(int sptr, char *ag_name);
+
+/**
+   \brief ...
+ */
+void load_uplevel_addresses(int display_temp);
+
+/**
+   \brief ...
+ */
+void put_fstr(int sptr, int add_null);
+
+/**
+   \brief ...
+ */
+void put_section(int sect);
+
+/**
+   \brief ...
+ */
+void set_ag_argdtlist_is_valid(int gblsym);
+
+/**
+   \brief ...
+ */
+void set_ag_lltype(int gblsym, LL_Type *llt);
+
+/**
+   \brief ...
+ */
+void set_ag_return_lltype(int gblsym, LL_Type *llt);
+
+/**
+   \brief ...
+ */
+void set_bss_addr(int size);
+
+/**
+   \brief ...
+ */
+void set_llvmag_entry(int gblsym);
+
+/**
+   \brief ...
+ */
+void set_llvm_iface_oldname(int gblsym, char *nm);
+
+/**
+   \brief ...
+ */
+void set_private_size(ISZ_T sz);
+
+/**
+   \brief ...
+ */
+void sym_is_refd(int sptr);
+
 
 #endif

--- a/tools/flang2/flang2exe/llassem_common.c
+++ b/tools/flang2/flang2exe/llassem_common.c
@@ -20,20 +20,17 @@
    Some various functions that emit LLVM IR.
  */
 
-#include "gbldefs.h"
+#include "llassem_common.h"
+#include "dtypeutl.h"
 #include "error.h"
-#include "global.h"
-#include "symtab.h"
 #include "dinit.h"
 #include "version.h"
 #include "machreg.h"
 #include "assem.h"
 #include "x86.h"
-#include "ili.h"
 #include "llutil.h"
 #include "cgllvm.h"
 #include "cg.h"
-#include "ll_structure.h"
 #include "llassem.h"
 
 /* define globals */
@@ -940,10 +937,10 @@ void
 put_addr(int sptr, ISZ_T off, int dtype)
 {
   const char *name, *elem_type;
-  LOGICAL is_static_or_common_block_var, in_fortran;
+  bool is_static_or_common_block_var, in_fortran;
 
-  in_fortran = FALSE;
-  in_fortran = TRUE;
+  in_fortran = false;
+  in_fortran = true;
 
   /* Static and common block variables require special handling for now */
   is_static_or_common_block_var = (SCG(sptr) == SC_STATIC);
@@ -1020,7 +1017,7 @@ mk_struct_for_llvm_init(const char *name, int size)
   DTY(dtype + 4) = 0; /* align */
   DTY(dtype + 5) = 0;
   if (size == 0)
-    process_ftn_dtype_struct(dtype, sname, TRUE);
+    process_ftn_dtype_struct(dtype, sname, true);
   return dtype;
 }
 

--- a/tools/flang2/flang2exe/llassem_common.h
+++ b/tools/flang2/flang2exe/llassem_common.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef LLASSEM_COMMON_H_
+#define LLASSEM_COMMON_H_
+
+#include "gbldefs.h"
+#include "global.h"
+#include "symtab.h"
+#include "ll_structure.h"
+
+/**
+   \brief ...
+ */
+ISZ_T put_skip(ISZ_T old, ISZ_T New);
+
+/**
+   \brief ...
+ */
+char *put_next_member(char *ptr);
+
+/**
+   \brief ...
+ */
+int add_member_for_llvm(int sym, int prev, DTYPE dtype, ISZ_T size);
+
+/**
+   \brief ...
+ */
+int mk_struct_for_llvm_init(const char *name, int size);
+
+/**
+   \brief ...
+ */
+LL_Value *gen_ptr_offset_val(int offset, LL_Type *ret_type, char *ptr_nm);
+
+/**
+   \brief ...
+ */
+void add_init_routine(char *initroutine);
+
+/**
+   \brief ...
+ */
+void emit_init(int tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
+               ISZ_T loc_base, ISZ_T *i8cnt, int *ptrcnt, char **cptr);
+
+/**
+   \brief ...
+ */
+void init_daz(void);
+
+/**
+   \brief ...
+ */
+void init_flushz(void);
+
+/**
+   \brief ...
+ */
+void init_huge_tlb(void);
+
+/**
+   \brief ...
+ */
+void init_ktrap(void);
+
+/**
+   \brief ...
+ */
+void init_Mcuda_compiled(void);
+
+/**
+   \brief ...
+ */
+void put_addr(int sptr, ISZ_T off, int dtype);
+
+/**
+   \brief ...
+ */
+void put_i32(int val);
+
+/**
+   \brief ...
+ */
+void put_int4(int val);
+
+/**
+   \brief ...
+ */
+void put_short(int val);
+
+/**
+   \brief ...
+ */
+void put_string_n(char *p, ISZ_T len, int size);
+
+#endif // LLASSEM_COMMON_H_

--- a/tools/flang2/flang2exe/lldebug.h
+++ b/tools/flang2/flang2exe/lldebug.h
@@ -20,10 +20,12 @@
    \brief Debug info generation for LLVM IR.
  */
 
-#ifndef LLDEBUG_H__
-#define LLDEBUG_H__
+#ifndef LLDEBUG_H_
+#define LLDEBUG_H_
 
+#include "gbldefs.h"
 #include "ll_structure.h"
+#include "llutil.h"
 
 /**
    \brief Allocate and initialize debug info generation for module
@@ -76,7 +78,7 @@ LL_MDRef lldbg_emit_module_mdnode(LL_DebugInfo *db, int sptr);
    lldbg_set_func_ptr().
  */
 void lldbg_emit_subprogram(LL_DebugInfo *db, int sptr, int ret_dtype,
-                           int findex, LOGICAL);
+                           int findex, bool targetNVVM);
 
 /**
    \brief Create a metadata node for the outlined subprogram \p sptr
@@ -94,7 +96,7 @@ void lldbg_emit_subprogram(LL_DebugInfo *db, int sptr, int ret_dtype,
  */
 void lldbg_emit_outlined_subprogram(LL_DebugInfo *db, int sptr, int findex,
                                     const char *func_name, int startlineno,
-                                    LOGICAL);
+                                    bool targetNVVM);
 
 /**
    \brief Provide a function pointer to the curent subprogram
@@ -167,7 +169,6 @@ int lldbg_encode_expression_arg(LL_DW_OP_t op, int value);
 
 void lldbg_emit_line(LL_DebugInfo *, int lineno);
 void lldbg_emit_lv_list(LL_DebugInfo *);
-void lldbg_emit_outlined_parameter_list(LL_DebugInfo *, int, int *, int);
 void lldbg_emit_cmblk_variables(LL_DebugInfo *, int, int, char *, int);
 LL_MDRef lldbg_emit_ptr_param_variable(LL_DebugInfo *, int, int, int);
 
@@ -212,4 +213,160 @@ char *get_llvm_mips_sname(int sptr);
 
 void lldbg_cleanup_missing_bounds(LL_DebugInfo *db, int findex);
 
-#endif /* LLDEBUG_H__ */
+/**
+   \brief ...
+ */
+char *lldbg_alloc(INT size);
+
+/**
+   \brief ...
+ */
+int lldbg_encode_expression_arg(LL_DW_OP_t op, int value);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_cons_line(LL_DebugInfo *db);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_emit_compile_unit(LL_DebugInfo *db);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_emit_empty_expression_mdnode(LL_DebugInfo *db);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_emit_expression_mdnode(LL_DebugInfo *db, unsigned cnt, ...);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_emit_local_variable(LL_DebugInfo *db, int sptr, int findex, int emit_dummy_as_local);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_emit_module_mdnode(LL_DebugInfo *db, int sptr);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_emit_param_variable(LL_DebugInfo *db, int sptr, int findex, int parnum, bool unnamed);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_emit_ptr_param_variable(LL_DebugInfo *db, int sptr, int findex, int parnum);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_get_line(LL_DebugInfo *db);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_get_var_line(LL_DebugInfo *db, int sptr);
+
+/**
+   \brief ...
+ */
+LL_MDRef lldbg_subprogram(LL_DebugInfo *db);
+
+/**
+   \brief ...
+ */
+void lldbg_cleanup_missing_bounds(LL_DebugInfo *db, int findex);
+
+/**
+   \brief ...
+ */
+void lldbg_emit_accel_function_static_variables(LL_DebugInfo *db, int sptr, int findex, char *name, int addrspace);
+
+/**
+   \brief ...
+ */
+void lldbg_emit_accel_global_variable(LL_DebugInfo *db, int sptr, int findex, LL_Value *var_ptr, int addrspace, int is_local);
+
+/**
+   \brief ...
+ */
+void lldbg_emit_accel_texture_variable(LL_DebugInfo *db, char *symname, int findex, char *modname, char *texname, int is_def, int is_local, int addrspace);
+
+/**
+   \brief ...
+ */
+void lldbg_emit_global_variable(LL_DebugInfo *db, int sptr, BIGINT off, int findex, LL_Value *value);
+
+/**
+   \brief ...
+ */
+void lldbg_emit_line(LL_DebugInfo *db, int lineno);
+
+/**
+   \brief ...
+ */
+void lldbg_emit_lv_list(LL_DebugInfo *db);
+
+/**
+   \brief ...
+ */
+void lldbg_emit_outlined_parameter_list(LL_DebugInfo *db, int findex, DTYPE *param_dtypes, int num_args);
+
+/**
+   \brief ...
+ */
+void lldbg_free(LL_DebugInfo *db);
+
+/**
+   \brief ...
+ */
+void lldbg_function_end(LL_DebugInfo *db, int func);
+
+/**
+   \brief ...
+ */
+void lldbg_init_arrays(LL_DebugInfo *db);
+
+/**
+   \brief ...
+ */
+void lldbg_init(LL_Module *module);
+
+/**
+   \brief ...
+ */
+void lldbg_register_value_call(LL_DebugInfo *db, INSTR_LIST *instr, int sptr);
+
+/**
+   \brief ...
+ */
+void lldbg_reset_dtype_array(LL_DebugInfo *db, const int off);
+
+/**
+   \brief ...
+ */
+void lldbg_set_func_ptr(LL_DebugInfo *db, LL_Value *func_ptr);
+
+/**
+   \brief ...
+ */
+void lldbg_update_arrays(LL_DebugInfo *db, int lastDType, int newSz);
+
+/**
+   \brief ...
+ */
+void lldbg_emit_imported_entity(LL_DebugInfo *db, int entity_sptr,
+                                int func_sptr, int is_mod);
+
+/**
+   \brief ...
+ */
+void lldbg_create_cmblk_mem_mdnode_list(int sptr, int gblsym);
+
+#endif /* LLDEBUG_H_ */

--- a/tools/flang2/flang2exe/llopt.c
+++ b/tools/flang2/flang2exe/llopt.c
@@ -193,7 +193,7 @@ optimize_block(INSTR_LIST *last_block_instr)
 /**
    \brief Determine if \p cand has the form <tt>1.0 / y</tt>
  */
-static LOGICAL
+static bool
 is_recip(OPERAND *cand)
 {
   if (cand && cand->tmps) {

--- a/tools/flang2/flang2exe/llsched.h
+++ b/tools/flang2/flang2exe/llsched.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef LLSCHED_H_
+#define LLSCHED_H_
+
+#include "gbldefs.h"
+#include "llutil.h"
+
+/**
+
+/**
+   \brief ...
+ */
+int enhanced_conflict(int nme1, int nme2);
+
+/**
+   \brief ...
+ */
+void check_circular_dep(INSTR_LIST *istart);
+
+/**
+   \brief ...
+ */
+void sched_block_breadth_first(INSTR_LIST *istart, int level);
+
+/**
+   \brief ...
+ */
+void sched_block(INSTR_LIST *istart, INSTR_LIST *iend);
+
+/**
+   \brief ...
+ */
+void sched_instructions(INSTR_LIST *istart);
+
+#endif // LLSCHED_H_

--- a/tools/flang2/flang2exe/llutil.c
+++ b/tools/flang2/flang2exe/llutil.c
@@ -20,16 +20,12 @@
    Contains misc. utility routines for LLVM Code Generator
  */
 
-#include "gbldefs.h"
-#include "error.h"
-#include "global.h"
-#include "symtab.h"
 #include "llutil.h"
+#include "dtypeutl.h"
+#include "error.h"
 #include "dinit.h"
-#include "ili.h"
 #include "ll_write.h"
 #include "lldebug.h"
-#include "ll_structure.h"
 #include "llassem.h"
 #include "cgllvm.h"
 
@@ -114,7 +110,7 @@ void ll_override_type_string(LL_Type *llt, const char *str);
 static LL_ABI_Info *ll_abi_for_missing_prototype(LL_Module *module,
                                                  DTYPE return_dtype,
                                                  int func_sptr, int jsra_flags);
-static LOGICAL LLTYPE_equiv(LL_Type *ty1, LL_Type *ty2);
+static bool LLTYPE_equiv(LL_Type *ty1, LL_Type *ty2);
 
 FILE *LLVMFIL = NULL;
 
@@ -789,8 +785,8 @@ llis_function_kind(DTYPE dtype)
 }
 
 int
-is_struct_kind(DTYPE dtype, LOGICAL check_return,
-               LOGICAL return_vector_as_struct)
+is_struct_kind(DTYPE dtype, bool check_return,
+               bool return_vector_as_struct)
 {
   switch (DTY(dtype)) {
   case TY_STRUCT:
@@ -1078,7 +1074,7 @@ make_lltype_from_iface(SPTR sptr)
 #define IS_FTN_PROC_PTR(sptr) \
   ((DTY(DTYPEG(sptr)) == TY_PTR) && (DTY(DTY(DTYPEG(sptr) + 1)) == TY_PROC))
 
-LOGICAL
+bool
 is_function(int sptr)
 {
   const int stype = STYPEG(sptr);
@@ -1764,7 +1760,7 @@ print_dbg_line(LL_MDRef md)
    This is for use in sanity assertions.
    FIXME: i32 and i64 types are conflated in many f90_correct tests.
  */
-static LOGICAL
+static bool
 LLTYPE_equiv(LL_Type *ty1, LL_Type *ty2)
 {
   return TRUE;
@@ -1816,7 +1812,7 @@ write_vconstant_value(int sptr, LL_Type *type)
  */
 void
 write_constant_value(int sptr, LL_Type *type, INT conval0, INT conval1,
-                     LOGICAL uns)
+                     bool uns)
 {
   const char *ctype;
   INT num[2] = {0, 0};
@@ -2327,7 +2323,7 @@ indent(int change)
 }
 #endif
 
-LOGICAL
+bool
 small_aggr_return(DTYPE dtype)
 {
 #if   defined(TARGET_LLVM_X8664)
@@ -2785,7 +2781,7 @@ write_defs(LLDEF *def_list, int check_type_in_struct_def_type)
  * @return TRUE if there is any entry with printed==0, FALSE if all are printed
  * or the list is empty
  */
-LOGICAL
+bool
 defs_to_write(LLDEF *def_list)
 {
   LLDEF *cur_def;
@@ -3024,7 +3020,7 @@ process_dtype_struct(DTYPE dtype)
    print the type out (assuming that it has already been 'printed').
  */
 char *
-process_ftn_dtype_struct(DTYPE dtype, char *tname, LOGICAL printed)
+process_ftn_dtype_struct(DTYPE dtype, char *tname, bool printed)
 {
   int tag, dty;
   char *d_name;
@@ -3350,7 +3346,7 @@ ll_abi_return_type(LL_ABI_Info *abi)
     return abi->arg[0].type;
 }
 
-LOGICAL
+bool
 ll_abi_use_llvm_varargs(LL_ABI_Info *abi)
 {
   if (abi->is_varargs)
@@ -3425,7 +3421,7 @@ ll_abi_complete_arg_info(LL_ABI_Info *abi, LL_ABI_ArgInfo *arg, DTYPE dtype)
    TODO: Rename this function since process_sptr is not called in here.
  */
 LL_ABI_Info *
-process_ll_abi_func_ftn_mod(LL_Module *mod, int func_sptr, LOGICAL update)
+process_ll_abi_func_ftn_mod(LL_Module *mod, int func_sptr, bool update)
 {
   int i, ty, ret_dtype;
   char *param;
@@ -3524,7 +3520,7 @@ process_ll_abi_func_ftn_mod(LL_Module *mod, int func_sptr, LOGICAL update)
     for (i = 1, param = get_argdtlist(gblsym); param;
          ++i, param = get_next_argdtlist(param)) {
       LL_Type *llt = get_lltype_from_argdtlist(param);
-      const LOGICAL byval = get_byval_from_argdtlist(param);
+      const bool byval = get_byval_from_argdtlist(param);
       abi->arg[i].type = llt; /* HACK FIXME */
       abi->arg[i].kind = byval ? LL_ARG_DIRECT : LL_ARG_INDIRECT;
       abi->arg[i].ftn_pass_by_val = byval;
@@ -3557,7 +3553,7 @@ process_ll_abi_func_ftn_mod(LL_Module *mod, int func_sptr, LOGICAL update)
    \brief Wrapper to process_ll_abi_func_ftn_mod() passing the default module
  */
 LL_ABI_Info *
-process_ll_abi_func_ftn(int func_sptr, LOGICAL use_sptrs)
+process_ll_abi_func_ftn(int func_sptr, bool use_sptrs)
 {
   return process_ll_abi_func_ftn_mod(cpu_llvm_module, func_sptr, use_sptrs);
 }

--- a/tools/flang2/flang2exe/machreg.c
+++ b/tools/flang2/flang2exe/machreg.c
@@ -17,7 +17,7 @@
 
 /*  machreg.c - Machine register definitions for the i386/387 */
 
-#include "gbldefs.h"
+#include "machreg.h"
 #include "error.h"
 #include "global.h"
 #include "symtab.h"
@@ -33,7 +33,7 @@ static int _mr_getnext(int rtype);
 
 static int getnext_reg; /* current register for retry (mr_getnext) */
 
-static LOGICAL mr_restore;          /* need to backout for KR registers? */
+static bool mr_restore;          /* need to backout for KR registers? */
 static char mr_restore_next_global; /* saving the mr.next_global field */
 static char mr_restore_nused;       /* saving the mr.nused field */
 
@@ -334,7 +334,7 @@ int _mr_getnext(int rtype)
   mreg = getnext_reg;
   getnext_reg++;
   if (mreg >= mr->next_global) {
-    mr_restore = TRUE;
+    mr_restore = true;
     mr_restore_nused = mr->nused;
     mr_restore_next_global = mr->next_global;
     /* same comment as in _mr_getreg */

--- a/tools/flang2/flang2exe/main.c
+++ b/tools/flang2/flang2exe/main.c
@@ -31,6 +31,7 @@
 #include "cgraph.h"
 #include "x86.h"
 #include "dbg_out.h"
+#include "rmsmove.h"
 #include "mwd.h"
 #include "llassem.h"
 #include "cgllvm.h"
@@ -66,9 +67,9 @@ extern int errno;
 
 /* contents of this file:  */
 
-static void reptime();
+static void reptime(void);
 static void init(int, char *[]);
-static void reinit();
+static void reinit(void);
 
 static int saveoptflag;
 static int savevectflag;
@@ -594,23 +595,22 @@ init(int argc, char *argv[])
   register_action_map_arg(arg_parser, "qq", phase_dump_map, dump_map);
 
   /* Other flags */
-  register_integer_arg(arg_parser, "opt", &(flg.opt), 1);
-  register_integer_arg(arg_parser, "ieee", &(flg.ieee), 0);
+  register_integer_arg(arg_parser, "opt", &flg.opt, 1);
+  register_integer_arg(arg_parser, "ieee", &flg.ieee, 0);
   register_inform_level_arg(arg_parser, "inform",
-                            (inform_level_t *)&(flg.inform), LV_Inform);
-  register_integer_arg(arg_parser, "endian", &(flg.endian), 0);
-  register_boolean_arg(arg_parser, "mp", (bool *)&(flg.smp), false);
+                            (inform_level_t *)&flg.inform, LV_Inform);
+  register_integer_arg(arg_parser, "endian", &flg.endian, 0);
+  register_boolean_arg(arg_parser, "mp", &flg.smp, false);
   register_boolean_arg(arg_parser, "reentrant", &arg_reentrant, false);
-  register_integer_arg(arg_parser, "terse", &(flg.terse), 1);
-  register_boolean_arg(arg_parser, "quad", (bool *)&(flg.quad), false);
-  register_boolean_arg(arg_parser, "save", (bool *)&(flg.save), false);
+  register_integer_arg(arg_parser, "terse", &flg.terse, 1);
+  register_boolean_arg(arg_parser, "quad", &flg.quad, false);
+  register_boolean_arg(arg_parser, "save", &flg.save, false);
   register_string_arg(arg_parser, "tp", &tp, NULL);
-  register_integer_arg(arg_parser, "astype", &(flg.astype), 0);
-  register_boolean_arg(arg_parser, "recursive", (bool *)&(flg.recursive),
-                       false);
-  register_integer_arg(arg_parser, "vect", &(vect_val), 0);
-  register_string_arg(arg_parser, "cmdline", &(cmdline), NULL);
-  register_boolean_arg(arg_parser, "debug", (bool *)&(flg.debug), false);
+  register_integer_arg(arg_parser, "astype", &flg.astype, 0);
+  register_boolean_arg(arg_parser, "recursive", &flg.recursive, false);
+  register_integer_arg(arg_parser, "vect", &vect_val, 0);
+  register_string_arg(arg_parser, "cmdline", &cmdline, NULL);
+  register_boolean_arg(arg_parser, "debug", &flg.debug, false);
 
   /* Run argument parser */
   parse_arguments(arg_parser, argc, argv);

--- a/tools/flang2/flang2exe/mth.h
+++ b/tools/flang2/flang2exe/mth.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
  * limitations under the License.
  *
  */
+
+#ifndef MTH_H_
+#define MTH_H_
 
 /*  mth.h - 'parameterize' the names of the __mth_i/__fmth_i ... functions.
  *          Macros are not used for the new naming conventions, i.e.,
@@ -57,9 +60,6 @@ atan2
 div
  */
 
-#ifndef __MTH_H
-#define __MTH_H
-
 typedef enum MTH_FN {
   MTH_acos,
   MTH_asin,
@@ -84,11 +84,6 @@ typedef enum MTH_FN {
   MTH_tanh,
   MTH_mod,
 } MTH_FN;
-
-extern char *make_math_name(MTH_FN, int, LOGICAL, DTYPE);
-extern char *make_math_name_vabi(MTH_FN, int, LOGICAL, DTYPE);
-extern char *make_math(MTH_FN, SPTR *, int, LOGICAL, DTYPE, int, int, ...);
-void llmk_math_name(char *buff, int fn, int vlen, bool mask, DTYPE resdt);
 
 #define MTH_I_DFIXK "__mth_i_dfixk"
 
@@ -250,4 +245,4 @@ void llmk_math_name(char *buff, int fn, int vlen, bool mask, DTYPE resdt);
 #define MTH_I_KBTEST "ftn_i_bktest"
 #define MTH_I_KBCLR "ftn_i_kibclr"
 
-#endif /* __MTH_H */
+#endif // MTH_H_

--- a/tools/flang2/flang2exe/mwd.c
+++ b/tools/flang2/flang2exe/mwd.c
@@ -19,7 +19,7 @@
  * \brief mw's dump routines
  */
 
-#include "gbldefs.h"
+#include "mwd.h"
 #include "error.h"
 #include "machar.h"
 #include "global.h"
@@ -27,16 +27,17 @@
 #include "ilm.h"
 #include "fih.h"
 #include "ili.h"
+#include "iliutil.h"
+#include "dtypeutl.h"
 #include "machreg.h"
 #ifdef SOCPTRG
 #include "soc.h"
 #endif
-#include "mwd.h"
 #include "llutil.h"
 
 static int putdtypex(DTYPE dtype, int len);
 static void _printnme(int n);
-static LOGICAL g_dout = TRUE;
+static bool g_dout = true;
 
 #if defined(HOST_WIN)
 #define vsnprintf _vsnprintf
@@ -2638,18 +2639,18 @@ dflg(void)
   }
 } /* dflg */
 
-static LOGICAL
+static bool
 simpledtype(int dtype)
 {
   if (dtype < 0 || dtype >= stb.dt.stg_avail)
-    return FALSE;
+    return false;
   if (DTY(dtype) < 0 || DTY(dtype) > TY_MAX)
-    return FALSE;
+    return false;
   if (dlen(DTY(dtype)) == 1)
-    return TRUE;
+    return true;
   if (DTY(dtype) == TY_PTR)
-    return TRUE;
-  return FALSE;
+    return true;
+  return false;
 } /* simpledtype */
 
 static int
@@ -5163,7 +5164,7 @@ static char *nmetypes[] = {"unknown ", "indirect", "variable",
                            "member  ", "element ", "safe    "};
 
 void
-_dumpnme(int n, LOGICAL dumpdefsuses)
+_dumpnme(int n, bool dumpdefsuses)
 {
   int store, pte;
   dfile = gbl.dbgfil ? gbl.dbgfil : stderr;
@@ -5248,7 +5249,7 @@ void
 dumpnnme(int n)
 {
   linelen = 0;
-  _dumpnme(n, FALSE);
+  _dumpnme(n, false);
   putline();
 } /* dumpnme */
 
@@ -5256,7 +5257,7 @@ void
 dumpnme(int n)
 {
   linelen = 0;
-  _dumpnme(n, TRUE);
+  _dumpnme(n, true);
   putline();
 } /* dumpnme */
 

--- a/tools/flang2/flang2exe/mwd.h
+++ b/tools/flang2/flang2exe/mwd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2000-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,115 +14,944 @@
  * limitations under the License.
  *
  */
+
+#ifndef MWD_H_
+#define MWD_H_
+
 /** \file
  * \brief Header for mw's dump routines
  */
 
+#include "gbldefs.h"
+#include <stdio.h>
+#include "symtab.h"
+
 #if DEBUG
-extern char *printname(int sptr);
-extern void putdtype(DTYPE dtype);
-extern void ds(int sptr);
-extern void dsa(void);
-extern void dss(int l, int u);
-extern void dsym(int sptr);
-extern void dsyms(int l, int u);
 
-extern void ddtype(int dtype);
-extern void ddtypes(void);
-extern void dumpdtype(int dtype);
-extern void dumpdtypes(void);
+/**
+   \brief ...
+ */
+char *getprintnme(int n);
 
-extern void dili(int ilix);
-extern void dilitre(int ilix);
-extern void dilt(int ilt);
-extern void dumpilt(int ilt);
+/**
+   \brief ...
+ */
+char *printname(int sptr);
 
-extern void db(int block);
-extern void dbih(void);
-extern void dbihonly(void);
-extern void dumpblock(int block);
-extern void dumptblock(char *title, int block);
-extern void dumpblocks(char *title);
-extern void dumpblocksonly(void);
-extern void dumpfnode(int v);
-extern void dumpfgraph(void);
-extern void printnme(int n);
-extern void dumpnmetree(int n);
-extern void dumpnme(int n);
-extern void dumpnnme(int n);
-extern void _dumpnme(int n, LOGICAL dumpdefsuses);
-extern void dumpnmes(void);
-extern void dumpdefnmes(void);
-extern void dumpdef(int def);
-extern void _dumpdef(int def, int dumpuses);
-extern void _dumpuse(int use, int dumpdefs);
-extern void dumpdefs(void);
-extern void dumpuse(int use);
-extern void dumpuses(void);
-extern void dumploop(int l);
-extern void dumploops(void);
-extern void dumploopsbv(int bvlen);
-extern void dumplooptree(void);
-extern void dumplili(int li);
-extern void dumpalllili(void);
-extern void dumptlili(char *title);
+/**
+   \brief ...
+ */
+int putdty(TY_KIND dty);
 
-extern void dumpauses(void);
-extern void dumpreducdefs(void);
-extern void dumpuseddefs(void);
-extern void dumpliveoutdefs(void);
-extern void dumpliveinuses(void);
-extern void dumpuseduses(void);
-extern void dumpprivatelist(void);
-extern void dumpivlist(void);
-
-extern void dumplong(void);
-extern void dumpdiff(void);
-extern void dumpddiff(int);
-extern void dumpdfs(void);
-
-extern void putmwline(void);
-
-extern void dumpregion(int r);
-extern void dumpregionnest(int r);
-void simpleprintregionnest(char *msg, int r);
-extern void dumpregions(void);
-void printregions(void);
-extern void dumprnest(void);
-extern void dumpscalar(int s);
-extern void dumpscalarlist(int ss);
-extern void dumpscalars(void);
-extern void dumpstmt(int s);
-extern void dumpstmts(void);
-extern void dumpvloop(int l);
-extern void dumpvloops(void);
-extern void dumpsub(int s);
-extern void dumpsubs(void);
-extern void putsubs(int s1, int n1);
-extern void _putsubs(char *name, int s1, int n1);
-extern void dumpmr(int m);
-extern void dumpmemref(int m);
-extern void dumpmemrefs(void);
-void dumpinds(void);
-extern void dumpvind(int i);
-extern void dumpvinds(void);
-extern void dumpvindl(int i1, int n);
-extern void printili(int i);
+/**
+   \brief ...
+ */
 void checkfgraph(char *s);
-extern void printblocks(void);
-extern void printblock(int block);
-extern void printfgraph(void);
-extern void printfnode(int v);
-extern void printilt(int i);
-extern void dumparefs(void);
-extern void dumparef(int arefx);
-extern void putnme(char *s, int nme);
-void printregionnest(char *msg, int r);
-void dgbl(void);
-void dumpdvls(void);
-void stackcheck(void);
-void stackvars(void);
-void dumpilts(void);
+
+/**
+   \brief ...
+ */
+void checktags(char *phase);
+
+/**
+   \brief ...
+ */
+void dbihonly(void);
+
+/**
+   \brief ...
+ */
+void dbih(void);
+
+/**
+   \brief ...
+ */
+void db(int block);
+
+/**
+   \brief ...
+ */
+void ddtype(int dtype);
+
+/**
+   \brief ...
+ */
+void ddtypes(void);
+
+/**
+   \brief ...
+ */
+void dfih(int f);
+
+/**
+   \brief ...
+ */
 void dflg(void);
-void dumpaccrout(void);
-#endif
+
+/**
+   \brief ...
+ */
+void dgbl(void);
+
+/**
+   \brief ...
+ */
+void dili(int ilix);
+
+/**
+   \brief ...
+ */
+void dilitre(int ilix);
+
+/**
+   \brief ...
+ */
+void dilt(int ilt);
+
+/**
+   \brief ...
+ */
+void dsa(void);
+
+/**
+   \brief ...
+ */
+void ds(int sptr);
+
+/**
+   \brief ...
+ */
+void dss(int l, int u);
+
+/**
+   \brief ...
+ */
+void dsym(int sptr);
+
+/**
+   \brief ...
+ */
+void dsyms(int l, int u);
+
+/**
+   \brief ...
+ */
+void dumpabnd(int abx);
+
+/**
+   \brief ...
+ */
+void dumpabnds(void);
+
+/**
+   \brief ...
+ */
+void dumpacacheinfo(int cx);
+
+/**
+   \brief ...
+ */
+void dumpacexprs(void);
+
+/**
+   \brief ...
+ */
+void dumpacivs(void);
+
+/**
+   \brief ...
+ */
+void dumpacsymt(int first, int last);
+
+/**
+   \brief ...
+ */
+void dumpadef(int def);
+
+/**
+   \brief ...
+ */
+void _dumpadef(int def, int dumpuses);
+
+/**
+   \brief ...
+ */
+void dumpallloops(void);
+
+/**
+   \brief ...
+ */
+void dumpallploops(void);
+
+/**
+   \brief ...
+ */
+void _dumpaloop(int lpx, bool dumpprivate);
+
+/**
+   \brief ...
+ */
+void dumpalooponly(int lpx);
+
+/**
+   \brief ...
+ */
+void dumpanmelist(int nmelist);
+
+/**
+   \brief ...
+ */
+void dumpanmetree(int nmex);
+
+/**
+   \brief ...
+ */
+void dumparef(int arefx);
+
+/**
+   \brief ...
+ */
+void dumparefs(void);
+
+/**
+   \brief ...
+ */
+void dumparefxlist(int arefxlist);
+
+/**
+   \brief ...
+ */
+void dumpause(int use);
+
+/**
+   \brief ...
+ */
+void _dumpause(int use, int dumpdefs);
+
+/**
+   \brief ...
+ */
+void dumpauselist(int use);
+
+/**
+   \brief ...
+ */
+void dumpauses(void);
+
+/**
+   \brief ...
+ */
+void dumpblock(int block);
+
+/**
+   \brief ...
+ */
+void dumpblocks(char *title);
+
+/**
+   \brief ...
+ */
+void dumpblocksonly(void);
+
+/**
+   \brief ...
+ */
+void _dumpchildaloopsclist(int lpx);
+
+/**
+   \brief ...
+ */
+void _dumpchildaloops(int lpx);
+
+/**
+   \brief ...
+ */
+void dumpddiff(int v);
+
+/**
+   \brief ...
+ */
+void dumpdef(int def);
+
+/**
+   \brief ...
+ */
+void _dumpdef(int def, int dumpuses);
+
+/**
+   \brief ...
+ */
+void dumpdeflist(int deflist);
+
+/**
+   \brief ...
+ */
+void dumpdefnmes(void);
+
+/**
+   \brief ...
+ */
+void dumpdefs(void);
+
+/**
+   \brief ...
+ */
+void dumpdfs(void);
+
+/**
+   \brief ...
+ */
+void dumpdiff(void);
+
+/**
+   \brief ...
+ */
+void dumpdtype(int dtype);
+
+/**
+   \brief ...
+ */
+void dumpdtypes(void);
+
+/**
+   \brief ...
+ */
+void dumpdvl(int d);
+
+/**
+   \brief ...
+ */
+void dumpdvls(void);
+
+/**
+   \brief ...
+ */
+void dumpfgraph(void);
+
+/**
+   \brief ...
+ */
+void dumpfg(void);
+
+/**
+   \brief ...
+ */
+void dumpfile(int f);
+
+/**
+   \brief ...
+ */
+void dumpfiles(void);
+
+/**
+   \brief ...
+ */
+void dumpfnodehead(int v);
+
+/**
+   \brief ...
+ */
+void dumpfnode(int v);
+
+/**
+   \brief ...
+ */
+void dumpiltdeflist(int iltx);
+
+/**
+   \brief ...
+ */
+void dumpilt(int ilt);
+
+/**
+   \brief ...
+ */
+void dumpiltmrlist(int iltx);
+
+/**
+   \brief ...
+ */
+void dumpilts(void);
+
+/**
+   \brief ...
+ */
+void dumpiltuselist(int iltx);
+
+/**
+   \brief ...
+ */
+void dumpind(int i);
+
+/**
+   \brief ...
+ */
+void dumpinds(void);
+
+/**
+   \brief ...
+ */
+void dumpiv(int ivx);
+
+/**
+   \brief ...
+ */
+void dumpivlist(void);
+
+/**
+   \brief ...
+ */
+void dumpliveinuses(void);
+
+/**
+   \brief ...
+ */
+void dumpliveoutdefs(void);
+
+/**
+   \brief ...
+ */
+void dumplong(void);
+
+/**
+   \brief ...
+ */
+void dumploop(int l);
+
+/**
+   \brief ...
+ */
+void _dumploop(int l, bool dumpldst, bool dumpbits, int nest);
+
+/**
+   \brief ...
+ */
+void dumploopsbv(int bvlen);
+
+/**
+   \brief ...
+ */
+void dumploops(void);
+
+/**
+   \brief ...
+ */
+void _dumplooptree(int l, int nest);
+
+/**
+   \brief ...
+ */
+void dumplooptree(void);
+
+/**
+   \brief ...
+ */
+void dumpmemref(int m);
+
+/**
+   \brief ...
+ */
+void dumpmemrefs(void);
+
+/**
+   \brief ...
+ */
+void _dumpmode2(int mode2);
+
+/**
+   \brief ...
+ */
+void _dumpmode3(int mode3);
+
+/**
+   \brief ...
+ */
+void _dumpmode(int mode);
+
+/**
+   \brief ...
+ */
+void dumpmr(int m);
+
+/**
+   \brief ...
+ */
+void dumpnatural(void);
+
+/**
+   \brief ...
+ */
+void dumpnewdtypes(int olddtavail);
+
+/**
+   \brief ...
+ */
+void dumpnme(int n);
+
+/**
+   \brief ...
+ */
+void _dumpnme(int n, bool dumpdefsuses);
+
+/**
+   \brief ...
+ */
+void dumpnmes(void);
+
+/**
+   \brief ...
+ */
+void dumpnmetree(int n);
+
+/**
+   \brief ...
+ */
+void dumpnnme(int n);
+
+/**
+   \brief ...
+ */
+void dumpnst2(int n);
+
+/**
+   \brief ...
+ */
+void dumpnst(int n);
+
+/**
+   \brief ...
+ */
+void _dumpparentaloopsclist(int lpx);
+
+/**
+   \brief ...
+ */
+void _dumpparentaloops(int lpx);
+
+/**
+   \brief ...
+ */
+void dumpploop(int plpx);
+
+/**
+   \brief ...
+ */
+void _dumpplooptree(int plpx);
+
+/**
+   \brief ...
+ */
+void dumpprivatelist(void);
+
+/**
+   \brief ...
+ */
+void dumpreddeflist(int deflist);
+
+/**
+   \brief ...
+ */
+void dumpred(int r);
+
+/**
+   \brief ...
+ */
+void dumpredlist(int r);
+
+/**
+   \brief ...
+ */
+void dumpreducdeflist(int defx);
+
+/**
+   \brief ...
+ */
+void dumpreducdefs(void);
+
+/**
+   \brief ...
+ */
+void dumpregion(int r);
+
+/**
+   \brief ...
+ */
+void dumpregionnest(int r);
+
+/**
+   \brief ...
+ */
+void dumpregions(void);
+
+/**
+   \brief ...
+ */
+void dumprnest(void);
+
+/**
+   \brief ...
+ */
+void dumpscalar(int s);
+
+/**
+   \brief ...
+ */
+void dumpscalarlist(int ss);
+
+/**
+   \brief ...
+ */
+void dumpscalars(void);
+
+/**
+   \brief ...
+ */
+void dumpshort(void);
+
+/**
+   \brief ...
+ */
+void dumpsizes(void);
+
+/**
+   \brief ...
+ */
+void dumpstmt(int s);
+
+/**
+   \brief ...
+ */
+void dumpstmts(void);
+
+/**
+   \brief ...
+ */
+void dumpstore(int s);
+
+/**
+   \brief ...
+ */
+void dumpstorelist(int s);
+
+/**
+   \brief ...
+ */
+void dumpsub(int s);
+
+/**
+   \brief ...
+ */
+void dumpsubs(void);
+
+/**
+   \brief ...
+ */
+void dumptblock(char *title, int block);
+
+/**
+   \brief ...
+ */
+void dumpuseddefs(void);
+
+/**
+   \brief ...
+ */
+void dumpuseduses(void);
+
+/**
+   \brief ...
+ */
+void dumpuse(int use);
+
+/**
+   \brief ...
+ */
+void _dumpuse(int use, int dumpdefs);
+
+/**
+   \brief ...
+ */
+void dumpuses(void);
+
+/**
+   \brief ...
+ */
+void dumpvdef(int def);
+
+/**
+   \brief ...
+ */
+void _dumpvdef(int def, int dumpuses);
+
+/**
+   \brief ...
+ */
+void dumpvilt(int iltx);
+
+/**
+   \brief ...
+ */
+void dumpvind(int i);
+
+/**
+   \brief ...
+ */
+void dumpvindl(int i1, int n);
+
+/**
+   \brief ...
+ */
+void dumpvinds(void);
+
+/**
+   \brief ...
+ */
+void dumpvloop(int l);
+
+/**
+   \brief ...
+ */
+void dumpvlooplist(int list);
+
+/**
+   \brief ...
+ */
+void dumpvloops(void);
+
+/**
+   \brief ...
+ */
+void dumpvuse(int use);
+
+/**
+   \brief ...
+ */
+void _dumpvuse(int use, int dumpdefs);
+
+/**
+   \brief ...
+ */
+void pprintnme(int n);
+
+/**
+   \brief ...
+ */
+void printblock(int block);
+
+/**
+   \brief ...
+ */
+void printblockline(int block);
+
+/**
+   \brief ...
+ */
+void printblocksline(void);
+
+/**
+   \brief ...
+ */
+void printblocks(void);
+
+/**
+   \brief ...
+ */
+void printblockt(int firstblock, int lastblock);
+
+/**
+   \brief ...
+ */
+void printblocktt(int firstblock, int lastblock);
+
+/**
+   \brief ...
+ */
+void printfgraph(void);
+
+/**
+   \brief ...
+ */
+void printfnode(int v);
+
+/**
+   \brief ...
+ */
+void printili(int i);
+
+/**
+   \brief ...
+ */
+void printilt(int i);
+
+/**
+   \brief ...
+ */
+void printloop(int lpx);
+
+/**
+   \brief ...
+ */
+void printnme(int n);
+
+/**
+   \brief ...
+ */
+void printregion(int r);
+
+/**
+   \brief ...
+ */
+void printregionnest(char *msg, int r);
+
+/**
+   \brief ...
+ */
+void _printregionnest(int r);
+
+/**
+   \brief ...
+ */
+void printregions(void);
+
+/**
+   \brief ...
+ */
+void putarefherelists(int lpx);
+
+/**
+   \brief ...
+ */
+void putareflists(int lpx);
+
+/**
+   \brief ...
+ */
+void putasub(int asubx, int nest);
+
+/**
+   \brief ...
+ */
+void putcoeff(int coefx, int nest);
+
+/**
+   \brief ...
+ */
+void putdtype(DTYPE dtype);
+
+/**
+   \brief ...
+ */
+void _putdtype(DTYPE dtype, int structdepth);
+
+/**
+   \brief ...
+ */
+void putili(char *name, int ilix);
+
+/**
+   \brief ...
+ */
+void putint1(int d);
+
+/**
+   \brief ...
+ */
+void putlpxareflist(int lpx, char *listname, int list, int nest);
+
+/**
+   \brief ...
+ */
+void putmode(int mode);
+
+/**
+   \brief ...
+ */
+void putmwline(void);
+
+/**
+   \brief ...
+ */
+void putnestarefherelists(int lpx);
+
+/**
+   \brief ...
+ */
+void _putnestareflists(int lpx, int nest, int flags);
+
+/**
+   \brief ...
+ */
+void putnme(char *s, int nme);
+
+/**
+   \brief ...
+ */
+void putnnaref(int arefx, int nest);
+
+/**
+   \brief ...
+ */
+void putptelist(int pte);
+
+/**
+   \brief ...
+ */
+void putredtype(int rt);
+
+/**
+   \brief ...
+ */
+void putsclist(char *name, int list);
+
+/**
+   \brief ...
+ */
+void putsoc(int socptr);
+
+/**
+   \brief ...
+ */
+void _putsubs(char *name, int s1, int n1);
+
+/**
+   \brief ...
+ */
+void putsubs(int s1, int n1);
+
+/**
+   \brief ...
+ */
+void simpledumpregion(int r);
+
+/**
+   \brief ...
+ */
+void simpledumpstmt(int s);
+
+/**
+   \brief ...
+ */
+void simpleprintregion(int r);
+
+/**
+   \brief ...
+ */
+void simpleprintregionnest(char *msg, int r);
+
+/**
+   \brief ...
+ */
+void _simpleprintregionnest(int r);
+
+/**
+   \brief ...
+ */
+void stackcheck(void);
+
+/**
+   \brief ...
+ */
+void stackvars(void);
+
+#endif // DEBUG == 1
+#endif // MWD_H_

--- a/tools/flang2/flang2exe/outliner.h
+++ b/tools/flang2/flang2exe/outliner.h
@@ -15,78 +15,291 @@
  *
  */
 
+#ifndef OUTLINER_H_
+#define OUTLINER_H_
+
 /** \file
  * \brief Various definitions for the outliner module
  */
 
-#ifndef __OUTLINER_H__
-#define __OUTLINER_H__
+#include <stdio.h>
 
-/* Dump the list of variables for the parallel regions specified by 'sptr'.
- * These variables should be used to make the uplevel struct when making a call
- * to this outlined region.
- */
-void dump_parsyms(int sptr);
-char *ll_get_outlined_funcname(int, int);
-
-int ll_reset_parfile(void);
-int ll_rewrite_ilms(int, int, int);
-void ll_write_ilm_header(int, int);
-void ll_write_ilm_end(void);
-void ilm_outlined_pad_ilm(int);
-void llWriteNopILM(int, int, int);
-LOGICAL ll_ilm_is_rewriting(void);
-void setRewritingILM();
-void unsetRewritingILM();
+extern FILE *par_file1;
+extern FILE *par_file2;
+extern FILE *par_curfile;
 
 int ll_has_cuda_constructor(void);
 void ll_save_cuda_constructor(void);
 
-int ll_make_outlined_call(int, int, int, int);
-int ll_make_outlined_call2(int, int);
-int ll_make_outlined_func(int, int);
-int ll_make_outlined_task(int, int);
-int ll_make_outlined_task_call(int, int);
-int *ll_make_sections_args(int, int, int, int);
-void ll_make_ftn_outlined_params(int, int, int *);
-int ll_get_hostprog_arg(int, int);
+/**
+   \brief ...
+ */
+bool ll_ilm_is_rewriting(void);
 
-int llvm_ilms_rewrite_mode(void);
-int llvm_get_unique_sym(void);
-void llvm_set_unique_sym(int);
-int ll_get_gtid_val_ili(void);
+/**
+   \brief ...
+ */
+char *ll_get_outlined_funcname(int fileno, int lineno);
+
+/**
+   \brief ...
+ */
+int ll_ad_outlined_func2(int result_opc, int call_opc, int sptr, int nargs,
+                         int *args);
+
+/**
+   \brief ...
+ */
+int ll_create_task_sptr(void);
+
+/**
+   \brief ...
+ */
 int ll_get_gtid_addr_ili(void);
-void ll_reset_gtid();
-int ll_get_gtid();
-int ll_save_gtid_val(int);
 
-/* Routines for handling uplevel arguments */
-int ll_load_outlined_args(int, int, LOGICAL);
-int ll_get_uplevel_sym();
+/**
+   \brief ...
+ */
+int ll_get_gtid_val_ili(void);
 
-extern int ll_ad_outlined_func2(int, int, int, int, int *);
-extern int ll_make_outlined_garg(int, int *, int *);
-extern int ll_get_uplevel_arg(void);
-extern int ll_get_uplevel_offset(int sptr);
-extern int ll_get_shared_arg(int func_sptr);
-extern void ll_reset_outlined_func(void);
-extern void ll_open_parfiles(void);
-extern void ll_set_outlined_currsub(void);
-extern int ll_has_more_outlined(void);
-extern void ll_unlink_parfiles(void);
-extern void restartRewritingILM(int);
+/**
+   \brief ...
+ */
+int ll_get_gtid(void);
 
-extern int llvmAddConcurEntryBlk(int);
-extern void llvmAddConcurExitBlk(int);
+/**
+   \brief ...
+ */
+int ll_get_hostprog_arg(int func_sptr, int whicharg);
 
-extern void update_acc_with_fn(int);
+/**
+   \brief ...
+ */
+int ll_get_shared_arg(int func_sptr);
 
-extern void start_taskdup(int, int );
-extern void stop_taskdup(int, int );
-extern void finish_taskdup_routine(int, int, INT);
+/**
+   \brief ...
+ */
+int ll_get_uplevel_arg(void);
 
-void setOutlinedPragma(int, int);
-void llvmSetExpbCurIlt(void);
+/**
+   \brief ...
+ */
+int ll_get_uplevel_offset(int sptr);
+
+/**
+   \brief ...
+ */
+int ll_get_uplevel_sym(void);
+
+/**
+   \brief ...
+ */
+int ll_has_more_outlined(void);
+
+/**
+   \brief ...
+ */
+int ll_load_outlined_args(int scope_blk_sptr, int callee_sptr, bool clone);
+
+/**
+   \brief ...
+ */
+int ll_make_outlined_call2(int func_sptr, int uplevel_ili);
+
+/**
+   \brief ...
+ */
+int ll_make_outlined_call(int func_sptr, int arg1, int arg2, int arg3);
+
+/**
+   \brief ...
+ */
+int ll_make_outlined_func(int stblk_sptr, int scope_sptr);
+
+/**
+   \brief ...
+ */
+int ll_make_outlined_garg(int nargs, int *argili, int *arg_dtypes);
+
+/**
+   \brief ...
+ */
+int ll_make_outlined_gjsr(int func_sptr, int nargs, int arg1, int arg2, int arg3);
+
+/**
+   \brief ...
+ */
+int ll_make_outlined_task_call(int func_sptr, int task_sptr);
+
+/**
+   \brief ...
+ */
+int ll_make_outlined_task(int stblk_sptr, int scope_sptr);
+
+/**
+   \brief ...
+ */
+int *ll_make_sections_args(int lbSym, int ubSym, int stSym, int lastSym);
+
+/**
+   \brief ...
+ */
+int ll_make_uplevel_type(int stblk_sptr);
+
+/**
+   \brief ...
+ */
+int llProcessNextTmpfile(void);
+
+/**
+   \brief ...
+ */
+int ll_reset_parfile(void);
+
+/**
+   \brief ...
+ */
+int ll_rewrite_ilms(int lineno, int ilmx, int len);
+
+/**
+   \brief ...
+ */
+int ll_save_gtid_val(int bih);
+
+/**
+   \brief ...
+ */
+int llvmAddConcurEntryBlk(int bih);
+
+/**
+   \brief ...
+ */
 int llvmGetExpbCurIlt(void);
 
-#endif /* __OUTLINER_H__ */
+/**
+   \brief ...
+ */
+int llvm_get_unique_sym(void);
+
+/**
+   \brief ...
+ */
+int llvm_ilms_rewrite_mode(void);
+
+/**
+   \brief Dump the list of variables for the parallel regions specified by
+   'sptr'.
+
+   These variables should be used to make the uplevel struct when making a call
+   to this outlined region.
+ */
+void dump_parsyms(int sptr);
+
+/**
+   \brief ...
+ */
+void finish_taskdup_routine(int curilm, int fnsptr, INT offset);
+
+/**
+   \brief ...
+ */
+void ilm_outlined_pad_ilm(int curilm);
+
+/**
+   \brief ...
+ */
+void ll_make_ftn_outlined_params(int func_sptr, int paramct, int *argtype);
+
+/**
+   \brief ...
+ */
+void ll_open_parfiles(void);
+
+/**
+   \brief ...
+ */
+void ll_reset_gtid(void);
+
+/**
+   \brief ...
+ */
+void ll_reset_outlined_func(void);
+
+/**
+   \brief ...
+ */
+void ll_set_outlined_currsub(void);
+
+/**
+   \brief ...
+ */
+void ll_unlink_parfiles(void);
+
+/**
+   \brief ...
+ */
+void llvmAddConcurExitBlk(int bih);
+
+/**
+   \brief ...
+ */
+void llvmSetExpbCurIlt(void);
+
+/**
+   \brief ...
+ */
+void llvm_set_unique_sym(int sptr);
+
+/**
+   \brief ...
+ */
+void ll_write_ilm_end(void);
+
+/**
+   \brief ...
+ */
+void ll_write_ilm_header(int outlined_sptr, int curilm);
+
+/**
+   \brief ...
+ */
+void llWriteNopILM(int lineno, int ilmx, int len);
+
+/**
+   \brief ...
+ */
+void restartRewritingILM(int curilm);
+
+/**
+   \brief ...
+ */
+void setOutlinedPragma(int func_sptr, int saved);
+
+/**
+   \brief ...
+ */
+void setRewritingILM(void);
+
+/**
+   \brief ...
+ */
+void start_taskdup(int task_fnsptr, int curilm);
+
+/**
+   \brief ...
+ */
+void stop_taskdup(int task_fnsptr, int curilm);
+
+/**
+   \brief ...
+ */
+void unsetRewritingILM(void);
+
+/**
+   \brief ...
+ */
+void update_acc_with_fn(int fnsptr);
+
+
+#endif /* OUTLINER_H_ */

--- a/tools/flang2/flang2exe/ppc64le-Linux/machreg.h
+++ b/tools/flang2/flang2exe/ppc64le-Linux/machreg.h
@@ -15,6 +15,11 @@
  *
  */
 
+#ifndef MACHREG_H_
+#define MACHREG_H_
+
+#include "gbldefs.h"
+
 extern const int scratch_regs[];
 
 /* Define registers for x86-32.
@@ -350,12 +355,14 @@ extern RGSETB rgsetb;
 
 /*****  External Function Declarations  *****/
 
-extern int mr_getnext(int rtype);
-extern int mr_getreg(int rtype);
-extern int mr_get_rgset();
-extern int mr_gindex(int rtype, int regno);
-extern void mr_end();
-extern void mr_init();
-extern void mr_reset_frglobals();
-extern void mr_reset(int rtype);
-extern void mr_reset_numglobals(int);
+ int mr_getnext(int rtype);
+ int mr_getreg(int rtype);
+ int mr_get_rgset();
+ int mr_gindex(int rtype, int regno);
+ void mr_end();
+ void mr_init();
+ void mr_reset_frglobals();
+ void mr_reset(int rtype);
+ void mr_reset_numglobals(int);
+
+#endif

--- a/tools/flang2/flang2exe/regutil.h
+++ b/tools/flang2/flang2exe/regutil.h
@@ -121,8 +121,8 @@ typedef struct {
   RAT *stg_base;
   int stg_avail;
   int stg_size;
-  LOGICAL mexits;   /* true => multiple exits in current loop */
-  LOGICAL use_agra; /* true => alternate global reg alloc */
+  bool mexits;   /* true => multiple exits in current loop */
+  bool use_agra; /* true => alternate global reg alloc */
 } RATB;
 
 /*****  Macros for RAT *****/

--- a/tools/flang2/flang2exe/rmsmove.c
+++ b/tools/flang2/flang2exe/rmsmove.c
@@ -21,6 +21,8 @@
  * Smove may be added by the expander, or by other transformations, such as the
  * accelerator compiler or IPA, when adding struct assignments.
  */
+
+#include "rmsmove.h"
 #include "gbldefs.h"
 #include "error.h"
 #include "global.h"
@@ -50,7 +52,7 @@ fixup_nme(int nmex, int msize, int offset, int iter)
   int sym;
   char *name = NULL;
   int name_len;
-  LOGICAL is_malloced = FALSE;
+  bool is_malloced = FALSE;
 
   if (nmex <= 0 || NME_TYPE(nmex) != NT_VAR || NME_SYM(nmex) <= 0)
     return nmex;
@@ -107,7 +109,7 @@ rm_smove(void)
   if (USE_GSMOVE)
     exp_remove_gsmove();
   for (bihx = gbl.entbih; bihx; bihx = BIH_NEXT(bihx)) {
-    LOGICAL have_smove = FALSE;
+    bool have_smove = FALSE;
     rdilts(bihx);
     for (iltx = BIH_ILTFIRST(bihx); iltx; iltx = ILT_NEXT(iltx)) {
       ilix = ILT_ILIP(iltx);

--- a/tools/flang2/flang2exe/rmsmove.h
+++ b/tools/flang2/flang2exe/rmsmove.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef RMSMOVE_H_
+#define RMSMOVE_H_
+
+/**
+   \brief ...
+ */
+void rm_smove(void);
+
+#endif

--- a/tools/flang2/flang2exe/semant.h
+++ b/tools/flang2/flang2exe/semant.h
@@ -126,7 +126,7 @@ typedef struct noscope_sym {
   int oldsptr;
   int newsptr;
   int lineno;
-  LOGICAL is_dovar;
+  bool is_dovar;
 } NOSCOPE_SYM;
 
 typedef struct { /* DO-IF stack entries */
@@ -193,7 +193,7 @@ typedef struct { /* DO-IF stack entries */
                              *     Other         - information for the outer
                              *                     scheduling loop.
                              */
-        LOGICAL is_ordered; /* loop has the ordered attribute */
+        bool is_ordered; /* loop has the ordered attribute */
       } v2;
     } v;
   } omp;
@@ -543,7 +543,7 @@ typedef struct {
 /*  declare global semant variables:  */
 
 typedef struct {
-  LOGICAL wrilms;        /* set to FALSE if don't need to write ILM's */
+  bool wrilms;        /* set to FALSE if don't need to write ILM's */
   int doif_size;         /* size in records of DOIF stack area.  */
   DOIF *doif_base;       /* base pointer for DOIF stack area. */
   int doif_depth;        /* current DO-IF nesting level */
@@ -575,29 +575,29 @@ typedef struct {
   int atemps;            /* avail counter for array bounds temporaries */
   int itemps;            /* avail counter for temporaries named 'ixxx' */
   int ptemps;            /* avail counter for inliner ptr temporaries */
-  LOGICAL savall;        /* SAVE statement w.o. symbols specified */
-  LOGICAL savloc;        /* at least one local variable SAVE'd */
-  LOGICAL none_implicit; /* insure that variables are declared - set
+  bool savall;        /* SAVE statement w.o. symbols specified */
+  bool savloc;        /* at least one local variable SAVE'd */
+  bool none_implicit; /* insure that variables are declared - set
                             TRUE if IMPLICIT NONE seen */
   STSK *stsk_base;       /* base pointer for structure stack area */
   int stsk_size;         /* size in records of structure stack area */
   int stsk_depth;        /* current structure depth (i.e. stack top) */
   int stag_dtype;        /* structure tag dtype pointer */
   int psfunc;            /* next <var ref> may be lhs of statement func */
-  LOGICAL dinit_error;   /* error flag during DATA stmt processing */
+  bool dinit_error;   /* error flag during DATA stmt processing */
   int dinit_count;       /* # elements left in current dcl id to init */
-  LOGICAL dinit_data;    /* TRUE if in DATA stmt, FALSE if type dcl or
+  bool dinit_data;    /* TRUE if in DATA stmt, FALSE if type dcl or
                             structure init stmt */
   struct {               /* info for variable format expression */
     int temps;           /*   counter for temporary labels */
     int labels;          /*   pointer to list of vfe labels */
   } vf_expr;
-  LOGICAL ignore_stmt; /* TRUE => parser is to ignore current stmt */
+  bool ignore_stmt; /* TRUE => parser is to ignore current stmt */
   int switch_size;     /* size of switch/CGOTO list area */
   int switch_avl;      /* next available word in switch list area */
   int bu_switch_avl;   /* switch_avl for bottom-up Minline */
-  LOGICAL temps_reset; /* TRUE if semant general temps can be resused */
-  LOGICAL in_stfunc;   /* in statement function def */
+  bool temps_reset; /* TRUE if semant general temps can be resused */
+  bool in_stfunc;   /* in statement function def */
   int p_adjarr;        /* pointer to list of based adjustable array-objects */
   int in_dim;          /* in <dimension list> */
                        /*
@@ -625,8 +625,8 @@ typedef struct {
   int tkntyp;        /* token effecting semant reduction */
   struct {           /* atomic */
     int lineno;      /* line number of atomic */
-    LOGICAL seen;    /* atomic directive just seen */
-    LOGICAL pending; /* atomic directive not yet applied */
+    bool seen;    /* atomic directive just seen */
+    bool pending; /* atomic directive not yet applied */
     int action_type; /* (read|write|update|capture) */
   } atomic;
   int parallel;            /* parallel nesting level - PARALLEL, DOACROSS,
@@ -634,10 +634,10 @@ typedef struct {
                             *  0 - not parallel
                             * >0 - parallel nesting level (1 => outermost)
                             */
-  LOGICAL expect_do;       /* next statement after DOACROSS, PDO, or
+  bool expect_do;       /* next statement after DOACROSS, PDO, or
                             * PARALLELDO needs to be a DO.
                             */
-  LOGICAL close_pdo;       /* A DO loop for a PDO, PARALLELDO, or DOACROSS
+  bool close_pdo;       /* A DO loop for a PDO, PARALLELDO, or DOACROSS
                             * has been processed and its removal from the
                             * DOIF stack is delayed until the next
                             * statement is processed.  For PDO and
@@ -669,7 +669,7 @@ typedef struct {
                             * iteration data structure.
                             */
   int blksymnum;
-  LOGICAL ignore_default_none; /* don't perform the OMP DEFAULT(NONE) check */
+  bool ignore_default_none; /* don't perform the OMP DEFAULT(NONE) check */
   int collapse;                /* collapse value for the pardo or pdo */
   int collapse_depth;          /* depth of collapse loop; 1 => innermost */
   int task;                    /* depth of task
@@ -747,53 +747,73 @@ extern INT cast_types[NTYPE][2][2];
 #define DPSCON(a) ad2ilm(IM_DPSCON, a)
 #define DPNULL ad1ilm(IM_DPNULL)
 
-extern void dmp_const(CONST *acl, int indent);
+ void dmp_const(CONST *acl, int indent);
 
 /*  declare external functions called only from within semant: */
 
-extern void emit_epar(void); /* semsmp.c: */
-extern void emit_bcs_ecs(int);
-extern void end_parallel_clause(int);
-extern void add_dflt_allocated(int);
-extern void add_dflt_firstprivate(int, int);
-extern INT chkcon(), const_fold(); /* semutil.c: */
-extern ISZ_T chkcon_to_isz(struct sst *, LOGICAL);
-extern INT chktyp(), chk_scalartyp();
-extern INT chk_arr_extent();
-extern int mkexpr(), chkvar(), add_base(), chksubstr(), get_temp(int),
-    get_itemp(int), mkvarref();
-extern int mklvalue(), mkmember();
-extern int mklabelvar64(int);
-extern LOGICAL is_varref();
-extern void binop(), mklogint4(), link_members(), chkstruct(), assign(),
-    do_begin(DOINFO *, int, int, int), do_parbegin(DOINFO *, int, int, int),
-    do_lastval(DOINFO *, int, int, int), do_end(DOINFO *), cngtyp(),
-    mklogint4(), negate_const();
-extern INT cngcon(INT oldval, int oldtyp, int newtyp);
-extern char *prtsst();
-extern DOINFO *get_doinfo(int);
+ void emit_epar(void); /* semsmp.c: */
+ void emit_bcs_ecs(int);
+ void end_parallel_clause(int);
+ void add_dflt_allocated(int);
+ void add_dflt_firstprivate(int, int);
+INT chkcon();
+INT const_fold(); /* semutil.c: */
+ ISZ_T chkcon_to_isz(struct sst *, bool);
+INT chktyp();
+ INT chk_scalartyp();
+ INT chk_arr_extent();
+int mkexpr();
+int chkvar();
+int add_base();
+int chksubstr();
+int get_temp(int);
+int get_itemp(int);
+int mkvarref();
+ int mklvalue(), mkmember();
+ int mklabelvar64(int);
+ bool is_varref();
+void binop();
+void mklogint4();
+void link_members();
+void chkstruct();
+void assign();
+void do_begin(DOINFO *, int, int, int);
+void do_parbegin(DOINFO *, int, int, int);
+void  do_lastval(DOINFO *, int, int, int);
+void do_end(DOINFO *);
+ void cngtyp();
+void    mklogint4();
+void negate_const();
+ INT cngcon(INT oldval, int oldtyp, int newtyp);
+ char *prtsst();
+ DOINFO *get_doinfo(int);
 
-extern void chk_adjarr(), gen_arrdsc(); /* semutil2.c: */
-extern int mk_arrdsc();
-extern void gen_allocate(int, int, int);
-extern void gen_deallocate(int, int);
-extern void sem_set_storage_class(int);
-extern int enter_lexical_block(int);
-extern void exit_lexical_block(int);
-extern void dmp_doif(int);
+void chk_adjarr();
+ void gen_arrdsc(); /* semutil2.c: */
+ int mk_arrdsc();
+ void gen_allocate(int, int, int);
+ void gen_deallocate(int, int);
+ void sem_set_storage_class(int);
+ int enter_lexical_block(int);
+ void exit_lexical_block(int);
+ void dmp_doif(int);
 
-extern int ad1ilm(int), ad2ilm(int, int),
-    ad3ilm(int, int, int), /* ilmutil.c: */
-    ad4ilm(int, int, int, int), ad5ilm(int, int, int, int, int);
-extern void dumpilmtrees(void);
-extern int lnegate();
-extern void wrilms(int), add_ilms(ILM_T *), mkbranch(int, int, int);
-extern void gwrilms(int nilms);
-extern void fini_next_gilm(void);
-extern void init_next_gilm(void);
-extern void swap_next_gilm(void);
-extern int rdilms(void);
-extern void rewindilms(void);
+int ad1ilm(int);
+int ad2ilm(int, int);
+int    ad3ilm(int, int, int); /* ilmutil.c: */
+int    ad4ilm(int, int, int, int);
+ int ad5ilm(int, int, int, int, int);
+ void dumpilmtrees(void);
+ int lnegate();
+void wrilms(int);
+void add_ilms(ILM_T *); 
+void mkbranch(int, int, int);
+ void gwrilms(int nilms);
+ void fini_next_gilm(void);
+ void init_next_gilm(void);
+ void swap_next_gilm(void);
+ int rdilms(void);
+ void rewindilms(void);
 #if DEBUG
 /* FIXME those two functions do the same thing, also see _dumpilms */
 void dmpilms(void);
@@ -804,17 +824,17 @@ void dinit(VAR *ivl, CONST *ict); /* dinit.c */
 bool dinit_ok(int);
 void dmp_ivl(VAR *, FILE *);
 void dmp_ict(CONST *, FILE *);
-extern void semfin(); /* semfin.c */
-extern int mklogopnd();
+ void semfin(); /* semfin.c */
+ int mklogopnd();
 int declref(int, int, int); /* semsym.c */
-int declsym(int, int, LOGICAL);
+int declsym(int, int, bool);
 int refsym(int, int);
 int getocsym(int, int);
 int newsym(int);
 int ref_ident(int);
 int ref_based_object(int);
 int decl_private_sym(int);
-void par_push_scope(LOGICAL);
+void par_push_scope(bool);
 void par_pop_scope(void);
 int sem_check_scope(int, int);
 
@@ -827,13 +847,12 @@ int ref_stfunc();
 int ref_entry();
 int chkarg();
 int select_gsame(int);
-extern int mkipval(INT);
-extern void subr_call();
+ int mkipval(INT);
+ void subr_call();
 void define_stfunc();
 
 /* semutil0.c */
 void semant_init(void);
 void semant_reinit(void);
-LOGICAL sem_eq_str(int, char *);
 
 #endif // SEMANT_H_

--- a/tools/flang2/flang2exe/semsym.c
+++ b/tools/flang2/flang2exe/semsym.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,21 +28,6 @@
 #include "symtab.h"
 #include "semant.h"
 
-/**
-   \brief Look up symbol having a specific symbol type.
-
-   If a symbol is found in the same overloading class and has the same
-   symbol type, it is returned to the caller.  If a symbol is found in
-   the same overloading class, the action of declref depends on the
-   stype of the existing symbol and value of the argument def:
-   1.  if symbol is an unfrozen intrinsic and def is 'd' (define), its
-       intrinsic property is removed and a new symbol is declared,
-   2.  if def is 'd', a multiple declaration error occurs, or
-   3.  if def is not 'd', an 'illegal use' error occurs.
-
-   If an error occurs or a matching symbol is not found, one is
-   created and its symbol type is initialized.
- */
 int
 declref(int sptr, int stype, int def)
 {
@@ -83,17 +68,8 @@ return2:
   return sptr;
 }
 
-/**
-   \brief Declare a new symbol.
-
-   An error can occur if the symbol is already in the symbol table:
-   - if the symbol types match treat as an error if 'errflg' is true
-     otherwise its okay and return symbol to caller
-   - else if symbol is an intrinsic attempt to remove symbol's
-     intrinsic property otherwise it is an error
- */
 int
-declsym(int sptr, int stype, LOGICAL errflg)
+declsym(int sptr, int stype, bool errflg)
 {
   register int st, sptr1, first;
 

--- a/tools/flang2/flang2exe/semutil0.c
+++ b/tools/flang2/flang2exe/semutil0.c
@@ -20,6 +20,7 @@
  * \brief SCFTN semantic analyzer module element.
  */
 
+#include "semutil0.h"
 #include "gbldefs.h"
 #include "error.h"
 #include "global.h"
@@ -29,12 +30,8 @@
 #include "ilmtp.h"
 #include "machar.h"
 #include "outliner.h"
-
-extern void scan_include();
-extern void scan_options();
-extern void chkstruct();
-extern void assign();
-extern void addlabel();
+#include "dtypeutl.h"
+#include "expand.h"
 
 #define SERROR(e, f, c)                 \
   {                                     \
@@ -49,7 +46,7 @@ extern void addlabel();
    \brief Initialize semantic analyzer for new user subprogram unit.
  */
 void
-semant_reinit()
+semant_reinit(void)
 {
   if (flg.smp && llvm_ilms_rewrite_mode()) {
   } else
@@ -895,7 +892,7 @@ type_conv_error:
    \return TRUE if fortran character constant is equal to pattern (pattern is
    always uppercase)
  */
-LOGICAL
+bool
 sem_eq_str(int con, char *pattern)
 {
   char *p1, *p2;

--- a/tools/flang2/flang2exe/semutil0.h
+++ b/tools/flang2/flang2exe/semutil0.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef SEMUTIL0_H_
+#define SEMUTIL0_H_
+
+#include "gbldefs.h"
+
+/**
+   \brief ...
+ */
+bool sem_eq_str(int con, char *pattern);
+
+/**
+   \brief ...
+ */
+INT cngcon(INT oldval, int oldtyp, int newtyp);
+
+/**
+   \brief ...
+ */
+int getrval(int ilmptr);
+
+/**
+   \brief ...
+ */
+void semant_init(void);
+
+/**
+   \brief ...
+ */
+void semant_reinit(void);
+
+#endif // SEMUTIL0_H_

--- a/tools/flang2/flang2exe/symacc.c
+++ b/tools/flang2/flang2exe/symacc.c
@@ -32,12 +32,8 @@
 
 /* FIXME: This file is compiled with different gbldefs.h included
    depending on in which part of the build it is recompiled. */
-#include "scutil.h"
-#include "gbldefs.h"
-#include "global.h"
+#include "symacc.h"
 #include "error.h"
-#include "sharedefs.h"
-#include "symtab.h"
 #include <stdarg.h>
 
 #ifndef STANDARD_MAXIDLEN
@@ -97,7 +93,6 @@ realloc_sym_storage()
 
 /**
    \brief Look up symbol with indicated name.
-
    \return If there is already such a symbol, the pointer to the
    existing symbol table entry; or 0 if a symbol doesn't exist.
    \param name is a symbol name.

--- a/tools/flang2/flang2exe/symacc.h
+++ b/tools/flang2/flang2exe/symacc.h
@@ -15,6 +15,16 @@
  *
  */
 
+#ifndef SYMACC_H_
+#define SYMACC_H_
+
+#include "scutil.h"
+#include "gbldefs.h"
+#include "global.h"
+struct SYM;
+#include "symtab.h"
+#include "sharedefs.h"
+
 /**
  * \file
  * \brief Various definitions for symacc.
@@ -59,7 +69,7 @@ public:
 #define INDEX_BY(T, Index) T *
 #endif
 
-#if defined(__cplusplus) && !defined(HACK_EAS)
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -102,7 +112,7 @@ void realloc_sym_storage();
 
 /*  symbol table typedef declarations */
 
-typedef struct {
+typedef struct SYM {
   SYMTYPE stype : 8;
   SC_KIND sc : 8;
   unsigned b3 : 8;
@@ -230,6 +240,8 @@ void symini_errfatal(int n);
 void symini_error(int n, int s, int l, const char *c1, const char *c2);
 void symini_interr(const char *txt, int val, int sev);
 
-#if defined(__cplusplus) && !defined(HACK_EAS)
+#if defined(__cplusplus)
 }
 #endif
+
+#endif // SYMACC_H_

--- a/tools/flang2/flang2exe/symtab.c
+++ b/tools/flang2/flang2exe/symtab.c
@@ -27,12 +27,9 @@
 
 #include "gbldefs.h"
 #include "error.h"
-#include "global.h"
-#include "machar.h"
 #include "symtab.h"
-
+#include "machar.h"
 #include "symtabdf.h"
-
 #include "syminidf.h"
 #include "soc.h"
 #include "llmputil.h"
@@ -41,21 +38,16 @@
 /* implicit data types */
 static struct {
   int dtype;
-  LOGICAL set; /* True if set by IMPLICIT stmt */
+  bool set; /* True if set by IMPLICIT stmt */
 } dtimplicit[26 + 26 + 2];
 
-extern void implicit_int(int default_int); /* forward declaration */
 static void cng_generic(char *, char *);
 static void cng_specific(char *, char *);
 static void cng_inttyp(char *, int);
-static void clear_vc();
+static void clear_vc(void);
 
 /* entry hack? */
 static ENTRY onlyentry;
-/* dump storage overlap chains */
-extern void dmp_socs(int sptr, FILE *file);
-/* init TY_CHAR table in dtypeutil */
-extern void init_chartab();
 
 /*
  * Define macro which converts character into index into these arrays:
@@ -500,7 +492,7 @@ static int dblm0;
 
 /* need to clear it per function */
 static void
-clear_vc()
+clear_vc(void)
 {
   int arrsize = (TY_MAX + 1) * TY_VECT_MAXLEN;
   BZERO(vc0, int, arrsize);

--- a/tools/flang2/flang2exe/upper.c
+++ b/tools/flang2/flang2exe/upper.c
@@ -19,7 +19,7 @@
  * \brief upper - import the lowered F90/HPF code
  */
 
-#include "gbldefs.h"
+#include "upper.h"
 #include "error.h"
 #include "global.h"
 #include "symtab.h"
@@ -29,7 +29,6 @@
 #include "main.h"
 #include "soc.h"
 #include "dinit.h"
-#include "upper.h"
 #include "nme.h"
 #include "fih.h"
 #include "pragma.h"
@@ -69,8 +68,8 @@ static long getlval(char *valname);
 static int getbit(char *bitname);
 
 #define STB_UPPER() (gbl.stbfil != NULL)
-static void do_llvm_sym_is_refd();
-static void build_agoto();
+static void do_llvm_sym_is_refd(void);
+static void build_agoto(void);
 
 static void init_upper(void);
 static void read_fileentries(void);
@@ -5997,8 +5996,8 @@ IPA_allcall_safe(int sptr)
 } /* IPA_allcall_safe */
 
 static struct {
-  LOGICAL smp;
-  LOGICAL recursive;
+  bool smp;
+  bool recursive;
   int profile;
   int x5;
   int x121;
@@ -6120,7 +6119,7 @@ llvm_get_uplevel_newsptr(int oldsptr)
 }
 
 static void
-build_agoto()
+build_agoto(void)
 {
   extern void exp_build_agoto(int *, int); /* exp_rte.c */
   int i;

--- a/tools/flang2/flang2exe/upper.h
+++ b/tools/flang2/flang2exe/upper.h
@@ -15,6 +15,9 @@
  *
  */
 
+#ifndef UPPER_H_
+#define UPPER_H_
+
 /** \file
  * \brief Header file for upper - import the lowered F90/HPF code
  */
@@ -120,9 +123,7 @@
  *                Internal procedures passed as arguments and pointer targets
  */
 
-#ifndef UPPER_H_
-#define UPPER_H_
-
+#include "gbldefs.h"
 #include "semant.h"
 
 #define VersionMajor 1
@@ -249,5 +250,4 @@ void upper(int stb_processing);
  */
 void upper_save_syminfo(void);
 
-
-#endif
+#endif // UPPER_H_

--- a/tools/flang2/flang2exe/verify.c
+++ b/tools/flang2/flang2exe/verify.c
@@ -21,6 +21,7 @@
 #include "symtab.h"
 #include "verify.h"
 #include "ili.h"
+#include "iliutil.h"
 
 #if DEBUG
 

--- a/tools/flang2/flang2exe/x86_64-Linux/ll_abi.c
+++ b/tools/flang2/flang2exe/x86_64-Linux/ll_abi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2017-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,9 @@
 
 /* ll_abi.c - Lowering x86-64 function calls to LLVM IR. */
 
-#include "gbldefs.h"
+#include "ll_abi.h"
+#include "dtypeutl.h"
 #include "error.h"
-#include "global.h"
-#include "symtab.h"
-#include "llutil.h"
-#include "ll_structure.h"
 
 #define DT_VOIDNONE DT_NONE
 
@@ -142,7 +139,7 @@ amd64_update_class(void *context, DTYPE dtype, unsigned address,
   }
 
   if (size <= 8) {
-    LOGICAL is_ptr = DTY(dtype) == TY_PTR;
+    bool is_ptr = DTY(dtype) == TY_PTR;
     enum amd64_class cls = AMD64_MEMORY;
     if (DT_ISINT(dtype) || is_ptr)
       cls = AMD64_INTEGER;
@@ -329,7 +326,7 @@ void
 ll_abi_classify_arg_dtype(LL_ABI_Info *abi, LL_ABI_ArgInfo *arg, DTYPE dtype)
 {
   enum amd64_class ebc[2];
-  LOGICAL inregs;
+  bool inregs;
 
   inregs = amd64_classify(ebc, dtype) == 0;
 

--- a/tools/flang2/flang2exe/x86_64-Linux/ll_abi.h
+++ b/tools/flang2/flang2exe/x86_64-Linux/ll_abi.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef LL_ABI_H_
+#define LL_ABI_H_
+
+#include "gbldefs.h"
+#include "global.h"
+#include "symtab.h"
+#include "llutil.h"
+#include "ll_structure.h"
+
+/**
+   \brief ...
+ */
+unsigned ll_abi_classify_va_arg_dtype(DTYPE dtype, unsigned *num_gp,
+                                      unsigned *num_fp);
+
+/**
+   \brief ...
+ */
+void ll_abi_classify_arg_dtype(LL_ABI_Info *abi, LL_ABI_ArgInfo *arg,
+                               DTYPE dtype);
+
+/**
+   \brief ...
+ */
+void ll_abi_classify_return_dtype(LL_ABI_Info *abi, DTYPE dtype);
+
+/**
+   \brief ...
+ */
+void ll_abi_compute_call_conv(LL_ABI_Info *abi, int func_sptr, int jsra_flags);
+
+#endif

--- a/tools/flang2/flang2exe/x86_64-Linux/machreg.h
+++ b/tools/flang2/flang2exe/x86_64-Linux/machreg.h
@@ -15,6 +15,11 @@
  *
  */
 
+#ifndef MACHREG_H_
+#define MACHREG_H_
+
+#include "gbldefs.h"
+
 extern const int scratch_regs[];
 
 /* Define registers for x86-64.
@@ -507,12 +512,50 @@ extern RGSETB rgsetb;
 
 /*****  External Function Declarations  *****/
 
-extern int mr_getnext(int rtype);
-extern int mr_getreg(int rtype);
-extern int mr_get_rgset();
-extern int mr_gindex(int rtype, int regno);
-extern void mr_end();
-extern void mr_init();
-extern void mr_reset_frglobals();
-extern void mr_reset(int rtype);
-extern void mr_reset_numglobals(int);
+/**
+   \brief ...
+ */
+int mr_getnext(int rtype);
+
+/**
+   \brief ...
+ */
+int mr_getreg(int rtype);
+
+/**
+   \brief ...
+ */
+int mr_get_rgset(void);
+
+/**
+   \brief ...
+ */
+int mr_gindex(int rtype, int regno);
+
+/**
+   \brief ...
+ */
+void mr_end(void);
+
+/**
+   \brief ...
+ */
+void mr_init(void);
+
+/**
+   \brief ...
+ */
+void mr_reset_frglobals(void);
+
+/**
+   \brief ...
+ */
+void mr_reset(int rtype);
+
+/**
+   \brief ...
+ */
+void mr_reset_numglobals(int reduce_by);
+
+
+#endif // MACHREG_H_

--- a/tools/flang2/utils/ilmtp/CMakeLists.txt
+++ b/tools/flang2/utils/ilmtp/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2017-2018, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+add_definitions("-DILMTOOLBUILD")
 
 add_executable(ilmtp
   ilmtp.cpp

--- a/tools/flang2/utils/symtab/symtab.in.h
+++ b/tools/flang2/utils/symtab/symtab.in.h
@@ -22,6 +22,7 @@
  *  \brief symbol table for Fortran backend
  */
 
+#include "global.h"
 #include <stdarg.h>
 
 /* clang-format off */

--- a/tools/shared/direct.c
+++ b/tools/shared/direct.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,10 @@
  * \brief Directive/pragma support modules
  */
 
-#include "gbldefs.h"
-#include "error.h"
-#include "global.h"
-#include "symtab.h"
 #include "direct.h"
+#include "pragma.h"
+#include "ilidir.h"
+#include "miscutil.h"
 
 #if DEBUG
 static void dmp_dirset(DIRSET *);
@@ -124,9 +123,9 @@ direct_init(void)
   direct.loop = direct.gbl;
   direct.rou_begin = direct.gbl;
 
-  direct.loop_flag = FALSE; /* seen pragma with loop scope */
-  direct.in_loop = FALSE;   /* in loop with pragmas */
-  direct.carry_fwd = FALSE;
+  direct.loop_flag = false; /* seen pragma with loop scope */
+  direct.in_loop = false;   /* in loop with pragmas */
+  direct.carry_fwd = false;
 
   direct.avail = 0;
   NEW(direct.stgb, DIRSET, (direct.size = 16));
@@ -205,7 +204,7 @@ direct_rou_end(void)
   direct.rou = direct.gbl;
   direct.loop = direct.gbl;
   direct.rou_begin = direct.gbl;
-  direct.carry_fwd = FALSE;
+  direct.carry_fwd = false;
 #ifdef FE90
   direct.dynlpg.avail = 1;
 #endif
@@ -267,8 +266,8 @@ direct_loop_end(int beg_line, int end_line)
 #endif
 
   if (direct.lpg_stk.top == 0) {
-    direct.loop_flag = FALSE;
-    direct.in_loop = FALSE;
+    direct.loop_flag = false;
+    direct.in_loop = false;
   } else if (XBIT(59, 1)) {
     direct.loop =
         direct.lpg.stgb[direct.lpg_stk.stgb[direct.lpg_stk.top].dirx].dirset;
@@ -464,7 +463,7 @@ store_dirset(DIRSET *currdir)
  * \param restore TRUE if called when restoring effects of OPTIONS
  */
 void
-dirset_options(LOGICAL restore)
+dirset_options(bool restore)
 {
   if (restore)
     direct.rou_begin.x[70] = direct.gbl.x[70];

--- a/tools/shared/direct.h
+++ b/tools/shared/direct.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,19 @@
  *
  */
 
+#ifndef DIRECT_H_
+#define DIRECT_H_
+
 /**
    \file
    \brief directive/pragma data structures.
  */
+
+#include "gbldefs.h"
+#include "error.h"
+#include "global.h"
+#include "symtab.h"
+#include <stdio.h>
 
 #ifdef FE90
 /* INDEPENDENT information */
@@ -70,7 +79,7 @@ typedef struct _index_reuse_ {/* contents of one INDEX_REUSE directive */
   struct _index_reuse_ *next;
 } INDEX_REUSE;
 
-#endif
+#endif // FE90
 
 typedef struct {
   /* NOTES:
@@ -117,9 +126,9 @@ typedef struct {
                        *  For C, this structure must be saved away for each
                        *  function appearing in the source file.
                        */
-  LOGICAL loop_flag; /**< Seen pragma with loop scope */
-  LOGICAL in_loop;   /**< Currently in loop with pragmas */
-  LOGICAL carry_fwd; /**< If global/routine pragma seen, must be carried
+  bool loop_flag; /**< Seen pragma with loop scope */
+  bool in_loop;   /**< Currently in loop with pragmas */
+  bool carry_fwd; /**< If global/routine pragma seen, must be carried
                       * forward to all outer loops which follow in the
                       * routine.
                       */
@@ -166,32 +175,77 @@ typedef struct {
 
 extern DIRECT direct;
 
-void direct_init(void); /* direct.c */
-int direct_import(FILE *);
-void direct_rou_end(void);
-void direct_loop_enter(void);
-void direct_loop_end(int, int);
-void direct_rou_load(int);
-void direct_rou_setopt(int, int);
-void load_dirset(DIRSET *);  /* utility to load a dirset into flg */
-void store_dirset(DIRSET *); /* store flg into a dirset */
-void dirset_options(LOGICAL);
-
-void push_lpprg(int);
-
-void ili_lpprg_init(void); /* ilidir.c */
-void open_pragma(int);
-void close_pragma(void);
 #ifdef FE90
-void open_dynpragma(int, int);
+void open_dynpragma(int, int); /* ilidir.h */
 void save_dynpragma(int);
-#endif
-void push_pragma(int);
-void pop_pragma(void);
-void direct_fini(void);
-#ifdef FE90
 void direct_loop_save(void);
 #endif
+
 void direct_export(FILE *ff);
+
+/**
+   \brief ...
+ */
+int direct_import(FILE *ff);
+
+/**
+   \brief ...
+ */
+void direct_fini(void);
+
+/**
+   \brief ...
+ */
+void direct_init(void);
+
+/**
+   \brief ...
+ */
+void direct_loop_end(int beg_line, int end_line);
+
+/**
+   \brief ...
+ */
+void direct_loop_enter(void);
+
+/**
+   \brief ...
+ */
+void direct_rou_end(void);
+
+/**
+   \brief ...
+ */
+void direct_rou_load(int func);
+
+/**
+   \brief ...
+ */
+void direct_rou_setopt(int func, int opt);
+
+/**
+   \brief ...
+ */
 void direct_xf(char *fn, int x, int v);
+
+/**
+   \brief ...
+ */
 void direct_yf(char *fn, int x, int v);
+
+/**
+   \brief ...
+ */
+void dirset_options(bool restore);
+
+/**
+   \brief ...
+ */
+void load_dirset(DIRSET *currdir);
+
+/**
+   \brief ...
+ */
+void store_dirset(DIRSET *currdir);
+
+#endif // DIRECT_H_

--- a/tools/shared/error.c
+++ b/tools/shared/error.c
@@ -607,12 +607,12 @@ errWithSrc(error_code_t ecode, enum error_severity sev, int eline,
     col = srcCol;
   display_error(ecode, sev, contNo + eline, op1, op2, col, srcFile);
   if (col > 0 && srcLine != NULL) {
-    LOGICAL isLeadingChars;
+    bool isLeadingChars;
     int numLeadingTabs;
     len = strlen(srcLine);
-    for (numLeadingTabs = i = 0, isLeadingChars = TRUE; i < len; ++i) {
+    for (numLeadingTabs = i = 0, isLeadingChars = true; i < len; ++i) {
       if (i == (col - 1)) {
-        isLeadingChars = FALSE;
+        isLeadingChars = false;
       }
       if (isLeadingChars && srcLine[i] == '\t') {
         /* Keep track of tabs that appear before column number. */

--- a/tools/shared/ilidir.c
+++ b/tools/shared/ilidir.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
  * blocks have been created for a function.
  */
 
+#include "ilidir.h"
 #include "gbldefs.h"
 #include "global.h"
 #include "error.h"
@@ -52,7 +53,7 @@
 
 static int first;      /* beginning loopset index for function; 0 => doesn't
                         * exist */
-static LOGICAL opened; /* TRUE if open_pragma found a set which applies to a
+static bool opened; /* TRUE if open_pragma found a set which applies to a
                         * loop */
 
 static int find_lpprg(int);
@@ -93,13 +94,13 @@ open_pragma(int line)
   LPPRG *lpprg;
   int match;
 
-  opened = FALSE;
+  opened = false;
   match = find_lpprg(line);
   if (match) {
     lpprg = direct.lpg.stgb + match;
     TR2("    begline %d, endline %d\n", lpprg->beg_line, lpprg->end_line);
     load_dirset(&lpprg->dirset);
-    opened = TRUE;
+    opened = true;
 #ifdef FE90
     direct.indep = lpprg->indep;
     direct.index_reuse_list = lpprg->index_reuse_list;
@@ -116,7 +117,7 @@ close_pragma(void)
 {
   if (opened) {
     load_dirset(&direct.rou_begin);
-    opened = FALSE;
+    opened = false;
 #ifdef FE90
     direct.indep = NULL;
     direct.index_reuse_list = NULL;

--- a/tools/shared/ilidir.h
+++ b/tools/shared/ilidir.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef ILIDIR_H_
+#define ILIDIR_H_
+
+/**
+   \brief ...
+ */
+void close_pragma(void);
+
+/**
+   \brief ...
+ */
+void ili_lpprg_init(void);
+
+/**
+   \brief ...
+ */
+void open_pragma(int line);
+
+/**
+   \brief ...
+ */
+void pop_pragma(void);
+
+/**
+   \brief ...
+ */
+void push_pragma(int line);
+
+#endif // ILIDIR_H_

--- a/tools/shared/llmputil.c
+++ b/tools/shared/llmputil.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,12 @@
 
 /* llmputil.c: OpenMP utility routines for our LLVM compilers */
 
-#include "gbldefs.h"
-#include "global.h"
-#include "error.h"
 #include "llmputil.h"
+#include "error.h"
 #include "symtab.h"
-#ifdef FE90
 #include "dtypeutl.h"
+#ifndef FE90
+#include "iliutil.h"
 #endif
 
 /* Global container of uplevel pointers */

--- a/tools/shared/llmputil.h
+++ b/tools/shared/llmputil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,15 @@
  *
  */
 
+#ifndef LLMPUTIL_H_
+#define LLMPUTIL_H_
+
 /** \file
  *  \brief OpenMP utility routines for LLVM compilers
  */
 
-#ifndef __LLMPUTIL_H__
-#define __LLMPUTIL_H__
+#include "gbldefs.h"
+#include "global.h"
 
 /** Uplevel data structure containing a list of shared variables for the region
  * nest that this uplevel belongs to.  The shared variables in this structure
@@ -99,14 +102,6 @@ extern void llmp_task_set_fnsptr(LLTask *task, int task_sptr);
 /* Return a task a object associated to 'task_sptr' */
 extern LLTask *llmp_task_get_by_fnsptr(int task_sptr);
 
-/* Add a private sptr to the task object.
- * priv:   sptr to the private copy of the private variable.
- *         ADDRESSP is called to set the offset to the kmpc task
- *         object where this private data will live during program
- *         execution.
- */
-extern int llmp_task_add_private(LLTask *task, int shared, int priv);
-
 /* Create a task object if it does not already exist for 'scope_sptr'.
  * Add a private sptr to the task object.
  * shared, priv: See llmp_task_add_private
@@ -118,13 +113,145 @@ extern void llmp_task_add(int scope_sptr, int shared, int priv);
  */
 extern int llmp_task_get_private(const LLTask *task, int sptr, int incl);
 
-void llmp_concur_add_shared_var(int stblock_sptr, int shared_sptr);
+/**
+   \brief ...
+ */
+int llmp_add_shared_var(LLUplevel *up, int shared_sptr);
+
+/**
+   \brief ...
+ */
+int llmp_get_next_key(void);
+
+/**
+   \brief ...
+ */
+int llmp_task_add_loopvar(LLTask *task, int num, int dtype);
+
+/**
+   \brief Add a private sptr to the task object.
+   priv:   sptr to the private copy of the private variable.
+           ADDRESSP is called to set the offset to the kmpc task
+           object where this private data will live during program
+           execution.
+ /
+ */
+int llmp_task_add_private(LLTask *task, int shared_sptr, int private_sptr);
+
+/**
+   \brief ...
+ */
+int llmp_task_get_base_task_size(void);
+
+/**
+   \brief ...
+ */
+int llmp_task_get_private(const LLTask *task, int sptr, int encl);
+
+/**
+   \brief ...
+ */
+INT llmp_task_get_privoff(int sptr, const LLTask *task);
+
+/**
+   \brief ...
+ */
+int llmp_task_get_size(LLTask *task);
+
+/**
+   \brief ...
+ */
+int llmp_uplevel_has_child(int uplevel);
+
+/**
+   \brief ...
+ */
+int llmp_uplevel_has_parent(int uplevel);
+
+/**
+   \brief ...
+ */
+LLTask *llmp_create_task(int scope_sptr);
+
+/**
+   \brief ...
+ */
+LLTask *llmp_get_task(int scope_sptr);
+
+/**
+   \brief ...
+ */
+LLTask *llmp_task_get_by_fnsptr(int task_sptr);
+
+/**
+   \brief ...
+ */
+LLUplevel *llmp_create_uplevel_bykey(int key);
+
+/**
+   \brief ...
+ */
+LLUplevel *llmp_create_uplevel(int uplevel_sptr);
+
+/**
+   \brief ...
+ */
+LLUplevel *llmp_get_uplevel(int uplevel_sptr);
+
+/**
+   \brief ...
+ */
+void dump_all_uplevel(void);
+
+/**
+   \brief ...
+ */
+void dump_uplevel(LLUplevel *up);
+
+/**
+   \brief ...
+ */
 void llmp_add_shared_var_charlen(LLUplevel *up, int shared_sptr);
 
-extern int llmp_task_add_loopvar(LLTask*, int, int);
-extern LLTask* llGetTask(int);
-extern int llTaskAllocSptr();
-extern INT llmp_task_get_privoff(int, const LLTask *);
-extern LOGICAL is_llvm_local_private(int);
+/**
+   \brief ...
+ */
+void llmp_append_uplevel(int from_sptr, int to_sptr);
 
-#endif /* __LLMPUTIL_H__ */
+/**
+   \brief ...
+ */
+void llmp_concur_add_shared_var(int uplevel_sptr, int shared_sptr);
+
+/**
+   \brief ...
+ */
+void llmp_copy_child_uplevel(int outermost, int curr_parent);
+
+/**
+   \brief ...
+ */
+void llmp_reset_uplevel(void);
+
+/**
+   \brief ...
+ */
+void llmp_set_parent_uplevel(int outer, int current);
+
+/**
+   \brief ...
+ */
+void llmp_task_add(int scope_sptr, int shared_sptr, int private_sptr);
+
+/**
+   \brief ...
+ */
+void llmp_task_set_fnsptr(LLTask *task, int task_sptr);
+
+/**
+   \brief ...
+ */
+void llmp_uplevel_set_dtype(LLUplevel *up, int dtype);
+
+
+#endif /* LLMPUTIL_H_ */

--- a/tools/shared/miscutil.c
+++ b/tools/shared/miscutil.c
@@ -19,9 +19,10 @@
     \brief Compiler miscellaneous utility programs.
  */
 
-#include "gbldefs.h"
+#include "miscutil.h"
 #include "global.h"
 #include "error.h"
+#include "main.h"
 
 #include <stdbool.h>
 #include "flang/ArgParser/xflag.h"
@@ -46,7 +47,7 @@ mkfname(char *oldname, char *oldsuf, char *newsuf)
  * literal and a letter "L" needs to be prepended to the target string.
 */
 char *
-literal_string(char *oldstr, int userlen, LOGICAL isStringW)
+literal_string(char *oldstr, int userlen, bool isStringW)
 {
   static char newstr[MAX_FILENAME_LEN];
   char *from, *end, *curr, c;
@@ -90,7 +91,7 @@ literal_string(char *oldstr, int userlen, LOGICAL isStringW)
   return newstr;
 }
 
-LOGICAL
+bool
 is_xflag_bit(int indx)
 {
   return is_xflag_bitvector(indx);
@@ -166,7 +167,7 @@ stg_alloc_base(STG *stg, int dtsize, int size, char *name)
  * reset stg_cleared if we're initializing or extending the cleared region
  */
 void
-stg_clear_force(STG *stg, int r, int n, LOGICAL force)
+stg_clear_force(STG *stg, int r, int n, bool force)
 {
   if (r >= 0 && n > 0) {
     STG *thisstg;
@@ -188,7 +189,7 @@ void
 stg_clear(STG *stg, int r, int n)
 {
   if (r >= 0 && n > 0)
-    stg_clear_force(stg, r, n, FALSE);
+    stg_clear_force(stg, r, n, false);
 } /* stg_clear */
 
 /*
@@ -207,7 +208,7 @@ void
 stg_alloc(STG *stg, int dtsize, int size, char *name)
 {
   stg_alloc_base(stg, dtsize, size, name);
-  stg_clear_force(stg, 0, 1, TRUE);
+  stg_clear_force(stg, 0, 1, true);
 } /* stg_alloc */
 
 /*
@@ -268,11 +269,11 @@ stg_need(STG *stg)
     }
     /* we have to clear all newly allocated elements, in case there
      * are sidecars with the NOCLEAR flag set, so they get initially cleared */
-    stg_clear_force(stg, oldsize, newsize - oldsize, TRUE);
+    stg_clear_force(stg, oldsize, newsize - oldsize, true);
   }
   if (stg->stg_avail > stg->stg_cleared) {
     /* clear any new elements */
-    stg_clear_force(stg, stg->stg_cleared, stg->stg_avail - stg->stg_cleared, TRUE);
+    stg_clear_force(stg, stg->stg_cleared, stg->stg_avail - stg->stg_cleared, true);
   }
 } /* stg_need */
 
@@ -292,7 +293,7 @@ stg_alloc_sidecar(STG *basestg, STG *stg, int dtsize, char *name)
   stg_alloc_base(stg, dtsize, basestg->stg_size, name);
   stg->stg_avail = basestg->stg_avail;
   /* clear sidecar for any already-allocated elements */
-  stg_clear_force(stg, 0, stg->stg_size, TRUE);
+  stg_clear_force(stg, 0, stg->stg_size, true);
   /* link this sidecar to the list of sidecars for the basestg */
   stg->stg_sidecar = basestg->stg_sidecar;
   basestg->stg_sidecar = (void *)stg;

--- a/tools/shared/miscutil.h
+++ b/tools/shared/miscutil.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef MISCUTIL_H_
+#define MISCUTIL_H_
+
+#include "gbldefs.h"
+#include "sharedefs.h"
+#include <stdio.h>
+
+/**
+   \brief ...
+ */
+bool is_xflag_bit(int indx);
+
+/**
+   \brief ...
+ */
+char *literal_string(char *oldstr, int userlen, bool isStringW);
+
+/**
+   \brief ...
+ */
+char *mkfname(char *oldname, char *oldsuf, char *newsuf);
+
+/**
+   \brief ...
+ */
+int license_prc2(void);
+
+/**
+   \brief ...
+ */
+int license_prc(void);
+
+/**
+   \brief ...
+ */
+int stg_next_freelist(STG *stg);
+
+/**
+   \brief ...
+ */
+int stg_next(STG *stg, int n);
+
+/**
+   \brief ...
+ */
+void fprintf_str_esc_backslash(FILE *f, char *str);
+
+/**
+   \brief ...
+ */
+void set_xflag(int indx, INT val);
+
+/**
+   \brief ...
+ */
+void set_yflag(int indx, INT val);
+
+/**
+   \brief ...
+ */
+void stg_add_freelist(STG *stg, int r);
+
+/**
+   \brief ...
+ */
+void stg_alloc_sidecar(STG *basestg, STG *stg, int dtsize, char *name);
+
+/**
+   \brief ...
+ */
+void stg_alloc(STG *stg, int dtsize, int size, char *name);
+
+/**
+   \brief ...
+ */
+void stg_clear_all(STG *stg);
+
+/**
+   \brief ...
+ */
+void stg_clear_force(STG *stg, int r, int n, bool force);
+
+/**
+   \brief ...
+ */
+void stg_clear(STG *stg, int r, int n);
+
+/**
+   \brief ...
+ */
+void stg_delete_sidecar(STG *basestg, STG *stg);
+
+/**
+   \brief ...
+ */
+void stg_delete(STG *stg);
+
+/**
+   \brief ...
+ */
+void stg_need(STG *stg);
+
+/**
+   \brief ...
+ */
+void stg_set_freelink(STG *stg, int offset);
+
+#endif // MISCUTIL_H_

--- a/tools/shared/nme.h
+++ b/tools/shared/nme.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,16 @@
  *
  */
 
+#ifndef NME_H_
+#define NME_H_
+
 /** \file
  *  \brief NME data structures and definitions
  */
 
-#ifndef NME_H
-
 typedef struct {
   char type;   /* One of the following NT_ defs. */
-  char inlarr; /* nonzero if an inlined array ref; else 0 */
+  bool inlarr; /**< true iff an inlined array ref */
   char pd1;
   char pd2;
   int stl;       /* STL item pointer: rsvd for invariant */
@@ -198,58 +199,17 @@ typedef enum NT_KIND {
 #define RPCT_NME2(i) nmeb.rpct.stg_base[RPCT_CHECK(i)].nme2
 #define RPCT_HSHLNK(i) nmeb.rpct.stg_base[RPCT_CHECK(i)].hshlnk
 
-/***** External Functions *****/
-
-extern int add_arrnme(NT_KIND, SPTR, int, ISZ_T, int, LOGICAL);
-extern int add_rpct_nme(int orig_nme, int rpct_loop);
-extern int addnme(NT_KIND, int, int, ISZ_T);
-extern int basesym_of(int);
-extern int basenme_of(int);
-extern int zbasenme_of(int);
-extern void add_rpct(int rpct_nme1, int rpct_nme2);
-extern LOGICAL is_presym(int);
-extern void loc_of(int);
-extern void loc_of_vol(int);
-extern DTYPE dt_nme(int);
-
-extern int lookupnme(NT_KIND type, int insym, int nm, ISZ_T cnst);
-
-int print_nme(int nme);
-int __print_nme(FILE *ff, int nme);
-extern int build_sym_nme(int sym, int offset, LOGICAL ptr_mem_op);
-extern LOGICAL basenme_is_static(int);
-extern void dumpname(int);
-void dmpnme(void);
-int hlconflict(int nm1, int nm2);
-void nme_init(void);
-void nme_end(void);
-int addpte(int type, SPTR sptr, int val, int next);
-#ifdef PTRSTOREP
-void ptrstore_of(int nme);
-#endif
-
 #ifndef FE90
-/* #if defined(I386) || defined(X86_64) || defined(X86_32) || defined(LX) ||
- * defined(SPARC) || defined(ST100) */
-extern int conflict(int, int); /* determine if there is a conflict between
-                                  the loads/stores represented by the two
-                                  names table pointers.    */
-extern LOGICAL
-is_smove_member(int); /* determine whether the given nme represents
-                       * loads and stores for remaining parts of a
-                       * structure copy.
-                       */
-/* Values returned by conflict() function */
 #define SAME -1
 #define NOCONFLICT 0
 #define CONFLICT 1
 #define UNKCONFLICT 2
-/* #endif */
 #endif
 
 /***** External Data Declarations *****/
 
 extern NMEB nmeb;
 
-#define NME_H
-#endif
+#include "nmeutil.h"
+
+#endif // NME_H_

--- a/tools/shared/nmeutil.h
+++ b/tools/shared/nmeutil.h
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NMEUTIL_H_
+#define NMEUTIL_H_
+
+#include "gbldefs.h"
+#include "global.h"
+#include "symtab.h"
+#include "nme.h"
+#include <stdio.h>
+
+/**
+   \brief ...
+ */
+bool basenme_is_static(int nme);
+
+/**
+   \brief ...
+ */
+bool is_presym(int nme);
+
+/**
+   \brief ...
+ */
+bool is_smove_member(int nme);
+
+/**
+   \brief ...
+ */
+DTYPE dt_nme(int nm);
+
+/**
+   \brief Main add NME routine
+
+   Enter nme into the NME area.
+
+<pre>
+  the type NT_INDARR is used to distinguish the cases:
+    typedef float* fp;
+    typedef float f10[10];
+    fp* ppf;		// pointer to pointer to float
+    fp a10pf[10];	// array of 10 pointers to float
+    f10* pa10f;	// pointer to array of 10 floats
+   ppf[i][j]		// appears as IM_ELEMENT -> IM_PLD -> IM_ELEMENT ->
+  IM_PLD -> ppf
+   a10pf[i][j]		// appears as IM_ELEMENT -> IM_PLD -> IM_ELEMENT ->
+  a10pf
+   pa10f[i][j]		// appears as IM_ELEMENT -> IM_ELEMENT -> IM_PLD ->
+  pa10f
+  NT_INDARR is used when an IM_ELEMENT -> IM_PLD appears in the ILM file.
+</pre>
+ */
+int add_arrnme(NT_KIND type, SPTR insym, int nm, ISZ_T cnst, int sub,
+               bool inlarr);
+
+/**
+   \brief ...
+ */
+int addnme(NT_KIND type, int insym, int nm, ISZ_T cnst);
+
+/**
+   \brief ...
+ */
+int add_nme_with_pte(int nm, int ptex);
+
+/**
+   \brief ...
+ */
+int addpte(int type, SPTR sptr, int val, int next);
+
+/**
+   \brief ...
+ */
+int add_rpct_nme(int orig_nme, int rpct_loop);
+
+/**
+   \brief ...
+ */
+int basenme_of(int nme);
+
+/**
+   \brief ...
+ */
+int basesym_of(int nme);
+
+/**
+   \brief ...
+ */
+int _build_sym_nme(DTYPE dt, int curr_off, int offset, int nme);
+
+/**
+   \brief ...
+ */
+int build_sym_nme(int sym, int offset, bool ptr_mem_op);
+
+/**
+   \brief ...
+ */
+int _conflict(int nm1, int nm2);
+
+/**
+   \brief ...
+ */
+int conflict(int nm1, int nm2);
+
+/**
+   \brief ...
+ */
+int hlconflict(int nm1, int nm2);
+
+/**
+   \brief ...
+ */
+int lookupnme(NT_KIND type, int insym, int nm, ISZ_T cnst);
+
+/**
+   \brief ...
+ */
+int __print_nme(FILE *ff, int nme);
+
+/**
+   \brief ...
+ */
+int print_nme(int nme);
+
+/**
+   \brief ...
+ */
+int usersym_of(int nme);
+
+/**
+   \brief ...
+ */
+int zbasenme_of(int nme);
+
+/**
+   \brief ...
+ */
+void add_rpct(int rpct_nme1, int rpct_nme2);
+
+/**
+   \brief ...
+ */
+void count_conflict(void);
+
+/**
+   \brief ...
+ */
+void dmpnmeall(int flag);
+
+/**
+   \brief ...
+ */
+void __dmpnme(FILE *f, int i, int flag);
+
+/**
+   \brief ...
+ */
+void dmpnme(void);
+
+/**
+   \brief ...
+ */
+void __dumpname(FILE *f, int opn);
+
+/**
+   \brief ...
+ */
+void dumpname(int opn);
+
+/**
+   \brief ...
+ */
+void __dumpnme(FILE *f, int opn);
+
+/**
+   \brief ...
+ */
+void loc_of(int nme);
+
+/**
+   \brief ...
+ */
+void loc_of_vol(int nme);
+
+/**
+   \brief ...
+ */
+void nme_end(void);
+
+/**
+   \brief ...
+ */
+void nme_init(void);
+
+/**
+   \brief ...
+ */
+void PrintTopHash(void);
+
+/**
+   \brief ...
+ */
+void PrintTopNMEHash(void);
+
+#endif // NMEUTIL_H_

--- a/tools/shared/rte.h
+++ b/tools/shared/rte.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1996-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,7 +201,7 @@ extern int get_kind(int);
 extern int get_gbase(int);
 extern int get_gbase2(int);
 extern int get_desc_tag(int);
-extern void rewrite_asn(int, int, LOGICAL, int);
+extern void rewrite_asn(int, int, bool, int);
 extern void get_static_descriptor(int);
 extern void set_descriptor_sc(int);
 extern int get_descriptor_sc(void);

--- a/tools/shared/rtlRtnsDesc.h
+++ b/tools/shared/rtlRtnsDesc.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2016-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef FE_RTLRTNSDESC_H
-#define FE_RTLRTNSDESC_H
+#ifndef FE_RTLRTNSDESC_H_
+#define FE_RTLRTNSDESC_H_
 
 /**
  * \file  Runtime Library routine descriptions.
@@ -28,8 +28,8 @@
 typedef struct {
   char *baseNm;
   char fullNm[64];
-  LOGICAL I8Descr;
+  bool I8Descr;
   char largeRetValPrefix[4];
 } FtnRteRtn;
 
-#endif /* FE_RTLRTNSDESC_H */
+#endif /* FE_RTLRTNSDESC_H_ */

--- a/tools/shared/utils/global.h
+++ b/tools/shared/utils/global.h
@@ -18,7 +18,13 @@
 #ifndef GLOBAL_H_
 #define GLOBAL_H_
 
-/* global.h - FTN global variables and flags. */
+/**
+   \file
+   \brief FTN global variables and flags.
+ */
+
+#include "universal.h"
+#include <stdio.h>
 
 /* An index into the symbol table. */
 typedef enum SPTR {
@@ -53,11 +59,11 @@ typedef struct {
   FILE *objfil;    /* file pointer for output object file */
   FILE *asmfil;    /* file pointer for output assembly file */
   FILE *stbfil;    /* file pointer for symbols and datatype for llvm compiler */
-  LOGICAL eof_flag;
+  bool eof_flag;
   SPTR currsub;  /* symtab ptr to current subprogram */
   SPTR caller;   /* symtab ptr to current caller (for bottom-up inlining) */
   int cgr_index; /* call graph index to current subprogram */
-  LOGICAL arets; /* set to true if any entry contains an
+  bool arets; /* set to true if any entry contains an
                     alternate return.  */
   RUTYPE rutype;    /* RU_PROG, RU_SUBR, RU_FUNC, or RU_BDATA */
   int funcline;  /* line number of header statement */
@@ -96,9 +102,9 @@ typedef struct {
                          * compiled, incremented by assem_init */
   char *file_name;      /* full pathname of input file; -file may override */
   int ftn_true;         /* value of .TRUE.; -1 (default) or 1 (-x 125 8) */
-  LOGICAL has_program;  /* true if a fortran 'program' has been seen */
-  LOGICAL in_include;   /* set to true if source is from an include file */
-  LOGICAL nowarn;       /* if TRUE, don't issue warning & informational errors*/
+  bool has_program;  /* true if a fortran 'program' has been seen */
+  bool in_include;   /* set to true if source is from an include file */
+  bool nowarn;       /* if TRUE, don't issue warning & informational errors*/
   int internal;         /* internal subprogram state:
                          * 0 - current subprogram does not contain internal
                          *     subprograms.
@@ -112,7 +118,7 @@ typedef struct {
                          * a vector of pointers used to locate a thread's
                          * copy of the common block.
                          */
-  LOGICAL nofperror;    /* if TRUE, error.c:fperror() does not report errors */
+  bool nofperror;    /* if TRUE, error.c:fperror() does not report errors */
   int fperror_status;   /* error status of a floating point operation
                          * performed by scutil.
                          */
@@ -134,7 +140,7 @@ typedef struct {
 #ifdef PGF90
   int typedescs; /* list of type descriptors */
 #endif
-  LOGICAL denorm; /* enforce denorm for the current subprogram */
+  bool denorm; /* enforce denorm for the current subprogram */
   int outlined;   /* is outlined function .*/
   int usekmpc;    /* use KMPC runtime. turned on for -ta=multicore for llvm. */
 } GBL;
@@ -147,55 +153,55 @@ extern GBL gbl;
 #define TPNVERSION 25
 
 typedef struct {
-  LOGICAL asmcode;
-  LOGICAL list;
-  LOGICAL object;
-  LOGICAL xref;
-  LOGICAL code;
-  LOGICAL include;
-  int debug;
+  bool asmcode;
+  bool list;
+  bool object;
+  bool xref;
+  bool code;
+  bool include;
+  bool debug;
   int opt;
-  LOGICAL depchk;
-  LOGICAL depwarn;
-  LOGICAL dclchk;
-  LOGICAL locchk;
-  LOGICAL onetrip;
-  LOGICAL save;
+  bool depchk;
+  bool depwarn;
+  bool dclchk;
+  bool locchk;
+  bool onetrip;
+  bool save;
   int inform;
   UINT xoff;
   UINT xon;
-  LOGICAL ucase;
+  bool ucase;
   char **idir;
-  LOGICAL dlines;
+  bool dlines;
   int extend_source;
-  LOGICAL i4;
-  LOGICAL line;
-  LOGICAL symbol;
+  bool i4;
+  bool line;
+  bool symbol;
   int profile;
-  LOGICAL standard;
+  bool standard;
   int dbg[96];
-  LOGICAL dalign; /* TRUE if doubles are double word aligned */
+  bool dalign; /* TRUE if doubles are double word aligned */
   int astype;     /* target dependent value to support multiple asm's */
-  LOGICAL recursive;
+  bool recursive;
   int ieee;
   int inliner;
   int autoinline;
   int vect;
-  LOGICAL endian;
-  LOGICAL terse;
+  int endian;
+  int terse;
   int dollar;   /* defines the char to which '$' is translated */
   int x[251];   /* x flags */
-  LOGICAL quad; /* quad align "unconstrained objects" if sizeof >= 16 */
+  bool quad; /* quad align "unconstrained objects" if sizeof >= 16 */
   int anno;
-  LOGICAL qa; /* TRUE => -qa appeared on command line */
-  LOGICAL es;
-  LOGICAL p;
+  bool qa; /* TRUE => -qa appeared on command line */
+  bool es;
+  bool p;
   char **def;
   char *stdinc; /* NULL => use std include; 1 ==> do not look in
                  * std dir; o.w., use value as the std dir */
-  LOGICAL smp;  /* TRUE => allow smp directives */
+  bool smp;  /* TRUE => allow smp directives */
   int errorlimit;
-  LOGICAL trans_inv; /* global equiv to -Mx,7,0x10000 */
+  bool trans_inv; /* global equiv to -Mx,7,0x10000 */
   int tpcount;
   int tpvalue[TPNVERSION]; /* target processor(s), for unified binary */
 } FLG;

--- a/tools/shared/utils/symacc.c
+++ b/tools/shared/utils/symacc.c
@@ -32,19 +32,11 @@
 
 /* FIXME: This file is compiled with different gbldefs.h included
    depending on in which part of the build it is recompiled. */
-#include "scutil.h"
-#include "gbldefs.h"
-#include "global.h"
+#include "symacc.h"
 #ifdef UTILSYMTAB
 #include "universal.h"
 #else
 #include "error.h"
-#endif
-#include "sharedefs.h"
-#ifdef INIT
-#include "symacc.h"
-#else
-#include "symtab.h"
 #endif
 #include <stdarg.h>
 
@@ -149,7 +141,6 @@ realloc_sym_storage()
 
 /**
    \brief Look up symbol with indicated name.
-
    \return If there is already such a symbol, the pointer to the
    existing symbol table entry; or 0 if a symbol doesn't exist.
    \param name is a symbol name.

--- a/tools/shared/utils/symacc.h
+++ b/tools/shared/utils/symacc.h
@@ -15,6 +15,16 @@
  *
  */
 
+#ifndef SYMACC_H_
+#define SYMACC_H_
+
+#include "scutil.h"
+#include "gbldefs.h"
+#include "global.h"
+struct SYM;
+#include "symtab.h"
+#include "sharedefs.h"
+
 /**
  * \file
  * \brief Various definitions for symacc.
@@ -59,7 +69,7 @@ public:
 #define INDEX_BY(T, Index) T *
 #endif
 
-#if defined(__cplusplus) && !defined(HACK_EAS)
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -122,7 +132,7 @@ void realloc_sym_storage();
 /*  symbol table typedef declarations */
 
 #ifndef PGHPF
-typedef struct {
+typedef struct SYM {
   SYMTYPE stype : 8;
   SC_KIND sc : 8;
   unsigned b3 : 8;
@@ -178,7 +188,7 @@ typedef struct {
 #endif
 
 #ifdef PGHPF
-typedef struct {
+typedef struct SYM {
   SYMTYPE stype : 8;
   SC_KIND sc : 8;
   unsigned b3 : 8;
@@ -375,6 +385,8 @@ void symini_errfatal(int n);
 void symini_error(int n, int s, int l, const char *c1, const char *c2);
 void symini_interr(const char *txt, int val, int sev);
 
-#if defined(__cplusplus) && !defined(HACK_EAS)
+#if defined(__cplusplus)
 }
 #endif
+
+#endif // SYMACC_H_

--- a/tools/shared/utils/symutil.cpp
+++ b/tools/shared/utils/symutil.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2016-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -290,6 +290,11 @@ private:
       exit(1);
     }
   }
+ 
+  void flushline(std::ostream* outf)
+  {
+    *outf<<line<<"\n";
+  }
 
   void
   read_symtab_n()
@@ -352,6 +357,7 @@ private:
         tmpss.str("");
         tmpss.clear();
         os = &tmpss;
+        flushline(&out1);
         goto again;
 
       case LT_SI:
@@ -405,6 +411,7 @@ private:
         tmpss.str("");
         tmpss.clear();
         os = &tmpss;
+        flushline(&out1);
         goto again;
 
       case LT_DE:
@@ -439,6 +446,7 @@ private:
       default:
         printError(FATAL, "Unknown LT: can't happen\n");
       }
+      flushline(os);
     again:
       lt = getLineAndTokenize(elt, os);
     }


### PR DESCRIPTION
Add header files for all C modules.

This very large change makes a 1:1 correspondence between C module
implmentations (.c files) and C module interfaces (.h files).  Per
the LLVM coding conventions (most) of the .c files include their
own .h file first and then any additional .h files needed by the
implementation.  Also per the LLVM coding convention, doxygen comment
stubs have been added to all exported functions for all modules.
However, many of these stubs will need to be completed.

This change also removes the use of LOGICAL from flang2
and replaces it with the C++ standard type bool.