### PR TITLE
Automatically SAVE module variable marked as THREADPRIVATE

### DIFF
--- a/test/mp_correct/copyin.f90
+++ b/test/mp_correct/copyin.f90
@@ -1,0 +1,13 @@
+! RUN: %flang %s -fopenmp -fsyntax-only
+
+module somemod
+  integer, allocatable :: something(:)
+  !$OMP THREADPRIVATE(something)
+end module somemod
+
+program some
+  use somemod
+
+  !$OMP PARALLEL COPYIN(something)
+  !$OMP END PARALLEL
+end program some

--- a/tools/flang1/flang1exe/semant.c
+++ b/tools/flang1/flang1exe/semant.c
@@ -3749,6 +3749,8 @@ semant1(int rednum, SST *top)
       if (sptr == 0)
         continue;
       THREADP(sptr, 1);
+      if (sem.mod_sym)
+        SAVEP(sptr, 1);
 
       if (STYPEG(sptr) != ST_CMBLK && !DCLDG(sptr) && !SAVEG(sptr) &&
           !sem.savall) {


### PR DESCRIPTION
Without this change compiler segfaults on COPYIN of module variables.
