### PR TITLE
libflangrti.so should depend on libompstub.so instead of libomp.so

### DIFF
--- a/runtime/flang/CMakeLists.txt
+++ b/runtime/flang/CMakeLists.txt
@@ -465,6 +465,16 @@ add_flang_library(flang_static
   ${SHARED_SOURCES}
   )
 set_property(TARGET flang_static PROPERTY OUTPUT_NAME flang)
+add_flang_library(flang-omp_static
+  ${FTN_INTRINSICS_DESC_INDEP}
+  ${FTN_INTRINSICS_DESC_DEP}
+  ${FTN_INTRINSICS_I8}
+  ${FTN_SUPPORT_DESC_INDEP}
+  ${FTN_SUPPORT_DESC_DEP}
+  ${FTN_SUPPORT_I8}
+  ${SHARED_SOURCES}
+  )
+set_property(TARGET flang-omp_static PROPERTY OUTPUT_NAME flang-omp)
 
 set(SHARED_LIBRARY TRUE)
 add_flang_library(flang_shared
@@ -477,9 +487,22 @@ add_flang_library(flang_shared
   ${SHARED_SOURCES}
   )
 set_property(TARGET flang_shared PROPERTY OUTPUT_NAME flang)
+add_flang_library(flang-omp_shared
+  ${FTN_INTRINSICS_DESC_INDEP}
+  ${FTN_INTRINSICS_DESC_DEP}
+  ${FTN_INTRINSICS_I8}
+  ${FTN_SUPPORT_DESC_INDEP}
+  ${FTN_SUPPORT_DESC_DEP}
+  ${FTN_SUPPORT_I8}
+  ${SHARED_SOURCES}
+  )
+set_property(TARGET flang-omp_shared PROPERTY OUTPUT_NAME flang-omp)
+
 target_link_libraries(flang_shared ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/libflangrti.so)
+target_link_libraries(flang-omp_shared ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/libflangrti-omp.so)
 # Resolve symbols against libm and librt
 target_link_libraries(flang_shared m rt)
+target_link_libraries(flang-omp_shared m rt)
 
 set(SHARED_LIBRARY FALSE)
 
@@ -554,12 +577,17 @@ set_source_files_properties(
   OBJECT_DEPENDS ${CMAKE_Fortran_MODULE_DIRECTORY}/iso_c_binding.mod
   )
 
-set_target_properties(flang_static flang_shared
+set_target_properties(flang_static flang_shared flang-omp_static flang-omp_shared
   PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY ${FLANG_RTE_LIB_DIR}
   )
-  
+
 target_include_directories(flang_static 
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
+  )
+target_include_directories(flang-omp_static
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
@@ -570,24 +598,45 @@ target_include_directories(flang_shared
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   )
+target_include_directories(flang-omp_shared
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
+  )
 
 # Make sure the compiler is built before we bootstrap
 add_dependencies(flang_static 
   flang1
   flang2
+  flangrti_static
+  )
+add_dependencies(flang-omp_static
+  flang1
+  flang2
+  flangrti-omp_static
   )
 
 # Make sure the compiler is built before we bootstrap
 add_dependencies(flang_shared 
   flang1
   flang2
+  flangrti_shared
+  )
+add_dependencies(flang-omp_shared
+  flang1
+  flang2
+  flangrti-omp_shared
   )
 
 target_compile_options(flang_static PRIVATE -fPIC)
+target_compile_options(flang-omp_static PRIVATE -fPIC)
 
 target_compile_options(flang_shared PRIVATE -fPIC)
+target_compile_options(flang-omp_shared PRIVATE -fPIC)
 
 target_compile_options(flang_static PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreentrant>)
+target_compile_options(flang-omp_static PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreentrant>)
 
 target_compile_options(flang_shared PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreentrant>)
+target_compile_options(flang-omp_shared PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreentrant>)
 

--- a/runtime/flangrti/CMakeLists.txt
+++ b/runtime/flangrti/CMakeLists.txt
@@ -87,16 +87,27 @@ add_flang_library(flangrti_static
   ${SHARED_SOURCES}
   )
 set_property(TARGET flangrti_static PROPERTY OUTPUT_NAME flangrti)
-
+add_flang_library(flangrti-omp_static
+  ${PGC_SRC_FILES}
+  ${SHARED_SOURCES}
+  )
+set_property(TARGET flangrti-omp_static PROPERTY OUTPUT_NAME flangrti-omp)
 
 set(SHARED_LIBRARY TRUE)
 add_flang_library(flangrti_shared
   ${PGC_SRC_FILES}
   ${SHARED_SOURCES}
   )
+add_flang_library(flangrti-omp_shared
+  ${PGC_SRC_FILES}
+  ${SHARED_SOURCES}
+  )
+
+target_link_libraries(flangrti_shared ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/libompstub.so)
 
 # Resolve symbols against libm
 target_link_libraries(flangrti_shared m)
+target_link_libraries(flangrti-omp_shared m)
 
 # Import OpenMP
 if (NOT DEFINED LIBOMP_EXPORT_DIR)
@@ -104,7 +115,7 @@ if (NOT DEFINED LIBOMP_EXPORT_DIR)
     FLANG_LIBOMP
     libomp.so
     HINTS ${CMAKE_BINARY_DIR}/lib)
-  target_link_libraries(flangrti_shared ${FLANG_LIBOMP})
+  target_link_libraries(flangrti-omp_shared ${FLANG_LIBOMP})
 endif()
 
 find_library( 
@@ -113,18 +124,33 @@ find_library(
   HINTS ${CMAKE_BINARY_DIR}/lib)
 target_link_libraries(flangrti_shared ${LIBPGMATH})
 
+find_library( 
+  LIBPGMATH
+  libpgmath.so
+  HINTS ${CMAKE_BINARY_DIR}/lib)
+target_link_libraries(flangrti-omp_shared ${LIBPGMATH})
+
 if( ${TARGET_ARCHITECTURE} STREQUAL "aarch64" )
   target_compile_definitions(flangrti_static PRIVATE TARGET_LINUX_ARM)
+  target_compile_definitions(flangrti-omp_static PRIVATE TARGET_LINUX_ARM)
   target_compile_definitions(flangrti_shared PRIVATE TARGET_LINUX_ARM)
+  target_compile_definitions(flangrti-omp_shared PRIVATE TARGET_LINUX_ARM)
 elseif( ${TARGET_ARCHITECTURE} STREQUAL "ppc64le" )
   target_compile_definitions(flangrti_static PRIVATE TARGET_LINUX_POWER)
+  target_compile_definitions(flangrti-omp_static PRIVATE TARGET_LINUX_POWER)
   target_compile_definitions(flangrti_shared PRIVATE TARGET_LINUX_POWER)
+  target_compile_definitions(flangrti-omp_shared PRIVATE TARGET_LINUX_POWER)
 endif()
 
 set_property(TARGET flangrti_shared PROPERTY OUTPUT_NAME flangrti)
+set_property(TARGET flangrti-omp_shared PROPERTY OUTPUT_NAME flangrti-omp)
 set(SHARED_LIBRARY FALSE)
 
 target_include_directories(flangrti_static
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+target_include_directories(flangrti-omp_static
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
@@ -133,15 +159,27 @@ target_include_directories(flangrti_shared
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
+target_include_directories(flangrti-omp_shared
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 
-set_target_properties(flangrti_shared flangrti_static
+add_dependencies(flangrti_shared
+    ompstub_shared
+  )
+
+set_target_properties(flangrti_shared flangrti_static flangrti-omp_shared flangrti-omp_static
                       PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${FLANG_RTE_LIB_DIR})
 
 target_compile_options(flangrti_static PRIVATE -fPIC)
+target_compile_options(flangrti-omp_static PRIVATE -fPIC)
 
 target_compile_options(flangrti_shared PRIVATE -fPIC)
+target_compile_options(flangrti-omp_shared PRIVATE -fPIC)
 
 target_compile_options(flangrti_static PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreentrant>)
+target_compile_options(flangrti-omp_static PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreentrant>)
 
 target_compile_options(flangrti_shared PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreentrant>)
+target_compile_options(flangrti-omp_shared PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreentrant>)
 


### PR DESCRIPTION
This commit drops unfortunate dependency of libflangrti.so
on libomp.so.

For non-OpenMP programs (built without -fopenmp flag) frontend
driver instructs the linker to link against libompstub.so library,
which exports stubs for all OpenMP runtime library symbols. This is
because Flang runtime library contains calls to those symbols
(for OpenMP programs, final binary is linked against libomp.so
instead).

Apart form above, all of the Fortran programs are linked against
libflang.so and libflangrti.so. Unfortunately, before this change
libflangrti.so was depending on full blown OpenMP runtime library
(libomp.so).

This commit creates two sets of Flang runtime shared objects with
following chains of dependencies:

1. libflang.so -> libflangrti.so -> libompstub.so
2. libflang-omp.so -> libflangrti-omp.so -> libomp.so

Note that in order for this change to be in effect, relevant commit
must be also applied on the clang repository.
