### PR TITLE
Pull 2018-06-07T16-59 Recent NVIDIA Changes

### DIFF
--- a/tools/flang1/flang1exe/main.c
+++ b/tools/flang1/flang1exe/main.c
@@ -806,6 +806,8 @@ init(int argc, char *argv[])
   register_boolean_arg(arg_parser, "recursive", (bool *)&(flg.recursive),
                        false);
   register_string_arg(arg_parser, "cmdline", &(flg.cmdline), NULL);
+  register_boolean_arg(arg_parser, "es", (bool *)&(flg.es), false);
+  register_boolean_arg(arg_parser, "pp", (bool *)&(flg.p), false);
 
   /* Set values form command line arguments */
   parse_arguments(arg_parser, argc, argv);


### PR DESCRIPTION
Fix a bug exposed by Flang issue #492.
Enables flang1 to consume -es and -pp flags generated by the flang driver.