### PR TITLE
Pull 2018-06-08T04-58 Recent NVIDIA Changes

### DIFF
--- a/tools/flang1/flang1exe/findloop.c
+++ b/tools/flang1/flang1exe/findloop.c
@@ -524,7 +524,7 @@ top_sort(void)
       if (OPTDBG(9, 8))
         fprintf(gbl.dbgfil, "            innermost loop %d\n", k);
     }
-  assert(r != n, "top_sort: wrong qlink", r, 3);
+  assert(r != n, "top_sort: wrong qlink", r, ERR_Severe);
 
   /*
    * Go through the relations and create the order - this continues until
@@ -541,7 +541,7 @@ top_sort(void)
       if (--COUNT(SUCC(p)) == 0)
         r = QLINK(r) = SUCC(p);
   }
-  assert(n == 1, "wrong top_sort", n, 3);
+  assert(n == 1, "wrong top_sort", n, ERR_Severe);
 
   /* free up the top array and the area used for the successors  */
 
@@ -1103,7 +1103,7 @@ convert_loop(int loop)
    * label referenced is the one which labels the new head
    */
   tmp = ILT_NEXT(tmp);
-  assert(tmp == BIH_ILTLAST(tailbih), "convert_loop: wrong last ilt", tmp, 3);
+  assert(tmp == BIH_ILTLAST(tailbih), "convert_loop: wrong last ilt", tmp, ERR_Severe);
   new_tree = rewr_ili((int)ILT_ILIP(br_ilt), 1, 1);
   ILT_ILIP(tmp) = compl_br((int)new_tree, label);
   if (OPTDBG(9, 8))
@@ -1141,7 +1141,7 @@ convert_loop(int loop)
       break;
     }
   }
-  assert(p != PSI_P_NULL, "convert_loop: head not succ of tail", tail, 3);
+  assert(p != PSI_P_NULL, "convert_loop: head not succ of tail", tail, ERR_Severe);
 
   /*
    * remove tail from the predecessor list of head and add tail to the
@@ -1160,7 +1160,7 @@ convert_loop(int loop)
     }
     q = p;
   }
-  assert(p != PSI_P_NULL, "convert_loop: tail not pred of head", head, 3);
+  assert(p != PSI_P_NULL, "convert_loop: tail not pred of head", head, ERR_Severe);
   BIH_FT(tailbih) = 1;
 
   /*
@@ -1241,7 +1241,7 @@ reorder_dfn_loops()
   }
 #if DEBUG
   if (n != opt.nloops) {
-    interr("reorder_dfn_loops: wrong number of loops", n, 3);
+    interr("reorder_dfn_loops: wrong number of loops", n, ERR_Severe);
   }
 #endif
 } /* reorder_dfn_loops */
@@ -1277,7 +1277,7 @@ reorderloops()
   }
 #if DEBUG
   if (n != opt.nloops) {
-    interr("reorderloops: wrong number of loops", n, 3);
+    interr("reorderloops: wrong number of loops", n, ERR_Severe);
   }
 #endif
 } /* reorderloops */

--- a/tools/flang1/flang1exe/pointsto.c
+++ b/tools/flang1/flang1exe/pointsto.c
@@ -839,7 +839,7 @@ is_source_global(int psdx)
         break;
       default:
         /* real error */
-        interr("bad PTE type", TPTE_TYPE(ptex), 4);
+        interr("bad PTE type", TPTE_TYPE(ptex), ERR_Fatal);
         return TRUE;
       }
     }
@@ -940,7 +940,7 @@ is_source_nonlocal(int psdx)
         break;
       default:
         /* real error */
-        interr("bad PTE type", TPTE_TYPE(ptex), 2);
+        interr("bad PTE type", TPTE_TYPE(ptex), ERR_Warning);
         return TRUE;
       }
     }
@@ -1658,7 +1658,7 @@ make_init_assignment(int v, int sourcesptr, int stars, int targettype,
     ASNEXT(asx) = 0;
     break;
   default:
-    interr("bad target type", targettype, 4);
+    interr("bad target type", targettype, ERR_Fatal);
     return;
   }
   if (asx) {
@@ -1806,7 +1806,7 @@ mark_apte_targets(int psdx)
           break;
         default:
           /* real error */
-          interr("bad PTE type", TPTE_TYPE(ptex), 2);
+          interr("bad PTE type", TPTE_TYPE(ptex), ERR_Warning);
           break;
         }
       }
@@ -1820,7 +1820,7 @@ mark_apte_targets(int psdx)
   case TT_UNK:
   case TT_UNINIT:
   default:
-    interr("bad PSD type", PSD_TYPE(psdx), 4);
+    interr("bad PSD type", PSD_TYPE(psdx), ERR_Fatal);
     break;
   }
 } /* mark_apte_targets */
@@ -1872,7 +1872,7 @@ might_target(int psdx)
         break;
       default:
         /* real error */
-        interr("bad PTE type", TPTE_TYPE(ptex), 2);
+        interr("bad PTE type", TPTE_TYPE(ptex), ERR_Warning);
         return TRUE;
       }
     }
@@ -2255,7 +2255,7 @@ effective_rhs(int psdx)
     return ptelistx;
   default:
     /* real error */
-    interr("pointsto: unknown RHS type in assignment", PSD_TYPE(psdx), 4);
+    interr("pointsto: unknown RHS type in assignment", PSD_TYPE(psdx), ERR_Fatal);
     return TPTE_UNK;
   }
 } /* effective_rhs */
@@ -2315,12 +2315,12 @@ interpret(int asx)
       break;
     case TT_MEM:
       /* not used yet */
-      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), 2);
+      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), ERR_Warning);
       unk_all();
       break;
     default:
       /* real error */
-      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), 4);
+      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), ERR_Fatal);
       unk_all();
       break;
     }
@@ -2351,12 +2351,12 @@ interpret(int asx)
       break;
     case TT_MEM:
       /* not used yet */
-      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), 2);
+      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), ERR_Warning);
       unk_all();
       break;
     default:
       /* real error */
-      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), 4);
+      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), ERR_Fatal);
       unk_all();
       break;
     }
@@ -2459,12 +2459,12 @@ interpret(int asx)
       break;
     case TT_MEM:
       /* ### really want to handle member LHS types */
-      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), 2);
+      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), ERR_Warning);
       Trace(("unknown LHS type in assignment"));
       break;
     default:
       /* real error */
-      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), 4);
+      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), ERR_Fatal);
       Trace(("unknown LHS type in assignment"));
       break;
     }
@@ -2516,12 +2516,12 @@ interpret(int asx)
       break;
     case TT_MEM:
       /* ### really want to handle member LHS types */
-      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), 2);
+      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), ERR_Warning);
       Trace(("unknown LHS type in assignment"));
       break;
     default:
       /* real error */
-      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), 4);
+      interr("pointsto: unknown LHS type in assignment", PSD_TYPE(lhspsdx), ERR_Fatal);
       Trace(("unknown LHS type in assignment"));
       break;
     }
@@ -2604,7 +2604,7 @@ imprecise_match(int lptex, int ptex)
       return ptex;
     default:
       /* real error */
-      interr("pointsto: unknown TPTE target type", TPTE_TYPE(lptex), 4);
+      interr("pointsto: unknown TPTE target type", TPTE_TYPE(lptex), ERR_Fatal);
       return 0;
     }
   } else {
@@ -2860,7 +2860,7 @@ check_pte(char *ch)
   }
   if (bad) {
     /* real error, consistency check failure */
-    interr(ch, 0, 4);
+    interr(ch, 0, ERR_Fatal);
   }
 } /* check_pte */
 #endif
@@ -4400,7 +4400,7 @@ points_to(void)
     }
     if (asx > 0) {
       /* real error, didn't finish assignments from previous block */
-      interr("pointsto: didn't finish all symbolic assignments", asx, 4);
+      interr("pointsto: didn't finish all symbolic assignments", asx, ERR_Fatal);
     }
 #if DEBUG
     if (DBGBIT(TRACEFLAG, TRACEBIT)) {

--- a/tools/flang1/flang1exe/symacc.c
+++ b/tools/flang1/flang1exe/symacc.c
@@ -50,26 +50,26 @@ sym_init_first(void)
   int i;
 
   int sizeof_SYM = sizeof(SYM) / sizeof(INT);
-  assert(sizeof_SYM == 44, "bad SYM size", sizeof_SYM, 4);
+  assert(sizeof_SYM == 44, "bad SYM size", sizeof_SYM, ERR_Fatal);
 
   if (stb.stg_base == NULL) {
     STG_ALLOC(stb, 1000);
-    assert(stb.stg_base, "sym_init: no room for symtab", stb.stg_size, 4);
+    assert(stb.stg_base, "sym_init: no room for symtab", stb.stg_size, ERR_Fatal);
     stb.n_size = 5024;
     NEW(stb.n_base, char, stb.n_size);
-    assert(stb.n_base, "sym_init: no room for namtab", stb.n_size, 4);
+    assert(stb.n_base, "sym_init: no room for namtab", stb.n_size, ERR_Fatal);
     stb.n_base[0] = 0;
     STG_ALLOC(stb.dt, 400);
-    assert(stb.dt.stg_base, "sym_init: no room for dtypes", stb.dt.stg_size, 4);
+    assert(stb.dt.stg_base, "sym_init: no room for dtypes", stb.dt.stg_size, ERR_Fatal);
     stb.w_size = 32;
     NEW(stb.w_base, INT, stb.w_size);
-    assert(stb.w_base, "sym_init: no room for wtab", stb.w_size, 4);
+    assert(stb.w_base, "sym_init: no room for wtab", stb.w_size, ERR_Fatal);
   }
 
   stb.namavl = 1;
   stb.wrdavl = 0;
   for (i = 0; i <= HASHSIZE; i++)
-    stb.hashtb[i] = 0;
+    stb.hashtb[i] = SPTR_NULL;
 
   DT_INT = DT_INT4;
   DT_REAL = DT_REAL4;
@@ -133,8 +133,7 @@ lookupsym(const char *name, int olength)
 
     return sptr;
   }
-
-  return 0;
+  return SPTR_NULL;
 } /* lookupsym */
 
 /** \brief Issue diagnostic for identifer that is too long.
@@ -462,27 +461,27 @@ is_cimag_flt0(SPTR sptr)
 bool
 is_cmplx_dbl0(SPTR sptr)
 {
-  if (is_dbl0(CONVAL1G(sptr)) && is_dbl0(CONVAL2G(sptr)))
-    return true;
-  return false;
+  return is_dbl0((SPTR)CONVAL1G(sptr)) && // ???
+    is_dbl0((SPTR)CONVAL2G(sptr)); // ???
 }
 
 bool
 is_cmplx_quad0(SPTR sptr)
 {
-  return is_quad0(CONVAL1G(sptr)) && is_quad0(CONVAL2G(sptr));
+  return is_quad0((SPTR)CONVAL1G(sptr)) && // ???
+    is_quad0((SPTR)CONVAL2G(sptr)); // ???
 }
 
 void
 symini_errfatal(int n)
 {
-  errfatal(n);
+  errfatal((error_code_t)n);
 }
 
 void
 symini_error(int n, int s, int l, const char *c1, const char *c2)
 {
-  error(n, s, l, c1, c2);
+  error((error_code_t)n, (enum error_severity)s, l, c1, c2);
 }
 
 void

--- a/tools/flang2/flang2exe/asm_anno.c
+++ b/tools/flang2/flang2exe/asm_anno.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2002-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ annomod_initx(ANNO *ahead)
 
   if (modcnt == 0) {
     if ((fanno = fopen(SOURCE_FILE, "rb")) == NULL) {
-      error(2, 2, 0, SOURCE_FILE, CNULL);
+      error(2, ERR_Warning, 0, SOURCE_FILE, CNULL);
       return ahead;
     }
   } else if (fanno == NULL)
@@ -188,7 +188,7 @@ annomod_initx(ANNO *ahead)
     }
   }
 
-  assert(cnt == cnt1, "annomod_init: cnt != cnt1 :", cnt1, 3);
+  assert(cnt == cnt1, "annomod_init: cnt != cnt1 :", cnt1, ERR_Severe);
 
 /* ********
  * step 3:
@@ -378,7 +378,7 @@ annomod_asm(int blkno)
 
   if (amod->bihd != blkno) {
 #if DEBUG
-    interr("Inconsistent anno records for blkno: ", blkno, 1);
+    interr("Inconsistent anno records for blkno: ", blkno, ERR_Informational);
 #endif
     flg.anno = 0;
     return;
@@ -387,7 +387,7 @@ annomod_asm(int blkno)
 again:
   lanno.curpos = ftell(fanno);
   if (lanno.curpos < 0) {
-    interr("annomod_asm(): cannot ftell into source for module:", modcnt, 2);
+    interr("annomod_asm(): cannot ftell into source for module:", modcnt, ERR_Warning);
     amod = NULL;
     return;
   }

--- a/tools/flang2/flang2exe/bih.h
+++ b/tools/flang2/flang2exe/bih.h
@@ -18,13 +18,15 @@
 #ifndef BIH_H_
 #define BIH_H_
 
+#include "symtab.h"
+
 /**
    \file
    \brief BIH data structures and definitions
  */
 
 typedef struct {
-  int label;
+  SPTR label;
   int lineno;
   union {
     UINT all;

--- a/tools/flang2/flang2exe/bihutil.c
+++ b/tools/flang2/flang2exe/bihutil.c
@@ -62,8 +62,8 @@ bih_init(void)
   bihb.stg_max = 0;
 #if DEBUG
   assert(((char *)&BIH_BLKCNT(0) - (char *)&bihb.stg_base[0]) % 8 == 0,
-         "offset of BIH_BLKCNT must be a multiple of 8", 0, 4);
-  assert(sizeof(BIH) % 8 == 0, "size of BIH must be a multiple of 8", 0, 4);
+         "offset of BIH_BLKCNT must be a multiple of 8", 0, ERR_Fatal);
+  assert(sizeof(BIH) % 8 == 0, "size of BIH must be a multiple of 8", 0, ERR_Fatal);
 #endif
 }
 
@@ -96,7 +96,7 @@ exp_addbih(int after)
   p->next = BIH_NEXT(after);
   BIH_NEXT(after) = i;
   BIH_PREV(p->next) = i;
-  p->label = 0;
+  p->label = SPTR_NULL;
   p->lineno = 0;
   p->flags.all = 0;
   p->flags2.all = 0;
@@ -141,7 +141,7 @@ addnewbih(int after, int flags, int fih)
     p->next = next;
     BIH_PREV(next) = i;
   }
-  p->label = 0;
+  p->label = SPTR_NULL;
   p->lineno = 0;
   p->flags.all = 0;
   p->flags2.all = 0;
@@ -287,7 +287,7 @@ merge_bih(int curbih)
       return 0;
     }
     ILIBLKP(label, 0);
-    BIH_LABEL(nextbih) = 0;
+    BIH_LABEL(nextbih) = SPTR_NULL;
   }
 
   firstilt = BIH_ILTFIRST(nextbih);
@@ -339,7 +339,7 @@ merge_bih(int curbih)
 
 #if DEBUG
   assert((BIH_PARSECT(curbih) ^ BIH_PARSECT(nextbih)) == 0,
-         "merge_bih:parsect,nonparsect", curbih, 3);
+         "merge_bih:parsect,nonparsect", curbih, ERR_Severe);
 #endif
 
   wrilts(curbih);

--- a/tools/flang2/flang2exe/cgllvm.h
+++ b/tools/flang2/flang2exe/cgllvm.h
@@ -126,7 +126,6 @@ void llvm_write_ctors(void);
 extern FILE *par_file1;
 extern FILE *par_file2;
 
-int get_return_type(int func_sptr);
 int cg_get_type(int n, int v1, int v2);
 void build_routine_and_parameter_entries(SPTR func_sptr, LL_ABI_Info *abi,
                                          LL_Module *module);
@@ -138,26 +137,10 @@ void write_external_function_declarations(int);
 OPERAND *mk_alloca_instr(LL_Type *ptrTy);
 INSTR_LIST *mk_store_instr(OPERAND *val, OPERAND *addr);
 
-int get_return_type(int);
 #ifdef TARGET_LLVM_X8664
 LL_Type *maybe_fixup_x86_abi_return(LL_Type *sig);
 #endif
 
-/* ll_ftn.c */
-void store_llvm_localfptr(void);
-void stb_process_routine_parameters(void);
-int get_entries_argnum(void);
-void get_local_overlap_size(void);
-void write_master_entry_routine(void);
-char *get_llvm_ifacenm(int sptr);
-int get_iface_sptr(int sptr);
-int is_iso_cptr(int d_dtype);
- void ll_process_routine_parameters(int sptr);
-void fix_llvm_fptriface(void);
-char *get_entret_arg_name(void);
-
-/* vpar.c */
-void llvmRewriteConcurIli(int bbih, int ebih, int display);
-void vpar(void);
+#include "ll_ftn.h"
 
 #endif /* CGLLVM_H__ */

--- a/tools/flang2/flang2exe/cgmain.c
+++ b/tools/flang2/flang2exe/cgmain.c
@@ -4388,7 +4388,7 @@ gen_const_expr(int ilix, LL_Type *expected_type)
     break;
 #endif
   default:
-    interr("Unknown gen_const_expr opcode", ILI_OPC(ilix), 4);
+    interr("Unknown gen_const_expr opcode", ILI_OPC(ilix), ERR_Fatal);
   }
   return operand;
 } /* gen_const_expr */
@@ -5741,7 +5741,7 @@ gen_mulh_expr(int ilix)
     shr_instr = I_LSHR;
     break;
   default:
-    interr("Unknown mulh opcode", ILI_OPC(ilix), 4);
+    interr("Unknown mulh opcode", ILI_OPC(ilix), ERR_Fatal);
   }
 
   /* Extend both sides to i128. */
@@ -6602,7 +6602,7 @@ gen_arg_operand(LL_ABI_Info *abi, unsigned abi_arg, int arg_ili)
     break;
 
   default:
-    interr("Unknown ABI argument kind", arg->kind, 4);
+    interr("Unknown ABI argument kind", arg->kind, ERR_Fatal);
   }
 
   if (need_load) {
@@ -6652,7 +6652,7 @@ get_next_arg(int arg_ili)
     return ILI_OPND(arg_ili, 3);
 
   default:
-    interr("Unknown IL_ARG opcode", arg_ili, 4);
+    interr("Unknown IL_ARG opcode", arg_ili, ERR_Fatal);
     return IL_NULL;
   }
 }
@@ -9616,7 +9616,7 @@ gen_switch(int ilix)
     is_64bit = true;
     break;
   default:
-    interr("gen_switch(): Unexpected jump ili", ilix, 4);
+    interr("gen_switch(): Unexpected jump ili", ilix, ERR_Fatal);
   }
 
   instr = make_instr(I_SW);
@@ -10250,7 +10250,7 @@ create_global_initializer(GBL_LIST *gitem, const char *flag_str,
   const char *initializer;
   char *gname;
 
-  assert(sptr, "gitem must be initialized", 0, 4);
+  assert(sptr, "gitem must be initialized", 0, ERR_Fatal);
   assert(gitem->global_def == NULL, "gitem already has an initializer", sptr,
          ERR_Fatal);
   assert(SNAME(sptr), "sptr must have an LLVM name", sptr, ERR_Fatal);
@@ -12921,7 +12921,7 @@ insert_entry_label(int ilt)
   INSTR_LIST *Curr_Instr = gen_instr(I_NONE, NULL, NULL, make_label_op(sptr));
   ad_instr(0, Curr_Instr);
   llvm_info.return_ll_type = make_lltype_from_dtype(
-      gbl.arets ? DT_INT : get_return_type(DTYPEG(sptr)));
+      gbl.arets ? DT_INT : get_return_type(sptr)); // ???: possible bug
 }
 
 void

--- a/tools/flang2/flang2exe/dtypeutl.c
+++ b/tools/flang2/flang2exe/dtypeutl.c
@@ -398,12 +398,11 @@ dlen(TY_KIND dty)
     return 2;
   case TY_ARRAY:
   case TY_PFUNC:
-    return 3;
   case TY_VECT:
     return 3;
   case TY_STRUCT:
   case TY_UNION:
-    return 5;
+    return 6;
   case TY_PARAM:
     return 4;
   case TY_PROC:

--- a/tools/flang2/flang2exe/exp_ftn.c
+++ b/tools/flang2/flang2exe/exp_ftn.c
@@ -127,7 +127,7 @@ exp_ac(ILM_OP opc, ILM *ilmp, int curilm)
   nme = 0;
   switch (opc) {
   default:
-    interr("exp_ac:ilm not cased", opc, 3);
+    interr("exp_ac:ilm not cased", opc, ERR_Severe);
     return;
   case IM_LNOT:
     op1 = ILI_OF(ILM_OPND(ilmp, 1));
@@ -1134,7 +1134,7 @@ exp_ac(ILM_OP opc, ILM *ilmp, int curilm)
     ILM_NME(curilm) = IL_UICMP;
     return;
   case IM_UDICMP:
-    interr("exp_ac: no IL_UDICMP ??", curilm, 3);
+    interr("exp_ac: no IL_UDICMP ??", curilm, ERR_Severe);
     ILM_NME(curilm) = IL_ICMP;
     return;
   case IM_PCMP:
@@ -1483,7 +1483,7 @@ compute_sdsc_subscr(ILM *ilmp)
    */
 
   sdsc = AD_SDSC(adp);
-  assert(sdsc != 0, "compute_sdsc_subscr: sdsc is zero", sdsc, 3);
+  assert(sdsc != 0, "compute_sdsc_subscr: sdsc is zero", sdsc, ERR_Severe);
   PTRSAFEP(sdsc, 1);
 
   /* this code duplicates much of what is done in compute_subscr(),
@@ -1660,7 +1660,7 @@ compute_sdsc_subscr(ILM *ilmp)
     base = ILM_OPND(basep, 1);
     basenm = NME_OF(base);
     base = ILI_OF(base);
-    assert(base, "compute_sdsc_subscr: base is NULL", base, 3);
+    assert(base, "compute_sdsc_subscr: base is NULL", base, ERR_Severe);
   }
 
   /* compute the static descriptor linearized version of this
@@ -2031,7 +2031,7 @@ get_sdsc_element(int sdsc, int indx, int membase, int membase_nme)
     } else if (SCG(sdsc) == SC_BASED) {
       int anme;
       if (!MIDNUMG(sdsc)) {
-        interr("based section descriptor has no pointer", sdsc, 4);
+        interr("based section descriptor has no pointer", sdsc, ERR_Fatal);
       }
       acon = mk_address(MIDNUMG(sdsc));
       anme = addnme(NT_VAR, sdsc, 0, (INT)0);
@@ -2079,7 +2079,7 @@ create_sdsc_subscr(int nmex, int sptr, int nsubs, int *subs, int dtype,
    */
 
   sdsc = AD_SDSC(adp);
-  assert(sdsc != 0, "create_sdsc_subscr: sdsc is zero", sdsc, 3);
+  assert(sdsc != 0, "create_sdsc_subscr: sdsc is zero", sdsc, ERR_Severe);
   PTRSAFEP(sdsc, 1);
 
   /* this code duplicates much of what is done in compute_subscr(),
@@ -2209,7 +2209,7 @@ create_sdsc_subscr(int nmex, int sptr, int nsubs, int *subs, int dtype,
   if (STYPEG(sdsc) == ST_MEMBER) {
     /* find the base ILM and NME */
     base = sdscilix;
-    assert(base, "compute_sdsc_subscr: base is NULL", base, 3);
+    assert(base, "compute_sdsc_subscr: base is NULL", base, ERR_Severe);
   }
 
   /* compute the static descriptor linearized version of this
@@ -2615,7 +2615,7 @@ inlarr(int curilm, int odtype, bool bigobj)
      */
     dtype = DTYPEG(sym);
 #if DEBUG
-    assert(DTY(dtype) == TY_ARRAY, "inlarr:BASE/MEMBER-not TY_ARRAY", sym, 3);
+    assert(DTY(dtype) == TY_ARRAY, "inlarr:BASE/MEMBER-not TY_ARRAY", sym, ERR_Severe);
 #endif
     adp = AD_DPTR(dtype);
     sdsc = AD_SDSC(adp);
@@ -2625,14 +2625,14 @@ inlarr(int curilm, int odtype, bool bigobj)
       ILM *basep;
       /* find the base ILM and NME */
       basep = (ILM *)(ilmb.ilm_base + ILM_OPND(ilmp, 2));
-      assert(ILM_OPC(basep) == IM_PLD, "inlarr: not PLD", ILM_OPND(ilmp, 2), 3);
+      assert(ILM_OPC(basep) == IM_PLD, "inlarr: not PLD", ILM_OPND(ilmp, 2), ERR_Severe);
       basep = (ILM *)(ilmb.ilm_base + ILM_OPND(basep, 1));
       assert(ILM_OPC(basep) == IM_MEMBER, "inlarr: not MEMBER",
              ILM_OPND(ilmp, 1), 3);
       base = ILM_OPND(basep, 1);
       basenm = NME_OF(base);
       base = ILI_OF(base);
-      assert(base, "inlarr: base is NULL", base, 3);
+      assert(base, "inlarr: base is NULL", base, ERR_Severe);
     }
 #if DEBUG
     if (DBGBIT(49, 0x4000)) {
@@ -2730,7 +2730,7 @@ inlarr(int curilm, int odtype, bool bigobj)
     break;
 
   default:
-    interr("inlarr:bad ilmopc", ILM_OPC(ilmp), 3);
+    interr("inlarr:bad ilmopc", ILM_OPC(ilmp), ERR_Severe);
   }
 }
 
@@ -3831,7 +3831,7 @@ exp_misc(ILM_OP opc, ILM *ilmp, int curilm)
   case IM_ADJARR:
     sym = ILM_OPND(ilmp, 1);
 #if DEBUG
-    assert(STYPEG(sym) == ST_ENTRY, "exp_misc: not ST_ENTRY in ilm", curilm, 3);
+    assert(STYPEG(sym) == ST_ENTRY, "exp_misc: not ST_ENTRY in ilm", curilm, ERR_Severe);
 #endif
     if (AFTENTG(sym)) {
       tmp = ad1ili(IL_JMP, (int)ILM_OPND(ilmp, 2));
@@ -3856,7 +3856,7 @@ exp_misc(ILM_OP opc, ILM *ilmp, int curilm)
   case IM_CMSIZE:
     sym = ILM_OPND(ilmp, 1); /* common block symbol */
 #if DEBUG
-    assert(STYPEG(sym) == ST_CMBLK, "exp_misc: CMSIZE not cmblk", sym, 3);
+    assert(STYPEG(sym) == ST_CMBLK, "exp_misc: CMSIZE not cmblk", sym, ERR_Severe);
 #endif
     ilix = ad_kconi(SIZEG(sym));
     ILM_RESULT(curilm) = ilix;
@@ -3957,7 +3957,7 @@ exp_misc(ILM_OP opc, ILM *ilmp, int curilm)
       default:
         if (IM_TYPE(ILM_OPC(ilmp1)) == IMTY_CONS)
           return; /* substituted by inlining? */
-        interr("pragma: bad ilmopc", ILM_OPC(ilmp1), 3);
+        interr("pragma: bad ilmopc", ILM_OPC(ilmp1), ERR_Severe);
         pragmasym = 0;
       }
       depth = 0;
@@ -4220,12 +4220,12 @@ exp_misc(ILM_OP opc, ILM *ilmp, int curilm)
     if (get_is_in_atomic_capture()) {
       if (get_capture_read_ili() == 0 || get_capture_update_ili() == 0 ||
           !get_atomic_capture_created()) {
-        error(155, 3, gbl.lineno, "Invalid/Incomplete atomic capture.", CNULL);
+        error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid/Incomplete atomic capture.", CNULL);
       }
       set_is_in_atomic_capture(0);
     } else {
       if (!get_atomic_store_created()) {
-        error(155, 3, gbl.lineno, "Invalid atomic region.", CNULL);
+        error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic region.", CNULL);
       }
       set_is_in_atomic(0);
       set_is_in_atomic_read(0);
@@ -4235,7 +4235,7 @@ exp_misc(ILM_OP opc, ILM *ilmp, int curilm)
 #endif
 
   default:
-    interr("exp_misc:ilm not cased", opc, 3);
+    interr("exp_misc:ilm not cased", opc, ERR_Severe);
   }
 }
 
@@ -4374,7 +4374,7 @@ frte_func(SPTR (*pf)(const char *), const char *root)
   p = bf;
   strcpy(p, root);
 #if DEBUG
-  assert((int)strlen(bf) <= 31, "frte_func:exceed bf", sizeof(bf), 3);
+  assert((int)strlen(bf) <= 31, "frte_func:exceed bf", sizeof(bf), ERR_Severe);
 #endif
   sym = (*pf)(bf);
   return sym;

--- a/tools/flang2/flang2exe/exp_fvec.c
+++ b/tools/flang2/flang2exe/exp_fvec.c
@@ -44,7 +44,7 @@ void eval_fvec(int ilmx)
 
   opc = ILM_OPC((ILM *)(ilmb.ilm_base + ilmx));
   if (IM_VEC(opc)) {
-    interr("eval_fvec: vector not impl", ilmx, 3);
+    interr("eval_fvec: vector not impl", ilmx, ERR_Severe);
   } else {
     eval_ilm(ilmx);
   }

--- a/tools/flang2/flang2exe/exp_rte.c
+++ b/tools/flang2/flang2exe/exp_rte.c
@@ -761,7 +761,7 @@ pp_entries(void)
               ) {
         sym = CLENG(osym);
 #if DEBUG
-        assert(sym != 0, "pp_entries: 0 clen", parg[savlenpos], 3);
+        assert(sym != 0, "pp_entries: 0 clen", parg[savlenpos], ERR_Severe);
 #endif
         parg[pos] = sym;
         COPYPRMSP(sym, 1);
@@ -1033,7 +1033,7 @@ pp_entries_mixedstrlen(void)
                 ) {
           sym = CLENG(osym);
 #if DEBUG
-          assert(sym != 0, "pp_entries_mixedstrlen: 0 clen", parg[pos], 3);
+          assert(sym != 0, "pp_entries_mixedstrlen: 0 clen", parg[pos], ERR_Severe);
 #endif
           COPYPRMSP(sym, 1);
           COPYPRMSP(func, 1);
@@ -1245,7 +1245,7 @@ check_desc(int func, int sptr)
   if (seenCC && seenDesc && seenSym && seenClass) {
 
     NEW(scratch, int, nargs);
-    assert(scratch, "check_desc: out of memory!", 0, 4);
+    assert(scratch, "check_desc: out of memory!", 0, ERR_Fatal);
     swap_from = pos2;
     swap_to = pos3 + (pos - pos4);
     scratch[swap_to] = dpdscp[swap_from];
@@ -1996,7 +1996,7 @@ cp_memarg(int sym, INT off, int dtype)
     break;
   default:
     asym = 0;
-    interr("unrec dtype in cp_memarg", dtype, 3);
+    interr("unrec dtype in cp_memarg", dtype, ERR_Severe);
     break;
   }
   if (gbl.internal == 1 && asym != 0)
@@ -2331,7 +2331,7 @@ gen_bindC_retval(finfo_t *fp)
       ilix = ad2ili(IL_MVKR, ilix, RES_IR(0));
       break;
     default:
-      interr("expand:illegal return expr", retv, 3);
+      interr("expand:illegal return expr", retv, ERR_Severe);
       break;
     }
   }
@@ -2411,7 +2411,7 @@ gen_funcret(finfo_t *fp)
     move = ad2ili(IL_MVKR, ili1, KR_RETVAL);
     break;
   default:
-    interr("gen_funcret: illegal dtype, sym", fval, 3);
+    interr("gen_funcret: illegal dtype, sym", fval, ERR_Severe);
     return;
   }
 
@@ -2457,7 +2457,7 @@ exp_cgoto(ILM *ilmp, int curilm)
     }
   }
 #endif
-  assert(n != 0, "exp_cgoto: cnt is zero, at ilm", curilm, 3);
+  assert(n != 0, "exp_cgoto: cnt is zero, at ilm", curilm, ERR_Severe);
   if (ILI_OPC(sw_val) == IL_ICON) {
     /*
      * switch value is a constant -- search switch list for the equal
@@ -2696,7 +2696,7 @@ exp_agoto(ILM *ilmp, int curilm)
     }
   }
 #endif
-  assert(n != 0, "exp_agoto: cnt is zero, at ilm", curilm, 3);
+  assert(n != 0, "exp_agoto: cnt is zero, at ilm", curilm, ERR_Severe);
   genswitch((INT)1, n);
   exp_label(sw_array[0].clabel);
 }
@@ -2832,7 +2832,7 @@ add_arg_ili(int ilix, int nme, int dtype)
     break;
 
   default:
-    interr("exp_call:bad ili for BYVAL", ilix, 3);
+    interr("exp_call:bad ili for BYVAL", ilix, ERR_Severe);
   }
 } /* add_arg_ili */
 
@@ -2871,7 +2871,7 @@ gen_arg_ili(void)
       arg_dp(arg_ili[i].ili_arg, &ainfo);
       break;
     default:
-      interr("exp_call: ili arg type not cased", arg_ili[i].ili_arg, 3);
+      interr("exp_call: ili arg type not cased", arg_ili[i].ili_arg, ERR_Severe);
       break;
     }
   }
@@ -2944,7 +2944,7 @@ cmplx_to_mem(int real, int imag, int dtype, int *addr, int *nme)
   int r_op1, i_op1, i_op2;
   int tmp;
 
-  assert(DT_ISCMPLX(dtype), "cmplx_to_mem: not complex dtype", dtype, 3);
+  assert(DT_ISCMPLX(dtype), "cmplx_to_mem: not complex dtype", dtype, ERR_Severe);
   if (DTY(dtype) == TY_CMPLX) {
     if (XBIT(70, 0x40000000) && !imag) {
       load = IL_LDSCMPLX;
@@ -3221,7 +3221,7 @@ exp_call(ILM_OP opc, ILM *ilmp, int curilm)
       exp_call_sym = ILM_OPND(ilmlnk, 2);
       break;
     default:
-      interr("exp_call: Procedure pointer not found", ilm1, 0);
+      interr("exp_call: Procedure pointer not found", ilm1, ERR_unused);
       break;
     }
     break;
@@ -3270,7 +3270,7 @@ exp_call(ILM_OP opc, ILM *ilmp, int curilm)
     break;
   default:
     exp_call_sym = ILM_OPND(ilmp, 2); /* external reference  */
-    interr("exp_call: Bad Function opc", opc, 3);
+    interr("exp_call: Bad Function opc", opc, ERR_Severe);
   }
 
   init_arg_ili(nargs);
@@ -3791,7 +3791,7 @@ exp_call(ILM_OP opc, ILM *ilmp, int curilm)
         add_to_args(IL_ARGDP, argili);
         break;
       default:
-        interr("exp_call:bad ili for DPVAL", argili, 3);
+        interr("exp_call:bad ili for DPVAL", argili, ERR_Severe);
       }
       break;
 
@@ -3931,7 +3931,7 @@ exp_call(ILM_OP opc, ILM *ilmp, int curilm)
                 break;
               }
             }
-            interr("exp_call: ili ret type not cased", argili, 3);
+            interr("exp_call: ili ret type not cased", argili, ERR_Severe);
           }
           if (ilix > 0)
             chk_block(ilix);
@@ -4247,7 +4247,7 @@ exp_call(ILM_OP opc, ILM *ilmp, int curilm)
     }
     break;
   default:
-    interr("exp_call: bad function opc", opc, 3);
+    interr("exp_call: bad function opc", opc, ERR_Severe);
   }
   end_arg_ili();
 }
@@ -4295,7 +4295,7 @@ exp_qjsr(char *ext, int res_dtype, ILM *ilmp, int curilm)
     res_nme = addnme(NT_VAR, res, 0, (INT)0);
     ADDRTKNP(res, 1);
   } else {
-    interr("exp_qjsr, illegal dtype", res_dtype, 3);
+    interr("exp_qjsr, illegal dtype", res_dtype, ERR_Severe);
     return;
   }
   nargs = ilms[ILM_OPC(ilmp)].oprs;
@@ -4311,7 +4311,7 @@ exp_qjsr(char *ext, int res_dtype, ILM *ilmp, int curilm)
     ilmlnk = (ILM *)(ilmb.ilm_base + ilm1); /* ith operand */
     switch (ILM_RESTYPE(ilm1)) {
     case ILM_ISCHAR:
-      interr("exp_qjsr: char arg not allowed", ilm1, 3);
+      interr("exp_qjsr: char arg not allowed", ilm1, ERR_Severe);
       break;
     case ILM_ISCMPLX:
       arg_sp((int)ILM_IRESULT(ilm1), &ainfo);
@@ -4354,7 +4354,7 @@ exp_qjsr(char *ext, int res_dtype, ILM *ilmp, int curilm)
         break;
 #endif
       default:
-        interr("exp_qjsr: ili ret type not cased", ilix, 3);
+        interr("exp_qjsr: ili ret type not cased", ilix, ERR_Severe);
         break;
       }
     }
@@ -4429,7 +4429,7 @@ exp_zqjsr(char *ext, int res_dtype, ILM *ilmp, int curilm)
     res_nme = addnme(NT_VAR, res, 0, (INT)0);
     ADDRTKNP(res, 1);
   } else {
-    interr("exp_zqjsr, illegal dtype", res_dtype, 3);
+    interr("exp_zqjsr, illegal dtype", res_dtype, ERR_Severe);
     return;
   }
   nargs = ilms[ILM_OPC(ilmp)].oprs;
@@ -4443,7 +4443,7 @@ exp_zqjsr(char *ext, int res_dtype, ILM *ilmp, int curilm)
     ilmlnk = (ILM *)(ilmb.ilm_base + ilm1); /* ith operand */
     switch (ILM_RESTYPE(ilm1)) {
     case ILM_ISCHAR:
-      interr("exp_zqjsr: char arg not allowed", ilm1, 3);
+      interr("exp_zqjsr: char arg not allowed", ilm1, ERR_Severe);
       break;
     case ILM_ISCMPLX:
       arg_sp((int)ILM_IRESULT(ilm1), &ainfo);
@@ -4486,7 +4486,7 @@ exp_zqjsr(char *ext, int res_dtype, ILM *ilmp, int curilm)
         break;
 #endif
       default:
-        interr("exp_zqjsr: ili ret type not cased", ilix, 3);
+        interr("exp_zqjsr: ili ret type not cased", ilix, ERR_Severe);
         break;
       }
     }
@@ -4792,7 +4792,7 @@ exp_fstring(ILM_OP opc, ILM *ilmp, int curilm)
         STYPEG(sym = CONVAL1G(ILI_OPND(ili1, 1))) == ST_CONST) {
 /* constant char str */
 #if DEBUG
-      assert(DTY(DTYPEG(sym)) == TY_CHAR, "non char op of ICHAR", ili1, 3);
+      assert(DTY(DTYPEG(sym)) == TY_CHAR, "non char op of ICHAR", ili1, ERR_Severe);
 #endif
       op1 = CONVAL1G(sym);               /* names area idx containing string */
       op2 = CONVAL2G(ILI_OPND(ili1, 1)); /* offset */
@@ -4841,7 +4841,7 @@ exp_fstring(ILM_OP opc, ILM *ilmp, int curilm)
     str1 = getstr((int)ILM_OPND(ilmp, 1));
     str2 = getstr((int)ILM_OPND(ilmp, 2));
 #if DEBUG
-    assert(str1->cnt == 1, "string store into concat", curilm, 3);
+    assert(str1->cnt == 1, "string store into concat", curilm, ERR_Severe);
 #endif
     /* special case string store into single char */
     if (strislen1(str1)) {
@@ -4891,7 +4891,7 @@ exp_fstring(ILM_OP opc, ILM *ilmp, int curilm)
       ili1 = ad1ili(IL_KIMV, ili1);
     ILM_RESULT(curilm) = ili1;
 #if DEBUG
-    assert(ILM_RESULT(curilm) != 0, "IM_LEN:len ili 0", curilm, 3);
+    assert(ILM_RESULT(curilm) != 0, "IM_LEN:len ili 0", curilm, ERR_Severe);
 #endif
     return;
   case IM_KLEN: /* length of string */
@@ -5044,7 +5044,7 @@ exp_fstring(ILM_OP opc, ILM *ilmp, int curilm)
     return;
 
   default:
-    interr("unrecognized fstr ILM", opc, 3);
+    interr("unrecognized fstr ILM", opc, ERR_Severe);
     break;
   }
 }
@@ -5668,7 +5668,7 @@ charlen(int sym)
   int addr;
 
 #if DEBUG
-  assert(CLENG(sym) != 0, "charlen: sym not adjustable-length char", sym, 3);
+  assert(CLENG(sym) != 0, "charlen: sym not adjustable-length char", sym, ERR_Severe);
 #endif
   lensym = CLENG(sym);
   if (!INTERNREFG(lensym) && gbl.internal > 1 && INTERNREFG(sym)) {
@@ -5695,7 +5695,7 @@ charaddr(int sym)
   int asym;
   int addr;
 
-  assert(SCG(sym) == SC_DUMMY, "charaddr: sym not dummy", sym, 3);
+  assert(SCG(sym) == SC_DUMMY, "charaddr: sym not dummy", sym, ERR_Severe);
   asym = mk_argasym(sym);
   addr = mk_address(sym);
 

--- a/tools/flang2/flang2exe/expand.c
+++ b/tools/flang2/flang2exe/expand.c
@@ -593,7 +593,7 @@ eval_ilm(int ilmx)
     break;
 
   default: /* error */
-    interr("eval_ilm: bad op type", IM_TYPE(opcx), 3);
+    interr("eval_ilm: bad op type", IM_TYPE(opcx), ERR_Severe);
     break;
   } /* end of switch on ILM opc  */
   if (IM_I8(opcx))
@@ -973,7 +973,7 @@ replace_by_zero(ILM_OP opc, ILM *ilmp, int curilm)
     break;
 
   default:
-    interr("replace_by_zero opc not cased", opc, 3);
+    interr("replace_by_zero opc not cased", opc, ERR_Severe);
     break;
   }
   /* CHANGE the ILM in place */
@@ -1029,7 +1029,7 @@ replace_by_one(ILM_OP opc, ILM *ilmp, int curilm)
     break;
 
   default:
-    interr("replace_by_one opc not cased", opc, 3);
+    interr("replace_by_one opc not cased", opc, ERR_Severe);
     break;
   }
   /* CHANGE the ILM in place */
@@ -1317,7 +1317,7 @@ exp_load(ILM_OP opc, ILM *ilmp, int curilm)
 #endif /* LONG_DOUBLE_FLOAT128 */
 
   default:
-    interr("exp_load opc not cased", opc, 3);
+    interr("exp_load opc not cased", opc, ERR_Severe);
     break;
   }
 
@@ -1680,7 +1680,7 @@ exp_store(ILM_OP opc, ILM *ilmp, int curilm)
       }
 
     default:
-      interr("PSEUDOST: bad link", curilm, 3);
+      interr("PSEUDOST: bad link", curilm, ERR_Severe);
     }
     break;
   /* complex stuff */
@@ -1881,7 +1881,7 @@ exp_store(ILM_OP opc, ILM *ilmp, int curilm)
 #endif /* LONG_DOUBLE_FLOAT128 */
 
   default:
-    interr("exp_store: ilm not cased", curilm, 3);
+    interr("exp_store: ilm not cased", curilm, ERR_Severe);
     break;
   } /*****  end of switch(opc)  *****/
 
@@ -2003,14 +2003,14 @@ exp_mac(ILM_OP opc, ILM *ilmp, int curilm)
         dtype = DT_FLOAT;
         num.numi[0] = 0;
         if (atoxf(nmptr, &num.numi[1], strlen(nmptr)) != 0)
-          interr("exp_mac: RSYM error", curilm, 3);
+          interr("exp_mac: RSYM error", curilm, ERR_Severe);
         goto get_con;
 
       case ILMO_DSYM:
         nmptr = ilmaux[ilmopr->aux];
         dtype = DT_DBLE;
         if (atoxd(nmptr, num.numd, strlen(nmptr)) != 0)
-          interr("exp_mac: DSYM error", curilm, 3);
+          interr("exp_mac: DSYM error", curilm, ERR_Severe);
         goto get_con;
 
       case ILMO_XRSYM:
@@ -2018,7 +2018,7 @@ exp_mac(ILM_OP opc, ILM *ilmp, int curilm)
         dtype = DT_FLOAT;
         num.numi[0] = 0;
         if (atoxi(nmptr, &num.numi[1], strlen(nmptr), 16) != 0)
-          interr("exp_mac: XRSYM error", curilm, 3);
+          interr("exp_mac: XRSYM error", curilm, ERR_Severe);
         goto get_con;
 
       case ILMO_XDSYM:
@@ -2031,17 +2031,17 @@ exp_mac(ILM_OP opc, ILM *ilmp, int curilm)
             if (*p)
               len++;
             else {
-              interr("exp_mac: XDSYM error1", curilm, 3);
+              interr("exp_mac: XDSYM error1", curilm, ERR_Severe);
               goto get_con;
             }
           }
           if (atoxi(nmptr, &num.numi[0], len, 16) != 0) {
-            interr("exp_mac: XDSYM error2", curilm, 3);
+            interr("exp_mac: XDSYM error2", curilm, ERR_Severe);
             goto get_con;
           }
           p++;
           if (atoxi(p, &num.numi[1], strlen(p), 16) != 0) {
-            interr("exp_mac: XDSYM error3", curilm, 3);
+            interr("exp_mac: XDSYM error3", curilm, ERR_Severe);
           }
         }
         goto get_con;
@@ -2050,14 +2050,14 @@ exp_mac(ILM_OP opc, ILM *ilmp, int curilm)
         dtype = DT_INT8;
         num.numi[0] = 0;
         if (atoxi64(nmptr, &num.numi[0], strlen(nmptr), 10) != 0)
-          interr("exp_mac: LSYM error", curilm, 3);
+          interr("exp_mac: LSYM error", curilm, ERR_Severe);
         goto get_con;
       case ILMO_ISYM:
         nmptr = ilmaux[ilmopr->aux];
         dtype = DT_INT;
         num.numi[0] = 0;
         if (atoxi(nmptr, &num.numi[1], strlen(nmptr), 10) != 0)
-          interr("exp_mac: ISYM error", curilm, 3);
+          interr("exp_mac: ISYM error", curilm, ERR_Severe);
 
       get_con:
         newili.opnd[i] = getcon(num.numi, dtype);
@@ -2086,35 +2086,35 @@ exp_mac(ILM_OP opc, ILM *ilmp, int curilm)
 #if defined(IR_RETVAL)
         newili.opnd[i] = IR_RETVAL;
 #else
-        interr("exp_mac: need IR_RETVAL", (int)ilmopr->type, 3);
+        interr("exp_mac: need IR_RETVAL", (int)ilmopr->type, ERR_Severe);
 #endif
         break;
       case ILMO_ARRET:
 #if defined(AR_RETVAL)
         newili.opnd[i] = AR_RETVAL;
 #else
-        interr("exp_mac: need AR_RETVAL", (int)ilmopr->type, 3);
+        interr("exp_mac: need AR_RETVAL", (int)ilmopr->type, ERR_Severe);
 #endif
         break;
       case ILMO_SPRET:
 #if defined(SP_RETVAL)
         newili.opnd[i] = SP_RETVAL;
 #else
-        interr("exp_mac: need SP_RETVAL", (int)ilmopr->type, 3);
+        interr("exp_mac: need SP_RETVAL", (int)ilmopr->type, ERR_Severe);
 #endif
         break;
       case ILMO_DPRET:
 #if defined(DP_RETVAL)
         newili.opnd[i] = DP_RETVAL;
 #else
-        interr("exp_mac: need DP_RETVAL", (int)ilmopr->type, 3);
+        interr("exp_mac: need DP_RETVAL", (int)ilmopr->type, ERR_Severe);
 #endif
         break;
       case ILMO_KRRET:
 #if defined(KR_RETVAL)
         newili.opnd[i] = KR_RETVAL;
 #else
-        interr("exp_mac: need KR_RETVAL", (int)ilmopr->type, 3);
+        interr("exp_mac: need KR_RETVAL", (int)ilmopr->type, ERR_Severe);
 #endif
         break;
 #if defined(ILMO_DRPOS)
@@ -2149,7 +2149,7 @@ exp_mac(ILM_OP opc, ILM *ilmp, int curilm)
 #endif
 
       default:
-        interr("exp_mac: opnd not handled", opc/*(int)ilmopr->type*/, 3);
+        interr("exp_mac: opnd not handled", opc/*(int)ilmopr->type*/, ERR_Severe);
 
       } /***  end of switch on operand type  ***/
     }   /*** end of noprs loop ***/
@@ -2196,7 +2196,7 @@ exp_mac(ILM_OP opc, ILM *ilmp, int curilm)
       break;
 
     default:
-      interr("exp_mac: bad ilmopr->type", newili.opc/*(int)ilmopr->type*/, 3);
+      interr("exp_mac: bad ilmopr->type", newili.opc/*(int)ilmopr->type*/, ERR_Severe);
     }
     /*
      * skip to the next ili template -- the length of the template is the
@@ -2240,19 +2240,19 @@ efunc(char *nm)
       else if (*p == 'l')
         resdt = DT_UINT8;
       else {
-        interr("efunc: unexpected u type", *p, 3);
+        interr("efunc: unexpected u type", *p, ERR_Severe);
       }
       break;
     case 'v':
       resdt = DT_NONE;
       break;
     default:
-      interr("efunc: unexpected result type", *p, 3);
+      interr("efunc: unexpected result type", *p, ERR_Severe);
       break;
     }
     while (*++p != '%') {
       if (*p == 0) {
-        interr("efunc: malformed result type", 0, 3);
+        interr("efunc: malformed result type", 0, ERR_Severe);
         p = nm;
         break;
       }
@@ -2411,7 +2411,7 @@ create_ref(int sym, int *pnmex, int basenm, int baseilix, int *pclen,
           else {
             clen = charlen(sym);
 #if DEBUG
-            assert(SDSCG(sym) != 0, "create_ref:Missing descriptor", sym, 3);
+            assert(SDSCG(sym) != 0, "create_ref:Missing descriptor", sym, ERR_Severe);
 #endif /* DEBUG */
           }
           mxlen = 0;
@@ -2436,7 +2436,7 @@ create_ref(int sym, int *pnmex, int basenm, int baseilix, int *pclen,
           } else {
             clen = charlen(sym);
 #if DEBUG
-            assert(SDSCG(sym) != 0, "create_ref:Missing descriptor", sym, 3);
+            assert(SDSCG(sym) != 0, "create_ref:Missing descriptor", sym, ERR_Severe);
 #endif
           }
           mxlen = 0;

--- a/tools/flang2/flang2exe/expatomics.c
+++ b/tools/flang2/flang2exe/expatomics.c
@@ -316,7 +316,7 @@ get_atomic_function_ex(ILI_OP opcode)
     }
   }
 
-  error(155, 3, gbl.lineno, "Invalid atomic operation.", CNULL);
+  error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic operation.", CNULL);
   return 0;
 }
 
@@ -445,7 +445,7 @@ get_atomic_function(ILI_OP opcode)
   case IL_SCMPLXSUB:
     return mk_prototype("atomicsubcmplx", "pure", DT_VOID_NONE, 3, DT_CPTR, DT_FLOAT, DT_FLOAT);
   default:
-    interr("Unsupported atomic opcode: ", opcode, 3);
+    interr("Unsupported atomic opcode: ", opcode, ERR_Severe);
     return 0;
   }
 }
@@ -645,7 +645,7 @@ create_atomic_capture_seq(int update_ili, int read_ili, int capture_first)
   st_opcode = ILI_OPC(read_ili);
   if (st_opcode != ILI_OPC(update_ili)) {
     /* This is not a legal atomic capture--data type mismatch */
-    interr("Atomic Capture: Mismatched storage operations.", 0, 3);
+    interr("Atomic Capture: Mismatched storage operations.", 0, ERR_Severe);
   }
 
   switch (st_opcode) {
@@ -700,7 +700,7 @@ create_atomic_capture_seq(int update_ili, int read_ili, int capture_first)
 #endif
     break;
   default:
-    interr("Create: Unexpected atomic store opcode", st_opcode, 3);
+    interr("Create: Unexpected atomic store opcode", st_opcode, ERR_Severe);
     break;
   }
 
@@ -720,7 +720,7 @@ create_atomic_capture_seq(int update_ili, int read_ili, int capture_first)
      */
     if (ILI_OPC(ILI_OPND(read_ili, 1)) == IL_CSEIR) {
       if (ILI_OPND(read_ili, 1) != ILI_OPND(update_op, 1)) {
-        interr("Mismatched CSE (1).\n", 0, 0);
+        interr("Mismatched CSE (1).\n", 0, ERR_unused);
       } else {
         allow_capture_last = 0;
       }
@@ -737,7 +737,7 @@ create_atomic_capture_seq(int update_ili, int read_ili, int capture_first)
      */
     if (ILI_OPC(ILI_OPND(read_ili, 1)) == IL_CSEIR) {
       if (ILI_OPND(read_ili, 1) != ILI_OPND(update_op, 2)) {
-        interr("Mismatched CSE (2).\n", 0, 0);
+        interr("Mismatched CSE (2).\n", 0, ERR_unused);
       } else {
         allow_capture_last = 0;
       }
@@ -748,7 +748,7 @@ create_atomic_capture_seq(int update_ili, int read_ili, int capture_first)
   }
 
   if (load_pt1 == -1 && load_pt2 == -1) {
-    interr("Can't find matching load operation in atomic capture.", 0, 3);
+    interr("Can't find matching load operation in atomic capture.", 0, ERR_Severe);
     return 0;
   }
 
@@ -772,7 +772,7 @@ create_atomic_capture_seq(int update_ili, int read_ili, int capture_first)
      */
     update_operand = ILI_OPND(update_op, 1);
   } else {
-    interr("Can't find load operation in atomic capture.", 0, 3);
+    interr("Can't find load operation in atomic capture.", 0, ERR_Severe);
     return 0;
   }
 
@@ -855,7 +855,7 @@ create_atomic_write_seq(int store_ili)
 #endif
     break;
   default:
-    interr("Create: Unexpected atomic store opcode", ILI_OPC(store_ili), 3);
+    interr("Create: Unexpected atomic store opcode", ILI_OPC(store_ili), ERR_Severe);
     break;
   }
 
@@ -1001,9 +1001,9 @@ get_atomic_update_opcode(int current_ili)
       store_opcode != IL_STSP && store_opcode != IL_STKR && 
       store_opcode != IL_STSCMPLX) {
     if(store_opcode == IL_STDCMPLX)
-       error(155, 3, gbl.lineno, "Double precision complex data type are not supported in atomic region within accelerator region.", CNULL);
+       error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Double precision complex data type are not supported in atomic region within accelerator region.", CNULL);
     else
-       interr("Error: Detected unexpected atomic store opcode.", store_opcode, 3);
+       interr("Error: Detected unexpected atomic store opcode.", store_opcode, ERR_Severe);
     return 0;
   }
 
@@ -1406,7 +1406,7 @@ create_atomic_seq(int store_ili)
     arg_dt = DT_FLOAT;
     break;
   default:
-    interr("Create: Unexpected atomic store opcode", ILI_OPC(store_ili), 3);
+    interr("Create: Unexpected atomic store opcode", ILI_OPC(store_ili), ERR_Severe);
     break;
   }
 #if defined(TARGET_X8664)
@@ -1474,7 +1474,7 @@ exp_end_atomic(int store, int curilm)
     atomic_opcode = get_atomic_update_opcode(store);
     if (atomic_opcode != 0) {
       if (get_atomic_store_created()) {
-        error(155, 3, gbl.lineno, "Invalid atomic expression", CNULL);
+        error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic expression", CNULL);
       } else if (atomic_opcode != IL_FREEIR) {
         int atomic_seq;
         atomic_seq = create_atomic_seq(store);
@@ -1487,7 +1487,7 @@ exp_end_atomic(int store, int curilm)
         /* Is there anything to do with FREEIR */
       }
     } else {
-      error(155, 3, gbl.lineno, "Invalid atomic expression", CNULL);
+      error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic expression", CNULL);
     }
     return true;
   }
@@ -1496,7 +1496,7 @@ exp_end_atomic(int store, int curilm)
     atomic_opcode = get_atomic_read_opcode(store);
     if (atomic_opcode != 0) {
       if (get_atomic_store_created()) {
-        error(155, 3, gbl.lineno, "Invalid atomic read expression", CNULL);
+        error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic read expression", CNULL);
       } else if (atomic_opcode != IL_FREEIR) {
         int atomic_seq;
         atomic_seq = create_atomic_read_seq(store);
@@ -1505,10 +1505,10 @@ exp_end_atomic(int store, int curilm)
         ILM_BLOCK(curilm) = expb.curbih;
         set_atomic_store_created(1);
       } else {
-        error(155, 3, gbl.lineno, "Invalid atomic read expression", CNULL);
+        error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic read expression", CNULL);
       }
     } else {
-      error(155, 3, gbl.lineno, "Invalid atomic read expression", CNULL);
+      error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic read expression", CNULL);
     }
     return true;
   }
@@ -1517,7 +1517,7 @@ exp_end_atomic(int store, int curilm)
     atomic_opcode = get_atomic_write_opcode(store);
     if (atomic_opcode != 0) {
       if (get_atomic_store_created()) {
-        error(155, 3, gbl.lineno, "Invalid atomic write expression", CNULL);
+        error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic write expression", CNULL);
       } else if (atomic_opcode != IL_FREEIR) {
         int atomic_seq;
         atomic_seq = create_atomic_write_seq(store);
@@ -1526,10 +1526,10 @@ exp_end_atomic(int store, int curilm)
         ILM_BLOCK(curilm) = expb.curbih;
         set_atomic_store_created(1);
       } else {
-        error(155, 3, gbl.lineno, "Invalid atomic write expression", CNULL);
+        error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic write expression", CNULL);
       }
     } else {
-      error(155, 3, gbl.lineno, "Invalid atomic write expression", CNULL);
+      error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic write expression", CNULL);
     }
     return true;
   }
@@ -1538,7 +1538,7 @@ exp_end_atomic(int store, int curilm)
     atomic_opcode = get_atomic_read_opcode(store);
     if (atomic_opcode != 0 && atomic_opcode != IL_FREEIR) {
       if (capture_read_ili != 0) {
-        error(155, 3, gbl.lineno,
+        error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno,
               "Invalid atomic capture block, multiple reads.", CNULL);
       } else {
         capture_read_ili = store;
@@ -1559,7 +1559,7 @@ exp_end_atomic(int store, int curilm)
     atomic_opcode = get_atomic_update_opcode(store);
     if (atomic_opcode != 0) {
       if (capture_update_ili != 0 && atomic_opcode != IL_FREEIR) {
-        error(155, 3, gbl.lineno,
+        error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno,
               "Invalid atomic capture block, multiple updates.", CNULL);
       } else if (atomic_opcode != IL_FREEIR) {
         capture_update_ili = store;
@@ -1649,7 +1649,7 @@ msz_from_atomic_pd(PD_KIND pd)
 {
   switch (pd) {
   default:
-    assert(0, "msz_from_atomic_pd: pd not atomic or not implemented", pd, 4);
+    assert(0, "msz_from_atomic_pd: pd not atomic or not implemented", pd, ERR_Fatal);
 
 #if TARGET_GNU_ATOMICS
   case PD_atomic_load_1:
@@ -2058,7 +2058,7 @@ auto_retrieve(auto_temp *temp)
 {
   switch (IL_TYPE(ILI_OPC(temp->expr))) {
   default:
-    interr("auto_retrieve: unexpected IL_TYPE", IL_TYPE(temp->expr), 4);
+    interr("auto_retrieve: unexpected IL_TYPE", IL_TYPE(temp->expr), ERR_Fatal);
   case ILTY_STORE:
   case ILTY_PSTORE:
     return ad_load(temp->expr);
@@ -2136,7 +2136,7 @@ exp_atomic_intrinsic(PD_KIND pd, ILM *ilmp, int curilm)
   aoc = atomic_op_category_from_pd(pd);
   switch (aoc) {
   default:
-    assert(false, "exp_atomic_intrinsic: unimplemented op class", aoc, 4);
+    assert(false, "exp_atomic_intrinsic: unimplemented op class", aoc, ERR_Fatal);
 
   case AOC_LOAD:
     stc = atomic_encode(msz, SS_PROCESS, AORG_CPLUS);
@@ -2745,7 +2745,7 @@ _ilis_are_matched(int rhs, int lhs, int* res, int* load)
       if (lhs_match_rhs(lop2, rop2)) {
         if (*res) {
           /* multiple occurrences of lhs on rhs */
-          error(155, 3, gbl.lineno, "Invalid atomic statement.", CNULL);
+          error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic statement.", CNULL);
         }
         *res = rhs;
         return;
@@ -2982,7 +2982,7 @@ exp_mp_atomic_update(ILM *ilmp)
     opnd[TMP_SPTR_IDX] = 0;
     expected_val = get_complex_update_operand(opnd, ilmp, nme, dtype);
     if (expected_val == 0) {
-        error(155, 3, gbl.lineno, "Invalid atomic update statement.", CNULL);
+        error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic update statement.", CNULL);
     }
     expected_sptr = opnd[TMP_SPTR_IDX];
     ASSNP(expected_sptr, 1);
@@ -3205,7 +3205,7 @@ exp_mp_atomic_capture(ILM *ilmp)
 
 capture_end:
   if (cpt.error) {
-    error(155, 3, gbl.lineno, "Invalid atomic capture statement(s).", CNULL);
+    error(S_0155_OP1_OP2, ERR_Severe, gbl.lineno, "Invalid atomic capture statement(s).", CNULL);
   }
   cpt.cnt++;
   return;

--- a/tools/flang2/flang2exe/expreg.c
+++ b/tools/flang2/flang2exe/expreg.c
@@ -337,16 +337,16 @@ assign1(int rtype)
            * the arg register that's assigned to its address as the
            * address expression in the the load.
            */
-          addr = ad1ili(IL_ARDF, (int)ADDRESSG(sym));
+          addr = ad1ili(IL_ARDF, ADDRESSG(sym));
           if (flg.endian &&
               (DTYPEG(sym) == DT_INT8 || DTYPEG(sym) == DT_LOG8)) {
             if (!XBIT(124, 0x400))
               /* 32bits of significance in 64 bits */
-              addr = ad3ili(IL_AADD, addr, ad_aconi((INT)4), 0);
+              addr = ad3ili(IL_AADD, addr, ad_aconi(4), 0);
           }
           RAT_ADDR(rat) = addr; /* switch addr expr */
-          ilix = ad3ili((int)ILI_OPC(ilix), addr, (int)ILI_OPND(ilix, 2),
-                        (int)ILI_OPND(ilix, 3));
+          ilix = ad3ili(ILI_OPC(ilix), addr, ILI_OPND(ilix, 2),
+                        ILI_OPND(ilix, 3));
           ilt = addilt(ilt, ilitmp = ad2ili(MV_RTYPE(rtype), ilix, areg));
           ADDNODE(list, ilitmp);
         }

--- a/tools/flang2/flang2exe/expsmp.c
+++ b/tools/flang2/flang2exe/expsmp.c
@@ -1453,7 +1453,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
       break;
     default:
 #if DEBUG
-      interr("exp_smp: IM_PDO unknown schedule", ILM_OPND(ilmp, 2) & 0xff, 3);
+      interr("exp_smp: IM_PDO unknown schedule", ILM_OPND(ilmp, 2) & 0xff, ERR_Severe);
 #endif
       doschedule = " static";
     }
@@ -2536,7 +2536,7 @@ shared_etask:
 #endif
 
   default:
-    interr("exp_smp: unsupported opc", opc, 3);
+    interr("exp_smp: unsupported opc", opc, ERR_Severe);
     break;
   }
 
@@ -2579,7 +2579,7 @@ jsrAddArg(int arglist, int opc, int argili)
     /* allow arguments to be passed in registers and on the stack */
     break;
   }
-  assert(is_daili_opcode(opc), "jsrAddArg: invalid opcode", opc, 4);
+  assert(is_daili_opcode(opc), "jsrAddArg: invalid opcode", opc, ERR_Fatal);
   if (opc == IL_DAIR || opc == IL_DAAR || opc == IL_DAKR)
     rg = IR(availIreg++);
   else {
@@ -2622,7 +2622,7 @@ makeCallResult(int opc, int callili)
     rg = AR_RETVAL;
     break;
   default:
-    interr("makeCallResult: invalid register free opcode", opc, 4);
+    interr("makeCallResult: invalid register free opcode", opc, ERR_Fatal);
   }
   ili = ad2ili(opc, callili, rg);
 
@@ -3141,10 +3141,10 @@ llGetTask(int scope)
   int sptr = scope;
   if (!scope)
     sptr = scopeSptr;
-  assert(sptr, "No scope for task found ", sptr, 4);
+  assert(sptr, "No scope for task found ", sptr, ERR_Fatal);
   LLTask *task = llmp_get_task(sptr);
   if (!task)
     task = llmp_create_task(sptr);
-  assert(task, "No task associated to this scope sptr", sptr, 4);
+  assert(task, "No task associated to this scope sptr", sptr, ERR_Fatal);
   return task;
 }

--- a/tools/flang2/flang2exe/exputil.c
+++ b/tools/flang2/flang2exe/exputil.c
@@ -656,7 +656,7 @@ check_ilm(int ilmx, int ilix)
             break;
 #endif /* LONG_DOUBLE_FLOAT128 */
           default:
-            interr("check_ilm: illegal store", ilix, 3);
+            interr("check_ilm: illegal store", ilix, ERR_Severe);
             goto wr_out;
           }
           ADDRCAND(ilix, nme);
@@ -670,7 +670,7 @@ check_ilm(int ilmx, int ilix)
             ADDRCAND(ilix, nme);
           } else {
             ilix = ILT_ILIP(iltx);
-            interr("check_ilm: illegal store1", ilix, 3);
+            interr("check_ilm: illegal store1", ilix, ERR_Severe);
           }
           goto wr_out;
         }
@@ -702,7 +702,7 @@ check_ilm(int ilmx, int ilix)
       fprintf(gbl.dbgfil,
               "check_ilm: bad reference, ilm %d(%s), ili %d, iliopc %d\n", ilmx,
               ilms[ILM_OPC((ILM *)(ilmb.ilm_base + ilmx))].name, ilix, opc);
-    interr("check_ilm: bad reference", ilmx, 3);
+    interr("check_ilm: bad reference", ilmx, ERR_Severe);
   }
 
   return saveilix;
@@ -1166,7 +1166,7 @@ mkfunc_sflags(const char *nmptr, const char *flags)
     }
 #if DEBUG
     else {
-      interr("mkfunc_sflags(): urecognized flag", sptr, 3);
+      interr("mkfunc_sflags(): urecognized flag", sptr, ERR_Severe);
       break;
     }
 #endif

--- a/tools/flang2/flang2exe/ili.h
+++ b/tools/flang2/flang2exe/ili.h
@@ -25,6 +25,8 @@
 
 #ifndef ILITP_UTIL  /* don't include if building ilitp utility prog*/
 #include "iliatt.h" /* defines ILI_OP */
+#else
+typedef unsigned short ILI_OP;
 #endif
 
 #include "atomic_common.h"
@@ -53,6 +55,8 @@ typedef struct {
 typedef struct {
   STG_MEMBERS(ILI);
 } ILIB;
+
+extern ILIB ilib;
 
 #define ILI_REPL(i) ilib.stg_base[i].count
 #define ILI_OPC(i) ((ILI_OP)ilib.stg_base[i].opc)
@@ -114,6 +118,8 @@ typedef struct {
 
   char oprflag[MAX_OPNDS]; /* ILIO_ type of each opnd.  See IL_OPRFLAG */
 } ILIINFO;
+
+extern ILIINFO ilis[];
 
 typedef enum ILIO_KIND {
   ILIO_NULL = 0,
@@ -250,8 +256,15 @@ typedef enum ILIA_RESULT {
 #define ILIA_ISCS(t) ((t) == ILIA_CS)
 #define ILIA_ISCD(t) ((t) == ILIA_CD)
 
-/* *** operand type:    ILIO_... e.g. ILIO_DPLNK */
+/* operand type:    ILIO_... e.g. ILIO_DPLNK */
+
+#ifdef __cplusplus
+inline ILIO_KIND IL_OPRFLAG(ILI_OP opcode, int opn) {
+  return static_cast<ILIO_KIND>(ilis[opcode].oprflag[opn - 1]);
+}
+#else
 #define IL_OPRFLAG(opcode, opn) (ilis[opcode].oprflag[opn - 1])
+#endif
 
 #define IL_OPRS(opc) (ilis[opc].oprs)
 #define IL_NAME(opc) (ilis[opc].name)
@@ -447,11 +460,6 @@ typedef struct {
 
 #define SCH_ATTR(i) (schinfo[(i)].attrs)
 #define SCH_LAT(i) (schinfo[(i)].latency)
-
-/*****  ILI External Data Declarations *****/
-
-extern ILIB ilib;
-extern ILIINFO ilis[];
 
 /* ---------------------------------------------------------------------- */
 

--- a/tools/flang2/flang2exe/iliutil.c
+++ b/tools/flang2/flang2exe/iliutil.c
@@ -321,7 +321,7 @@ addili(ILI *ilip)
       ilix = get_ili(ilip);
       break;
     default:
-      assert(false, "addili: unrec move opcode:", opc, 3);
+      assert(false, "addili: unrec move opcode:", opc, ERR_Severe);
     }
     break;
 
@@ -340,7 +340,7 @@ addili(ILI *ilip)
     break;
 #if DEBUG
   default:
-    interr("addili: illegal IL_TYPE(opc)", IL_TYPE(opc), 4);
+    interr("addili: illegal IL_TYPE(opc)", IL_TYPE(opc), ERR_Fatal);
     break;
 #endif
   }
@@ -771,7 +771,7 @@ ad_func(ILI_OP result_opc, ILI_OP call_opc, char *func_name, int nargs, ...)
         break;
 #endif
       default:
-        interr("ad_func: illegal arg", args[i].arg, 3);
+        interr("ad_func: illegal arg", args[i].arg, ERR_Severe);
         args[i].opc = IL_ARGIR;
         args[i].is_argili = 1;
         break;
@@ -850,7 +850,7 @@ ad_func(ILI_OP result_opc, ILI_OP call_opc, char *func_name, int nargs, ...)
     break;
 #endif
   default:
-    interr("ad_func: illegal result_opc", result_opc, 3);
+    interr("ad_func: illegal result_opc", result_opc, ERR_Severe);
   }
   va_end(vargs);
   return ilix;
@@ -916,7 +916,7 @@ vect_math(MTH_FN fn, char *root, int nargs, int vdt, int vopc,
    * on x86 - MACH_AMD_K8 or MACH_INTEL without SSE3
    */
   if (DTY(vdt) != TY_VECT) {
-    interr("vect_math: dtype is not vector", vdt, 3);
+    interr("vect_math: dtype is not vector", vdt, ERR_Severe);
     vdt = get_vector_dtype(DT_DBLE, 2);
   }
   if (XBIT_NEW_MATH_NAMES && fn != MTH_mod) {
@@ -937,7 +937,7 @@ vect_math(MTH_FN fn, char *root, int nargs, int vdt, int vopc,
       sprintf(oldname, "__fvd_%s", root);
       break;
     default:
-      interr("vect_math: unexpected element dtype", DTY(vdt + 1), 3);
+      interr("vect_math: unexpected element dtype", DTY(vdt + 1), ERR_Severe);
       typec = 'd';
       break;
     }
@@ -1019,7 +1019,7 @@ vect_math(MTH_FN fn, char *root, int nargs, int vdt, int vopc,
     func = mk_prototype(func_name, "f pure", vdt, 3, vdt, vdt, vdt);
     break;
   default:
-    interr("vect_math: unexpected number of args", nargs, 3);
+    interr("vect_math: unexpected number of args", nargs, ERR_Severe);
     func = mk_prototype(func_name, "f pure", vdt, 1, vdt);
     break;
   }
@@ -1376,7 +1376,7 @@ ad_cse(int ilix)
       break;
     }
   default:
-    interr("ad_cse: bad IL_RES", ilix, 3);
+    interr("ad_cse: bad IL_RES", ilix, ERR_Severe);
   }
   return (ilix);
 }
@@ -1651,7 +1651,7 @@ insert_argrsrv(ILI *ilip)
     return;
 #if DEBUG
   if (opc != IL_QJSR && opc != IL_JSR && opc != IL_JSRA)
-    interr("insert_argrsrv: unexpected proc", opc, 3);
+    interr("insert_argrsrv: unexpected proc", opc, ERR_Severe);
 #endif
 
   /* do not insert IL_ARGRSRV for routines that depend on the
@@ -1706,12 +1706,12 @@ insert_argrsrv(ILI *ilip)
       /* this path taken only with the first mem arg, after reg args */
       arg_ilix = ad2ili(IL_ARGRSRV, MR_MAX_ARGRSRV, arg_ilix);
 #if DEBUG
-      assert(prev_ilix, "insert_argrsrv: no reg args", ilip->opnd[0], 3);
+      assert(prev_ilix, "insert_argrsrv: no reg args", ilip->opnd[0], ERR_Severe);
 #endif
       ILI_OPND(prev_ilix, 3) = arg_ilix;
       break;
     default:
-      interr("insert_argrsrv: unexpected arg ili", ILI_OPC(arg_ilix), 3);
+      interr("insert_argrsrv: unexpected arg ili", ILI_OPC(arg_ilix), ERR_Severe);
     }
   }
 }
@@ -5106,7 +5106,7 @@ addarth(ILI *ilip)
         demorgans_opc = IL_KAND;
         break;
       default:
-        assert(0, "addarth: unexpected opcode DeMorgans ", opc, 4);
+        assert(0, "addarth: unexpected opcode DeMorgans ", opc, ERR_Fatal);
         break;
       }
 
@@ -6984,7 +6984,7 @@ addarth(ILI *ilip)
 
   default:
 #if DEBUG
-    interr("addarth:ili not handled", opc, 1);
+    interr("addarth:ili not handled", opc, ERR_Informational);
 #endif
     break;
   }
@@ -7789,7 +7789,7 @@ addbran(ILI *ilip)
      *   op2 = 1 (EQ), jump if op1 is false
      *   op2 = 2 (NE), jump if op1 is true
      */
-    assert(op2 == CC_EQ || op2 == CC_NE, "addbran:bad stc of LCJMPZ", op2, 3);
+    assert(op2 == CC_EQ || op2 == CC_NE, "addbran:bad stc of LCJMPZ", op2, ERR_Severe);
     switch (ILI_OPC(op1)) {
 
     case IL_ICON:
@@ -8407,8 +8407,8 @@ addbran(ILI *ilip)
 
       swarr = ilip->opnd[2];
 #if DEBUG
-      assert(ilip->opnd[3], "addbranJMPM 4th opnd zero", swarr, 3);
-      assert(ILI_OPC(op2) == IL_ICON, "addbranJMPM, range not icon", op2, 3);
+      assert(ilip->opnd[3], "addbranJMPM 4th opnd zero", swarr, ERR_Severe);
+      assert(ILI_OPC(op2) == IL_ICON, "addbranJMPM, range not icon", op2, ERR_Severe);
 #endif
       n = CONVAL2G(ILI_OPND(op2, 1));
       tv = CONVAL2G(ILI_OPND(op1, 1));
@@ -8548,7 +8548,7 @@ cmp_to_log(INT val, int rel)
     logval = icmp((INT)1, val) ^ 1;
     break;
   default:
-    interr("cmp_to_log: bad relation", rel, 3);
+    interr("cmp_to_log: bad relation", rel, ERR_Severe);
     return 0;
   }
 /*
@@ -8607,7 +8607,7 @@ get_ili(ILI *ilip)
    * operands
    */
 
-  assert(noprs <= ILTABSZ, "get_ili: noprs > ILTABSZ", opc, 3);
+  assert(noprs <= ILTABSZ, "get_ili: noprs > ILTABSZ", opc, ERR_Severe);
   tab = (noprs == 0) ? 0 : noprs - 1;
   /* search the hash links for this ILI  */
 
@@ -8644,7 +8644,7 @@ get_ili(ILI *ilip)
       opnd = ILI_OPND(p, i);
       if (opnd < 0 || opnd >= ilib.stg_size ||
           ILI_OPC(opnd) == GARB_COLLECTED) {
-        interr("bad ili link in get_ili", opc, 3);
+        interr("bad ili link in get_ili", opc, ERR_Severe);
       }
     }
   }
@@ -8680,7 +8680,7 @@ new_ili(ILI *ilip)
   noprs = ilis[opc].oprs;
 
 #if DEBUG
-  assert(noprs <= ILTABSZ, "new_ili: noprs > ILTABSZ", opc, 3);
+  assert(noprs <= ILTABSZ, "new_ili: noprs > ILTABSZ", opc, ERR_Severe);
 #endif
 
   /* NEW ENTRY */
@@ -8805,7 +8805,7 @@ garbage_collect(void (*mark_function)(int))
         ILI_VISIT(i) = 0;
         continue;
       }
-      assert(ILI_HSHLNK(i) == 0, "garbage_collection: bad hashlnk", i, 4);
+      assert(ILI_HSHLNK(i) == 0, "garbage_collection: bad hashlnk", i, ERR_Fatal);
       STG_ADD_FREELIST(ilib, i);
       ILI_OPCP(i, GARB_COLLECTED);
     } else if (ILI_VISIT(i) == GARB_VISITED) {
@@ -8844,7 +8844,7 @@ garbage_collect(void (*mark_function)(int))
       assert(ILI_OPC(i) == GARB_COLLECTED,
              "garbage_collection: free ILI not marked collected", i, 4);
     else {
-      interr("garbage_collection: ILI on free list more than once", i, 4);
+      interr("garbage_collection: ILI on free list more than once", i, ERR_Fatal);
     }
     ILI_VISIT(i) = 0;
   }
@@ -8863,7 +8863,7 @@ mark_ilitree(int ili, int val)
   int noprs;
 
   if (ILI_VISIT(ili)) {
-    assert(ILI_VISIT(ili) == val, "mark_ilitree: visit != val", ili, 4);
+    assert(ILI_VISIT(ili) == val, "mark_ilitree: visit != val", ili, ERR_Fatal);
     return;
   }
   opc = ILI_OPC(ili);
@@ -9154,7 +9154,7 @@ rewr_ili(int tree, int old, int New)
   int save_proc, save_all_acon;
 
 #if DEBUG
-  assert(tree > 0, "rewr_ili, bad tree", 0, 3);
+  assert(tree > 0, "rewr_ili, bad tree", 0, ERR_Severe);
 #endif
   if (rewrb.size == 0) {
     rewrb.size = 16;
@@ -9206,7 +9206,7 @@ rewr_ili_nme(int tree, int oldili, int newili, int oldnme, int newnme,
   int save_proc, New;
 
 #if DEBUG
-  assert(tree > 0, "rewr_ili_nme, bad tree", 0, 3);
+  assert(tree > 0, "rewr_ili_nme, bad tree", 0, ERR_Severe);
 #endif
   if (rewrb.size) {
     NEED(rewrb.cnt + 1, rewrb.base, int, rewrb.size, rewrb.size + 16);
@@ -9277,7 +9277,7 @@ rewr_indirect_nme(int nmex)
     break;
   default:
 #if DEBUG
-    interr("rewr_indirect_nme: unexpected nme", nmex, 3);
+    interr("rewr_indirect_nme: unexpected nme", nmex, ERR_Severe);
 #endif
     break;
   }
@@ -9307,7 +9307,7 @@ rewr_(int tree)
   bool changes;
 
 #if DEBUG
-  assert(tree > 0, "rewr_, bad tree", 0, 3);
+  assert(tree > 0, "rewr_, bad tree", 0, ERR_Severe);
 #endif
   if (ILI_VISIT(tree))
     return ILI_VISIT(tree);
@@ -9519,7 +9519,7 @@ rewr_nm(int nme)
   int new_nm, new_sub, j;
 #if DEBUG
   if (nme < 0 || nme >= nmeb.stg_size) {
-    interr("rewr_nm:bad names ptr", nme, 3);
+    interr("rewr_nm:bad names ptr", nme, ERR_Severe);
     return nme;
   }
 #endif
@@ -9583,7 +9583,7 @@ rewr_nm(int nme)
     break;
   default:
 #if DEBUG
-    interr("rewr_nm:unexp. nme", nme, 3);
+    interr("rewr_nm:unexp. nme", nme, ERR_Severe);
 #endif
     break;
   }
@@ -9601,7 +9601,7 @@ rewr_cln_ili(void)
   int tree;
 
 #if DEBUG
-  assert(rewrb.cnt, "rewr_cln_ili: cnt is zero", 0, 3);
+  assert(rewrb.cnt, "rewr_cln_ili: cnt is zero", 0, ERR_Severe);
 #endif
 
   for (i = 0; i < rewrb.cnt; i++) {
@@ -9616,7 +9616,7 @@ rewr_cln_ili(void)
 #if defined(MY_SCN) || defined(DEW)
   for (i = 1; i < ilib.stg_avail; i++)
     if (ILI_VISIT(i))
-      interr("rewr_cln_ili: visit not zero", i, 3);
+      interr("rewr_cln_ili: visit not zero", i, ERR_Severe);
 #endif
   if (rewrt.base) {
     FREE(rewrt.base);
@@ -9633,7 +9633,7 @@ rewr_cln(int tree)
   int i;
 
 #if DEBUG
-  assert(tree > 0, "rewr_cln, bad tree", 0, 3);
+  assert(tree > 0, "rewr_cln, bad tree", 0, ERR_Severe);
 #endif
   if (ILI_VISIT(tree)) {
     ILI_VISIT(tree) = 0;
@@ -9656,7 +9656,7 @@ rewr_cln_nm(int nme)
 {
 #if DEBUG
   if (nme < 0 || nme >= nmeb.stg_size) {
-    interr("rewr_cln_nm:bad names ptr", nme, 3);
+    interr("rewr_cln_nm:bad names ptr", nme, ERR_Severe);
     return;
   }
 #endif
@@ -9677,7 +9677,7 @@ rewr_cln_nm(int nme)
     break;
   default:
 #if DEBUG
-    interr("rewr_cln_nm:unexp. nme", nme, 3);
+    interr("rewr_cln_nm:unexp. nme", nme, ERR_Severe);
 #endif
     break;
   }
@@ -9918,7 +9918,7 @@ dump_msz(MSZ ms)
     break;
 #endif /* MSZ_F10 */
   default:
-    interr("Bad msz to LD/ST", ms, 3);
+    interr("Bad msz to LD/ST", ms, ERR_Severe);
     msz = "??";
   }
   return msz;
@@ -9991,7 +9991,7 @@ dump_ili(FILE *f, int i)
     fprintf(f, "%-4u **DELETED**\n", i);
     return;
   }
-  assert(opc > 0 && opc < N_ILI, "dump_ili: bad opc", i, 3);
+  assert(opc > 0 && opc < N_ILI, "dump_ili: bad opc", i, ERR_Severe);
   noprs = ilis[opc].oprs;
   fprintf(f, "%-4u %-9s  ", i, ilis[opc].name);
   for (j = 1; j <= noprs; j++) {
@@ -10031,7 +10031,7 @@ dump_ili(FILE *f, int i)
           okay = false;
         }
         if (!okay) 
-          interr("dump_ili:bad symbol table ptr", i, 4);
+          interr("dump_ili:bad symbol table ptr", i, ERR_Fatal);
       }
       fprintf(f, " %5u~", opn);
       if (opn>0) {
@@ -10125,7 +10125,7 @@ dump_ili(FILE *f, int i)
       }
       break;
     case ILIO_LNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
       switch (ILI_OPC(opn)) {
       case IL_KERNELNEST:
         break;
@@ -10144,38 +10144,38 @@ dump_ili(FILE *f, int i)
       fprintf(f, " %5u^", opn);
       break;
     case ILIO_IRLNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_IR, "dump_ili: ir link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_IR, "dump_ili: ir link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
     case ILIO_KRLNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_KR, "dump_ili: kr link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_KR, "dump_ili: kr link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
 #ifdef ILIO_PPLNK
     case ILIO_PPLNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_PR, "dump_ili: pr link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_PR, "dump_ili: pr link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
 #endif
     case ILIO_ARLNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_AR, "dump_ili: ar link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_AR, "dump_ili: ar link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
     case ILIO_SPLNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_SP, "dump_ili: sp link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_SP, "dump_ili: sp link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
     case ILIO_DPLNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
 #ifdef IL_DASPSP
       if (opc != IL_DASPSP || IL_RES(ILI_OPC(opn)) != ILIA_CS) { 
 #endif
-        assert(IL_RES(ILI_OPC(opn)) == ILIA_DP, "dump_ili: dp link exp", i, 3);
+        assert(IL_RES(ILI_OPC(opn)) == ILIA_DP, "dump_ili: dp link exp", i, ERR_Severe);
 #ifdef IL_DASPSP
       }
 #endif
@@ -10183,44 +10183,44 @@ dump_ili(FILE *f, int i)
       break;
 #ifdef ILIO_CSLNK
     case ILIO_QPLNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_QP, "dump_ili: qp link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_QP, "dump_ili: qp link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
     case ILIO_CSLNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_CS, "dump_ili: cs link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_CS, "dump_ili: cs link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
     case ILIO_CDLNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_CD, "dump_ili: cd link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_CD, "dump_ili: cd link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
     case ILIO_CQLNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_CQ, "dump_ili: cq link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_CQ, "dump_ili: cq link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
     case ILIO_128LNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_128, "dump_ili: 128 link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_128, "dump_ili: 128 link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
     case ILIO_256LNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_256, "dump_ili: 256 link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_256, "dump_ili: 256 link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
     case ILIO_512LNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_512, "dump_ili: 512 link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_512, "dump_ili: 512 link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
 #ifdef LONG_DOUBLE_FLOAT128
     case ILIO_FLOAT128LNK:
-      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, 3);
-      assert(IL_RES(ILI_OPC(opn)) == ILIA_FLOAT128, "dump_ili: doubledouble link exp", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dump_ili: bad ili lnk", i, ERR_Severe);
+      assert(IL_RES(ILI_OPC(opn)) == ILIA_FLOAT128, "dump_ili: doubledouble link exp", i, ERR_Severe);
       fprintf(f, " %5u^", opn);
       break;
 #endif
@@ -10303,7 +10303,7 @@ dilitree(int i)
 #ifdef ILIO_PPLNK
     case ILIO_PPLNK:
 #endif
-      assert(opn > 0 && opn < ilib.stg_size, "dilitree: bad ili lnk", i, 3);
+      assert(opn > 0 && opn < ilib.stg_size, "dilitree: bad ili lnk", i, ERR_Severe);
       dilitree(opn);
       break;
     default:
@@ -11419,7 +11419,7 @@ void
 dmpilitree(int i)
 {
 #if DEBUG
-  assert(i > 0, "dmpilitree: invalid value for ili pointer:", i, 3);
+  assert(i > 0, "dmpilitree: invalid value for ili pointer:", i, ERR_Severe);
   if (DBGBIT(10, 512))
     prilitree(i);
   else
@@ -11432,7 +11432,7 @@ void
 ddilitree(int i, int flag)
 {
   FILE *f = gbl.dbgfil;
-  assert(i > 0, "ddilitree: invalid value for ili pointer:", i, 3);
+  assert(i > 0, "ddilitree: invalid value for ili pointer:", i, ERR_Severe);
   gbl.dbgfil = stderr;
   if (flag) {
     prilitree(i);
@@ -11446,7 +11446,7 @@ void
 _ddilitree(int i, int flag)
 {
   FILE *f = gbl.dbgfil;
-  assert(i > 0, "_ddilitree: invalid value for ili pointer:", i, 3);
+  assert(i > 0, "_ddilitree: invalid value for ili pointer:", i, ERR_Severe);
   if (f == NULL)
     gbl.dbgfil = stderr;
   if (flag) {
@@ -12091,7 +12091,7 @@ ili_get_vect_dtype(int ilix)
   case IL_VBLEND:
     return ILI_OPND(ilix, 4);
   default:
-    interr("ili_get_vect_dtype missing case for ili opc", ILI_OPC(ilix), 3);
+    interr("ili_get_vect_dtype missing case for ili opc", ILI_OPC(ilix), ERR_Severe);
   }
   return 0;
 }
@@ -13029,7 +13029,7 @@ void
 addcallarg(int ili, int nme, int dtype)
 {
   if (nargs >= argsize)
-    interr("too many arguments in addcallarg", nargs, 4);
+    interr("too many arguments in addcallarg", nargs, ERR_Fatal);
   args[nargs].ili = ili;
   args[nargs].nme = nme;
   args[nargs].dtype = dtype;
@@ -13081,7 +13081,7 @@ genretvalue(int ilix, ILI_OP resultopc)
     ilix = ad2ili(resultopc, ilix, CS_RETVAL);
     break;
   default:
-    interr("genretvalue: illegal resultopc", resultopc, 3);
+    interr("genretvalue: illegal resultopc", resultopc, ERR_Severe);
   }
   return ilix;
 } /* genretvalue */
@@ -13242,7 +13242,7 @@ complement_int_cc(CC_RELATION cc)
   case CC_GT:
     return CC_LE;
   default:
-    interr("bad cc", cc, 3);
+    interr("bad cc", cc, ERR_Severe);
     return 0;
   }
 }
@@ -13277,7 +13277,7 @@ complement_ieee_cc(CC_RELATION cc)
     case CC_NOTGT:
       return CC_GT;
     default:
-      interr("bad cc", cc, 3);
+      interr("bad cc", cc, ERR_Severe);
       return 0;
     }
   }
@@ -13313,7 +13313,7 @@ commute_cc(CC_RELATION cc)
   case CC_NOTGT:
     return CC_NOTLT;
   default:
-    interr("bad cc", cc, 3);
+    interr("bad cc", cc, ERR_Severe);
     return 0;
   }
 }
@@ -13339,14 +13339,14 @@ combine_int_ccs(CC_RELATION binary_cc, CC_RELATION zero_cc)
     case CC_GT:
       break;
     default:
-      interr("bad binary_cc", binary_cc, 3);
+      interr("bad binary_cc", binary_cc, ERR_Severe);
     }
     return binary_cc;
   case CC_EQ:
   case CC_LE:
     return complement_int_cc(binary_cc);
   default:
-    interr("bad zero_cc", zero_cc, 3);
+    interr("bad zero_cc", zero_cc, ERR_Severe);
     return 0;
   }
 }
@@ -13377,14 +13377,14 @@ combine_ieee_ccs(CC_RELATION binary_cc, CC_RELATION zero_cc)
     case CC_NOTGT:
       break;
     default:
-      interr("bad binary_cc", binary_cc, 3);
+      interr("bad binary_cc", binary_cc, ERR_Severe);
     }
     return binary_cc;
   case CC_EQ:
   case CC_LE:
     return complement_ieee_cc(binary_cc);
   default:
-    interr("bad zero_cc", zero_cc, 3);
+    interr("bad zero_cc", zero_cc, ERR_Severe);
     return 0;
   }
 }
@@ -13410,7 +13410,7 @@ cc_includes_equality(CC_RELATION cc)
   case CC_NOTGT:
     return false;
   default:
-    interr("bad cc", cc, 3);
+    interr("bad cc", cc, ERR_Severe);
     return false;
   }
 }
@@ -13507,7 +13507,7 @@ ili_throw_label(int ilix)
   /* Look at the function call.  Extract the "alt" if not a GJSR/GJSRA */
   switch (opc) {
   default:
-    interr("ili_throw_label: not a call", ILI_OPC(ilix), 4);
+    interr("ili_throw_label: not a call", ILI_OPC(ilix), ERR_Fatal);
   case IL_QJSR:
     /* QJSR never throws */
     return 0;
@@ -13526,7 +13526,7 @@ ili_throw_label(int ilix)
   opc = ILI_OPC(ilix);
   switch (opc) {
   default:
-    interr("ili_throw_label: unexpected alt", opc, 4);
+    interr("ili_throw_label: unexpected alt", opc, ERR_Fatal);
   case IL_GJSR:
     return ILI_OPND(ilix, 3);
   case IL_GJSRA:
@@ -13549,7 +13549,7 @@ dt_to_mthtype(char mtype)
   case DT_DCMPLX:
     return 'z';
   }
-  interr("iliutil.c:dt_to_mthtype, unexpected mtype", mtype, 3);
+  interr("iliutil.c:dt_to_mthtype, unexpected mtype", mtype, ERR_Severe);
   return '?';
 }
 
@@ -13720,7 +13720,7 @@ atomic_info_index(ILI_OP opc)
   /* Get index of operand that encodes the ATOMIC_INFO. */
   switch (opc) {
   default:
-    assert(false, "atomic_info: not an atomic op", opc, 3);
+    assert(false, "atomic_info: not an atomic op", opc, ERR_Severe);
   case IL_CMPXCHGI:
   case IL_CMPXCHGKR:
   case IL_CMPXCHGA:
@@ -13905,7 +13905,7 @@ memory_order(int ilix)
   DEBUG_ASSERT(IL_HAS_FENCE(opc), "opc missing fence attribute");
   switch (opc) {
   default:
-    assert(false, "memory_order: unimplemented op", opc, 3);
+    assert(false, "memory_order: unimplemented op", opc, ERR_Severe);
   case IL_CMPXCHGI:
   case IL_CMPXCHGKR:
   case IL_CMPXCHGA: {
@@ -14082,7 +14082,7 @@ iadd_ili_ili(int leftx, int rightx)
 {
   int ilix;
   if (leftx < 0 || rightx < 0)
-    interr("iadd_ili_ili argument error", 0, 4);
+    interr("iadd_ili_ili argument error", 0, ERR_Fatal);
   if (leftx == 0)
     return rightx;
   if (rightx == 0)
@@ -14129,7 +14129,7 @@ isub_ili_ili(int leftx, int rightx)
 {
   int ilix;
   if (leftx < 0 || rightx < 0)
-    interr("isub_ili_ili argument error", 0, 4);
+    interr("isub_ili_ili argument error", 0, ERR_Fatal);
   if (rightx == 0)
     return leftx;
   if (leftx == 0) {
@@ -14209,7 +14209,7 @@ idiv_ili_const(int valilix, ISZ_T valconst)
   if (valconst == 1)
     return valilix;
   if (valilix < 0)
-    interr("div_ili_const argument error", 0, 4);
+    interr("div_ili_const argument error", 0, ERR_Fatal);
   if (valconst == -1)
     return isub_ili_ili(0, valilix);
   if (IL_RES(ILI_OPC(valilix)) == ILIA_KR) {
@@ -14227,7 +14227,7 @@ idiv_ili_ili(int leftx, int rightx)
 {
   int ilix;
   if (leftx < 0 || rightx < 0)
-    interr("div_ili_ili argument error", 0, 4);
+    interr("div_ili_ili argument error", 0, ERR_Fatal);
   if (IL_RES(ILI_OPC(leftx)) == ILIA_KR || IL_RES(ILI_OPC(rightx)) == ILIA_KR) {
     ilix = ad2ili(IL_KDIV, ikmove(leftx), ikmove(rightx));
   } else {
@@ -14241,7 +14241,7 @@ imax_ili_ili(int leftx, int rightx)
 {
   int ilix;
   if (leftx < 0 || rightx < 0)
-    interr("max_ili_ili argument error", 0, 4);
+    interr("max_ili_ili argument error", 0, ERR_Fatal);
   if (IL_RES(ILI_OPC(leftx)) == ILIA_KR || IL_RES(ILI_OPC(rightx)) == ILIA_KR) {
     ilix = ad2ili(IL_KMAX, ikmove(leftx), ikmove(rightx));
   } else {
@@ -14255,7 +14255,7 @@ imin_ili_ili(int leftx, int rightx)
 {
   int ilix;
   if (leftx < 0 || rightx < 0)
-    interr("min_ili_ili argument error", 0, 4);
+    interr("min_ili_ili argument error", 0, ERR_Fatal);
   if (IL_RES(ILI_OPC(leftx)) == ILIA_KR || IL_RES(ILI_OPC(rightx)) == ILIA_KR) {
     ilix = ad2ili(IL_KMIN, ikmove(leftx), ikmove(rightx));
   } else {

--- a/tools/flang2/flang2exe/iltutil.c
+++ b/tools/flang2/flang2exe/iltutil.c
@@ -212,9 +212,9 @@ moveilt(int iltx, int before)
 static void
 srcfunc(int ilix)
 {
-  register int noprs, /* number of lnk operands in ilix	 */
-      i,              /* index variable			 */
-      opc;            /* ili opcode of ilix			 */
+  int noprs; /* number of lnk operands in ilix	 */
+  int i;              /* index variable			 */
+  ILI_OP opc;            /* ili opcode of ilix			 */
 
   if (IL_TYPE(opc = ILI_OPC(ilix)) == ILTY_PROC && opc >= IL_JSR) {
     iltb.callfg = 1;

--- a/tools/flang2/flang2exe/kmpcutil.c
+++ b/tools/flang2/flang2exe/kmpcutil.c
@@ -971,7 +971,7 @@ mp_sched_to_kmpc_sched(int sched)
     return KMP_DISTRIBUTE_STATIC_CHUNKED;
 
   default:
-    error(155, ERR_Warning, gbl.lineno, "Unsupported OpenMP schedule type.",
+    error(S_0155_OP1_OP2, ERR_Warning, gbl.lineno, "Unsupported OpenMP schedule type.",
           NULL);
   }
   return KMP_SCH_DEFAULT;

--- a/tools/flang2/flang2exe/ll_ftn.h
+++ b/tools/flang2/flang2exe/ll_ftn.h
@@ -19,6 +19,7 @@
 #define LL_FTN_H_
 
 #include "gbldefs.h"
+#include "symtab.h"
 #include "ll_structure.h"
 
 /**
@@ -59,7 +60,7 @@ int get_entries_argnum(void);
 /**
    \brief ...
  */
-int get_iface_sptr(int sptr);
+SPTR get_iface_sptr(SPTR sptr);
 
 /**
    \brief ...
@@ -69,7 +70,7 @@ int get_master_sptr(void);
 /**
    \brief ...
  */
-int get_return_type(int func_sptr);
+DTYPE get_return_type(SPTR func_sptr);
 
 /**
    \brief ...

--- a/tools/flang2/flang2exe/ll_write.c
+++ b/tools/flang2/flang2exe/ll_write.c
@@ -1245,7 +1245,7 @@ write_mdref(FILE *out, LL_Module *module, LL_MDRef rmdref,
     break;
 
   default:
-    interr("Invalid MDRef kind", LL_MDREF_kind(mdref), 4);
+    interr("Invalid MDRef kind", LL_MDREF_kind(mdref), ERR_Fatal);
   }
 }
 
@@ -1306,7 +1306,7 @@ write_mdfield(FILE *out, LL_Module *module, int needs_comma, LL_MDRef mdref,
   case MDRef_String:
     assert(tmpl->type == StringField, "metadata elem should not be a string",
            tmpl->type, 4);
-    assert(value < module->mdstrings_count, "Bad string MDRef", value, 4);
+    assert(value < module->mdstrings_count, "Bad string MDRef", value, ERR_Fatal);
     if (!mandatory && strcmp(module->mdstrings[value], "!\"\"") == 0)
       return FALSE;
     /* The mdstrings[] entry is formatted as !"...". String the leading !. */
@@ -1314,7 +1314,7 @@ write_mdfield(FILE *out, LL_Module *module, int needs_comma, LL_MDRef mdref,
     break;
 
   case MDRef_Constant:
-    assert(value < module->constants_count, "Bad constant MDRef", value, 4);
+    assert(value < module->constants_count, "Bad constant MDRef", value, ERR_Fatal);
     switch (tmpl->type) {
     case ValueField:
       fprintf(out, "%s%s: %s %s", prefix, tmpl->name,
@@ -1373,7 +1373,7 @@ write_mdfield(FILE *out, LL_Module *module, int needs_comma, LL_MDRef mdref,
       break;
 
     case BoolField:
-      assert(value <= 1, "boolean value expected", value, 4);
+      assert(value <= 1, "boolean value expected", value, ERR_Fatal);
       fprintf(out, "%s%s: %s", prefix, tmpl->name, value ? "true" : "false");
       break;
 
@@ -1405,7 +1405,7 @@ write_mdfield(FILE *out, LL_Module *module, int needs_comma, LL_MDRef mdref,
     break;
 
   default:
-    interr("Invalid MDRef kind", LL_MDREF_kind(mdref), 4);
+    interr("Invalid MDRef kind", LL_MDREF_kind(mdref), ERR_Fatal);
   }
 
   return TRUE;
@@ -1485,7 +1485,7 @@ get_metadata_name(enum LL_MDName name)
   case MD_nvvmir_version:
     return "!nvvmir.version";
   default:
-    interr("Unknown metadata name", name, 4);
+    interr("Unknown metadata name", name, ERR_Fatal);
   }
   return NULL;
 }
@@ -2023,7 +2023,7 @@ ll_write_global_objects(FILE *out, LLVMModuleRef module)
       fprintf(out, " alias ");
       break;
     default:
-      interr("ll_write_global_objects: invalid global kind", object->kind, 4);
+      interr("ll_write_global_objects: invalid global kind", object->kind, ERR_Fatal);
     }
 
     /* Print an initializer following the type. */

--- a/tools/flang2/flang2exe/llassem.c
+++ b/tools/flang2/flang2exe/llassem.c
@@ -43,6 +43,7 @@
 #include "expand.h"
 #include "outliner.h"
 #include "upper.h"
+#include "llassem_common.h"
 
 fptr_local_t fptr_local = {0};
 
@@ -3735,7 +3736,7 @@ sym_is_refd(int sptr)
     break;
 
   default:
-    /*	interr("sym_is_refd:bad sty", sptr, 2);*/
+
     break;
   }
 

--- a/tools/flang2/flang2exe/llassem.h
+++ b/tools/flang2/flang2exe/llassem.h
@@ -308,9 +308,7 @@ void ll_override_type_string(LL_Type *llt, const char *str);
 
 int alignment(DTYPE);
 char *gen_llvm_vconstant(const char *, int, int, int);
-int get_int_dtype_from_size(int);
 int add_member_for_llvm(int, int, DTYPE, ISZ_T);
-int mk_struct_for_llvm_init(const char *name, int size);
 LL_Type *update_llvm_typedef(DTYPE dtype, int sptr, int rank);
 int llvm_get_unique_sym(void);
 
@@ -351,7 +349,6 @@ char *get_main_progname(void);
 LL_Type *get_lltype_from_argdtlist(char *argdtlist);
 void addag_llvm_argdtlist(int gblsym, int arg_num, int arg_sptr, LL_Type *);
 int get_master_sptr(void);
-int generic_dummy_dtype(void);
 LL_Type *make_generic_dummy_lltype(void);
 void set_llvm_iface_oldname(int, char *);
 LL_Type *get_local_overlap_vartype(void);

--- a/tools/flang2/flang2exe/llassem_common.c
+++ b/tools/flang2/flang2exe/llassem_common.c
@@ -147,7 +147,7 @@ put_skip(ISZ_T old, ISZ_T New)
       }
     }
   } else {
-    assert(amt == 0, "assem.c-put_skip old,new not in sync", New, 3);
+    assert(amt == 0, "assem.c-put_skip old,new not in sync", New, ERR_Severe);
   }
   return amt;
 }
@@ -362,7 +362,7 @@ emit_init(int tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
     first_data = 0;
     break;
   default:
-    assert(tdtype > 0, "emit_init:bad dinit rec", tdtype, 3);
+    assert(tdtype > 0, "emit_init:bad dinit rec", tdtype, ERR_Severe);
     size_of_item = size_of(tdtype);
 
     if (*repeat_cnt > 1) {
@@ -605,7 +605,7 @@ emit_init(int tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
 #endif /* LONG_DOUBLE_FLOAT128 */
 
       default:
-        interr("emit_init:bad dt", tdtype, 3);
+        interr("emit_init:bad dt", tdtype, ERR_Severe);
       }
       *addr += size_of_item;
       if (DTY(tdtype) != TY_PTR)
@@ -1025,10 +1025,12 @@ put_addr(int sptr, ISZ_T off, int dtype)
     fprintf(ASMFIL, "%ld", (long)off);
 }
 
-int
+DTYPE
 mk_struct_for_llvm_init(const char *name, int size)
 {
-  int tag, dtype, gblsym;
+  int tag;
+  DTYPE dtype;
+  int gblsym;
   char sname[MXIDLN];
 
   snprintf(sname, sizeof(sname), "struct%s", name);

--- a/tools/flang2/flang2exe/llassem_common.h
+++ b/tools/flang2/flang2exe/llassem_common.h
@@ -41,7 +41,7 @@ int add_member_for_llvm(int sym, int prev, DTYPE dtype, ISZ_T size);
 /**
    \brief ...
  */
-int mk_struct_for_llvm_init(const char *name, int size);
+DTYPE mk_struct_for_llvm_init(const char *name, int size);
 
 /**
    \brief ...

--- a/tools/flang2/flang2exe/lldebug.c
+++ b/tools/flang2/flang2exe/lldebug.c
@@ -2320,17 +2320,23 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
     type_mdnode = db->dtype_array[dtype];
   if (LL_MDREF_IS_NULL(type_mdnode)) {
     if (is_assumed_char(dtype)) {
+#if defined(FLANG_LLVM_EXTENSIONS)
       if ((!skipDataDependentTypes) &&
           ll_feature_has_diextensions(&db->module->ir)) {
         type_mdnode =
           lldbg_create_assumed_len_string_type_mdnode(db, sptr, findex);
       } else {
+#endif
         type_mdnode = lldbg_emit_type(db, DT_CPTR, sptr, findex, false, false,
                                       false);
+#if defined(FLANG_LLVM_EXTENSIONS)
         if (!skipDataDependentTypes) {
+#endif
           dtype_array_check_set(db, dtype, type_mdnode);
+#if defined(FLANG_LLVM_EXTENSIONS)
         }
       }
+#endif
     } else
       if (DT_ISBASIC(dtype) && (DTY(dtype) != TY_PTR)) {
 

--- a/tools/flang2/flang2exe/llsched.c
+++ b/tools/flang2/flang2exe/llsched.c
@@ -39,7 +39,8 @@ init_sched_graph(int size, int srank)
 {
   size_dg = size;
   srank_dg = srank;
-  matrix_dg = realloc(matrix_dg, size * size * sizeof(INSTR_LIST));
+  matrix_dg = (INSTR_LIST**)realloc(matrix_dg, size * size *
+                                    sizeof(INSTR_LIST));
   if (matrix_dg)
     memset(matrix_dg, 0, size * size * sizeof(INSTR_LIST));
   return (matrix_dg != NULL);

--- a/tools/flang2/flang2exe/machreg.c
+++ b/tools/flang2/flang2exe/machreg.c
@@ -382,11 +382,11 @@ mr_get_rgset()
 
   rgset = rgsetb.stg_avail++;
   if (rgsetb.stg_avail > MAXRAT)
-    error(7, 4, 0, CNULL, CNULL);
+    error(7, ERR_Fatal, 0, CNULL, CNULL);
   NEED(rgsetb.stg_avail, rgsetb.stg_base, RGSET, rgsetb.stg_size,
        rgsetb.stg_size + 100);
   if (rgsetb.stg_base == NULL)
-    error(7, 4, 0, CNULL, CNULL);
+    error(7, ERR_Fatal, 0, CNULL, CNULL);
 
   RGSET_XR(rgset) = 0;
 

--- a/tools/flang2/flang2exe/main.c
+++ b/tools/flang2/flang2exe/main.c
@@ -182,13 +182,13 @@ llvm_restart:
 #if DEBUG & sun
   if (DBGBIT(7, 4))
     if (malloc_verify() != 1)
-      interr("main: malloc_verify failsA", errno, 4);
+      interr("main: malloc_verify failsA", errno, ERR_Fatal);
 #endif
     reinit();
 #if DEBUG & sun
   if (DBGBIT(7, 4))
     if (malloc_verify() != 1)
-      interr("main: malloc_verify failsB", errno, 4);
+      interr("main: malloc_verify failsB", errno, ERR_Fatal);
 #endif
   xtimes[0] += getcpu();
   /* don't increment if it is outlined function because it
@@ -732,7 +732,7 @@ empty_cl:
 
   /* open sourcefile */
   if ((gbl.srcfil = fopen(sourcefile, "r")) == NULL) {
-    error(2, 4, 0, sourcefile, "");
+    error(2, ERR_Fatal, 0, sourcefile, "");
   } else {
     char *s;
     gbl.src_file = (char *)malloc(strlen(sourcefile) + 1);
@@ -786,7 +786,7 @@ do_curr_file:
 
   if (stboutfile) {
     if ((gbl.stbfil = fopen(stboutfile, "r")) == NULL)
-      error(2, 4, 0, stboutfile, "");
+      error(2, ERR_Fatal, 0, stboutfile, "");
   } else {
     gbl.stbfil = NULL;
   }

--- a/tools/flang2/flang2exe/mwd.c
+++ b/tools/flang2/flang2exe/mwd.c
@@ -575,7 +575,7 @@ putsym(const char *s, SPTR sptr)
 } /* putsym */
 
 static void
-putnsym(char *s, int sptr)
+putnsym(char *s, SPTR sptr)
 {
   if (sptr != 0)
     putsym(s, sptr);
@@ -1039,7 +1039,7 @@ dsym(int sptr)
   case ST_LABEL:
   case ST_BASE:
   case ST_UNKNOWN:
-    dtype = 0;
+    dtype = DT_NONE;
     break;
   default:
     dtype = DTYPEG(0);
@@ -2395,7 +2395,7 @@ dgbl(void)
   memcpy(&mbl, &gbl, sizeof(gbl));
   dfile = gbl.dbgfil ? gbl.dbgfil : stderr;
   putsym("gbl.currsub", mbl.currsub);
-  mbl.currsub = 0;
+  mbl.currsub = SPTR_NULL;
   putnstring("gbl.datetime", mbl.datetime);
   memset(mbl.datetime, 0, sizeof(mbl.datetime));
   putline();
@@ -2429,14 +2429,14 @@ dgbl(void)
   mbl.typedescs = 0;
   putline();
   putnsym("gbl.outersub", mbl.outersub);
-  mbl.outersub = 0;
+  mbl.outersub = SPTR_NULL;
   putline();
   putnzint("gbl.vfrets", mbl.vfrets);
   mbl.vfrets = 0;
   putnzint("gbl.func_count", mbl.func_count);
   mbl.func_count = 0;
   putnzint("gbl.rutype=", mbl.rutype);
-  mbl.rutype = 0;
+  mbl.rutype = (RUTYPE)0; // ??? no 0 value defined
   putnzint("gbl.funcline=", mbl.funcline);
   mbl.funcline = 0;
   putnzint("gbl.threadprivate=", mbl.threadprivate);
@@ -2840,7 +2840,7 @@ putdty(TY_KIND dty)
 void
 _putdtype(DTYPE dtype, int structdepth)
 {
-  int dty;
+  TY_KIND dty;
   ADSC *ad;
   int numdim;
   dfile = gbl.dbgfil ? gbl.dbgfil : stderr;
@@ -2951,7 +2951,8 @@ putdtype(DTYPE dtype)
 static int
 putdtypex(DTYPE dtype, int len)
 {
-  int dty, r = 0;
+  TY_KIND dty;
+  int r = 0;
   ADSC *ad;
   int numdim;
   if (len < 0)
@@ -3055,7 +3056,7 @@ putdtypex(DTYPE dtype, int len)
 } /* putdtypex */
 
 void
-dumpdtype(int dtype)
+dumpdtype(DTYPE dtype)
 {
   ADSC *ad;
   int numdim;
@@ -3119,7 +3120,7 @@ dumpdtype(int dtype)
 } /* dumpdtype */
 
 void
-ddtype(int dtype)
+ddtype(DTYPE dtype)
 {
   dumpdtype(dtype);
 } /* ddtype */
@@ -3127,7 +3128,7 @@ ddtype(int dtype)
 void
 dumpdtypes(void)
 {
-  int dtype;
+  DTYPE dtype;
   dfile = gbl.dbgfil ? gbl.dbgfil : stderr;
   fprintf(dfile, "\n********** DATATYPE TABLE **********\n");
   for (dtype = 1; dtype < stb.dt.stg_avail; dtype += dlen(DTY(dtype))) {
@@ -3139,7 +3140,7 @@ dumpdtypes(void)
 void
 dumpnewdtypes(int olddtavail)
 {
-  int dtype;
+  DTYPE dtype;
   dfile = gbl.dbgfil ? gbl.dbgfil : stderr;
   fprintf(dfile, "\n********** DATATYPE TABLE **********\n");
   for (dtype = olddtavail; dtype < stb.dt.stg_avail; dtype += dlen(DTY(dtype))) {
@@ -3212,7 +3213,7 @@ smsz(int m)
 char* scond(int);
 
 static void
-putstc(int opc, int opnum, int opnd)
+putstc(ILI_OP opc, int opnum, int opnd)
 {
   static char *msz;
   switch (ilstckind(opc, opnum)) {
@@ -3387,7 +3388,9 @@ _put_device_type(int d)
 static void
 _printili(int i)
 {
-  int n, k, j, noprs, opc, o, typ, sptr;
+  int n, k, j, noprs;
+  ILI_OP opc;
+  int o, typ, sptr;
   char *opval;
   static char *ccval[] = {"??",  "==",  "!=", "<",   ">=",  "<=", ">",
                           "!==", "!!=", "!<", "!>=", "!<=", "!>"};
@@ -4390,7 +4393,7 @@ printblocksline(void)
 void
 dili(int ilix)
 {
-  int opc;
+  ILI_OP opc;
   dfile = gbl.dbgfil ? gbl.dbgfil : stderr;
 
   if (full)
@@ -4417,14 +4420,14 @@ dili(int ilix)
       opnd = ILI_OPND(ilix, j);
       switch (IL_OPRFLAG(opc, j)) {
       case ILIO_SYM:
-        putsym("sym", opnd);
+        putsym("sym", (SPTR)opnd);
         if (opc == IL_ACON) {
           putnsym("base", CONVAL1G(opnd));
           putnzbigint("offset", ACONOFFG(opnd));
         }
         break;
       case ILIO_OFF:
-        putsym("sym", opnd);
+        putsym("sym", (SPTR)opnd);
         break;
       case ILIO_NME:
         putnme("nme", opnd);

--- a/tools/flang2/flang2exe/mwd.h
+++ b/tools/flang2/flang2exe/mwd.h
@@ -71,7 +71,7 @@ void db(int block);
 /**
    \brief ...
  */
-void ddtype(int dtype);
+void ddtype(DTYPE dtype);
 
 /**
    \brief ...
@@ -306,7 +306,7 @@ void dumpdiff(void);
 /**
    \brief ...
  */
-void dumpdtype(int dtype);
+void dumpdtype(DTYPE dtype);
 
 /**
    \brief ...

--- a/tools/flang2/flang2exe/outliner.c
+++ b/tools/flang2/flang2exe/outliner.c
@@ -297,7 +297,7 @@ ll_ad_outlined_func2(int result_opc, int call_opc, int sptr, int nargs,
       rg += 2;
       break;
     default:
-      interr("ll_ad_outlined_func2: illegal arg", arg, 3);
+      interr("ll_ad_outlined_func2: illegal arg", arg, ERR_Severe);
       break;
     }
   }
@@ -828,7 +828,7 @@ ll_rewrite_ilms(int lineno, int ilmx, int len)
       while (len) {
         nw = fwrite((char *)&nop, sizeof(ILM_T), 1, par_curfile);
 #if DEBUG
-        assert(nw, "error write to temp file in ll_rewrite_ilms", nw, 4);
+        assert(nw, "error write to temp file in ll_rewrite_ilms", nw, ERR_Fatal);
 #endif
         len--;
       };
@@ -846,7 +846,7 @@ ll_rewrite_ilms(int lineno, int ilmx, int len)
     {
       nw = fwrite((char *)ilmpx, sizeof(ILM_T), len, par_curfile);
 #if DEBUG
-      assert(nw, "error write to temp file in ll_rewrite_ilms", nw, 4);
+      assert(nw, "error write to temp file in ll_rewrite_ilms", nw, ERR_Fatal);
 #endif
     }
   }
@@ -980,7 +980,7 @@ llWriteNopILM(int lineno, int ilmx, int len)
   while (len) {
       nw = fwrite((char *)&nop, sizeof(ILM_T), 1, par_curfile);
 #if DEBUG
-      assert(nw, "error write to temp file in ll_rewrite_ilms", nw, 4);
+      assert(nw, "error write to temp file in ll_rewrite_ilms", nw, ERR_Fatal);
 #endif
     len--;
   };

--- a/tools/flang2/flang2exe/regutil.c
+++ b/tools/flang2/flang2exe/regutil.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1993-2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -350,7 +350,7 @@ addrcand(int ilix)
 
   default:
     if (ILI_RAT(ilix) == 0) {
-      assert(ILI_RAT(ilix) != 0, "addrcand: no cand for ili", ilix, 3);
+      assert(ILI_RAT(ilix) != 0, "addrcand: no cand for ili", ilix, ERR_Severe);
       return;
     }
     RCAND_COUNT(ILI_RAT(ilix)) += rcandb.weight;
@@ -608,7 +608,7 @@ get_msize(int msz)
     p = "i8";
     break;
   default:
-    interr("get_msize: unknown msize", msz, 2);
+    interr("get_msize: unknown msize", msz, ERR_Warning);
     p = "??";
   }
   return p;
@@ -985,7 +985,7 @@ mkrtemp_cpx_sc(DTYPE dtype, SC_KIND sc)
     type = 4;
     break;
   default:
-    interr("mkrtemp_cpx: illegal dtype", dtype, 3);
+    interr("mkrtemp_cpx: illegal dtype", dtype, ERR_Severe);
     type = 6;
   }
 
@@ -1024,7 +1024,7 @@ mkrtemp_arg1_sc(DTYPE dtype, SC_KIND sc)
   else if (dtype == DT_INT8)
     type = 4;
   else {
-    interr("mkrtemp_cpx: illegal dtype", dtype, 3);
+    interr("mkrtemp_cpx: illegal dtype", dtype, ERR_Severe);
     type = 6;
   }
 
@@ -1194,7 +1194,7 @@ _assn_rtemp(int ili, int temp)
     }
 
   default:
-    interr("_assn_rtemp: illegal ili for temp assn", ili, 3);
+    interr("_assn_rtemp: illegal ili for temp assn", ili, ERR_Severe);
   }
   RCAND_NEXT(rcand) = reg[rtype].rcand;
   reg[rtype].rcand = rcand;
@@ -1311,7 +1311,7 @@ select_rtemp(int ili)
     break;
 #endif
   default:
-    interr("select_rtemp: bad ili", ili, 3);
+    interr("select_rtemp: bad ili", ili, ERR_Severe);
     type = 0;
   }
   return type;

--- a/tools/flang2/flang2exe/regutil.h
+++ b/tools/flang2/flang2exe/regutil.h
@@ -45,7 +45,7 @@ typedef struct LST_TAG {
   {                                                                \
     LST *node;                                                     \
     node = (LST *)getitem(LST_AREA, sizeof(struct LST_TAG));       \
-    assert(node != 0, "no space allocated for linked-list", 0, 3); \
+    assert(node != 0, "no space allocated for linked-list", 0, ERR_Severe); \
     node->item = entry;                                            \
     node->next = l;                                                \
     l = node;                                                      \
@@ -194,11 +194,11 @@ typedef struct {
   {                                                         \
     i = ratb.stg_avail++;                                   \
     if (ratb.stg_avail > MAXRAT)                            \
-      error(7, 4, 0, CNULL, CNULL);                         \
+      error((error_code_t)7, ERR_Severe, 0, CNULL, CNULL); \
     NEED(ratb.stg_avail, ratb.stg_base, RAT, ratb.stg_size, \
          ratb.stg_size + 100);                              \
     if (ratb.stg_base == NULL)                              \
-      error(7, 4, 0, CNULL, CNULL);                         \
+      error((error_code_t)7, ERR_Severe, 0, CNULL, CNULL); \
   }
 
 /*****  Register Candidate Table  *****/
@@ -317,8 +317,8 @@ typedef struct {
 #define IS_PRIVATE(s) (SCG(s) == SC_PRIVATE)
 
 /* macros used to access register defining/moving ili */
-#define RTYPE_DF(rtype) (il_rtype_df[rtype])
-#define MV_RTYPE(rtype) (il_mv_rtype[rtype])
+#define RTYPE_DF(rtype) ((ILI_OP)il_rtype_df[rtype])
+#define MV_RTYPE(rtype) ((ILI_OP)il_mv_rtype[rtype])
 
 /*****  External Data Declarations  *****/
 

--- a/tools/flang2/flang2exe/rmsmove.c
+++ b/tools/flang2/flang2exe/rmsmove.c
@@ -30,7 +30,8 @@
 #include "ili.h"
 
 static struct {
-  int msz, msize, ld, st;
+  int msz, msize;
+  ILI_OP ld, st;
 } info[4] = {
     {MSZ_I8, 8, IL_LDKR, IL_STKR},
     {MSZ_WORD, 4, IL_LD, IL_ST},
@@ -44,9 +45,9 @@ static struct {
 static int
 fixup_nme(int nmex, int msize, int offset, int iter)
 {
-  int new_sym;
+  SPTR new_sym;
   int new_nme;
-  int new_dtype;
+  DTYPE new_dtype;
   static char buf[100];
   int buf_len = 100;
   int sym;
@@ -78,7 +79,7 @@ fixup_nme(int nmex, int msize, int offset, int iter)
     name = &buf[0];
   } else {
     name = (char *)malloc(name_len);
-    assert(name != NULL, "Fail to malloc a buffer", nmex, 4);
+    assert(name != NULL, "Fail to malloc a buffer", nmex, ERR_Fatal);
     is_malloced = TRUE;
   }
 

--- a/tools/flang2/flang2exe/scope.c
+++ b/tools/flang2/flang2exe/scope.c
@@ -39,16 +39,16 @@
    ST_BLOCK entry.
 */
 
-#include "gbldefs.h"
+#include "scope.h"
 #include "error.h"
 #include "global.h"
-#include "symtab.h"
 #include "ilm.h"
 #include "ilmtp.h"
 #include "ili.h"
 #include "go.h"
 #include "scope.h"
 #include "flang/ADT/hash.h"
+#include "symfun.h"
 
 /* For addlabel(). */
 #include "semant.h"
@@ -79,7 +79,7 @@ is_scope_root(SPTR sptr)
    entries.
  */
 bool
-scope_contains(int outer, int inner)
+scope_contains(SPTR outer, SPTR inner)
 {
   ICHECK(VALIDSYM(outer) &&
          (is_scope_root(outer) || STYPEG(outer) == ST_BLOCK));

--- a/tools/flang2/flang2exe/scope.h
+++ b/tools/flang2/flang2exe/scope.h
@@ -18,6 +18,9 @@
 #ifndef SCOPE_H_
 #define SCOPE_H_
 
+#include "gbldefs.h"
+#include "symtab.h"
+
 /**
    \file
    Functions for dealing with lexical scopes and the lifetimes of
@@ -51,7 +54,7 @@ extern int current_scope;
 /**
    \brief ...
  */
-bool scope_contains(int outer, int inner);
+bool scope_contains(SPTR outer, SPTR inner);
 
 /**
    \brief ...

--- a/tools/flang2/flang2exe/semsym.c
+++ b/tools/flang2/flang2exe/semsym.c
@@ -49,10 +49,10 @@ declref(int sptr, int stype, int def)
             goto return1;
           }
           /* multiple declaration */
-          error(44, 3, gbl.lineno, SYMNAME(first), CNULL);
+          error(44, ERR_Severe, gbl.lineno, SYMNAME(first), CNULL);
         } else
           /* illegal use of symbol */
-          error(84, 3, gbl.lineno, SYMNAME(first), CNULL);
+          error(84, ERR_Severe, gbl.lineno, SYMNAME(first), CNULL);
         break;
       }
       goto return2; /* found, return it */
@@ -85,7 +85,7 @@ declsym(int sptr, int stype, bool errflg)
       if (stype == st) {
         /* Possible attempt to multiply define symbol */
         if (errflg) {
-          error(44, 3, gbl.lineno, SYMNAME(first), CNULL);
+          error(44, ERR_Severe, gbl.lineno, SYMNAME(first), CNULL);
           break;
         } else
           goto return2;
@@ -96,7 +96,7 @@ declsym(int sptr, int stype, bool errflg)
             sptr = sptr1;
           goto return1;
         } else {
-          error(43, 3, gbl.lineno, "symbol", SYMNAME(first));
+          error(43, ERR_Severe, gbl.lineno, "symbol", SYMNAME(first));
           break;
         }
       }
@@ -192,7 +192,7 @@ newsym(int sptr)
 
   if (EXPSTG(sptr)) {
     /* Symbol previously frozen as an intrinsic */
-    error(43, 3, gbl.lineno, "intrinsic", SYMNAME(sptr));
+    error(43, ERR_Severe, gbl.lineno, "intrinsic", SYMNAME(sptr));
     return 0;
   }
   /*
@@ -212,7 +212,7 @@ newsym(int sptr)
   /*
    * create a new symbol with the same name:
    */
-  error(35, 1, gbl.lineno, SYMNAME(sptr), CNULL);
+  error(35, ERR_Informational, gbl.lineno, SYMNAME(sptr), CNULL);
   sp2 = insert_sym(sptr);
 
   /* transfer dtype if it was explicitly declared for sptr:  */

--- a/tools/flang2/flang2exe/semutil0.c
+++ b/tools/flang2/flang2exe/semutil0.c
@@ -37,10 +37,10 @@
   {                                     \
     char bf[20];                        \
     sprintf(bf, f, c);                  \
-    error(e, 2, gbl.lineno, bf, CNULL); \
+    error(e, ERR_Warning, gbl.lineno, bf, CNULL); \
   }
 
-#define ERR170(s) error(170, 2, gbl.lineno, s, CNULL)
+#define ERR170(s) error(170, ERR_Warning, gbl.lineno, s, CNULL)
 
 /**
    \brief Initialize semantic analyzer for new user subprogram unit.

--- a/tools/flang2/flang2exe/symacc.c
+++ b/tools/flang2/flang2exe/symacc.c
@@ -50,26 +50,26 @@ sym_init_first(void)
   int i;
 
   int sizeof_SYM = sizeof(SYM) / sizeof(INT);
-  assert(sizeof_SYM == 36, "bad SYM size", sizeof_SYM, 4);
+  assert(sizeof_SYM == 36, "bad SYM size", sizeof_SYM, ERR_Fatal);
 
   if (stb.stg_base == NULL) {
     STG_ALLOC(stb, 1000);
-    assert(stb.stg_base, "sym_init: no room for symtab", stb.stg_size, 4);
+    assert(stb.stg_base, "sym_init: no room for symtab", stb.stg_size, ERR_Fatal);
     stb.n_size = 5024;
     NEW(stb.n_base, char, stb.n_size);
-    assert(stb.n_base, "sym_init: no room for namtab", stb.n_size, 4);
+    assert(stb.n_base, "sym_init: no room for namtab", stb.n_size, ERR_Fatal);
     stb.n_base[0] = 0;
     STG_ALLOC(stb.dt, 400);
-    assert(stb.dt.stg_base, "sym_init: no room for dtypes", stb.dt.stg_size, 4);
+    assert(stb.dt.stg_base, "sym_init: no room for dtypes", stb.dt.stg_size, ERR_Fatal);
     stb.w_size = 32;
     NEW(stb.w_base, INT, stb.w_size);
-    assert(stb.w_base, "sym_init: no room for wtab", stb.w_size, 4);
+    assert(stb.w_base, "sym_init: no room for wtab", stb.w_size, ERR_Fatal);
   }
 
   stb.namavl = 1;
   stb.wrdavl = 0;
   for (i = 0; i <= HASHSIZE; i++)
-    stb.hashtb[i] = 0;
+    stb.hashtb[i] = SPTR_NULL;
 
 }
 
@@ -124,8 +124,7 @@ lookupsym(const char *name, int olength)
 
     return sptr;
   }
-
-  return 0;
+  return SPTR_NULL;
 } /* lookupsym */
 
 /** \brief Issue diagnostic for identifer that is too long.
@@ -448,27 +447,27 @@ is_cimag_flt0(SPTR sptr)
 bool
 is_cmplx_dbl0(SPTR sptr)
 {
-  if (is_dbl0(CONVAL1G(sptr)) && is_dbl0(CONVAL2G(sptr)))
-    return true;
-  return false;
+  return is_dbl0((SPTR)CONVAL1G(sptr)) && // ???
+    is_dbl0((SPTR)CONVAL2G(sptr)); // ???
 }
 
 bool
 is_cmplx_quad0(SPTR sptr)
 {
-  return is_quad0(CONVAL1G(sptr)) && is_quad0(CONVAL2G(sptr));
+  return is_quad0((SPTR)CONVAL1G(sptr)) && // ???
+    is_quad0((SPTR)CONVAL2G(sptr)); // ???
 }
 
 void
 symini_errfatal(int n)
 {
-  errfatal(n);
+  errfatal((error_code_t)n);
 }
 
 void
 symini_error(int n, int s, int l, const char *c1, const char *c2)
 {
-  error(n, s, l, c1, c2);
+  error((error_code_t)n, (enum error_severity)s, l, c1, c2);
 }
 
 void

--- a/tools/flang2/flang2exe/symfun.h
+++ b/tools/flang2/flang2exe/symfun.h
@@ -20,6 +20,7 @@
 
 #include "gbldefs.h"
 #include "symtab.h"
+#include "ili.h"
 
 #ifdef __cplusplus
 
@@ -223,6 +224,38 @@ inline void DTySetFst(DTYPE dtype, ISZ_T val) {
   DTySet(static_cast<DTYPE>(static_cast<int>(dtype) + 1), val);
 }
 
+// ===========
+// ILI getters
+
+inline ILI_OP ILIOpcode(int ilix) {
+  //Precond(ILIIsValid(ilix));
+  return ILI_OPC(ilix);
+}
+
+inline bool ILIIsConstant(int ilix) {
+  return IL_TYPE(ILIOpcode(ilix)) == ILTY_CONS;
+}
+
+inline SPTR ILIConstantSymbol(int ilix) {
+  Precond(ILIIsConstant(ilix));
+  return static_cast<SPTR>(ILI_OPND(ilix, 1));
+}
+
+// ===========
+// STB getters
+
+inline SPTR STGetEnclosingFunction(int index) {
+  return static_cast<SPTR>(ENCLFUNCG(index));
+}
+#undef ENCLFUNCG
+#define ENCLFUNCG(X) STGetEnclosingFunction(X)
+
+inline SPTR STGetCrossRefLink(int index) {
+  return static_cast<SPTR>(XREFLKG(index));
+}
+#undef XREFLKG
+#define XREFLKG(X) STGetCrossRefLink(X)
+
 #else // !__cplusplus
 
 #define DTyValidRange(D) (((D) > DT_NONE) && ((unsigned)(D) < stb.dt.stg_avail))
@@ -251,6 +284,9 @@ inline void DTySetFst(DTYPE dtype, ISZ_T val) {
 #define DTySetFst(D,E)       (DTY((D) + 1) = (E))
 
 #define SptrValidRange(S)    (((S) > NOSYM) && ((unsigned)(S) < stb.stg_avail))
+
+#define ILIOpcode(I)         ILI_OPC(I)
+#define ILIConstantSymbol(I) ILI_OPND(I, 1)
 
 #endif // __cplusplus
 

--- a/tools/flang2/flang2exe/symtab.c
+++ b/tools/flang2/flang2exe/symtab.c
@@ -234,8 +234,8 @@ cng_generic(char *old, char *New)
   os = getsym(old, strlen(old));
   ns = getsym(New, strlen(New));
 #if DEBUG
-  assert(STYPEG(os) == ST_GENERIC, "cng_generic not intr", os, 3);
-  assert(STYPEG(ns) == ST_GENERIC, "cng_generic not intr", ns, 3);
+  assert(STYPEG(os) == ST_GENERIC, "cng_generic not intr", os, ERR_Severe);
+  assert(STYPEG(ns) == ST_GENERIC, "cng_generic not intr", ns, ERR_Severe);
 #endif
   COPYFIELD(w9);
   COPYFIELD(w10);
@@ -257,8 +257,8 @@ cng_specific(char *old, char *New)
   os = getsym(old, strlen(old));
   ns = getsym(New, strlen(New));
 #if DEBUG
-  assert(STYPEG(os) == ST_INTRIN, "cng_specific not intr", os, 3);
-  assert(STYPEG(ns) == ST_INTRIN, "cng_specific not intr", ns, 3);
+  assert(STYPEG(os) == ST_INTRIN, "cng_specific not intr", os, ERR_Severe);
+  assert(STYPEG(ns) == ST_INTRIN, "cng_specific not intr", ns, ERR_Severe);
 #endif
   DTYPEP(os, DTYPEG(ns));
   COPYFIELD(w9);
@@ -276,7 +276,7 @@ cng_inttyp(char *old, int dt)
   int ss;
   ss = getsym(old, strlen(old));
 #if DEBUG
-  assert(STYPEG(ss) == ST_INTRIN, "cng_inttyp not intr", ss, 3);
+  assert(STYPEG(ss) == ST_INTRIN, "cng_inttyp not intr", ss, ERR_Severe);
 #endif
   INTTYPP(ss, dt);
 }
@@ -751,9 +751,9 @@ newimplicit(int firstc, int lastc, int dtype)
       temp[0] = 'a' + i;
       temp[1] = 0;
       if (dtype == dtimplicit[i].dtype)
-        error(54, 2, gbl.lineno, temp, CNULL);
+        error(54, ERR_Warning, gbl.lineno, temp, CNULL);
       else
-        error(54, 3, gbl.lineno, temp, CNULL);
+        error(54, ERR_Severe, gbl.lineno, temp, CNULL);
     }
     dtimplicit[i].dtype = dtype;
     dtimplicit[i].set = TRUE;
@@ -990,7 +990,7 @@ getprint(int sptr)
     break;
 
   default:
-    interr("getprint:bad const dtype", sptr, 1);
+    interr("getprint:bad const dtype", sptr, ERR_Informational);
   }
   return b;
 }
@@ -1408,7 +1408,7 @@ symdentry(FILE *file, int sptr)
     break;
 
   default:
-    interr("symdmp: bad symbol type", stype, 1);
+    interr("symdmp: bad symbol type", stype, ERR_Informational);
   }
 }
 
@@ -1542,7 +1542,7 @@ set_ccflags(int sptr, SYMTYPE stype)
    name is of the form . <letter> dddd where dddd is the decimal
    representation of n.
  */
-int
+SPTR
 getccsym(int letter, int n, SYMTYPE stype)
 {
   char name[16];
@@ -1551,7 +1551,7 @@ getccsym(int letter, int n, SYMTYPE stype)
   sprintf(name, ".%c%04d", letter, n); /* at least 4, could be more */
   sptr = getsym(name, strlen(name));
   set_ccflags(sptr, stype);
-  return (sptr);
+  return sptr;
 }
 
 /**
@@ -1559,17 +1559,17 @@ getccsym(int letter, int n, SYMTYPE stype)
    of the form . <letter> dddd where dddd is the decimal
    representation of n.
  */
-int
+SPTR
 getnewccsym(int letter, int n, int stype)
 {
   char name[32];
-  int sptr;
+  SPTR sptr;
 
   sprintf(name, ".%c%04d", letter, n); /* at least 4, could be more */
   NEWSYM(sptr);
   NMPTRP(sptr, putsname(name, strlen(name)));
   set_ccflags(sptr, stype);
-  return (sptr);
+  return sptr;
 } /* getnewccsym */
 
 /**
@@ -1593,8 +1593,7 @@ getccsym_sc(int letter, int n, int stype, int sc)
   }
 
   SCP(sptr, sc);
-
-  return (sptr);
+  return sptr;
 }
 
 /**
@@ -1757,7 +1756,7 @@ insert_sym(int first)
   else {
     /* scan hash list to find immed. predecessor of first: */
     for (i = stb.hashtb[hashval]; (j = HASHLKG(i)) != first; i = j)
-      assert(j != 0, "insert_sym: bad hash", first, 4);
+      assert(j != 0, "insert_sym: bad hash", first, ERR_Fatal);
     HASHLKP(i, sptr);
   }
 
@@ -1789,10 +1788,10 @@ insert_sym_first(int first)
   return sptr;
 }
 
-int
+SPTR
 getlab(void)
 {
-  return (getccsym('B', stb.lbavail++, ST_LABEL));
+  return getccsym('B', stb.lbavail++, ST_LABEL);
 }
 
 int
@@ -1919,7 +1918,7 @@ vmk_prototype(LLVMCallBack_t llCallBack, char *name, char *attr, DTYPE resdt,
   unsigned flags = 0;
 
   if (nargs > 64) {
-    interr("vmk_prototype: nargs exceeds", 64, 3);
+    interr("vmk_prototype: nargs exceeds", 64, ERR_Severe);
     nargs = 64;
   }
   sptr = getsym(name, strlen(name));

--- a/tools/flang2/flang2exe/upper.c
+++ b/tools/flang2/flang2exe/upper.c
@@ -718,7 +718,7 @@ do_pastilm:
   }
   freearea(4); /* free memory used to build static initializations */
   if (errors) {
-    interr("Errors in ILM file", errors, 4);
+    interr("Errors in ILM file", errors, ERR_Fatal);
   }
   llvm_stb_processing = 0;
 } /* upper */
@@ -1946,7 +1946,7 @@ read_symbol(void)
   if (dtype > datatypecount) {
     fprintf(stderr, "Datatype count was %d, but new datatype is %d\n",
             datatypecount, dtype);
-    interr("upper() FAIL", 0, 4);
+    interr("upper() FAIL", 0, ERR_Fatal);
   }
 #endif
   if (dtype > 0) {
@@ -3485,7 +3485,7 @@ fix_symbol(void)
           const int newMid = symbolxref[midnum];
           MIDNUMP(sptr, newMid);
           if (POINTERG(sptr) && newMid) {
-            assert(!REVMIDLNKG(newMid), "REVMIDLNK already set", newMid, 4);
+            assert(!REVMIDLNKG(newMid), "REVMIDLNK already set", newMid, ERR_Fatal);
             REVMIDLNKP(newMid, sptr);
           }
         }

--- a/tools/flang2/flang2exe/xref.c
+++ b/tools/flang2/flang2exe/xref.c
@@ -26,6 +26,7 @@
 #include "global.h"
 #include "symtab.h"
 #include "dtypeutl.h"
+#include "symfun.h"
 
 struct memitem {
   int type; /* 0 - xref, 1 - par xref */

--- a/tools/flang2/utils/symtab/symini.cpp
+++ b/tools/flang2/utils/symtab/symini.cpp
@@ -466,6 +466,7 @@ private:
   write_symfile()
   {
     /* now write symfile */
+    fprintf(out1, "#ifndef SYMINIDF_H_\n#define SYMINIDF_H_\n\n");
     fprintf(out1, "#define INIT_SYMTAB_SIZE %d\n", stb.stg_avail);
     fprintf(out1, "#define INIT_NAMES_SIZE %d\n", stb.namavl);
     fprintf(out1, "static SYM init_sym[INIT_SYMTAB_SIZE] = {\n");
@@ -475,18 +476,18 @@ private:
       xp = &stb.stg_base[i];
       assert(xp->stype <= ST_MAX);
       assert(xp->sc <= SC_MAX);
-      fprintf(out1, "\t{%s, %s, %d, %d, %d, %d, %d, %d, %d,\t/* %s */\n",
-              SYMTYPE_names[xp->stype], SC_KIND_names[xp->sc], xp->b3, xp->b4,
-              xp->dtype, xp->hashlk, xp->symlk, xp->scope, xp->nmptr,
-              SYMNAME(i));
+      fprintf(out1, "\t{%s, %s, %d, %d, (DTYPE)%d, (SPTR)%d, (SPTR)%d, %d, "
+              "%d,\t/* %s */\n", SYMTYPE_names[xp->stype],
+              SC_KIND_names[xp->sc], xp->b3, xp->b4, xp->dtype, xp->hashlk,
+              xp->symlk, xp->scope, xp->nmptr, SYMNAME(i));
       fprintf(out1, "\t ");
       for (int i = 1; i != 33; ++i) {
         fprintf(out1, "%d,", 0 /*xp->f*/);
       }
       fprintf(out1, "\n");
-      fprintf(out1, "\t %d, %d, %ld, %d, %d, %d, %ld, %d, %d, %d, %d,\n", xp->w8,
-              xp->w9, xp->w10, xp->w11, xp->w12, xp->w13, xp->w14, xp->w15,
-              xp->w16, xp->w17, xp->w18);
+      fprintf(out1, "\t %d, %d, %ld, %d, %d, %d, %ld, %d, %d, %d, %d,\n",
+              xp->w8, xp->w9, xp->w10, xp->w11, xp->w12, xp->w13, xp->w14,
+              xp->w15, xp->w16, xp->w17, xp->w18);
       fprintf(out1, "\t ");
       for (int i = 33; i != 65; ++i) {
         fprintf(out1, "%d,", 0 /*xp->f*/);
@@ -533,6 +534,7 @@ private:
       fprintf(out1, "%5d, ", stb.hashtb[i]);
     }
     fprintf(out1, "\n};\n");
+    fprintf(out1, "#endif // SYMINIDF_H_\n");
   }
 };
 

--- a/tools/flang2/utils/symtab/symtab.in.h
+++ b/tools/flang2/utils/symtab/symtab.in.h
@@ -167,7 +167,7 @@ extern short dttypes[TY_MAX+1];
 #define RETADJP(s,v)    (( stb.stg_base)[s].w10 = (v))
 #define XREFLKG(s)      (( stb.stg_base)[s].w16)
 #define XREFLKP(s,v)    (( stb.stg_base)[s].w16 = (v))
-#define NOSYM 1
+#define NOSYM ((SPTR)1)
 
 typedef enum etls_levels {
     ETLS_PROCESS,
@@ -378,7 +378,7 @@ int getccsym_copy(int oldsptr);
 /**
    \brief ...
  */
-int getccsym(int letter, int n, SYMTYPE stype);
+SPTR getccsym(int letter, int n, SYMTYPE stype);
 
 /**
    \brief ...
@@ -398,12 +398,12 @@ int get_entry_item(void);
 /**
    \brief ...
  */
-int getlab(void);
+SPTR getlab(void);
 
 /**
    \brief ...
  */
-int getnewccsym(int letter, int n, int stype);
+SPTR getnewccsym(int letter, int n, int stype);
 
 /**
    \brief ...

--- a/tools/shared/ccffinfo.c
+++ b/tools/shared/ccffinfo.c
@@ -2259,7 +2259,7 @@ _ccff_info(int msgtype, char *msgid, int fihx, int lineno, const char *varname,
     /* 1st character must be alpha */
     if ((argformat[0] < 'a' || argformat[0] > 'z') &&
         (argformat[0] < 'A' || argformat[0] > 'Z')) {
-      interr("ccff_info: bad argument format", 0, 3);
+      interr("ccff_info: bad argument format", 0, ERR_Severe);
       return NULL;
     }
 #ifndef FE90
@@ -2275,7 +2275,7 @@ _ccff_info(int msgtype, char *msgid, int fihx, int lineno, const char *varname,
     for (argend = argformat + 1; *argend && *argend != '='; ++argend)
       ;
     if (argend[0] != '=') {
-      interr("ccff_info: bad argument format", 0, 3);
+      interr("ccff_info: bad argument format", 0, ERR_Severe);
       return NULL;
     }
     ll = argend - argformat;

--- a/tools/shared/fih.h
+++ b/tools/shared/fih.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2008-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ typedef struct {
   char *filename; /**< file name (only) */
   char *fullname; /**< full file name */
   char *funcname; /**< function name */
-  char *ccffinfo; /**< opaque pointer used for CCFF info */
+  void *ccffinfo; /**< opaque pointer used for CCFF info */
   int functag;    /**< integer function tag; ilm index of the function header */
   int parent;     /**< file into which this is inlined or included */
   int flags;      /**< file flags */

--- a/tools/shared/ilidir.c
+++ b/tools/shared/ilidir.c
@@ -227,7 +227,7 @@ push_pragma(int line)
   top++;
   if (top >= STK_SZ) {
 #if DEBUG
-    interr("push_pragma:stkovflw", line, 3);
+    interr("push_pragma:stkovflw", line, ERR_Severe);
 #endif
     top = STK_SZ - 1;
   }
@@ -255,7 +255,7 @@ pop_pragma(void)
 
 #if DEBUG
   if (top <= 0) {
-    interr("pop_pragma:stkuflw", gbl.lineno, 3);
+    interr("pop_pragma:stkuflw", gbl.lineno, ERR_Severe);
     load_dirset(&direct.rou_begin);
     return;
   }

--- a/tools/shared/llmputil.c
+++ b/tools/shared/llmputil.c
@@ -45,7 +45,7 @@ get_uplevel(int stblock_sptr)
   int key;
   LLUplevel *up;
   assert(STYPEG(stblock_sptr) == ST_BLOCK, "Uplevel key must be an ST_BLOCK",
-         stblock_sptr, 4);
+         stblock_sptr, ERR_Fatal);
 
   /* Index */
   key = PARSYMSG(stblock_sptr);
@@ -56,7 +56,7 @@ get_uplevel(int stblock_sptr)
     up = (LLUplevel *)(&llmp_all_uplevels.base[key]);
 
   assert(up && key, "Could not locate uplevel instance for stblock",
-         stblock_sptr, 4);
+         stblock_sptr, ERR_Fatal);
 
   return up;
 }
@@ -68,7 +68,7 @@ llmp_create_uplevel(int stblock_sptr)
   LLUplevel *up;
 
   assert(STYPEG(stblock_sptr) == ST_BLOCK, "Uplevel key must be an ST_BLOCK",
-         stblock_sptr, 4);
+         stblock_sptr, ERR_Fatal);
 
   /* Avoid processing an already created uplevel */
   if (PARSYMSG(stblock_sptr))
@@ -166,7 +166,7 @@ llmp_create_uplevel_bykey(int key)
 {
   LLUplevel *up;
 
-  assert(key <= llmp_all_uplevels.avl, "Invalid uplevel key", key, 4);
+  assert(key <= llmp_all_uplevels.avl, "Invalid uplevel key", key, ERR_Fatal);
 
   up = (LLUplevel *)(&llmp_all_uplevels.base[key]);
   memset(up, 0, sizeof(LLUplevel));
@@ -283,7 +283,7 @@ llmp_task_get_by_fnsptr(int task_sptr)
 }
 
 int
-llmp_task_add_private(LLTask *task, int shared_sptr, int private_sptr)
+llmp_task_add_private(LLTask *task, int shared_sptr, SPTR private_sptr)
 {
   int pad = 0;
   int size;
@@ -321,7 +321,7 @@ llmp_task_add_private(LLTask *task, int shared_sptr, int private_sptr)
 
 
 int
-llmp_task_add_loopvar(LLTask *task, int num, int dtype)
+llmp_task_add_loopvar(LLTask *task, int num, DTYPE dtype)
 /* put loop variables on task_alloc array after private vars */
 {
   int pad = 0;
@@ -345,11 +345,11 @@ llmp_task_add_loopvar(LLTask *task, int num, int dtype)
 }
 
 void
-llmp_task_add(int scope_sptr, int shared_sptr, int private_sptr)
+llmp_task_add(int scope_sptr, int shared_sptr, SPTR private_sptr)
 {
   LLTask *task;
   assert(scope_sptr && STYPEG(scope_sptr) == ST_BLOCK,
-         "Task key must be a scope sptr (ST_BLOCK)", scope_sptr, 4);
+         "Task key must be a scope sptr (ST_BLOCK)", scope_sptr, ERR_Fatal);
 
   task = llmp_get_task(scope_sptr);
   if (!task)

--- a/tools/shared/llmputil.h
+++ b/tools/shared/llmputil.h
@@ -24,6 +24,7 @@
 
 #include "gbldefs.h"
 #include "global.h"
+#include "symtab.h"
 
 /** Uplevel data structure containing a list of shared variables for the region
  * nest that this uplevel belongs to.  The shared variables in this structure
@@ -126,7 +127,7 @@ int llmp_get_next_key(void);
 /**
    \brief ...
  */
-int llmp_task_add_loopvar(LLTask *task, int num, int dtype);
+int llmp_task_add_loopvar(LLTask *task, int num, DTYPE dtype);
 
 /**
    \brief Add a private sptr to the task object.
@@ -136,7 +137,7 @@ int llmp_task_add_loopvar(LLTask *task, int num, int dtype);
            execution.
  /
  */
-int llmp_task_add_private(LLTask *task, int shared_sptr, int private_sptr);
+int llmp_task_add_private(LLTask *task, int shared_sptr, SPTR private_sptr);
 
 /**
    \brief ...
@@ -241,7 +242,7 @@ void llmp_set_parent_uplevel(int outer, int current);
 /**
    \brief ...
  */
-void llmp_task_add(int scope_sptr, int shared_sptr, int private_sptr);
+void llmp_task_add(int scope_sptr, int shared_sptr, SPTR private_sptr);
 
 /**
    \brief ...

--- a/tools/shared/nme.h
+++ b/tools/shared/nme.h
@@ -18,19 +18,34 @@
 #ifndef NME_H_
 #define NME_H_
 
+#include "gbldefs.h"
+#include "symtab.h"
+
 /** \file
  *  \brief NME data structures and definitions
  */
 
+typedef enum NT_KIND {
+  NT_INDARR =
+      -2, /* for C/C++, only used by expand; element of a pointer deref */
+  NT_ADD = -1,
+  NT_UNK = 0, /* Unknown ref. e.g.  *(f()) */
+  NT_IND = 1, /* Indirect ref e.g. *p      */
+  NT_VAR = 2, /* Variable ref. (struct, array or scalar) */
+  NT_MEM = 3, /* Structure member ref. */
+  NT_ARR = 4, /* Array element ref. */
+  NT_SAFE = 5 /* special names; does not conflict with preceding refs */
+} NT_KIND;
+
 typedef struct {
-  char type;   /* One of the following NT_ defs. */
+  NT_KIND type : 8;
   bool inlarr; /**< true iff an inlined array ref */
   char pd1;
   char pd2;
   int stl;       /* STL item pointer: rsvd for invariant */
   int hshlnk;    /* link of names w/ identical hash val */
   int nm;        /* Dependent on type. */
-  int sym;       /* Dependent on type. */
+  SPTR sym;      /* Dependent on type. */
   int rfptr;     /* Dependent on type. */
   int exp_loop;  /* Dependent on type. */
   int f6;        /* Dependent on type. */
@@ -99,7 +114,7 @@ typedef struct {
 
 #if DEBUG
 #define NMECHECK(i)                                                        \
-  (((i) < 0 || (i) >= nmeb.stg_avail) ? (interr("bad nme index", i, 3), i) \
+  (((i) < 0 || (i) >= nmeb.stg_avail) ? (interr("bad nme index", i, ERR_Severe), i) \
                                       : (i))
 #else
 #define NMECHECK(i) i
@@ -134,18 +149,6 @@ typedef struct {
 #define NME_UNK 0
 #define NME_VOL 1
 
-typedef enum NT_KIND {
-  NT_INDARR =
-      -2, /* for C/C++, only used by expand; element of a pointer deref */
-  NT_ADD = -1,
-  NT_UNK = 0, /* Unknown ref. e.g.  *(f()) */
-  NT_IND = 1, /* Indirect ref e.g. *p      */
-  NT_VAR = 2, /* Variable ref. (struct, array or scalar) */
-  NT_MEM = 3, /* Structure member ref. */
-  NT_ARR = 4, /* Array element ref. */
-  NT_SAFE = 5 /* special names; does not conflict with preceding refs */
-} NT_KIND;
-
 /* Some files check if NT_INDARR is defined. */
 #define NT_INDARR NT_INDARR
 
@@ -176,7 +179,7 @@ typedef enum NT_KIND {
 #if DEBUG
 #define PTECHECK(i)                            \
   (((i) < 0 || (i) >= nmeb.pte.stg_avail)      \
-       ? (interr("bad pte index", i, 3), i, i) \
+       ? (interr("bad pte index", i, ERR_Severe), i, i) \
        : (i))
 #else
 #define PTECHECK(i) i
@@ -190,7 +193,7 @@ typedef enum NT_KIND {
 #if DEBUG
 #define RPCT_CHECK(i)                        \
   (((i) < 1 || (i) >= nmeb.rpct.stg_avail)   \
-       ? (interr("bad rpct index", i, 3), i) \
+       ? (interr("bad rpct index", i, ERR_Severe), i) \
        : (i))
 #else
 #define RPCT_CHECK(i) i

--- a/tools/shared/nmeutil.c
+++ b/tools/shared/nmeutil.c
@@ -28,6 +28,7 @@
 #include "mwd.h"
 #include "ili.h"
 #endif
+#include "dtypeutl.h"
 
 #ifndef FE90
 #include "ili.h"
@@ -332,7 +333,7 @@ add_arrnme(NT_KIND type, SPTR insym, int nm, ISZ_T cnst, int sub, bool inlarr)
    */
   i = STG_NEXT(nmeb);
   if (i > MAXNME)
-    error(7, 4, 0, CNULL, CNULL);
+    error(7, ERR_Fatal, 0, CNULL, CNULL);
   /*
    * NEW ENTRY - add the nme to the nme area and to its hash chain
    */
@@ -396,7 +397,7 @@ add_nme_with_pte(int nm, int ptex)
   }
   i = STG_NEXT(nmeb);
   if (i > MAXNME)
-    error(7, 4, 0, CNULL, CNULL);
+    error(7, ERR_Fatal, 0, CNULL, CNULL);
   if (EXPDBG(10, 256))
     fprintf(gbl.dbgfil, "adding based nme %d, based on %d with pte %d\n", i, nm,
             ptex);
@@ -468,7 +469,7 @@ add_rpct_nme(int orig_nme, int rpct_loop)
   rpct_nme = STG_NEXT(nmeb);
 
   if (rpct_nme > MAXNME)
-    error(7, 4, 0, CNULL, CNULL);
+    error(7, ERR_Fatal, 0, CNULL, CNULL);
 
   if (EXPDBG(10, 256))
     fprintf(gbl.dbgfil,
@@ -1175,7 +1176,7 @@ conflict(int nm1, int nm2)
     } else if (t2 == NT_MEM) {
 /* same base nme, but one is a MEM and one a VAR */
 #if DEBUG
-      assert(t1 == NT_VAR, "conflict: t1 not NT_VAR", t1, 3);
+      assert(t1 == NT_VAR, "conflict: t1 not NT_VAR", t1, ERR_Severe);
 #endif
       return CONFLICT;
     }
@@ -1424,7 +1425,7 @@ __print_nme(FILE *ff, int nme)
     fprintf(ff, ".%s", getprint((int)NME_SYM(nme)));
     break;
   default:
-    interr("print_nme:ill.sym", nme, 3);
+    interr("print_nme:ill.sym", nme, ERR_Severe);
     i = 0;
     break;
   }
@@ -1516,7 +1517,7 @@ __dmpnme(FILE *f, int i, int flag)
       fprintf(ff, "unknown\n");
     break;
   default:
-    interr("__dmpnme: illegal nme", NME_TYPE(i), 3);
+    interr("__dmpnme: illegal nme", NME_TYPE(i), ERR_Severe);
     fprintf(ff, "\n");
   }
 }
@@ -1574,7 +1575,7 @@ __dumpname(FILE *f, int opn)
     ff = stderr;
 
   if (opn < 0 || opn >= nmeb.stg_size) {
-    interr("__dumpname:bad names ptr", opn, 3);
+    interr("__dumpname:bad names ptr", opn, ERR_Severe);
     fprintf(ff, " %5u <BAD>", opn);
     return;
   }
@@ -1658,7 +1659,7 @@ __dumpnme(FILE *f, int opn)
     ff = stderr;
 
   if (opn < 0 || opn >= nmeb.stg_size) {
-    interr("__dumpnme:bad names ptr", opn, 3);
+    interr("__dumpnme:bad names ptr", opn, ERR_Severe);
     fprintf(ff, " %5u <BAD>", opn);
     return;
   }

--- a/tools/shared/pragma.c
+++ b/tools/shared/pragma.c
@@ -336,7 +336,7 @@ p_pragma(char *pg, int pline)
      */
     currp--;
   } else {
-    error(280, 2, lineno, ": G, R, L, or blank must follow $", CNULL);
+    error(280, ERR_Warning, lineno, ": G, R, L, or blank must follow $", CNULL);
     return;
   }
 
@@ -345,7 +345,7 @@ p_pragma(char *pg, int pline)
   err = do_sw();
 
   if (err && XBIT(0, 0x8000))
-    error(299, 2, lineno, pg, CNULL);
+    error(299, ERR_Warning, lineno, pg, CNULL);
 }
 
 #define SW_ASSOC 0
@@ -554,16 +554,16 @@ do_sw(void)
   if (scope != S_NONE && ((table[indx].scopes_allowed & scope) == 0)) {
     switch (scope) {
     case S_GLOBAL:
-      error(281, 2, lineno, "global scope illegal for", table[indx].cmd);
+      error(281, ERR_Warning, lineno, "global scope illegal for", table[indx].cmd);
       break;
     case S_ROUTINE:
-      error(281, 2, lineno, "routine scope illegal for", table[indx].cmd);
+      error(281, ERR_Warning, lineno, "routine scope illegal for", table[indx].cmd);
       break;
     case S_LOOP:
-      error(281, 2, lineno, "loop scope illegal for", table[indx].cmd);
+      error(281, ERR_Warning, lineno, "loop scope illegal for", table[indx].cmd);
       break;
     default:
-      error(281, 2, lineno, "illegal scope for", table[indx].cmd);
+      error(281, ERR_Warning, lineno, "illegal scope for", table[indx].cmd);
     }
     return false;
   }
@@ -1215,11 +1215,11 @@ do_sw(void)
     break;
   case SW_PARANDSER:
     if (currdir->x[58] & 0x04) {
-      error(420, 2, lineno, "serial_only", "parallel_and_serial");
+      error(420, ERR_Warning, lineno, "serial_only", "parallel_and_serial");
       break;
     }
     if (currdir->x[58] & 0x08) {
-      error(420, 2, lineno, "parallel_only", "parallel_and_serial");
+      error(420, ERR_Warning, lineno, "parallel_only", "parallel_and_serial");
       break;
     }
     do_now = true;
@@ -1231,11 +1231,11 @@ do_sw(void)
     break;
   case SW_PARALLEL:
     if (currdir->x[58] & 0x04) {
-      error(420, 2, lineno, "serial_only", "parallel_only");
+      error(420, ERR_Warning, lineno, "serial_only", "parallel_only");
       break;
     }
     if (currdir->x[58] & 0x10) {
-      error(420, 2, lineno, "parallel_and_serial", "parallel_only");
+      error(420, ERR_Warning, lineno, "parallel_and_serial", "parallel_only");
       break;
     }
     do_now = true;
@@ -1247,11 +1247,11 @@ do_sw(void)
     break;
   case SW_SERIAL:
     if (currdir->x[58] & 0x08) {
-      error(420, 2, lineno, "parallel_only", "serial_only");
+      error(420, ERR_Warning, lineno, "parallel_only", "serial_only");
       break;
     }
     if (currdir->x[58] & 0x10) {
-      error(420, 2, lineno, "parallel_and_serial", "serial_only");
+      error(420, ERR_Warning, lineno, "parallel_and_serial", "serial_only");
       break;
     }
     do_now = true;
@@ -1340,7 +1340,7 @@ do_sw(void)
       if (typ == T_COMMA)
         continue;
       if (typ != T_IDENT) {
-        error(281, 2, lineno, "malformed #pragma libm id [, id]...", CNULL);
+        error(281, ERR_Warning, lineno, "malformed #pragma libm id [, id]...", CNULL);
         break;
       }
       sptr = getsymbol(ctok);
@@ -1350,7 +1350,7 @@ do_sw(void)
 #endif
     break;
   default:
-    interr("do_sw: sw not recog", indx, 2);
+    interr("do_sw: sw not recog", indx, ERR_Warning);
     break;
   }
   return false;
@@ -1364,7 +1364,7 @@ set_flg(int diroff, int v)
 {
 #if DEBUG
   if (diroff < 0 || diroff > sizeof(DIRSET) / sizeof(int))
-    interr("pragma set_flg()d-unexp.diroff", diroff, 3);
+    interr("pragma set_flg()d-unexp.diroff", diroff, ERR_Severe);
 #endif
   ((int *)(&direct.rou_begin))[diroff] = v;
   TR2("   set_flg, diroff %d, v %08x\n", diroff, v);
@@ -1698,7 +1698,7 @@ retry:
       else
         break;
       if (++i >= TOKMAX) {
-        error(232, 3, lineno, CNULL, CNULL);
+        error(232, ERR_Severe, lineno, CNULL, CNULL);
         break;
       }
       p++;
@@ -1830,7 +1830,7 @@ again:
     break;
 #if DEBUG
   default:
-    interr("pragma-g_id:ill.state", g_id_state, 3);
+    interr("pragma-g_id:ill.state", g_id_state, ERR_Severe);
 #endif
   }
 
@@ -1838,7 +1838,7 @@ again:
 
 err:
   if (errstr != NULL)
-    error(281, 2, lineno, errstr, "- syntax error in identifier list");
+    error(281, ERR_Warning, lineno, errstr, "- syntax error in identifier list");
   g_id_state = 0;
   return T_ERR;
 }

--- a/tools/shared/salloc.c
+++ b/tools/shared/salloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ getitem(int area, int size)
 {
   char *p;
 
-  assert(area >= 0 && area < ANUM, "getitem: bad area", area, 4);
+  assert(area >= 0 && area < ANUM, "getitem: bad area", area, ERR_Fatal);
   size = ALIGN(size); /* round up to multiple of PTRSZ */
 
   if (areap[area] == NULL) {
@@ -59,7 +59,7 @@ getitem(int area, int size)
     NEW(p, char, sz);
     areap[area] = p;
     if (p == NULL)
-      interr("getitem: no mem avail", area, 4);
+      interr("getitem: no mem avail", area, ERR_Fatal);
     *((PTR *)p) = NULL;
     avail[area] = PTRSZ;
   } else if (avail[area] + size > SIZE) {
@@ -68,7 +68,7 @@ getitem(int area, int size)
       sz = size + PTRSZ;
     NEW(p, char, sz);
     if (p == NULL)
-      interr("getitem: no mem avail", area, 4);
+      interr("getitem: no mem avail", area, ERR_Fatal);
     *((PTR *)p) = areap[area];
     areap[area] = p;
     avail[area] = PTRSZ;
@@ -95,7 +95,7 @@ freearea(int area)
 {
   char *p, *q;
 
-  assert(area >= 0 && area < ANUM, "freearea: bad area", area, 4);
+  assert(area >= 0 && area < ANUM, "freearea: bad area", area, ERR_Fatal);
   for (p = areap[area]; p != NULL; p = q) {
     q = *((PTR *)p); /* get next before free!!! */
     FREE(p);

--- a/tools/shared/x86.c
+++ b/tools/shared/x86.c
@@ -701,7 +701,7 @@ set_tp(char *thistpname)
     int n, i, j;
     n = machvalue(thistpname);
     if (n <= 0) {
-      interr("Unexpected value for -tp switch", 0, 4);
+      interr("Unexpected value for -tp switch", 0, ERR_Fatal);
     } else {
       if (flg.tpcount == 0) {
         flg.tpvalue[flg.tpcount] = n;


### PR DESCRIPTION
code cleanup to permit building with C++.

Replace assert() and interr() arguments with enum values.

Modify symini.cpp to emit type-correct initializations.

This cleans up tons of type errors.

Fix type issues with second argument to error().

Fix for dlen(). Despite the comments, the two versions of dlen()
were, in fact, not the same.

More propagation of SPTR types.

Cleanup warnings in ccffinfo.c

Fix some error calls

Get bihutil.c, expreg.c, and xref.c to compile clean as C++

More C++ changes

- get llmputil.c to compile clean as C++
- fix up a number of typing issues in mwd.c

Convert llutil.c to C++

Convert llmputil.c to C++

Convert llsched.c
Convert symacc.c
Convert rmsmove.c