### PR TITLE
Memory operations should be inlined. Use builtins when possible.

### DIFF
--- a/runtime/flangrti/mcopy1.c
+++ b/runtime/flangrti/mcopy1.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mcopy1(char *dest, char *src, long cnt)
 {
@@ -27,3 +29,5 @@ __c_mcopy1(char *dest, char *src, long cnt)
   }
   return;
 }
+#endif
+

--- a/runtime/flangrti/mcopy2.c
+++ b/runtime/flangrti/mcopy2.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mcopy2(short *dest, short *src, long cnt)
 {
@@ -27,3 +29,5 @@ __c_mcopy2(short *dest, short *src, long cnt)
   }
   return;
 }
+#endif
+

--- a/runtime/flangrti/mcopy4.c
+++ b/runtime/flangrti/mcopy4.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mcopy4(int *dest, int *src, long cnt)
 {
@@ -27,3 +29,5 @@ __c_mcopy4(int *dest, int *src, long cnt)
   }
   return;
 }
+#endif
+

--- a/runtime/flangrti/mcopy8.c
+++ b/runtime/flangrti/mcopy8.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mcopy8(long long *dest, long long *src, long cnt)
 {
@@ -27,3 +29,5 @@ __c_mcopy8(long long *dest, long long *src, long cnt)
   }
   return;
 }
+#endif
+

--- a/runtime/flangrti/mset1.c
+++ b/runtime/flangrti/mset1.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mset1(char *dest, int value, long cnt)
 {
@@ -27,3 +29,5 @@ __c_mset1(char *dest, int value, long cnt)
   }
   return;
 }
+#endif
+

--- a/runtime/flangrti/mset2.c
+++ b/runtime/flangrti/mset2.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mset2(short *dest, int value, long cnt)
 {
@@ -27,3 +29,5 @@ __c_mset2(short *dest, int value, long cnt)
   }
   return;
 }
+#endif
+

--- a/runtime/flangrti/mset4.c
+++ b/runtime/flangrti/mset4.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mset4(int *dest, int value, long cnt)
 {
@@ -27,3 +29,5 @@ __c_mset4(int *dest, int value, long cnt)
   }
   return;
 }
+#endif
+

--- a/runtime/flangrti/mset8.c
+++ b/runtime/flangrti/mset8.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mset8(long long *dest, long long value, long cnt)
 {
@@ -27,3 +29,5 @@ __c_mset8(long long *dest, long long value, long cnt)
   }
   return;
 }
+#endif
+

--- a/runtime/flangrti/mzero1.c
+++ b/runtime/flangrti/mzero1.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mzero1(char *dest, long cnt)
 {
@@ -25,5 +27,6 @@ __c_mzero1(char *dest, long cnt)
   for (i = 0; i < cnt; i++) {
     dest[i] = 0;
   }
-  return;
 }
+#endif
+

--- a/runtime/flangrti/mzero2.c
+++ b/runtime/flangrti/mzero2.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mzero2(short *dest, long cnt)
 {
@@ -25,5 +27,6 @@ __c_mzero2(short *dest, long cnt)
   for (i = 0; i < cnt; i++) {
     dest[i] = 0;
   }
-  return;
 }
+#endif
+

--- a/runtime/flangrti/mzero4.c
+++ b/runtime/flangrti/mzero4.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mzero4(int *dest, long cnt)
 {
@@ -25,5 +27,6 @@ __c_mzero4(int *dest, long cnt)
   for (i = 0; i < cnt; i++) {
     dest[i] = 0;
   }
-  return;
 }
+#endif
+

--- a/runtime/flangrti/mzero8.c
+++ b/runtime/flangrti/mzero8.c
@@ -17,6 +17,8 @@
 
 #include "memops.h"
 
+#if !defined(__GNU_LIBRARY__) && \
+  !defined(__GNUC__) && !defined(__clang__)
 void
 __c_mzero8(long long *dest, long cnt)
 {
@@ -25,5 +27,6 @@ __c_mzero8(long long *dest, long cnt)
   for (i = 0; i < cnt; i++) {
     dest[i] = 0;
   }
-  return;
 }
+#endif
+

--- a/runtime/include/memops.h
+++ b/runtime/include/memops.h
@@ -19,6 +19,102 @@
  * \brief Various memory operations
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__GNU_LIBRARY__) && \
+  (defined(__GNUC__) || defined(__clang__))
+#include <sys/types.h>
+
+static inline void
+__attribute__((always_inline))
+__c_mzero1(char *dest, long cnt)
+{
+  (void) __builtin_memset(dest, 0, (size_t) cnt);
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mzero2(short *dest, long cnt)
+{
+  (void) __builtin_memset(dest, 0, (size_t) cnt * sizeof(short));
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mzero4(int *dest, long cnt)
+{
+  (void) __builtin_memset(dest, 0, (size_t) cnt * sizeof(int));
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mzero8(long long *dest, long cnt)
+{
+  (void) __builtin_memset(dest, 0, (size_t) cnt * sizeof(long long));
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mcopy1(char *dest, char *src, long cnt)
+{
+  (void) __builtin_memcpy(dest, src, (size_t) cnt);
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mcopy2(short *dest, short *src, long cnt)
+{
+  (void) __builtin_memcpy(dest, src, (size_t) cnt * sizeof(short));
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mcopy4(int *dest, int *src, long cnt)
+{
+  (void) __builtin_memcpy(dest, src, (size_t) cnt * sizeof(int));
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mcopy8(long long *dest, long long *src, long cnt)
+{
+  (void) __builtin_memcpy(dest, src, (size_t) cnt * sizeof(long long));
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mset1(char *dest, int value, long cnt)
+{
+  for (ssize_t i = 0; i < cnt; ++i)
+    dest[i] = (char) value;
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mset2(short *dest, int value, long cnt)
+{
+  for (ssize_t i = 0; i < cnt; ++i)
+    dest[i] = (short) value;
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mset4(int *dest, int value, long cnt)
+{
+  for (ssize_t i = 0; i < cnt; ++i)
+    dest[i] = value;
+}
+
+static inline void
+__attribute__((always_inline))
+__c_mset8(long long *dest, long long value, long cnt)
+{
+  for (ssize_t i = 0; i < cnt; ++i)
+    dest[i] = (long long) value;
+}
+#else
 void __c_mcopy1(char *dest, char *src, long cnt);
 void __c_mcopy2(short *dest, short *src, long cnt);
 void __c_mcopy4(int *dest, int *src, long cnt);
@@ -33,3 +129,9 @@ void __c_mzero1(char *dest, long cnt);
 void __c_mzero2(short *dest, long cnt);
 void __c_mzero4(int *dest, long cnt);
 void __c_mzero8(long long *dest, long cnt);
+#endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+


### PR DESCRIPTION
This pull request inlines all the mzero/mset/mcopy functions in libflangrti.
It uses __builtin_<memop> when possible. The changeset is specific to GCC
or clang.
