### PR TITLE
Systems without gcc (only clang) cannot build flang

### DIFF
--- a/runtime/flang/CMakeLists.txt
+++ b/runtime/flang/CMakeLists.txt
@@ -420,7 +420,7 @@ set(I8_FILES_DIR I8_sources)
 # Fortran files with macros as module names need to be preprocessed. 
 add_custom_command(
   OUTPUT "${I8_FILES_DIR}/ieee_arithmetic.F95"
-  COMMAND "${CMAKE_Fortran_COMPILER}" -E
+  COMMAND "${CMAKE_C_COMPILER}" -E -x c 
   "${CMAKE_CURRENT_SOURCE_DIR}/ieee_arithmetic.F95" -DDESC_I8 
   > "${I8_FILES_DIR}/ieee_arithmetic.F95"
   COMMENT "Preprocessing ieee_arithmetic.F95"
@@ -429,7 +429,7 @@ add_custom_command(
 
 add_custom_command(
   OUTPUT "${I8_FILES_DIR}/ieee_exceptions.F95"
-  COMMAND "${CMAKE_Fortran_COMPILER}" -E
+  COMMAND "${CMAKE_C_COMPILER}" -E -x c 
   "${CMAKE_CURRENT_SOURCE_DIR}/ieee_exceptions.F95" -DDESC_I8 
   > "${I8_FILES_DIR}/ieee_exceptions.F95"
   COMMENT "Preprocessing ieee_exceptions.F95"

--- a/runtime/flang/CMakeLists.txt
+++ b/runtime/flang/CMakeLists.txt
@@ -420,7 +420,7 @@ set(I8_FILES_DIR I8_sources)
 # Fortran files with macros as module names need to be preprocessed. 
 add_custom_command(
   OUTPUT "${I8_FILES_DIR}/ieee_arithmetic.F95"
-  COMMAND "${CMAKE_C_COMPILER}" -E 
+  COMMAND "${CMAKE_C_COMPILER}" -E -x c 
   "${CMAKE_CURRENT_SOURCE_DIR}/ieee_arithmetic.F95" -DDESC_I8 
   > "${I8_FILES_DIR}/ieee_arithmetic.F95"
   COMMENT "Preprocessing ieee_arithmetic.F95"
@@ -429,7 +429,7 @@ add_custom_command(
 
 add_custom_command(
   OUTPUT "${I8_FILES_DIR}/ieee_exceptions.F95"
-  COMMAND "${CMAKE_C_COMPILER}" -E 
+  COMMAND "${CMAKE_C_COMPILER}" -E -x c 
   "${CMAKE_CURRENT_SOURCE_DIR}/ieee_exceptions.F95" -DDESC_I8 
   > "${I8_FILES_DIR}/ieee_exceptions.F95"
   COMMENT "Preprocessing ieee_exceptions.F95"

--- a/runtime/flang/CMakeLists.txt
+++ b/runtime/flang/CMakeLists.txt
@@ -420,7 +420,7 @@ set(I8_FILES_DIR I8_sources)
 # Fortran files with macros as module names need to be preprocessed. 
 add_custom_command(
   OUTPUT "${I8_FILES_DIR}/ieee_arithmetic.F95"
-  COMMAND "${CMAKE_C_COMPILER}" -E -x c 
+  COMMAND "${CMAKE_Fortran_COMPILER}" -E
   "${CMAKE_CURRENT_SOURCE_DIR}/ieee_arithmetic.F95" -DDESC_I8 
   > "${I8_FILES_DIR}/ieee_arithmetic.F95"
   COMMENT "Preprocessing ieee_arithmetic.F95"
@@ -429,7 +429,7 @@ add_custom_command(
 
 add_custom_command(
   OUTPUT "${I8_FILES_DIR}/ieee_exceptions.F95"
-  COMMAND "${CMAKE_C_COMPILER}" -E -x c 
+  COMMAND "${CMAKE_Fortran_COMPILER}" -E
   "${CMAKE_CURRENT_SOURCE_DIR}/ieee_exceptions.F95" -DDESC_I8 
   > "${I8_FILES_DIR}/ieee_exceptions.F95"
   COMMENT "Preprocessing ieee_exceptions.F95"


### PR DESCRIPTION
Hi --

There's a peculiar bit of the flang compile process where a pair of .F95 files are run through the C preprocessor.

When clang is the C compiler being used, clang silently passes the handling of this preprocessor step to gcc. On systems where clang is the only C compiler available (such as OpenBSD/arm64 by default), this causes the build to fail. I'm not sure why gcc doesn't mind using the C preprocessor to handle .F95 files but that's a different issue.

I'm not certain that passing .F95 files through the C preprocessor is necessarily what is intended here, but this small fix allows systems that have only clang to build flang. This lets flang build and run successfully on OpenBSD/arm64. It should be a no-op with gcc.

Thanks.