### PR TITLE
Pull 2018-07-30T13-14 Recent NVIDIA Changes

### DIFF
--- a/lib/ArgParser/arg_parser.c
+++ b/lib/ArgParser/arg_parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2016-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -298,9 +298,9 @@ add_generic_argument(arg_parser_t *parser, const char *arg_name,
    * the key) */
   if (value_type == ARG_ActionMap) {
     action_map_t *target = ((action_map_bundle_t *)value_ptr)->output;
-    hashset_insert(parser->values, target);
+    hashset_replace(parser->values, target);
   } else {
-    hashset_insert(parser->values, value_ptr);
+    hashset_replace(parser->values, value_ptr);
   }
 }
 
@@ -478,9 +478,9 @@ parse_arguments(const arg_parser_t *parser, int argc, char **argv)
     /* Remember that the value as set */
     if (value->type == ARG_ActionMap) {
       action_map_t *target = ((action_map_bundle_t *)value->location)->output;
-      hashset_insert(parser->value_hits, target);
+      hashset_replace(parser->value_hits, target);
     } else {
-      hashset_insert(parser->value_hits, value->location);
+      hashset_replace(parser->value_hits, value->location);
     }
 
     ++argindex;

--- a/tools/flang2/flang2exe/cgllvm.h
+++ b/tools/flang2/flang2exe/cgllvm.h
@@ -51,17 +51,12 @@ void schedule(void);
 void process_global_lifetime_debug(void);
 OPERAND *gen_llvm_expr(int ilix, LL_Type *expected_type);
 void clear_deletable_flags(int ilix);
-TMPS *gen_extract_insert(int, LL_Type *, TMPS *, LL_Type *, TMPS *, LL_Type *,
-                         int);
-OPERAND *gen_call_to_builtin(int, char *, OPERAND *, LL_Type *, INSTR_LIST *,
-                             int);
 INSTR_LIST *llvm_info_last_instr(void);
 /* Use MSZ_TO_BYTES to detect presence of MSZ */
 #ifdef MSZ_TO_BYTES
 OPERAND *gen_address_operand(int, int, bool, LL_Type *, MSZ);
 DTYPE msz_dtype(MSZ msz);
 #endif
-const char *char_type(int dtype, int sptr);
 void update_external_function_declarations(const char *, char *, unsigned);
 void cg_fetch_clen_parampos(SPTR *len, int *param, SPTR sptr);
 
@@ -110,9 +105,6 @@ typedef enum {
 extern char **sptr_array;
 extern LL_Type **sptr_type_array;
 
-char *get_llvm_sname(int sptr);
-char *get_llvm_mips_sname(int sptr);
-
 void cg_llvm_init(void);
 void cg_llvm_end(void);
 void cg_llvm_fnend(void);
@@ -125,7 +117,6 @@ void llvm_write_ctors(void);
 extern FILE *par_file1;
 extern FILE *par_file2;
 
-int cg_get_type(int n, int v1, int v2);
 void build_routine_and_parameter_entries(SPTR func_sptr, LL_ABI_Info *abi,
                                          LL_Module *module);
 bool strict_match(LL_Type *, LL_Type *);

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -48,12 +48,12 @@ bool strict_match(LL_Type *ty1, LL_Type *ty2);
 /**
    \brief ...
  */
-char *dtype_struct_name(int dtype);
+char *dtype_struct_name(DTYPE dtype);
 
 /**
    \brief ...
  */
-char *gen_llvm_vconstant(const char *ctype, int sptr, int tdtype, int flags);
+char *gen_llvm_vconstant(const char *ctype, int sptr, DTYPE tdtype, int flags);
 
 /**
    \brief ...
@@ -63,12 +63,12 @@ char *get_label_name(int sptr);
 /**
    \brief ...
  */
-char *get_llvm_mips_sname(int sptr);
+char *get_llvm_mips_sname(SPTR sptr);
 
 /**
    \brief ...
  */
-char *get_llvm_sname(int sptr);
+char *get_llvm_sname(SPTR sptr);
 
 /**
    \brief ...
@@ -78,7 +78,7 @@ char *match_names(MATCH_Kind match_val);
 /**
    \brief ...
  */
-const char *char_type(int dtype, int sptr);
+const char *char_type(DTYPE dtype, SPTR sptr);
 
 /**
    \brief ...
@@ -98,7 +98,7 @@ INSTR_LIST *mk_store_instr(OPERAND *val, OPERAND *addr);
 /**
    \brief ...
  */
-int cg_get_type(int n, int v1, int v2);
+DTYPE cg_get_type(int n, TY_KIND v1, int v2);
 
 /**
    \brief ...
@@ -113,7 +113,7 @@ int match_llvm_types(LL_Type *ty1, LL_Type *ty2);
 /**
    \brief ...
  */
-int need_ptr(int sptr, int sc, int sdtype);
+int need_ptr(int sptr, int sc, DTYPE sdtype);
 
 /**
    \brief ...
@@ -136,7 +136,7 @@ OPERAND *gen_call_as_llvm_instr(int sptr, int ilix);
  */
 OPERAND *gen_call_to_builtin(int ilix, char *fname, OPERAND *params,
                              LL_Type *return_ll_type, INSTR_LIST *Call_Instr,
-                             int i_name);
+                             LL_InstrName i_name);
 
 /**
    \brief ...
@@ -151,7 +151,7 @@ OPERAND *mk_alloca_instr(LL_Type *ptrTy);
 /**
    \brief ...
  */
-TMPS *gen_extract_insert(int i_name, LL_Type *struct_type, TMPS *tmp,
+TMPS *gen_extract_insert(LL_InstrName i_name, LL_Type *struct_type, TMPS *tmp,
                          LL_Type *tmp_type, TMPS *tmp2, LL_Type *tmp2_type,
                          int index);
 

--- a/tools/flang2/flang2exe/exp_ftn.h
+++ b/tools/flang2/flang2exe/exp_ftn.h
@@ -27,7 +27,7 @@
 /**
    \brief ...
  */
-int create_array_ref(int nmex, int sptr, DTYPE dtype, int nsubs, int *subs,
+int create_array_ref(int nmex, SPTR sptr, DTYPE dtype, int nsubs, int *subs,
                      int ilix, int sdscilix, int inline_flag, int *pnme);
 
 /**

--- a/tools/flang2/flang2exe/exp_rte.h
+++ b/tools/flang2/flang2exe/exp_rte.h
@@ -31,12 +31,12 @@ bool bindC_function_return_struct_in_registers(int func_sym);
 /**
    \brief ...
  */
-int charaddr(int sym);
+int charaddr(SPTR sym);
 
 /**
    \brief ...
  */
-int charlen(int sym);
+int charlen(SPTR sym);
 
 /**
    \brief ...
@@ -121,12 +121,12 @@ void exp_fstring(ILM_OP opc, ILM *ilmp, int curilm);
 /**
    \brief ...
  */
-void exp_header(int sym);
+void exp_header(SPTR sym);
 
 /**
    \brief ...
  */
-void exp_qjsr(char *ext, int res_dtype, ILM *ilmp, int curilm);
+void exp_qjsr(char *ext, DTYPE res_dtype, ILM *ilmp, int curilm);
 
 /**
    \brief ...
@@ -160,4 +160,7 @@ void init_arg_ili(int n);
  *  \return true if the procedure has character dummy arguments, else false.
  */
 bool func_has_char_args(SPTR func);
+
+/// \brief Process referenced symbols, assigning them locations
+void AssignAddresses(void);
 #endif

--- a/tools/flang2/flang2exe/expand.c
+++ b/tools/flang2/flang2exe/expand.c
@@ -47,8 +47,10 @@
 extern int in_extract_inline; /* Bottom-up auto-inlining */
 
 static int efunc(const char *);
-static int create_ref(SPTR sym, int *pnmex, int basenm, int baseilix, int *pclen,
-	              int *pmxlen, int *prestype);
+static int create_ref(SPTR sym, int *pnmex, int basenm, int baseilix,
+                      int *pclen, int *pmxlen, int *prestype);
+static int jsr2qjsr(int);
+
 
 
 #define DO_PFO ((XBIT(148, 0x1000) && !XBIT(148, 0x4000)) || XBIT(148, 1))
@@ -2852,7 +2854,7 @@ ref_threadprivate_var(int cmsym, int *addr, int *nm, int mark)
      * of the thread's copy of the internal pointer variable; the
      * descriptor is 2 pointer units away from the pointer variable
      */
-    ili2 = ad_acon(0, 2 * size_of(DT_ADDR));
+    ili2 = ad_acon(SPTR_NULL, 2 * size_of(DT_ADDR));
     ili1 = ad3ili(IL_AADD, ili1, ili2, 0);
   }
 
@@ -2861,9 +2863,8 @@ ref_threadprivate_var(int cmsym, int *addr, int *nm, int mark)
 
 }
 
-static int jsr2qjsr(int);
 void
-exp_pure(int extsym, int nargs, ILM *ilmp, int curilm)
+exp_pure(SPTR extsym, int nargs, ILM *ilmp, int curilm)
 {
 #define MAX_PUREARGS 2
   int args[MAX_PUREARGS];

--- a/tools/flang2/flang2exe/expsmp.c
+++ b/tools/flang2/flang2exe/expsmp.c
@@ -2011,7 +2011,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
     /* C++ ONLY class copyprivate */
     argilm = ILM_OPND(ilmp, 2);
     sym = (SPTR)ILM_OPND((ILM *)(ilmb.ilm_base + argilm), 1); // ???
-    assign_rou = ad_acon(ILM_OPND(ilmp, 3), 0);
+    assign_rou = ad_acon((SPTR)ILM_OPND(ilmp, 3), 0); // ???
     if (DTY(DTYPEG(sym)) == TY_ARRAY) {
       element_size = getElemSize(DTYPEG(sym));
       num_elements = extent_of(DTYPEG(sym));
@@ -2064,7 +2064,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
     /* C++ ONLY class copyprivate */
     /* variable/class to be copied out */
     sym = (SPTR)ILM_OPND(ilmp, 2); // ???
-    assign_rou = ad_acon(ILM_OPND(ilmp, 3), 0);
+    assign_rou = ad_acon((SPTR)ILM_OPND(ilmp, 3), 0); // ???
     if (DTY(DTYPEG(sym)) == TY_ARRAY) {
       element_size = getElemSize(DTYPEG(sym));
       num_elements = extent_of(DTYPEG(sym));
@@ -3016,7 +3016,7 @@ _make_mp_get_threadprivate(int data_ili, int size_ili, int cache_ili)
 static int
 allocThreadprivate(SPTR sym, int *tmpthr)
 {
-  int cm;
+  SPTR cm;
   int size;
   int adr_vector;
   int adr_cm;
@@ -3055,7 +3055,7 @@ allocThreadprivate(SPTR sym, int *tmpthr)
      * which is a problem for computing the size
      * when starting with TPpfoo.
      */
-    int tptr;
+    SPTR tptr;
     int sdsptr;
     tptr = MIDNUMG(cm);
     adr_cm = ad_acon(tptr, 0); /* &tp_var */

--- a/tools/flang2/flang2exe/exputil.c
+++ b/tools/flang2/flang2exe/exputil.c
@@ -727,8 +727,7 @@ put_funccount(void)
 int
 mk_swlist(INT n, SWEL *swhdr, int doinit)
 {
-
-  int sym;
+  SPTR sym;
   int i;
   SWEL *swel;
   DTYPE dtype;
@@ -759,7 +758,7 @@ mk_swlist(INT n, SWEL *swhdr, int doinit)
     } while (i != 0);
   }
 
-  return (ad_acon(sym, (INT)0));
+  return ad_acon(sym, 0);
 }
 
 int

--- a/tools/flang2/flang2exe/ili.h
+++ b/tools/flang2/flang2exe/ili.h
@@ -321,6 +321,7 @@ typedef enum ILTY_KIND {
 /***** Values of conditions in relationals *****/
 
 typedef enum CC_RELATION {
+  CC_None,
   CC_EQ = 1,
   CC_NE = 2,
   CC_LT = 3,

--- a/tools/flang2/flang2exe/iliutil.h
+++ b/tools/flang2/flang2exe/iliutil.h
@@ -27,12 +27,20 @@
 #include "ili.h"
 #include "mth.h"
 
-/* exported variables */
-
 extern bool share_proc_ili;
 extern bool share_qjsr_ili;
 
-/* exported functions */
+#ifdef __cplusplus
+inline CC_RELATION CC_ILI_OPND(int ilix, int opn) {
+  return static_cast<CC_RELATION>(ILI_OPND(ilix, opn));
+}
+inline DTYPE DT_ILI_OPND(int ilix, int opn) {
+  return static_cast<DTYPE>(ILI_OPND(ilix, opn));
+}
+#else
+#define CC_ILI_OPND ILI_OPND
+#define DT_ILI_OPND ILI_OPND
+#endif
 
 /**
    \brief ...
@@ -55,7 +63,7 @@ ATOMIC_INFO atomic_info(int ilix);
 /**
    \brief ...
  */
-BIGINT get_isz_conili(int ili);
+ISZ_T get_isz_conili(int ili);
 
 /**
    \brief ...
@@ -222,33 +230,24 @@ int ad2func_kint(ILI_OP opc, char *name, int opn1, int opn2);
  */
 int ad2ili(ILI_OP opc, int opn1, int opn2);
 
-/**
-   \brief ...
- */
+/// \brief add ili with three operands
 int ad3ili(ILI_OP opc, int opn1, int opn2, int opn3);
 
-/**
-   \brief ...
- */
+/// \brief add ili with four operands
 int ad4ili(ILI_OP opc, int opn1, int opn2, int opn3, int opn4);
 
-/**
-   \brief ...
- */
+/// \brief add ili with five operands
 int ad5ili(ILI_OP opc, int opn1, int opn2, int opn3, int opn4, int opn5);
 
-/**
-   \brief ...
- */
-int ad_aconi(BIGINT val);
+/// \brief add ACON ili with specified (integer) constant
+int ad_aconi(ISZ_T val);
+
+/// \brief add ACON ili with specified symbol and offset
+int ad_acon(SPTR sym, ISZ_T val);
 
 /**
-   \brief ...
- */
-int ad_acon(int sym, BIGINT val);
-
-/**
-   \brief ...
+   \brief Add acon ili of an 64-bit constant whose value consists of m32 (most
+   significant 32 bits) and l32 (least significant 32 bits).
  */
 int ad_aconk(INT m32, INT l32);
 
@@ -257,9 +256,7 @@ int ad_aconk(INT m32, INT l32);
  */
 int ad_cmpxchg(ILI_OP opc, int ilix_val, int ilix_loc, int nme, int stc_atomic_info, int ilix_comparand, int ilix_is_weak, int ilix_success, int ilix_failure);
 
-/**
-   \brief ...
- */
+/// \brief add CSE ili of an ili
 int ad_cse(int ilix);
 
 /**
@@ -267,29 +264,22 @@ int ad_cse(int ilix);
  */
 int addili(ILI *ilip);
 
-/**
-   \brief ...
- */
+/// \brief Add a IL_FREEx with given operand
 int ad_free(int ilix);
 
-/**
-   \brief ...
- */
+/// \brief add ICON ili with specified constant value
 int ad_icon(INT val);
 
-/**
-   \brief ...
- */
-int ad_kconi(BIGINT v);
+/// \brief Add kcon ili of an 64-bit constant
+int ad_kconi(ISZ_T v);
 
 /**
-   \brief ...
+   \brief Add KCON ili of an 64-bit constant whose value consists of m32 (most
+   significant 32 bits) and l32 (least significant 32 bits).
  */
 int ad_kcon(INT m32, INT l32);
 
-/**
-   \brief ...
- */
+/// \brief Given a store ILI, generate the equivalent load ILI
 int ad_load(int stx);
 
 /**
@@ -325,7 +315,7 @@ int compl_br(int ilix, int lbl);
 /**
    \brief ...
  */
-int compute_address(int sptr);
+int compute_address(SPTR sptr);
 
 /**
    \brief ...
@@ -360,7 +350,7 @@ int has_cse(int ilix);
 /**
    \brief ...
  */
-int iadd_const_ili(BIGINT valconst, int valilix);
+int iadd_const_ili(ISZ_T valconst, int valilix);
 
 /**
    \brief ...
@@ -370,7 +360,7 @@ int iadd_ili_ili(int leftx, int rightx);
 /**
    \brief ...
  */
-int idiv_ili_const(int valilix, BIGINT valconst);
+int idiv_ili_const(int valilix, ISZ_T valconst);
 
 /**
    \brief ...
@@ -392,9 +382,7 @@ int ili_get_vect_arg_count(int ilix);
  */
 int ili_isdeleted(int ili);
 
-/**
-   \brief ...
- */
+/// \brief return nth operand of ili - skipping past CSE ili if present
 int ili_opnd(int ilix, int n);
 
 /**
@@ -430,7 +418,7 @@ int imin_ili_ili(int leftx, int rightx);
 /**
    \brief ...
  */
-int imul_const_ili(BIGINT valconst, int valilix);
+int imul_const_ili(ISZ_T valconst, int valilix);
 
 /**
    \brief ...
@@ -495,12 +483,12 @@ int ll_ad_outlined_func(ILI_OP result_opc, ILI_OP call_opc, char *func_name, int
 /**
    \brief ...
  */
-int mk_address(int sptr);
+int mk_address(SPTR sptr);
 
 /**
    \brief ...
  */
-int mk_charlen_parref_sptr(int sptr);
+int mk_charlen_parref_sptr(SPTR sptr);
 
 /**
    \brief ...
@@ -540,7 +528,7 @@ int sel_decr(int ili, int isi8);
 /**
    \brief ...
  */
-int sel_icnst(BIGINT val, int isi8);
+int sel_icnst(ISZ_T val, int isi8);
 
 /**
    \brief ...

--- a/tools/flang2/flang2exe/ll_dbgutl.c
+++ b/tools/flang2/flang2exe/ll_dbgutl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2013-2018, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,4 @@
 #include "symtab.h"
 
 static int expr_id;
-
-extern char *generate_function_name(int);
 

--- a/tools/flang2/flang2exe/ll_ftn.c
+++ b/tools/flang2/flang2exe/ll_ftn.c
@@ -33,6 +33,7 @@
 #include "expand.h"
 #include "llassem.h"
 #include "cgllvm.h"
+#include "cgmain.h"
 #include "symfun.h"
 
 /* debug switches:
@@ -525,7 +526,7 @@ ll_process_routine_parameters(SPTR func_sptr)
     set_llvm_iface_oldname(gblsym, get_llvm_name(func_sptr));
   }
 
-  add_ag_typename(gblsym, (char *)char_type(return_dtype, 0));
+  add_ag_typename(gblsym, char_type(return_dtype, SPTR_NULL));
   if (gbl.arets && (!CFUNCG(func_sptr)))
     set_ag_lltype(gblsym, make_lltype_from_dtype(DT_INT));
 

--- a/tools/flang2/flang2exe/ll_write.c
+++ b/tools/flang2/flang2exe/ll_write.c
@@ -1928,8 +1928,9 @@ write_metadata_node(FILE *out, LLVMModuleRef module, MDNodeRef node,
 }
 
 #ifdef __cplusplus
-inline LL_MDName NextMDName(LL_MDName name) {
-  return static_cast<LL_MDName>(static_cast<unsigned>(name) + 1);
+inline LL_MDName NextMDName(LL_MDName& name) {
+  name = static_cast<LL_MDName>(static_cast<unsigned>(name) + 1);
+  return name;
 }
 #else
 #define NextMDName(N) ++(N)

--- a/tools/flang2/flang2exe/llassem.c
+++ b/tools/flang2/flang2exe/llassem.c
@@ -36,6 +36,7 @@
 #include "ili.h"
 #include "llutil.h"
 #include "cgllvm.h"
+#include "cgmain.h"
 #include "cg.h"
 #include "ll_write.h"
 #include "ll_structure.h"
@@ -241,7 +242,7 @@ name_to_hash(const char *ag_name, int len)
 }
 
 static int
-add_ag_name(char *ag_name)
+add_ag_name(const char *ag_name)
 {
   int i, nptr, len, needed;
   char *np;
@@ -1586,7 +1587,7 @@ write_comm(void)
         else
           AG_ISTLS(gblsym) = 0;
       }
-      add_ag_typename(gblsym, (char *)char_type(DTYPEG(sptr), 0));
+      add_ag_typename(gblsym, char_type(DTYPEG(sptr), SPTR_NULL));
     }
   }
 }
@@ -2453,11 +2454,11 @@ write_externs(void)
         }
         if (LLTYPE(sptr) && (LLTYPE(sptr)->data_type == LL_VOID)) {
           nmptr = add_ag_name(
-              (char *)char_type(get_return_dtype(DT_NONE, NULL, 0), 0));
+              char_type(get_return_dtype(DT_NONE, NULL, 0), SPTR_NULL));
           AG_TYPENMPTR(gblsym) = nmptr;
         } else if (get_return_type(sptr) == 0) {
           nmptr = add_ag_name(
-              (char *)char_type(get_return_dtype(DT_NONE, NULL, 0), 0));
+              char_type(get_return_dtype(DT_NONE, NULL, 0), SPTR_NULL));
           AG_TYPENMPTR(gblsym) = nmptr;
         } else if (CFUNCG(sptr) && LLTYPE(sptr) && STYPEG(sptr) == ST_PROC) {
           write_ftn_type(LLTYPE(sptr), typeptr, 0);
@@ -2474,7 +2475,7 @@ write_externs(void)
            */
         } else {
           nmptr = add_ag_name((char *)char_type(
-              get_return_dtype(DTYPEG(sptr), NULL, 0), 0));
+              get_return_dtype(DTYPEG(sptr), NULL, 0), SPTR_NULL));
           AG_TYPENMPTR(gblsym) = nmptr;
         }
       }
@@ -2741,7 +2742,7 @@ get_hollerith_size(int sptr)
 void
 put_fstr(SPTR sptr, int add_null)
 {
-  const char *retc = (char *)char_type(DTYPEG(sptr), sptr);
+  const char *retc = char_type(DTYPEG(sptr), sptr);
   int len = 0;
 
 #ifdef HOLLG
@@ -4968,7 +4969,7 @@ get_ag_typename(int gblsym)
 }
 
 int
-add_ag_typename(int gblsym, char *typeName)
+add_ag_typename(int gblsym, const char *typeName)
 {
   INT nmptr;
   nmptr = add_ag_name(typeName);

--- a/tools/flang2/flang2exe/llassem.h
+++ b/tools/flang2/flang2exe/llassem.h
@@ -265,7 +265,6 @@ void put_int4(INT);
 
 void ll_override_type_string(LL_Type *llt, const char *str);
 int alignment(DTYPE);
-char *gen_llvm_vconstant(const char *, int, int, int);
 int add_member_for_llvm(int, int, DTYPE, ISZ_T);
 LL_Type *update_llvm_typedef(DTYPE dtype, int sptr, int rank);
 int llvm_get_unique_sym(void);
@@ -371,7 +370,7 @@ DTYPE get_ftn_typedesc_dtype(SPTR sptr);
 /**
    \brief ...
  */
-int add_ag_typename(int gblsym, char *typeName);
+int add_ag_typename(int gblsym, const char *typeName);
 
 /**
    \brief ...

--- a/tools/flang2/flang2exe/llassem_common.c
+++ b/tools/flang2/flang2exe/llassem_common.c
@@ -29,6 +29,7 @@
 #include "x86.h"
 #include "llutil.h"
 #include "cgllvm.h"
+#include "cgmain.h"
 #include "cg.h"
 #include "llassem.h"
 
@@ -268,7 +269,7 @@ emit_init(DTYPE tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
                           "first_data:%d i8cnt:%ld ptrcnt:%d\n",
               first_data, *i8cnt, *ptrcnt);
     }
-    put_addr((SPTR)tconval, 0, 0);
+    put_addr((SPTR)tconval, 0, DT_NONE); // ???
     (*ptrcnt)++;
     *addr += size_of(DT_CPTR);
     first_data = 0;
@@ -543,9 +544,9 @@ emit_init(DTYPE tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
                   first_data, *i8cnt, *ptrcnt);
         }
         if (STYPEG(tconval) != ST_CONST) {
-          put_addr(SPTR_NULL, tconval, 0);
+          put_addr(SPTR_NULL, tconval, DT_NONE);
         } else
-          put_addr((SPTR)CONVAL1G(tconval), CONVAL2G(tconval), 0);
+          put_addr((SPTR)CONVAL1G(tconval), CONVAL2G(tconval), DT_NONE); // ???
         break;
 
       case TY_CHAR:
@@ -957,7 +958,7 @@ gen_ptr_offset_val(int offset, LL_Type *ret_type, char *ptr_nm)
    \endverbatim
  */
 void
-put_addr(SPTR sptr, ISZ_T off, int dtype)
+put_addr(SPTR sptr, ISZ_T off, DTYPE dtype)
 {
   const char *name, *elem_type;
   bool is_static_or_common_block_var, in_fortran;

--- a/tools/flang2/flang2exe/llassem_common.h
+++ b/tools/flang2/flang2exe/llassem_common.h
@@ -87,7 +87,7 @@ void init_Mcuda_compiled(void);
 /**
    \brief ...
  */
-void put_addr(SPTR sptr, ISZ_T off, int dtype);
+void put_addr(SPTR sptr, ISZ_T off, DTYPE dtype);
 
 /**
    \brief ...

--- a/tools/flang2/flang2exe/lldebug.c
+++ b/tools/flang2/flang2exe/lldebug.c
@@ -32,7 +32,8 @@
 #include "fih.h"
 #include "llassem.h"
 #include "cgllvm.h"
-#include "ADT/hash.h"
+#include "cgmain.h"
+#include "flang/ADT/hash.h"
 #include "symfun.h"
 
 #include <stdlib.h>

--- a/tools/flang2/flang2exe/llutil.c
+++ b/tools/flang2/flang2exe/llutil.c
@@ -29,6 +29,7 @@
 #include "llassem.h"
 #include "llassem_common.h"
 #include "cgllvm.h"
+#include "cgmain.h"
 #include "x86.h"
 #include "symfun.h"
 
@@ -2340,8 +2341,8 @@ small_aggr_return(DTYPE dtype)
   return FALSE;
 }
 
-int
-get_return_dtype(DTYPE dtype, unsigned int *flags, unsigned int new_flag)
+DTYPE
+get_return_dtype(DTYPE dtype, unsigned *flags, unsigned new_flag)
 {
 #ifdef TARGET_LLVM_ARM
   if (!small_aggr_return(dtype)) {
@@ -3544,7 +3545,7 @@ process_ll_abi_func_ftn_mod(LL_Module *mod, SPTR func_sptr, bool update)
        */
       if (update || gbl.currsub == func_sptr ||
           get_master_sptr() == func_sptr || gbl.entries == func_sptr) {
-        const int sptr = get_sptr_from_argdtlist(param);
+        const SPTR sptr = (SPTR) get_sptr_from_argdtlist(param); // ???
         DTYPE dtype = DTYPEG(sptr);
         abi->arg[i].sptr = sptr;
         if (!dtype || is_iso_cptr(dtype))

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -143,7 +143,7 @@ typedef struct {
 
 /** \brief Node type in a list of globals */
 typedef struct GBL_TAG {
-  int sptr;           /**< sptr of the variable */
+  SPTR sptr;          /**< sptr of the variable */
   unsigned alignment; /**< in bytes */
   char *global_def;   /**< global definition */
   struct GBL_TAG *next;
@@ -266,7 +266,7 @@ typedef enum LL_InstrName {
    \brief INSTR_LIST flag values
  */
 typedef enum LL_InstrListFlags {
-  InstrListFlagsNull  = 0,
+  InstrListFlagsNull,
   VAR_ARGS_FLAG       = (1 << 0),
   CALL_FUNC_PTR_FLAG  = (1 << 1),
   CALL_INTRINSIC_FLAG = (1 << 2),
@@ -468,13 +468,6 @@ void write_struct_defs(void);
 
 /* Routines defined in cgmain.c for now, it will require too much work to move
  * them to llutil.c */
-void process_sptr(SPTR);
-void set_llvm_sptr_name(OPERAND *);
-int need_ptr(int, int, int);
-void dump_type_for_debug(LL_Type *);
-char *get_label_name(int);
-void print_tmp_name(TMPS *);
-char *dtype_struct_name(int);
 void append_llvm_used(OPERAND *op);
 void print_dbg_line_no_comma(LL_MDRef md);
 void print_dbg_line(LL_MDRef md);
@@ -754,7 +747,7 @@ typedef struct LL_ABI_ArgInfo_ {
   const struct LL_Type_ *type;
 
   /* Symbol table entry representing this function argument, if available. */
-  int sptr;
+  SPTR sptr;
 } LL_ABI_ArgInfo;
 
 /**
@@ -1082,12 +1075,13 @@ DTYPE get_int_dtype_from_size(int size);
 /**
    \brief ...
  */
-int get_return_dtype(DTYPE dtype, unsigned int *flags, unsigned int new_flag);
+DTYPE get_return_dtype(DTYPE dtype, unsigned *flags, unsigned new_flag);
 
 /**
    \brief ...
  */
-int is_struct_kind(DTYPE dtype, bool check_return, bool return_vector_as_struct);
+int is_struct_kind(DTYPE dtype, bool check_return,
+                   bool return_vector_as_struct);
 
 /**
    \brief ...

--- a/tools/flang2/flang2exe/main.c
+++ b/tools/flang2/flang2exe/main.c
@@ -32,6 +32,7 @@
 #include "x86.h"
 #include "dbg_out.h"
 #include "xref.h"
+#include "exp_rte.h"
 #include "rmsmove.h"
 #include "mwd.h"
 #include "llassem.h"

--- a/tools/flang2/flang2exe/mwd.c
+++ b/tools/flang2/flang2exe/mwd.c
@@ -1976,7 +1976,7 @@ dsym(int sptr)
     break;
 
   case ST_NML:
-    putsym("plist", ADDRESSG(0));
+    putsym("plist", (SPTR) ADDRESSG(0)); // ???
     ADDRESSP(0, 0);
     putsym("cmemf", CMEMFG(0));
     CMEMFP(0, 0);
@@ -2407,27 +2407,27 @@ dgbl(void)
   putsymlk("gbl.entries=", mbl.entries);
   mbl.entries = 0;
   putsymlk("gbl.cmblks=", mbl.cmblks);
-  mbl.cmblks = 0;
+  mbl.cmblks = SPTR_NULL;
   putsymlk("gbl.externs=", mbl.externs);
-  mbl.externs = 0;
+  mbl.externs = SPTR_NULL;
   putsymlk("gbl.consts=", mbl.consts);
-  mbl.consts = 0;
+  mbl.consts = SPTR_NULL;
   putsymlk("gbl.locals=", mbl.locals);
-  mbl.locals = 0;
+  mbl.locals = SPTR_NULL;
   putsymlk("gbl.statics=", mbl.statics);
-  mbl.statics = 0;
+  mbl.statics = SPTR_NULL;
   putsymlk("gbl.bssvars=", mbl.bssvars);
-  mbl.bssvars = 0;
+  mbl.bssvars = SPTR_NULL;
   putsymlk("gbl.locals=", mbl.locals);
-  mbl.locals = 0;
+  mbl.locals = SPTR_NULL;
   putsymlk("gbl.basevars=", mbl.basevars);
-  mbl.basevars = 0;
+  mbl.basevars = SPTR_NULL;
   putsymlk("gbl.asgnlbls=", mbl.asgnlbls);
   mbl.asgnlbls = 0;
   putsymlk("gbl.autobj=", mbl.autobj);
   mbl.autobj = 0;
   putsymlk("gbl.typedescs=", mbl.typedescs);
-  mbl.typedescs = 0;
+  mbl.typedescs = SPTR_NULL;
   putline();
   putnsym("gbl.outersub", mbl.outersub);
   mbl.outersub = SPTR_NULL;
@@ -2441,7 +2441,7 @@ dgbl(void)
   putnzint("gbl.funcline=", mbl.funcline);
   mbl.funcline = 0;
   putnzint("gbl.threadprivate=", mbl.threadprivate);
-  mbl.threadprivate = 0;
+  mbl.threadprivate = SPTR_NULL;
   putnzint("gbl.nofperror=", mbl.nofperror);
   mbl.nofperror = 0;
   putnzint("gbl.fperror_status=", mbl.fperror_status);
@@ -2485,9 +2485,9 @@ dgbl(void)
   putnzisz("gbl.paddr", mbl.paddr);
   mbl.paddr = 0;
   putline();
-  putnsym("gbl.prvt_sym_sz", mbl.prvt_sym_sz);
+  putnsym("gbl.prvt_sym_sz", (SPTR) mbl.prvt_sym_sz); // ???
   mbl.prvt_sym_sz = 0;
-  putnsym("gbl.stk_sym_sz", mbl.stk_sym_sz);
+  putnsym("gbl.stk_sym_sz", (SPTR) mbl.stk_sym_sz); // ???
   mbl.stk_sym_sz = 0;
   putline();
   putnstring("gbl.src_file", mbl.src_file);
@@ -2641,11 +2641,11 @@ dflg(void)
 } /* dflg */
 
 static bool
-simpledtype(int dtype)
+simpledtype(DTYPE dtype)
 {
-  if (dtype < 0 || dtype >= stb.dt.stg_avail)
+  if (dtype < DT_NONE || ((int)dtype) >= stb.dt.stg_avail)
     return false;
-  if (DTY(dtype) < 0 || DTY(dtype) > TY_MAX)
+  if (DTY(dtype) < TY_NONE || DTY(dtype) > TY_MAX)
     return false;
   if (dlen(DTY(dtype)) == 1)
     return true;
@@ -2856,7 +2856,7 @@ _putdtype(DTYPE dtype, int structdepth)
     break;
   case TY_CHAR:
     appendstring1("char*");
-    appendint1(DTY(dtype + 1));
+    appendint1(DTyCharLength(dtype));
     break;
   case TY_ARRAY:
     _putdtype(DTySeqTyElement(dtype), structdepth);
@@ -2876,7 +2876,7 @@ _putdtype(DTYPE dtype, int structdepth)
     appendstring1(")");
     break;
   case TY_PTR:
-    if (simpledtype(DTY(dtype + 1))) {
+    if (simpledtype(DTySeqTyElement(dtype))) {
       appendstring1("*");
       _putdtype(DTySeqTyElement(dtype), structdepth);
     } else {
@@ -2970,7 +2970,7 @@ putdtypex(DTYPE dtype, int len)
     break;
   case TY_CHAR:
     r += appendstring1("char*");
-    r += appendint1(DTY(dtype + 1));
+    r += appendint1(DTyCharLength(dtype));
     break;
   case TY_ARRAY:
     r += putdtypex(DTySeqTyElement(dtype), len - r);
@@ -2990,7 +2990,7 @@ putdtypex(DTYPE dtype, int len)
     r += appendstring1(")");
     break;
   case TY_PTR:
-    if (simpledtype(DTY(dtype + 1))) {
+    if (simpledtype(DTySeqTyElement(dtype))) {
       r += appendstring1("*");
       r += putdtypex(DTySeqTyElement(dtype), len - 4);
     } else {
@@ -3072,14 +3072,14 @@ dumpdtype(DTYPE dtype)
   putdty(DTY(dtype));
   switch (DTY(dtype)) {
   case TY_ARRAY:
-    putint("dtype", DTY(dtype + 1));
+    putint("dtype", DTySeqTyElement(dtype));
     ad = AD_DPTR(dtype);
     numdim = AD_NUMDIM(ad);
     putint("numdim", numdim);
     putnzint("scheck", AD_SCHECK(ad));
-    putnsym("zbase", AD_ZBASE(ad));
-    putnsym("numelm", AD_NUMELM(ad));
-    putnsym("sdsc", AD_SDSC(ad));
+    putnsym("zbase", (SPTR) AD_ZBASE(ad)); // ???
+    putnsym("numelm", (SPTR) AD_NUMELM(ad)); // ???
+    putnsym("sdsc", (SPTR) AD_SDSC(ad)); // ???
     if (numdim >= 1 && numdim <= 7) {
       int i;
       for (i = 0; i < numdim; ++i) {
@@ -3092,7 +3092,7 @@ dumpdtype(DTYPE dtype)
     }
     break;
   case TY_CHAR:
-    putint("len", DTY(dtype + 1));
+    putint("len", DTyCharLength(dtype));
     break;
   case TY_PARAM:
     putint("dtype", DTyArgType(dtype));
@@ -3132,7 +3132,7 @@ dumpdtypes(void)
   DTYPE dtype;
   dfile = gbl.dbgfil ? gbl.dbgfil : stderr;
   fprintf(dfile, "\n********** DATATYPE TABLE **********\n");
-  for (dtype = 1; dtype < stb.dt.stg_avail; dtype += dlen(DTY(dtype))) {
+  for (dtype = (DTYPE)1; ((int)dtype) < stb.dt.stg_avail; dtype += dlen(DTY(dtype))) {
     dumpdtype(dtype);
   }
   fprintf(dfile, "\n");
@@ -3145,7 +3145,7 @@ dumpnewdtypes(int olddtavail)
   DTYPE dtype;
   dfile = gbl.dbgfil ? gbl.dbgfil : stderr;
   fprintf(dfile, "\n********** DATATYPE TABLE **********\n");
-  for (dtype = olddtavail; dtype < stb.dt.stg_avail; dtype += dlen(DTY(dtype))) {
+  for (dtype = (DTYPE)olddtavail; ((int)dtype) < stb.dt.stg_avail; dtype += dlen(DTY(dtype))) {
     dumpdtype(dtype);
   }
   fprintf(dfile, "\n");
@@ -4424,7 +4424,7 @@ dili(int ilix)
       case ILIO_SYM:
         putsym("sym", (SPTR)opnd);
         if (opc == IL_ACON) {
-          putnsym("base", CONVAL1G(opnd));
+          putnsym("base", (SPTR) CONVAL1G(opnd)); // ???
           putnzbigint("offset", ACONOFFG(opnd));
         }
         break;
@@ -4590,7 +4590,10 @@ dili(int ilix)
 static void
 dilitreex(int ilix, int l, int notlast)
 {
-  int opc, noprs, j, jj, nlinks, nshift = 0;
+  ILI_OP opc;
+  int noprs, j, jj, nlinks;
+  int nshift = 0;
+
   dfile = gbl.dbgfil ? gbl.dbgfil : stderr;
   fprintf(dfile, "%s", prefix);
   dili(ilix);
@@ -5479,7 +5482,7 @@ dumpdvl(int d)
     return;
   }
   putint("dvl", d);
-  putsym("sym", DVL_SPTR(d));
+  putsym("sym", (SPTR) DVL_SPTR(d)); // ???
   putINT("conval", DVL_CONVAL(d));
   putline();
 } /* dumpdvl */

--- a/tools/flang2/flang2exe/outliner.c
+++ b/tools/flang2/flang2exe/outliner.c
@@ -605,10 +605,10 @@ ll_make_sections_args(int lbSym, int ubSym, int stSym, int lastSym)
   args[8] = genNullArg();            /* i32* ident     */
   args[7] = ll_get_gtid_val_ili();   /* i32 tid        */
   args[6] = ad_icon(KMP_SCH_STATIC); /* i32 schedule   */
-  args[5] = ad_acon(lastSym, 0);     /* i32* plastiter */
-  args[4] = ad_acon(lbSym, 0);       /* i32* plower    */
-  args[3] = ad_acon(ubSym, 0);       /* i32* pupper    */
-  args[2] = ad_acon(stSym, 0);       /* i32* pstridr   */
+  args[5] = ad_acon((SPTR)lastSym, 0);     /* i32* plastiter */ // ???
+  args[4] = ad_acon((SPTR)lbSym, 0);       /* i32* plower    */ // ???
+  args[3] = ad_acon((SPTR)ubSym, 0);       /* i32* pupper    */ // ???
+  args[2] = ad_acon((SPTR)stSym, 0);       /* i32* pstridr   */ // ???
   args[1] = ad_icon(1);              /* i32 incr       */
   args[0] = ad_icon(0);              /* i32 chunk      */
   ADDRTKNP(lbSym, 1);
@@ -1557,8 +1557,8 @@ ll_make_outlined_call2(int func_sptr, int uplevel_ili)
     arg1 = ll_get_hostprog_arg(GBL_CURRFUNC, 1);
     arg2 = ll_get_hostprog_arg(GBL_CURRFUNC, 2);
     arg3 = args[0] = uplevel_ili;
-    arg1 = args[2] = mk_address(arg1);
-    arg2 = args[1] = mk_address(arg2);
+    arg1 = args[2] = mk_address((SPTR)arg1); // ???
+    arg2 = args[1] = mk_address((SPTR)arg2); // ???
   }
 
   ilix = ll_ad_outlined_func2(IL_NONE, IL_JSR, func_sptr, nargs, args);

--- a/tools/shared/expand.h
+++ b/tools/shared/expand.h
@@ -309,7 +309,7 @@ void exp_load(ILM_OP opc, ILM *ilmp, int curilm);
 /**
    \brief ...
  */
-void exp_pure(int extsym, int nargs, ILM *ilmp, int curilm);
+void exp_pure(SPTR extsym, int nargs, ILM *ilmp, int curilm);
 
 /**
    \brief ...

--- a/tools/shared/symfun.h
+++ b/tools/shared/symfun.h
@@ -238,7 +238,7 @@ inline void DTySetAlgTySize(DTYPE dtype, ISZ_T val) {
 }
 
 inline void DTySetAlgTyTag(DTYPE dtype, SPTR tag) {
-  DTySet(static_cast<DTYPE>(static_cast<int>(dtype) + 2), tag);
+  DTySet(static_cast<DTYPE>(static_cast<int>(dtype) + 3), tag);
 }
 
 inline void DTySetAlgTyAlign(DTYPE dtype, ISZ_T val) {
@@ -326,9 +326,17 @@ ST_GetterInstance(ALTNAMEG, SPTR, AlternateName)
 #undef ALTNAMEG
 #define ALTNAMEG(X) STGetAlternateName(X)
 
+ST_GetterInstance(ARGTYPG, DTYPE, ArgumentType)
+#undef ARGTYPG
+#define ARGTYPG(X) STGetArgumentType(X)
+
 ST_GetterInstance(BASESYMG, SPTR, BaseSymbol)
 #undef BASESYMG
 #define BASESYMG(X) STGetBaseSymbol(X)
+
+ST_GetterInstance(BEGINSCOPELABG, SPTR, BeginScopeLabel)
+#undef BEGINSCOPELABG
+#define BEGINSCOPELABG(X) STGetBeginScopeLabel(X)
 
 ST_GetterInstance(CLENG, SPTR, CLength)
 #undef CLENG
@@ -338,7 +346,15 @@ ST_GetterInstance(CMEMFG, SPTR, CMemF)
 #undef CMEMFG
 #define CMEMFG(X) STGetCMemF(X)
 
+ST_GetterInstance(CMEMLG, SPTR, CMemL)
+#undef CMEMLG
+#define CMEMLG(X) STGetCMemL(X)
+
 ST_GetterInstance(CONVAL1G, SPTR, Pointee)
+
+ST_GetterInstance(DEFLABG, SPTR, DefLab)
+#undef DEFLABG
+#define DEFLABG(X) STGetDefLab(X)
 
 ST_GetterInstance(DEVCOPYG, SPTR, DeviceCopy)
 #undef DEVCOPYG
@@ -352,9 +368,49 @@ ST_GetterInstance(ENDLABG, SPTR, EndLabel)
 #undef ENDLABG
 #define ENDLABG(X) STGetEndLabel(X)
 
+ST_GetterInstance(ENDSCOPELABG, SPTR, EndScopeLabel)
+#undef ENDSCOPELABG
+#define ENDSCOPELABG(X) STGetEndScopeLabel(X)
+
+ST_GetterInstance(FMTPTG, SPTR, Fmtpt)
+#undef FMTPTG
+#define FMTPTG(X) STGetFmtpt(X)
+
 ST_GetterInstance(FVALG, SPTR, FValue)
 #undef FVALG
 #define FVALG(X) STGetFValue(X)
+
+ST_GetterInstance(GCMPLXG, SPTR, GComplex)
+#undef GCMPLXG
+#define GCMPLXG(X) STGetGComplex(X)
+
+ST_GetterInstance(GDBLEG, SPTR, GDouble)
+#undef GDBLEG
+#define GDBLEG(X) STGetGDouble(X)
+
+ST_GetterInstance(GDCMPLXG, SPTR, GDoubleComplex)
+#undef GDCMPLXG
+#define GDCMPLXG(X) STGetGDoubleComplex(X)
+
+ST_GetterInstance(GINTG, SPTR, GInteger)
+#undef GINTG
+#define GINTG(X) STGetGInteger(X)
+
+ST_GetterInstance(GINT8G, SPTR, GIntegerEight)
+#undef GINT8G
+#define GINT8G(X) STGetGIntegerEight(X)
+
+ST_GetterInstance(GREALG, SPTR, GReal)
+#undef GREALG
+#define GREALG(X) STGetGReal(X)
+
+ST_GetterInstance(GSAMEG, SPTR, GSame)
+#undef GSAMEG
+#define GSAMEG(X) STGetGSame(X)
+
+ST_GetterInstance(GSINTG, SPTR, GSInt)
+#undef GSINTG
+#define GSINTG(X) STGetGSInt(X)
 
 ST_GetterInstance(INMODULEG, SPTR, InModule)
 #undef INMODULEG
@@ -375,6 +431,10 @@ ST_GetterInstance(ORIGDUMMYG, SPTR, OrigDummy)
 ST_GetterInstance(PSMEMG, SPTR, PsMem)
 #undef PSMEMG
 #define PSMEMG(X) STGetPsMem(X)
+
+ST_GetterInstance(SCOPEG, SPTR, Scope)
+#undef SCOPEG
+#define SCOPEG(X) STGetScope(X)
 
 ST_GetterInstance(SDSCG, SPTR, SDSC)
 #undef SDSCG
@@ -400,6 +460,11 @@ ST_GetterInstance(THPRVTOPTG, SPTR, ThreadPrivate)
 #undef THPRVTOPTG
 #define THPRVTOPTG(X) STGetThreadPrivate(X)
 
+ST_GetterInstance(VARIANTG, SPTR, Variant)
+#undef VARIANTG
+#define VARIANTG(X) STGetVariant(X)
+
+ST_GetterInstance(XREFLKG, ISZ_T, DsrtInit)
 ST_GetterInstance(XREFLKG, SPTR, CrossRefLink)
 #undef XREFLKG
 #define XREFLKG(X) STGetCrossRefLink(X)

--- a/tools/shared/x86.c
+++ b/tools/shared/x86.c
@@ -27,43 +27,6 @@
 
 X86TYPE mach, mach_count;
 
-char *tpname[] = {"??",
-                  "py-64",
-                  "px-64",
-                  "p5",
-                  "athlon",
-                  "p6",
-                  "athlonxp",
-                  "piii",
-                  "k8-64",
-                  "p7-64",
-                  "k8-64e",
-                  "piv",
-                  "gh-64",
-                  "core2-64",
-                  "penryn-64",
-                  "shanghai-64",
-                  "istanbul-64",
-                  "nehalem-64",
-                  "bulldozer-64",
-                  "sandybridge-64",
-                  "ivybridge-64",
-                  "haswell-64",
-                  "larrabee-64",
-                  "piledriver-64",
-                  "zen-64",
-                  "knl-64",
-                  "skylake-64",
-                  "?"};
-
-char *version_name[] = {
-    "0",         "py",       "px",       "p5",         "athlon",
-    "p6",        "athlonxp", "piii",     "k8",         "p7",
-    "k8e",       "piv",      "gh",       "core2",      "penryn",
-    "shanghai",  "istanbul", "nehalem",  "bulldozer",  "sandybridge",
-    "ivybridge", "haswell",  "larrabee", "piledriver", "zen",
-    "knl",       "skylake"};
-
 void
 set_mach(X86TYPE *mach, int machtype)
 {

--- a/tools/shared/x86.h
+++ b/tools/shared/x86.h
@@ -153,9 +153,6 @@ extern X86TYPE mach, mach_count;
 #define TP_KNIGHTS_LANDING 25
 #define TP_SKYLAKE 26
 
-extern char *tpname[];
-extern char *version_name[];
-
 #define TEST_MACH(M) (++mach_count.type[M], mach.type[M])
 #define TEST_MACH2(M1, M2) \
   (++mach_count.type[M1], ++mach_count.type[M2], mach.type[M1] || mach.type[M2])


### PR DESCRIPTION
More conversion of Flang to C++

- Port of cgmain.c to C++.
  The ripple effect crosses many files for this one.
- Port iliutil.c to C++.
- Port exp_ftn.c and exp_rte.c to C++.
- Flang requires exp_rte.h for a complete list of prototypes.
  main.cpp will not compile with missing prototypes.
- Fix typo.
- Add a new function to return XREFLNK as a raw ISZ_T.
- Allow the arg-parser  to be built in debug mode.
  Hashes are kept to keep track of what options registered
  but the option stores are NOT distinct (-x and -y map to same array).
  Use hashset_replace, not hashset_insert
- Fix argument mismatch.
- Cleanup iliutil.cpp.
- Don't pass enums as varargs as this causes newish C++ compilers
  to crash the application.
- Fix typo in the include path of hash.h.
- Finish porting mwd.c to C++.
- Clean up some more TODOs.
- Remove some unused symbols from Flang.