### PR TITLE
Fix undefined behaviour in scan.c:alpha()

### DIFF
--- a/tools/flang1/flang1exe/scan.c
+++ b/tools/flang1/flang1exe/scan.c
@@ -4315,14 +4315,16 @@ alpha(void)
 
   /* step 1: extract maximal potential id string: */
 
-  ip = id - 1; /* point 1 before id[] */
+  ip = id;
   cp = --currc;
   count = MAXIDLEN * 4;
   do {
     c = *cp++;
     if (--count >= 0)
-      *++ip = c;
+      *ip++ = c;
   } while (isident(c));
+  if (ip != id)
+    --ip;
   *ip = '\0';
   --cp; /* point to first char after identifier
          * string */


### PR DESCRIPTION
The code initialised a pointer to a value that according to C is undefined
behavior (section 6.5.6, clause 8):

  char *ip = id - 1; /* point 1 before id[] */

This variable is then conditionally incremented and written to in a
do-while loop, but if the condition was never true, the value '\0' is
written to address 'id - 1'.

The functionality of alpha() breaks when compiled with LLVM 7.