### PR TITLE
Introduce buffered I/O and replace getc with buffered read

### DIFF
--- a/runtime/flang/backspace.c
+++ b/runtime/flang/backspace.c
@@ -74,20 +74,23 @@ _f90io_backspace(__INT_T *unit, __INT_T *bitv, __INT_T *iostat, int swap_bytes)
 
   if (f->nonadvance) {
     f->nonadvance = FALSE;
+    FIO_FCB_INVALIDATE_GETC_BUFFER(f, return __io_errno());
 #if defined(WINNT)
-    if (__fortio_binary_mode(f->fp))
-      __io_fputc('\r', f->fp);
+    if (__fortio_binary_mode(f->__io_fp))
+      __io_fputc('\r', f->__io_fp);
 #endif
-    __io_fputc('\n', f->fp);
-    if (__io_ferror(f->fp))
+    __io_fputc('\n', f->__io_fp);
+    if (__io_ferror(f->__io_fp))
       return __io_errno();
   }
 
-  fp = f->fp;
   /* if already at the beginning just return without error */
   /* if (f->nextrec < 2) */
-  if (__io_ftell(fp) == 0) /* use ftell in case file opened 'append' */
+  if (FIO_FCB_FTELL(f) == 0) /* use ftell in case file opened 'append' */
     return 0;
+
+  FIO_FCB_INVALIDATE_GETC_BUFFER(f, return __fortio_error(__io_errno()));
+  fp = f->__io_fp;
 
   if (f->form == FIO_UNFORMATTED) { /* CASE 1: unformatted file */
     int reclen;

--- a/runtime/flang/close.c
+++ b/runtime/flang/close.c
@@ -47,16 +47,16 @@ __fortio_close(FIO_FCB *f, int flag)
   if (f->nonadvance) {
     f->nonadvance = FALSE;
 #if defined(WINNT)
-    if (__fortio_binary_mode(f->fp))
-      __io_fputc('\r', f->fp);
+    if (__fortio_binary_mode(f->__io_fp))
+      __io_fputc('\r', f->__io_fp);
 #endif
-    __io_fputc('\n', f->fp);
-    if (__io_ferror(f->fp))
+    __io_fputc('\n', f->__io_fp);
+    if (__io_ferror(f->__io_fp))
       return __io_errno();
   }
 
   if (!f->stdunit) {
-    if (__io_fclose(f->fp) != 0) {
+    if (__io_fclose(f->__io_fp) != 0) {
       return __fortio_error(__io_errno());
     }
     if (flag == 0 && f->dispose == FIO_DELETE)
@@ -79,7 +79,7 @@ __fortio_close(FIO_FCB *f, int flag)
 #if defined(TARGET_OSX)
     if (f->unit != 5 && f->unit != -5)
 #endif
-      if (__io_fflush(f->fp) != 0)
+      if (__io_fflush(f->__io_fp) != 0)
         return __fortio_error(__io_errno());
   }
 
@@ -201,10 +201,10 @@ __fortio_cleanup(void)
        * consequently, need to extract the 'next' field now.
        */
       f_next = f->next;
-      if (f->fp == NULL) { /* open? */
+      if (f->__io_fp == NULL) { /* open? */
         continue;
       }
-      __io_fflush(f->fp);
+      __io_fflush(f->__io_fp);
       if (f->stdunit) { /* standard unit? */
         continue;
       }

--- a/runtime/flang/error.c
+++ b/runtime/flang/error.c
@@ -443,10 +443,11 @@ __fortio_error(int errval)
   }
 
   fioFcbTbls.error = TRUE;
-  if (fdesc && fdesc->fp && fdesc->acc == FIO_DIRECT) {
+  if (fdesc && fdesc->__io_fp && fdesc->acc == FIO_DIRECT) {
     /* leave file in consistent state:  */
     fdesc->nextrec = 1;
-    __io_fseek(fdesc->fp, 0L, SEEK_SET);
+    FIO_FCB_INVALIDATE_GETC_BUFFER_BEFORE_FSEEK(fdesc);
+    __io_fseek(fdesc->__io_fp, 0L, SEEK_SET);
   }
 
   if ((iobitv & FIO_BITV_EOR) && (errval == FIO_ETOOBIG)) {
@@ -837,7 +838,7 @@ win_set_binary(FIO_FCB *f)
 {
   FILE *fil;
 
-  fil = f->fp;
+  fil = f->__io_fp;
   if (!__fort_isatty(__fort_getfd(fil))) {
     __fortio_setmode_binary(fil);
   }
@@ -863,7 +864,7 @@ __fortio_init(void)
   /* preconnect stdin as unit -5 for * unit specifier */
   f = __fortio_alloc_fcb();
 
-  f->fp = __io_stdin();
+  f->__io_fp = __io_stdin();
   f->unit = -5;
   f->name = "stdin ";
   f->reclen = 0;
@@ -894,7 +895,7 @@ __fortio_init(void)
   /* preconnect stdout as unit -6 for * unit specifier */
   f = __fortio_alloc_fcb();
 
-  f->fp = __io_stdout();
+  f->__io_fp = __io_stdout();
   f->unit = -6;
   f->name = "stdout ";
   f->reclen = 0;
@@ -925,7 +926,7 @@ __fortio_init(void)
   /* preconnect stdin as unit 5 */
   f = __fortio_alloc_fcb();
 
-  f->fp = __io_stdin();
+  f->__io_fp = __io_stdin();
   f->unit = 5;
   f->name = "stdin ";
   f->reclen = 0;
@@ -956,7 +957,7 @@ __fortio_init(void)
   /* preconnect stdout as unit 6 */
   f = __fortio_alloc_fcb();
 
-  f->fp = __io_stdout();
+  f->__io_fp = __io_stdout();
   f->unit = 6;
   f->name = "stdout ";
   f->reclen = 0;
@@ -987,7 +988,7 @@ __fortio_init(void)
   /* preconnect stderr as unit 0 */
   f = __fortio_alloc_fcb();
 
-  f->fp = __io_stderr();
+  f->__io_fp = __io_stderr();
   f->unit = 0;
   f->name = "stderr ";
   f->reclen = 0;

--- a/runtime/flang/flush.c
+++ b/runtime/flang/flush.c
@@ -54,7 +54,7 @@ __INT_T *iostat;
       }
     }
 
-    if (__io_fflush(f->fp) != 0) {
+    if (__io_fflush(f->__io_fp) != 0) {
       s = __fortio_error(__io_errno());
       __fortio_errend03();
       return s;

--- a/runtime/flang/fstat3f.c
+++ b/runtime/flang/fstat3f.c
@@ -35,7 +35,7 @@ int ENT3F(FSTAT, fstat)(int *lu, int *statb)
 
   f = __fio_find_unit(*lu);
   if (f && !FIO_FCB_STDUNIT(f)) {
-    /* need a way to get f->fp's fildes */
+    /* need a way to get f->__io_fp's fildes */
     if (i = _stat32(FIO_FCB_NAME(f), &b))
       i = __io_errno();
   } else {
@@ -78,7 +78,7 @@ int ENT3F(FSTAT, fstat)(int *lu, int *statb)
 
   f = __fio_find_unit(*lu);
   if (f && !FIO_FCB_STDUNIT(f)) {
-    /** need a way to get f->fp's fildes **/
+    /** need a way to get f->__io_fp's fildes **/
     if ((i = stat(FIO_FCB_NAME(f), &b)))
       i = __io_errno();
   } else {

--- a/runtime/flang/fstat643f.c
+++ b/runtime/flang/fstat643f.c
@@ -59,7 +59,7 @@ int ENT3F(FSTAT64, fstat64)(int *lu, long long *statb)
 
   f = __fio_find_unit(*lu);
   if (f && !FIO_FCB_STDUNIT(f)) {
-    /** need a way to get f->fp's fildes **/
+    /** need a way to get f->__io_fp's fildes **/
     if (i = _stat64(FIO_FCB_NAME(f), bp))
       i = __io_errno();
   } else {
@@ -102,7 +102,7 @@ int ENT3F(FSTAT64, fstat64)(int *lu, long long *statb)
 
   f = __fio_find_unit(*lu);
   if (f && !FIO_FCB_STDUNIT(f)) {
-    /** need a way to get f->fp's fildes **/
+    /** need a way to get f->__io_fp's fildes **/
     if ((i = stat(FIO_FCB_NAME(f), &b)))
       i = __io_errno();
   } else {

--- a/runtime/flang/global.h
+++ b/runtime/flang/global.h
@@ -334,6 +334,24 @@ typedef struct fcb {
     on_error; \
 }
 
+#define FIO_FCB_FSEEK_SET(fcb, offset, on_error) if (0 <= ((fcb)->getc_bufpos)) { \
+  long tmp = ((fcb)->getc_bufpos) + ((offset) - ((fcb)->getc_filepos)); \
+  (fcb)->getc_filepos = offset; \
+  if ((0L <= tmp) && (tmp < ((fcb)->getc_inbuffer))) { \
+    (fcb)->getc_bufpos = tmp; \
+  } else { \
+    (fcb)->getc_bufpos = -1; \
+    if (__io_feof((fcb)->__io_fp)) \
+      __io_clearerr((fcb)->__io_fp); \
+    if (__io_fseek((fcb)->__io_fp, (offset), SEEK_SET) != 0) \
+      on_error; \
+  } \
+} else \
+{ \
+  if (__io_fseek((fcb)->__io_fp, (offset), SEEK_SET) != 0) \
+    on_error; \
+}
+
 #define FIO_FCB_BUFFERED_GETC(c, fcb, on_error) do { \
   if ((fcb)->getc_buffer_notuse) { \
     (c) = __io_fgetc((fcb)->__io_fp); \

--- a/runtime/flang/inquire.c
+++ b/runtime/flang/inquire.c
@@ -332,19 +332,22 @@ inquire(__INT_T *unit, char *file_ptr, __INT_T *bitv, __INT_T *iostat,
     *pending = FTN_FALSE;
   }
   if (pos) {
-    if (f != NULL)
-      *pos = __io_ftellx(f->fp) + 1;
+    if (f != NULL) {
+      *pos = FIO_FCB_FTELLX(f) + 1;
+    }
   }
   if (size) {
     FILE *lcl_fp;
     if (f != NULL) {
       seekoffx_t currpos;
-      lcl_fp = f->fp;
-      currpos = (seekoffx_t)__io_ftellx(f->fp);
-      if (__io_fseek(f->fp, 0L, SEEK_END) != 0)
+      lcl_fp = NULL;
+      currpos = (seekoffx_t)FIO_FCB_FTELLX(f);
+      FIO_FCB_INVALIDATE_GETC_BUFFER_BEFORE_FSEEK(f);
+      if (__io_fseek(f->__io_fp, 0L, SEEK_END) != 0)
         return (__fortio_error(__io_errno()));
-      *size = __io_ftellx(f->fp);
-      __io_fseek(f->fp, currpos, SEEK_SET);
+      *size = FIO_FCB_FTELLX(f);
+      FIO_FCB_INVALIDATE_GETC_BUFFER_BEFORE_FSEEK(f);
+      __io_fseek(f->__io_fp, currpos, SEEK_SET);
     } else if (file_ptr != NULL) { /* inquire by file and not connected */
       char btmpnam[MAX_NAMELEN + 1];
       char *tmpnam;
@@ -1483,17 +1486,20 @@ ENTF90IO(INQUIRE2A, inquire2a)
     *pending = FTN_FALSE;
   }
   if (pos != NULL) {
-    if (f != NULL)
-      *pos = __io_ftellx(f->fp) + 1;
+    if (f != NULL) {
+      *pos = FIO_FCB_FTELLX(f) + 1;
+    }
   }
   if (size != NULL) {
     if (f != NULL) {
       seekoffx_t currpos;
-      currpos = (seekoffx_t)__io_ftellx(f->fp);
-      if (__io_fseek(f->fp, 0L, SEEK_END) != 0)
+      currpos = (seekoffx_t)FIO_FCB_FTELLX(f);
+      FIO_FCB_INVALIDATE_GETC_BUFFER_BEFORE_FSEEK(f);
+      if (__io_fseek(f->__io_fp, 0L, SEEK_END) != 0)
         return (__fortio_error(__io_errno()));
-      *size = __io_ftellx(f->fp);
-      __io_fseek(f->fp, currpos, SEEK_SET);
+      *size = FIO_FCB_FTELLX(f);
+      FIO_FCB_INVALIDATE_GETC_BUFFER_BEFORE_FSEEK(f);
+      __io_fseek(f->__io_fp, currpos, SEEK_SET);
     } else
       *size = -1;
   }

--- a/runtime/flang/nmlread.c
+++ b/runtime/flang/nmlread.c
@@ -209,7 +209,8 @@ _f90io_nmlr_init(__INT_T *unit,
   }
 
   f->skip = 0;
-  gblfp = f->fp;
+  FIO_FCB_INVALIDATE_GETC_BUFFER_FULLY(f, return ERR_FLAG);
+  gblfp = f->__io_fp;
   internal_file = FALSE;
   gbl->decimal = f->decimal;
   gbl->unit = unit;
@@ -2180,12 +2181,13 @@ read_record(void)
     p = rbufp;
     byte_cnt = 0;
 
+    FIO_FCB_INVALIDATE_GETC_BUFFER_FULLY(f, return __io_errno());
     while (TRUE) {
       if (byte_cnt >= rbuf_size)
         p = alloc_rbuf(byte_cnt, TRUE);
-      ch = __io_fgetc(f->fp);
+      ch = __io_fgetc(f->__io_fp);
       if (ch == EOF) {
-        if (__io_feof(f->fp)) {
+        if (__io_feof(f->__io_fp)) {
           if (byte_cnt)
             break;
           return FIO_EEOF;
@@ -2193,10 +2195,10 @@ read_record(void)
         return __io_errno();
       }
       if (ch == '\r' && EOR_CRLF) {
-        ch = __io_fgetc(f->fp);
+        ch = __io_fgetc(f->__io_fp);
         if (ch == '\n')
           break;
-        __io_ungetc(ch, f->fp);
+        __io_ungetc(ch, f->__io_fp);
         ch = '\r';
       }
       if (ch == '\n')

--- a/runtime/flang/nmlwrite.c
+++ b/runtime/flang/nmlwrite.c
@@ -324,7 +324,7 @@ emit_eol(void)
 
   if (!internal_file) {
 #if defined(WINNT)
-    if (__fortio_binary_mode(f->fp)) {
+    if (__fortio_binary_mode(f->__io_fp)) {
       ret_err = write_char('\r');
       if (ret_err)
         return ret_err;
@@ -508,7 +508,8 @@ write_item(char *p, int len)
     __io_printf("write_item #%s#, len %d\n", p, len);
 
   if (!internal_file) {
-    if (len && FWRITE(p, len, 1, f->fp) != 1)
+    FIO_FCB_INVALIDATE_GETC_BUFFER(f, return __io_errno());
+    if (len && FWRITE(p, len, 1, f->__io_fp) != 1)
       return __io_errno();
     return 0;
   }

--- a/runtime/flang/rewind.c
+++ b/runtime/flang/rewind.c
@@ -50,20 +50,22 @@ _f90io_rewind(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
       }
     }
 
+    FIO_FCB_INVALIDATE_GETC_BUFFER(f, return __io_errno());
+
     /* append carriage return (maybe) */
 
     if (f->nonadvance) {
       f->nonadvance = FALSE;
 #if defined(WINNT)
-      if (__fortio_binary_mode(f->fp))
-        __io_fputc('\r', f->fp);
+      if (__fortio_binary_mode(f->__io_fp))
+        __io_fputc('\r', f->__io_fp);
 #endif
-      __io_fputc('\n', f->fp);
-      if (__io_ferror(f->fp))
+      __io_fputc('\n', f->__io_fp);
+      if (__io_ferror(f->__io_fp))
         return __io_errno();
     }
 
-    if (__io_fseek(f->fp, 0L, SEEK_SET) != 0)
+    if (__io_fseek(f->__io_fp, 0L, SEEK_SET) != 0)
       return __fortio_error(__io_errno());
 
     f->nextrec = 1;


### PR DESCRIPTION
This commit introduces 32k buffer for file I/O operations
and 32k buffer for fgetc() replacemnt routines.

This is follow-up of my work presented in pull request #642.

Some performance gain is observed and 'perf' trace does not
show getc operations at all, shifting the burden to actual
I/O system routines. In order to improve performance of these,
32k buffer is attached to every opened file by calling
setvbuf() function.

Due to suspicious way of passing pointers around in flang runtime,
all of the I/O buffers had to be allocated statically. In order to
prevent memory bloat, only limited number of simultaneously opened
files will be buffered, file descriptor ID is used for buffer
selection which is a thread-safe solution.

The test case I was using is following:
```
! *********************************************************
        program main

        implicit none
!       ---------------------------------------------------
        character(len=500) :: cart
        real(kind=8) :: t1,t2

!       ---------------------------------------------------
        open(unit=9,status='old',file='my_file.txt')
        open(unit=10,file='my_new_file.txt')
        call cpu_time(t1)
        do
!               read each line
                read(9,fmt='(A)') cart
!       ************************************************************
!       ************************************************************
!                       convert  process
!       ************************************************************
!       ************************************************************

                if(cart(1:4)=='/end') then
                        write(10,*) 'this is the end!'
                        exit
                else
                        write(10,*) cart
                endif
        enddo
        call cpu_time(t2)
        close(unit=9)
        close(unit=10)

        print*,' write and read :',t2-t1




!       ---------------------------------------------------

        end program main
! *********************************************************
```
[my_file.txt.gz](https://github.com/flang-compiler/flang/files/2724306/my_file.txt.gz)

Compiled with gfortran it gives much better timing results that when compiled with flang. My patch improves the timing of flang compiled program.