### PR TITLE
Fix in preprocessing for Flexi app

### DIFF
--- a/test/llvm_ir_correct/dot_preprocess.f90
+++ b/test/llvm_ir_correct/dot_preprocess.f90
@@ -1,0 +1,11 @@
+! RUN: %flang -cpp -S -emit-llvm %s -o - | FileCheck %s
+#define PP_N 10
+subroutine pp(n)
+implicit none
+integer :: n
+if (n-1.ne.PP_N) then
+  print *, 'Success'
+end if
+end subroutine pp
+
+! //CHECK: {{.*}}  = icmp eq i32 {{.*}}, 11

--- a/tools/flang1/flang1exe/accpp.c
+++ b/tools/flang1/flang1exe/accpp.c
@@ -4073,6 +4073,7 @@ nextok(char *tokval, int truth)
   char *savtokval = tokval;
   PPSYM *sp;
   char *comment_ptr;
+  int dot_seen;
 
 again:
   if ((c = inchar()) == EOF) {
@@ -4207,6 +4208,7 @@ again:
     /* must all be in buffer */
     p = lineptr;
   dotnum:
+    dot_seen=0;
     for (;;) {
       if (*p == 'E' || *p == 'e') {
         ++p;
@@ -4216,7 +4218,10 @@ again:
         ++p;
         if (*p == '+' || *p == '-')
           ++p;
-      } else if (*p == '.' || isident(*p))
+      } else if (*p == '.' && !dot_seen) {
+        ++p;
+        dot_seen=1;
+      } else if (isident(*p))
         ++p;
       else
         break;


### PR DESCRIPTION
The preprocessor in fortran detects 1.NE.PP_NUM as a number.
The fix uses the knowledge that a constant number can have
atmost one dot character in it. If more than one dot character
is seen then the scanning has gone too far ahead.
This fix removes PP_NUM from the number detected and allows
for substitution of PP_NUM with the defined preprocessor
value.