### PR TITLE
Enable support for simd directives

### DIFF
--- a/include/flang/Error/errmsg-in.n
+++ b/include/flang/Error/errmsg-in.n
@@ -1333,6 +1333,9 @@ LAUNCH_BOUNDS is now allowed on ATTRIBUTES(DEVICE) or host subprograms.
 .MS E 552 "LAUNCH_BOUNDS() values must be positive"
 The LAUNCH_BOUNDS maximum number of threads and minimum grid size must
 be positive integer values.
+.MS W 602 "No clause specified for the vector directive. Note: Only the always clause is supported."
+.MS W 603 "Unsupported clause specified for the vector directive. Only the always clause is supported."
+.MS W 604 "Unsupported clause specified for the omp simd directive. The directive will be ignored."
 .MS S 901 "#elif after #else"
 A preprocessor #elif directive was found after a #else directive; only
 #endif is allowed in this context.

--- a/test/directives/ivdep.f90
+++ b/test/directives/ivdep.f90
@@ -1,0 +1,19 @@
+! RUN: %flang -O2 -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s -check-prefix=METADATA
+
+subroutine sum(myarr1,myarr2,ub)
+  integer, pointer :: myarr1(:)
+  integer, pointer :: myarr2(:)
+  integer :: ub
+
+  !dir$ ivdep
+  do i=1,ub
+    myarr1(i) = myarr1(i)+myarr2(i)
+  end do
+end subroutine
+
+! CHECK:  {{.*}} add nsw <[[VF:[0-9]+]] x i32>{{.*}}
+! METADATA: load {{.*}}, !llvm.mem.parallel_loop_access ![[TAG1:[0-9]+]]
+! METADATA: store {{.*}}, !llvm.mem.parallel_loop_access ![[TAG1]]
+! METADATA: ![[TAG2:[0-9]+]] = !{!"llvm.loop.vectorize.enable", i1 true}
+! METADATA: ![[TAG1:[0-9]+]] = distinct !{![[TAG1]], ![[TAG2]]}

--- a/test/directives/lit.local.cfg
+++ b/test/directives/lit.local.cfg
@@ -1,0 +1,11 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# Directives test configuration
+
+config.suffixes = ['.f', '.FOR', '.for', '.f77', '.f90', '.f95', '.F', '.fpp',
+ '.FPP']
+

--- a/test/directives/novector.f90
+++ b/test/directives/novector.f90
@@ -1,0 +1,24 @@
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s -check-prefix=DISABLE-METADATA
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=IGNORE-DIRECTIVES
+! RUN: %flang -Hx,59,2 -S -emit-llvm -O2 %s -o - | FileCheck %s
+! RUN: %flang -S -emit-llvm -O2 %s -o - | FileCheck %s -check-prefix=NOVECTOR
+
+subroutine add(arr1,arr2,arr3,N)
+  integer :: i,N
+  integer :: arr1(N)
+  integer :: arr2(N)
+  integer :: arr3(N)
+
+  !dir$ novector
+  do i = 1, N
+    arr3(i) = arr1(i) - arr2(i)
+  end do
+end subroutine
+! DISABLE-METADATA: !"llvm.loop.vectorize.enable", i1 false
+! IGNORE-DIRECTIVES-NOT: !"llvm.loop.vectorize.enable", i1 false
+! CHECK: load <[[VF:[0-9]+]] x i32>
+! CHECK: sub {{.*}} <[[VF]] x i32>
+! CHECK: store <[[VF]] x i32>
+! NOVECTOR-NOT: load <[[VF:[0-9]+]] x i32>
+! NOVECTOR-NOT: sub {{.*}} <[[VF]] x i32>
+! NOVECTOR-NOT: store <[[VF]] x i32>

--- a/test/directives/omp_simd.f90
+++ b/test/directives/omp_simd.f90
@@ -1,0 +1,19 @@
+! RUN: %flang -fopenmp -O2 -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -fopenmp -S -emit-llvm %s -o - | FileCheck %s -check-prefix=METADATA
+
+subroutine sum(myarr1,myarr2,ub)
+  integer, pointer :: myarr1(:)
+  integer, pointer :: myarr2(:)
+  integer :: ub
+
+  !$omp simd
+  do i=1,ub
+    myarr1(i) = myarr1(i)+myarr2(i)
+  end do
+end subroutine
+
+! CHECK:  {{.*}} add nsw <[[VF:[0-9]+]] x i32>{{.*}}
+! METADATA: load {{.*}}, !llvm.mem.parallel_loop_access ![[TAG1:[0-9]+]]
+! METADATA: store {{.*}}, !llvm.mem.parallel_loop_access ![[TAG1]]
+! METADATA: ![[TAG2:[0-9]+]] = !{!"llvm.loop.vectorize.enable", i1 true}
+! METADATA: ![[TAG1:[0-9]+]] = distinct !{![[TAG1]], ![[TAG2]]}

--- a/test/directives/omp_simd_clause.f90
+++ b/test/directives/omp_simd_clause.f90
@@ -1,0 +1,21 @@
+! RUN: %flang -fopenmp -O2 -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -fopenmp -S -emit-llvm %s -o - | FileCheck %s -check-prefix=METADATA
+! RUN: %flang -fopenmp -O2 -c %s 2>&1 | FileCheck %s -check-prefix=WARNING
+
+subroutine sum(myarr1,myarr2,ub)
+  integer, pointer :: myarr1(:)
+  integer, pointer :: myarr2(:)
+  integer :: ub
+
+  !$omp simd collapse(2)
+  do i=1,ub
+    myarr1(i) = myarr1(i)+myarr2(i)
+  end do
+end subroutine
+
+! CHECK-NOT:  {{.*}} add nsw <[[VF:[0-9]+]] x i32>{{.*}}
+! METADATA-NOT: load {{.*}}, !llvm.mem.parallel_loop_access ![[TAG1:[0-9]+]]
+! METADATA-NOT: store {{.*}}, !llvm.mem.parallel_loop_access ![[TAG1]]
+! METADATA-NOT: ![[TAG2:[0-9]+]] = !{!"llvm.loop.vectorize.enable", i1 true}
+! METADATA-NOT: ![[TAG1:[0-9]+]] = distinct !{![[TAG1]], ![[TAG2]]}
+! WARNING: F90-W-0604-Unsupported clause specified for the omp simd directive

--- a/test/directives/vector.f90
+++ b/test/directives/vector.f90
@@ -1,0 +1,21 @@
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s -check-prefix=METADATA
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=IGNORE-DIRECTIVES
+! RUN: %flang -S -emit-llvm -O2 %s -o - | FileCheck %s
+! RUN: %flang -Hx,59,2 -S -emit-llvm -O2 %s -o - | FileCheck %s -check-prefix=VECTOR
+
+subroutine add(arr1,arr2,arr3,N)
+  integer :: arr1(N)
+  integer :: arr2(N)
+  integer :: arr3(N)
+
+  !dir$ vector always
+  do i = 1, N
+    arr3(i) = arr1(arr2(i))
+  end do
+end subroutine
+! METADATA: !"llvm.loop.vectorize.enable", i1 true
+! IGNORE-DIRECTIVES-NOT: !"llvm.loop.vectorize.enable", i1 true
+! CHECK: load <[[VF:[0-9]+]] x i32>
+! CHECK: store <[[VF]] x i32>
+! VECTOR-NOT: load <[[VF:[0-9]+]] x i32>
+! VECTOR-NOT: store <[[VF]] x i32>

--- a/test/directives/vector_directive1.f90
+++ b/test/directives/vector_directive1.f90
@@ -1,0 +1,14 @@
+! RUN: %flang -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO-CLAUSE
+
+subroutine add(arr1,arr2,arr3,N)
+  integer :: i,N
+  integer :: arr1(N)
+  integer :: arr2(N)
+  integer :: arr3(N)
+
+  !dir$ vector
+  do i = 1, N
+    arr3(i) = arr1(i) - arr2(i)
+  end do
+end subroutine
+! CHECK-NO-CLAUSE: F90-W-0602-No clause specified for the vector directive. Note: Only the always clause is supported.

--- a/test/directives/vector_directive2.f90
+++ b/test/directives/vector_directive2.f90
@@ -1,0 +1,14 @@
+! RUN: %flang -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-WRONG-CLAUSE
+
+subroutine add(arr1,arr2,arr3,N)
+  integer :: i,N
+  integer :: arr1(N)
+  integer :: arr2(N)
+  integer :: arr3(N)
+
+  !dir$ vector never
+  do i = 1, N
+    arr3(i) = arr1(i) - arr2(i)
+  end do
+end subroutine
+! CHECK-WRONG-CLAUSE: F90-W-0603-Unsupported clause specified for the vector directive. Only the always clause is supported.

--- a/test/directives/vector_directive3.f90
+++ b/test/directives/vector_directive3.f90
@@ -1,0 +1,15 @@
+! RUN: %flang -c %s 2>&1 | FileCheck %s -allow-empty --check-prefix=CHECK
+
+subroutine add(arr1,arr2,arr3,N)
+  integer :: i,N
+  integer :: arr1(N)
+  integer :: arr2(N)
+  integer :: arr3(N)
+
+  !dir$ vector always
+  do i = 1, N
+    arr3(i) = arr1(i) - arr2(i)
+  end do
+end subroutine
+! CHECK-NOT: F90-S-0602
+! CHECK-NOT: F90-S-0603

--- a/tools/flang1/flang1exe/semsmp.c
+++ b/tools/flang1/flang1exe/semsmp.c
@@ -1509,9 +1509,15 @@ semsmp(int rednum, SST *top)
    */
   case MP_STMT41:
     clause_errchk(BT_SIMD, "OMP SIMD");
-    sem.collapse = 0;
-    if (CL_PRESENT(CL_COLLAPSE)) {
-      sem.collapse = CL_VAL(CL_COLLAPSE);
+    if (CL_PRESENT(CL_SAFELEN) || CL_PRESENT(CL_LINEAR) ||
+        CL_PRESENT(CL_ALIGNED) || CL_PRESENT(CL_PRIVATE) ||
+        CL_PRESENT(CL_LASTPRIVATE) || CL_PRESENT(CL_REDUCTION) ||
+        CL_PRESENT(CL_COLLAPSE)) {
+      errwarn((error_code_t)604);
+      sem.expect_simd_do = FALSE;
+      par_push_scope(TRUE);
+      SST_ASTP(LHS, 0);
+      break;
     }
     sem.expect_simd_do = TRUE;
     par_push_scope(TRUE);

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -853,7 +853,7 @@ independent loop (forall-independent loop).
 .XB "0x200"
 don't perform tail recursion elimination
 .XB "0x400"
-don't perform idiom vector recognition for the PIII
+perform loop vectorisation.
 .XB "Ox800"
 Perform zero trip elimination - will we ever be able to switch the sense?
 .XB "0x1000"

--- a/tools/flang2/flang2exe/bih.h
+++ b/tools/flang2/flang2exe/bih.h
@@ -62,7 +62,8 @@ typedef struct {
 
       unsigned parsect : 1;   /* bih belongs to a parallel section */
       unsigned ujres : 1;     /* bih contains ujresidual start & count info */
-      unsigned simd : 1;       /* bih contains simd code */
+      unsigned simd : 1;      /* bih contains simd code */
+      unsigned nosimd : 1;    /* bih does not contain simd code */
 
       unsigned ldvol : 1; /* bih contains a load from volatile space */
       unsigned stvol : 1; /* bih contains a store to volatile space */
@@ -190,6 +191,7 @@ typedef struct {
 #define BIH_PARSECT(i) bihb.stg_base[i].flags.bits.parsect
 #define BIH_UJRES(i) bihb.stg_base[i].flags.bits.ujres
 #define BIH_SIMD(i) bihb.stg_base[i].flags.bits.simd
+#define BIH_NOSIMD(i) bihb.stg_base[i].flags.bits.nosimd
 #define BIH_LDVOL(i) bihb.stg_base[i].flags.bits.ldvol
 #define BIH_STVOL(i) bihb.stg_base[i].flags.bits.stvol
 #define BIH_ASM(i) bihb.stg_base[i].flags.bits.gasm

--- a/tools/flang2/flang2exe/bihutil.cpp
+++ b/tools/flang2/flang2exe/bihutil.cpp
@@ -216,6 +216,7 @@ merge_bih_flags(int to_bih, int fm_bih)
   BIH_INVIF(to_bih) = BIH_INVIF(to_bih) | BIH_INVIF(fm_bih);
   BIH_NOINVIF(to_bih) = BIH_NOINVIF(to_bih) | BIH_NOINVIF(fm_bih);
   BIH_SIMD(to_bih) = BIH_SIMD(to_bih) | BIH_SIMD(fm_bih);
+  BIH_NOSIMD(to_bih) = BIH_NOSIMD(to_bih) | BIH_NOSIMD(fm_bih);
   BIH_RESID(to_bih) = BIH_RESID(to_bih) | BIH_RESID(fm_bih);
   BIH_VCAND(to_bih) = BIH_VCAND(to_bih) | BIH_VCAND(fm_bih);
   BIH_MIDIOM(to_bih) = BIH_MIDIOM(to_bih) | BIH_MIDIOM(fm_bih);

--- a/tools/flang2/flang2exe/iltutil.cpp
+++ b/tools/flang2/flang2exe/iltutil.cpp
@@ -331,6 +331,8 @@ dump_ilt(FILE *ff, int bihx)
     fprintf(ff, " UJRES");
   if (BIH_SIMD(bihx))
     fprintf(ff, " SIMD");
+  if (BIH_NOSIMD(bihx))
+    fprintf(ff, " NOSIMD");
   if (BIH_LDVOL(bihx))
     fprintf(ff, " LDVOL");
   if (BIH_STVOL(bihx))

--- a/tools/flang2/flang2exe/mwd.cpp
+++ b/tools/flang2/flang2exe/mwd.cpp
@@ -4893,6 +4893,7 @@ db(int block)
   putbit("resid", BIH_RESID(block));
   putbit("ujres", BIH_UJRES(block));
   putbit("simd", BIH_SIMD(block));
+  putbit("nosimd", BIH_NOSIMD(block));
   putbit("ldvol", BIH_LDVOL(block));
   putbit("stvol", BIH_STVOL(block));
   putbit("task", BIH_TASK(block));


### PR DESCRIPTION
This commit enables support for the following simd directives. These
directives can be used to control vectorisation performed by LLVM. It
works by passing vectorisation metadata to LLVM.
Note that these directives do not control any vectorisation performed
by flang itself.
1) !dir$ ivdep (ignore mem-dep and vectorise)
2) !$omp simd (requires -fopenmp, ignore mem-dep and vectorise)
3) !dir$ vector always (ignore cost and vectorise)
4) !dir$ novector