### PR TITLE
Fix for segfault in multiple entries OpenMP functions (fixes #638 )

### DIFF
--- a/test/llvm_ir_correct/critical_entries.f90
+++ b/test/llvm_ir_correct/critical_entries.f90
@@ -1,0 +1,16 @@
+! RUN: %flang -fopenmp -S -emit-llvm %s -o - | FileCheck %s
+subroutine sub1
+  implicit none
+  integer :: x
+
+  write (*, *) "HELLO1"
+  entry sub2
+  x = 0
+  write (*, *) "HELLO2"
+!$OMP CRITICAL
+  x = x + 1
+!$OMP END CRITICAL
+end subroutine
+! CHECK: call i32 @__kmpc_global_thread_num
+! CHECK: call i32 @__kmpc_global_thread_num
+

--- a/tools/flang2/flang2exe/expsmp.cpp
+++ b/tools/flang2/flang2exe/expsmp.cpp
@@ -3029,7 +3029,17 @@ exp_mp_func_prologue(bool process_tp)
     }
   }
 
-  ll_save_gtid_val(bih);
+  if (has_multiple_entries(GBL_CURRFUNC)) {
+    if (bih)
+      ll_save_gtid_val(bih);
+    for (func = gbl.entries; func != NOSYM; func = SYMLKG(func)) {
+      bih = expb.curbih = findEnlabBih(func);
+      if (bih)
+        ll_save_gtid_val(bih);
+    }
+  } else {
+    ll_save_gtid_val(bih);
+  }
 }
 
 static void


### PR DESCRIPTION
This patch adds missing check for multiple entries in a function
that builds prologue for a Fortran function (or subroutine) that
contains at least one OpenMP directive.

Since ll_save_gtid_val() function usually used for single-entry
Fortran functions can handle only one entry, processing of multiple
entries is handled similarly in a for loop.

A short test case which validates this patch is also added
to the commit.