### PR TITLE
Fix issue with capturing procedure pointers to OpenMP parallel regions. Fixes TeaLeaf_ref building, see #461

### DIFF
--- a/test/mp_correct/subcallx.f90
+++ b/test/mp_correct/subcallx.f90
@@ -1,0 +1,46 @@
+! RUN: %flang -O0 -fopenmp -S -emit-llvm %s -o - 2>&1 | FileCheck %s
+
+program subcallx
+
+  implicit none
+
+  call sub2
+
+contains
+
+subroutine sub1(x)
+
+  implicit none
+
+  integer :: x
+
+  print *, "Hello from sub1", x
+
+end subroutine sub1
+
+! CHECK: define internal void @subcallx_sub2
+subroutine sub2
+
+  implicit none
+
+  interface
+    subroutine simple_sub(x)
+      implicit none
+      integer :: x
+    end subroutine
+  end interface
+
+  procedure(simple_sub), pointer :: pptr => null() ! CHECK: %"pptr$p_{{[0-9]+}}" = alloca void
+
+  pptr => sub1
+
+! CHECK: @subcallx__{{.+}}_ to i64*
+! CHECK: @__kmpc_fork_call
+! CHECK: define internal void @subcallx__{{.+}}_
+!$OMP PARALLEL
+  call pptr(123) ! CHECK-NOT: %"pptr${{.+}}_{{[0-9]+}}" = alloca
+!$OMP END PARALLEL
+
+end subroutine sub2
+
+end program subcallx

--- a/tools/flang1/flang1exe/semant3.c
+++ b/tools/flang1/flang1exe/semant3.c
@@ -1377,8 +1377,10 @@ semant3(int rednum, SST *top)
       sptr = SST_SYMG(RHS(1));
       if (!is_procedure_ptr(sptr)) {
         subr_call(RHS(1), itemp);
-      } else
+      } else {
+        (void)mkarg(RHS(1), &dum);
         ptrsubr_call(RHS(1), itemp);
+      }
     } else {
       ptrsubr_call(RHS(1), itemp);
     }


### PR DESCRIPTION
This commit provides additionally a test case which signals the problem
and verifies the solution.