### PR TITLE
runtime: ARM64 is a 64-bit architecture

### DIFF
--- a/runtime/flang/ftni64.h
+++ b/runtime/flang/ftni64.h
@@ -26,7 +26,7 @@
 
 #define __HAVE_LONGLONG_T
 
-#if defined(LINUX8664) || defined(OSX8664)
+#if defined(LINUX8664) || defined(OSX8664) || defined(TARGET_LLVM_ARM64)
 typedef long _LONGLONG_T;
 typedef unsigned long _ULONGLONG_T;
 #else
@@ -47,7 +47,7 @@ typedef union {
   _LONGLONG_T lv;
 } INT64D;
 
-#if defined(LINUX8664) || defined(OSX8664)
+#if defined(LINUX8664) || defined(OSX8664) || defined(TARGET_LLVM_ARM64)
 #define __I8RET_T long
 #define UTL_I_I64RET(m, l)                                                     \
   {                                                                            \

--- a/runtime/flang/ftnncharsup.c
+++ b/runtime/flang/ftnncharsup.c
@@ -160,7 +160,7 @@ int a2_len;                        /* length of a2 */
 
 #define __HAVE_LONGLONG_T
 
-#if defined(LINUX8664) || defined(OSX8664)
+#if defined(LINUX8664) || defined(OSX8664) || defined(TARGET_LLVM_ARM64)
 typedef long _LONGLONG_T;
 typedef unsigned long _ULONGLONG_T;
 #else

--- a/runtime/flang/miscsup_com.c
+++ b/runtime/flang/miscsup_com.c
@@ -816,7 +816,7 @@ ENTFTN(SYSCLK, sysclk)(__STAT_T *count, __STAT_T *count_rate,
 
   if (resol == 0) {
     int def;
-#if defined(TARGET_X8664)
+#if defined(TARGET_X8664) || defined(TARGET_LLVM_ARM64)
     def = 1000000;
 #else
     def = sizeof(__STAT_T) < 8 ? 1000 : 1000000;
@@ -2884,7 +2884,7 @@ ENTF90(TRIMA, trima)
   i = CLEN(expr);
   while (i > 0) {
     if (CADR(expr)[i - 1] != ' ') {
-#if defined(TARGET_X8664)
+#if defined(TARGET_X8664) || defined(TARGET_LLVM_ARM64)
       if (i <= 11) {
         int *rptr = ((int *)CADR(res));
         int *eptr = ((int *)CADR(expr));


### PR DESCRIPTION
There are places in the runtime code where AArch64 should be treated the same way as x86_64.
