### PR TITLE
libpgmath sanity: do not call sleep() in Linux systems

### DIFF
--- a/runtime/libpgmath/lib/common/dispatch.c
+++ b/runtime/libpgmath/lib/common/dispatch.c
@@ -74,16 +74,12 @@
 #include <time.h>
 #include <inttypes.h>
 
-#ifndef	TARGET_WIN
-  #include <unistd.h>
-  #define SLEEP(t) sleep(t)
-#else       // #ifndef _WIN64
+#if defined(TARGET_WIN)
   #include <windows.h>
   #include <io.h>
   #define SLEEP(t) Sleep(t*1000)
   #define strcasecmp _stricmp
-
-#endif      // #ifndef _WIN64
+#endif
 
 #if defined(TARGET_LINUX_X8664) || defined(TARGET_LINUX_POWER) || defined(TARGET_WIN)
 #include <malloc.h>


### PR DESCRIPTION
The disputed SLEEP() macro is never used in the libpgmath code for Linux.

Deleted here in order to prevent potential future use of sleep() function
not recommended due to potential messing with SIGALRM.

Note that non-Windows libpgmath code already uses nanosleep() for
sleeping, which is recommended.
