### PR TITLE
Make the NCAR Kernels tests into longtests

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -344,8 +344,7 @@ flags = flags.replace(',', ' ')
 config.substitutions.append(('%flags', '\"' + flags + '\"'))
 
 # Option to keep files generated while running tests.
-keep_file = lit_config.params.get('keep', None)
-if keep_file != None:
+if lit.util.pythonize_bool(lit_config.params.get('keep', None)):
   config.substitutions.append(('%keep', '1'))
 else:
   config.substitutions.append(('%keep', ''))
@@ -469,12 +468,11 @@ else:
     config.available_features.add("nozlib")
 
 # Check if we should run long running tests.
-if lit_config.params.get("run_long_tests", None) == "true":
+if lit.util.pythonize_bool(lit_config.params.get("run_long_tests", None)):
     config.available_features.add("long_tests")
 
 # Check if we should allow outputs to console.
-run_console_tests = int(lit_config.params.get('enable_console', '0'))
-if run_console_tests != 0:
+if lit.util.pythonize_bool(lit_config.params.get('enable_console', None)):
   config.available_features.add('console')
 
 lit.util.usePlatformSdkOnDarwin(config, lit_config)

--- a/test/ncar_kernels/lit.local.cfg
+++ b/test/ncar_kernels/lit.local.cfg
@@ -1,0 +1,4 @@
+# These tests take on the order of seconds to run, so skip them unless
+# we're running long tests.
+if 'long_tests' not in config.available_features:
+    config.unsupported = True


### PR DESCRIPTION
Many of these tests take tens of seconds and a few take minutes. Mark the
whole subdirectory as longtests so they can be disabled for make check-all
in development. We need to enable long-tests in CI.

Also use more modern lit cmdline processing utils in lit.cfg.

Signed-off-by: Richard Barton <richard.barton@arm.com>