### PR TITLE
Pull 2019-06-12T08-11 Recent NVIDIA Changes

### DIFF
--- a/include/flang/Error/errmsg-common.n
+++ b/include/flang/Error/errmsg-common.n
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (c) 2010-2018, NVIDIA CORPORATION.  All rights reserved.
+.\" * Copyright (c) 2010-2019, NVIDIA CORPORATION.  All rights reserved.
 .\" *
 .\" * Licensed under the Apache License, Version 2.0 (the "License");
 .\" * you may not use this file except in compliance with the License.
@@ -28,3 +28,4 @@ We have one spot for the preinclude file in the gbl. structure.  This is not
 a user visible switch.
 .MS F 704 "Compilation aborted due to previous errors."
 Compilation will abort immediately in case of Severe or Fatal error.
+.MS F 705 "Half precision implementation missing support - $"

--- a/runtime/flang/fioMacros.h
+++ b/runtime/flang/fioMacros.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2002-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1511,11 +1511,11 @@ F90_Desc *I8(__fort_inherit_template)(F90_Desc *d, __INT_T rank,
 
 proc *__fort_defaultproc(int rank);
 
-proc *__fort_localproc();
+proc *__fort_localproc(void);
 
-int __fort_myprocnum();
+int __fort_myprocnum(void);
 
-int __fort_is_ioproc();
+int __fort_is_ioproc(void);
 
 int I8(__fort_owner)(F90_Desc *d, __INT_T *gidx);
 
@@ -1716,7 +1716,7 @@ void __fort_initndx( int nd, int *cnts, int *ncnts, int *strs, int *nstrs,
 
 int __fort_findndx( int cpu, int nd, int low, int *nstrs, int *mults);
 
-void __fort_barrier();
+void __fort_barrier(void);
 
 void __fort_par_unlink(char *fn);
 

--- a/runtime/flang/fortDt.h
+++ b/runtime/flang/fortDt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1995-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ typedef enum {
   __INT2 = 24,       /**< Fortran integer*2 */
   __INT4 = 25,       /**< Fortran integer*4, integer */
   __INT8 = 26,       /**< Fortran integer*8 */
+  __REAL2 = 45,      /**< Fortran real*2, half */
   __REAL4 = 27,      /**< Fortran real*4, real */
   __REAL8 = 28,      /**< Fortran real*8, double precision */
   __REAL16 = 29,     /**< Fortran real*16 */
@@ -91,7 +92,7 @@ typedef enum {
  * runtime descriptor types cannot change.  Therefore, new values will
  * be added after any current values.
  */
-#define __NTYPES 45
+#define __NTYPES 46
 
 } _DIST_TYPE;
 
@@ -151,6 +152,8 @@ typedef unsigned int __INT4_UT;
 
 typedef long __INT8_T; /* 26 __INT8       integer*8 */
 typedef unsigned long __INT8_UT;
+
+typedef unsigned short __REAL2_T; /* 45 __REAL2      real*2 */
 
 typedef float __REAL4_T; /* 27 __REAL4      real*4 */
 

--- a/test/f90_correct/src/check.c
+++ b/test/f90_correct/src/check.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,35 @@
 #include <assert.h>
 
 extern int __hpf_lcpu;
+
+void
+checkh_(short* res, short* exp, int* np)
+{
+    int i;
+    int n = *np;
+    int tests_passed = 0;
+    int tests_failed = 0;
+
+    for (i = 0; i < n; i++) {
+      if (exp[i] & (~ res[i])) {
+            tests_failed ++;
+	    if( tests_failed < 100 )
+            printf(
+	    "test number %d FAILED. res %u(%04x)  exp %u(%04x)\n",
+	     i+1,res[i], res[i], exp[i], exp[i] );
+        } else {
+	    tests_passed ++;
+        }
+    }
+    if (tests_failed == 0) {
+	    printf(
+	"%3d tests completed. %d tests PASSED. %d tests failed.\n",
+                      n, tests_passed, tests_failed);
+    } else {
+	printf("%3d tests completed. %d tests passed. %d tests FAILED.\n",
+                      n, tests_passed, tests_failed);
+    }
+}
 
 void
 check_(int* res, int* exp, int* np)

--- a/tools/flang1/flang1exe/semant2.c
+++ b/tools/flang1/flang1exe/semant2.c
@@ -1826,11 +1826,12 @@ semant2(int rednum, SST *top)
       ast_conval(top);
     }
     break;
+
   /*
    *      <constant> ::= <real>    |
    */
 
-  case CONSTANT3:
+  case CONSTANT4:
     SST_DTYPEP(LHS, DT_REAL4);
     /* value set by scan */
     ast_conval(top);
@@ -1838,7 +1839,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <double>  |
    */
-  case CONSTANT4:
+  case CONSTANT5:
     SST_DTYPEP(LHS, DT_REAL8);
     /* value set by scan */
     ast_cnst(top);
@@ -1846,7 +1847,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <quad>     |
    */
-  case CONSTANT5:
+  case CONSTANT6:
     SST_DTYPEP(LHS, DT_QUAD);
     /* value set by scan */
     ast_cnst(top);
@@ -1854,7 +1855,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <complex> |
    */
-  case CONSTANT6:
+  case CONSTANT7:
     SST_DTYPEP(LHS, DT_CMPLX8);
     /* value set by scan */
     ast_cnst(top);
@@ -1862,7 +1863,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <dcomplex> |
    */
-  case CONSTANT7:
+  case CONSTANT8:
     SST_DTYPEP(LHS, DT_CMPLX16);
     /* value set by scan */
     ast_cnst(top);
@@ -1870,7 +1871,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <qcomplex> |
    */
-  case CONSTANT8:
+  case CONSTANT9:
     SST_DTYPEP(LHS, DT_QCMPLX);
     /* value set by scan */
     ast_cnst(top);
@@ -1878,7 +1879,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <nondec const> |
    */
-  case CONSTANT9:
+  case CONSTANT10:
     SST_DTYPEP(LHS, DT_WORD);
     /* value set by scan */
     ast_conval(top);
@@ -1886,7 +1887,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <nonddec const> |
    */
-  case CONSTANT10:
+  case CONSTANT11:
     SST_DTYPEP(LHS, DT_DWORD);
     /* value set by scan */
     ast_cnst(top);
@@ -1894,7 +1895,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <Hollerith>    |
    */
-  case CONSTANT11:
+  case CONSTANT12:
     SST_DTYPEP(LHS, DT_HOLL);
     /* value set by scan */
     ast_cnst(top);
@@ -1902,7 +1903,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <log const>     |
    */
-  case CONSTANT12:
+  case CONSTANT13:
     if (DTY(stb.user.dt_log) == TY_LOG8) {
       if ((INT)SST_CVALG(RHS(1)) == SCFTN_FALSE)
         val[0] = val[1] = 0;
@@ -1924,7 +1925,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <log kind const> |
    */
-  case CONSTANT13:
+  case CONSTANT14:
     /* token value of <log kind const> is an ST_CONST entry */
     sptr = SST_CVALG(RHS(1));
     dtype = DTYPEG(sptr);
@@ -1939,13 +1940,13 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <char literal>
    */
-  case CONSTANT14:
+  case CONSTANT15:
     break;
 
   /*
    *      <constant> ::= <kanji string> |
    */
-  case CONSTANT15:
+  case CONSTANT16:
     /*  compute number of Kanji chars in string: */
     sptr = SST_SYMG(RHS(1));         /* ST_CONST/TY_CHAR */
     i = string_length(DTYPEG(sptr)); /* length of string const */
@@ -1960,7 +1961,7 @@ semant2(int rednum, SST *top)
   /*
    *      <constant> ::= <elp> <expression> <cmplx comma> <expression> )
    */
-  case CONSTANT16:
+  case CONSTANT17:
     /*
      * special production to allow complex constants to be formed from
      * "general" real & imag expressions which evaluate to constants.

--- a/tools/flang1/flang1exe/semantio.c
+++ b/tools/flang1/flang1exe/semantio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1994-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -6149,6 +6149,8 @@ getWriteByDtypeRtn(int dtype, FormatType fmttyp)
     rtlRtn = (fmttyp == FT_LIST_DIRECTED) ? RTE_f90io_sc_i_ldw
                                           : RTE_f90io_sc_i_fmt_write;
     break;
+  case DT_BLOG:
+  case DT_SLOG:
   case DT_LOG4:
     rtlRtn = (fmttyp == FT_LIST_DIRECTED) ? RTE_f90io_sc_i_ldw
                                           : RTE_f90io_sc_i_fmt_write;

--- a/tools/flang1/flang1exe/semfunc.c
+++ b/tools/flang1/flang1exe/semfunc.c
@@ -4126,6 +4126,7 @@ ref_intrin(SST *stktop, ITEM *list)
   char tmpnm[64];
   FtnRtlEnum rtlRtn;
   int intrin; /* one of the I_* constants */
+  int is_real2_arg_error = 0;
 
   dtyper = 0;
   dtype1 = 0;
@@ -5585,6 +5586,7 @@ ref_pd(SST *stktop, ITEM *list)
   FtnRtlEnum rtlRtn;
   SPTR pdsym = SST_SYMG(stktop);
   int pdtype = PDNUMG(pdsym);
+  int is_real2_arg_error = 0;
 
 /* any integer type, or hollerith, or, if -x 51 0x20 not set, real/double */
 #define TYPELESS(dt)                     \
@@ -8473,9 +8475,9 @@ ref_pd(SST *stktop, ITEM *list)
         goto call_e74_arg;
       }
 
-      argt = mk_argt(4);
-
       dtype2 = DDTG(SST_DTYPEG(ARG_STK(2)));
+
+      argt = mk_argt(4);
 
       sem.arrdim.ndim = 1;
       sem.arrdim.ndefer = 0;
@@ -10850,7 +10852,6 @@ const_isz_val:
   else
     SST_CVALP(stktop, A_SPTRG(ast));
   return iszval;
-
 const_real_val:
   EXPSTP(pdsym, 1); /* freeze predeclared */
   SST_IDP(stktop, S_CONST);
@@ -11058,6 +11059,7 @@ ref_pd_subr(SST *stktop, ITEM *list)
   int argt_count;
   SST *sp;
   SST *stkp;
+  int is_real2_arg_error = 0;
 
   /* Count the number of arguments to function */
   count = 0;

--- a/tools/flang1/flang1exe/semutil.c
+++ b/tools/flang1/flang1exe/semutil.c
@@ -530,7 +530,6 @@ cngtyp(SST *old, int newtyp)
       goto type_error;
     }
     break;
-
   case TY_REAL:
     switch (from) {
     case TY_BLOG:
@@ -5255,7 +5254,8 @@ mod_type(int dtype, int ty, int kind, int len, int propagated, int sptr)
       if (len == 4)
         return (DT_REAL4);
     }
-    error(31, 2, gbl.lineno, (sptr) ? SYMNAME(sptr) : "real", CNULL);
+    error(31, 2, gbl.lineno, (sptr) ? SYMNAME(sptr) :
+                                     (ty == TY_HALF ? "real2" : "real"), CNULL);
     break;
   case TY_DCMPLX:
     if (sem.ogdtype == DT_CMPLX16 && kind != 0) {
@@ -5327,9 +5327,9 @@ prtsst(SST *stkptr)
     if (dtype == DT_QUAD || dtype == DT_REAL8 || DT_ISCMPLX(dtype)) {
       return (getprint(val));
     } else {
-      if (DT_ISREAL(dtype))
+      if (DT_ISREAL(dtype)) {
         sprintf(symbuf, "%f", *(float *)&val);
-      else if (DT_ISLOG(dtype)) {
+      } else if (DT_ISLOG(dtype)) {
         if (val == SCFTN_TRUE)
           sprintf(symbuf, ".TRUE.");
         else

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -10142,6 +10142,8 @@ eval_sqrt(ACL *arg, DTYPE dtype)
         error(155, 3, gbl.lineno,                                   \
               "Intrinsic not supported in initialization:", iname); \
         break;                                                      \
+      case TY_HALF:                                                 \
+        /* fallthrough to error */                                  \
       default:                                                      \
         error(155, 3, gbl.lineno,                                   \
               "Intrinsic not supported in initialization:", iname); \
@@ -10207,6 +10209,8 @@ FPINTRIN1("atan", eval_atan, xfatan, xdatan)
         error(155, 3, gbl.lineno,                                   \
               "Intrinsic not supported in initialization:", iname); \
         break;                                                      \
+      case TY_HALF:                                                 \
+        /* fallthrough to error */                                  \
       default:                                                      \
         error(155, 3, gbl.lineno,                                   \
               "Intrinsic not supported in initialization:", iname); \

--- a/tools/flang1/utils/prstab/gram.tki
+++ b/tools/flang1/utils/prstab/gram.tki
@@ -21,6 +21,7 @@ END   TK_EOL
 <letter>   TK_LETTER
 <integer>  TK_ICON
 <int kind const>  TK_K_ICON
+<half>     TK_HFCON
 <real>     TK_RCON
 <double>   TK_DCON
 <fmtstr>   TK_FMTSTR

--- a/tools/flang1/utils/prstab/gram.txt
+++ b/tools/flang1/utils/prstab/gram.txt
@@ -1012,6 +1012,7 @@
 
 <constant> ::=   <integer>  |
 		 <int kind const> |
+                 <half>     |
                  <real>     |
                  <double>   |
 		 <quad>     |

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -2239,8 +2239,10 @@ write_I_CALL(INSTR_LIST *curr_instr, bool emit_func_signature_for_call)
    */
   print_token("\t");
 #if defined(TARGET_LLVM_X8664)
+  /* by default on X86-64, a function returning INTEGER*2 is promoted to return INTEGER*4
+     and the return value truncated.*/
   if (return_type->data_type == LL_I16) {
-    callRequiresTrunc = !XBIT(183, 0x400000);
+      callRequiresTrunc = !XBIT(183, 0x400000);
   }
 #endif
   assert(return_type, "write_I_CALL: missing return type for call instruction",
@@ -6550,9 +6552,11 @@ get_call_sptr(int ilix)
 
   switch (opc) {
   case IL_JSR:
+  case IL_GJSR:
   case IL_QJSR:
     sptr = ILI_SymOPND(ilix, 1);
     break;
+  case IL_GJSRA:
   case IL_JSRA:
     addr = ILI_OPND(ilix, 1);
     if (ILI_OPC(addr) == IL_LDA) {

--- a/tools/flang2/flang2exe/dtypeutl.cpp
+++ b/tools/flang2/flang2exe/dtypeutl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -418,6 +418,7 @@ int
 alignment(DTYPE dtype)
 {
   TY_KIND ty;
+  int align_bits;
 
   switch (ty = DTY(dtype)) {
   case TY_DWORD:
@@ -460,7 +461,8 @@ alignment(DTYPE dtype)
     return dtypeinfo[ty].align;
 
   case TY_ARRAY:
-    return alignment(DTySeqTyElement(dtype));
+    align_bits = alignment(DTySeqTyElement(dtype));
+    return align_bits;
   case TY_VECT:
     return alignment(DTySeqTyElement(dtype));
 

--- a/tools/flang2/flang2exe/exp_ftn.cpp
+++ b/tools/flang2/flang2exe/exp_ftn.cpp
@@ -1279,7 +1279,8 @@ exp_ac(ILM_OP opc, ILM *ilmp, int curilm)
     ilmpx = (ILM *)(ilmb.ilm_base + ilmx);
 #if DEBUG
     assert(ILM_OPC(ilmpx) >= IM_ICMP && ILM_OPC(ilmpx) <= IM_NSCMP ||
-               ILM_OPC(ilmpx) == IM_KCMP || ILM_OPC(ilmpx) == IM_PCMP,
+               ILM_OPC(ilmpx) == IM_KCMP || ILM_OPC(ilmpx) == IM_PCMP ||
+               ILM_OPC(ilmpx) == IM_HFCMP,
            "expand:compare not operand of rel.", curilm, ERR_Severe);
 #endif
     if (ILM_RESTYPE(ilmx) == ILM_ISCHAR) {
@@ -3415,7 +3416,7 @@ exp_bran(ILM_OP opc, ILM *ilmp, int curilm)
     ILI_OP subop;  /* subtract op */
     ILI_OP cjmpop; /* compare and jump op */
     short msz;    /* msz for load/store */
-  } aif[4] = {
+  } aif[5] = {
       {IL_ICJMPZ, IL_CSEIR, DT_INT, IL_ST, IL_LD, IL_ICMPZ, IL_ISUB, IL_ICJMP,
        MSZ_WORD},
       {IL_FCJMPZ, IL_CSESP, DT_REAL, IL_STSP, IL_LDSP, IL_FCMPZ, IL_FSUB,
@@ -3448,7 +3449,7 @@ exp_bran(ILM_OP opc, ILM *ilmp, int curilm)
     break;
 
   case IM_KAIF: /* integer*8 arithmetic IF */
-    type = 3;
+    type = 4;
     goto comaif;
   case IM_IAIF: /* integer arithmetic IF */
     type = 0;

--- a/tools/flang2/flang2exe/exp_rte.cpp
+++ b/tools/flang2/flang2exe/exp_rte.cpp
@@ -2796,6 +2796,7 @@ static void from_addr_and_length(STRDESC *s, ainfo_t *ainfo_ptr);
 static void arg_ir(int, ainfo_t *);
 static void arg_kr(int, ainfo_t *);
 static void arg_ar(int, ainfo_t *, int);
+static void arg_hp(int, ainfo_t *);
 static void arg_sp(int, ainfo_t *);
 static void arg_dp(int, ainfo_t *);
 static void arg_charlen(int, ainfo_t *);

--- a/tools/flang2/flang2exe/ili.h
+++ b/tools/flang2/flang2exe/ili.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1994-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,35 +145,37 @@ typedef enum ILIO_KIND {
   ILIO_OFF = 5,
   ILIO_NME = 6,
   ILIO_IR = 7,
-  ILIO_SP = 8,
-  ILIO_DP = 9,
-  ILIO_CS = 10,
-  ILIO_CD = 11,
-  ILIO_AR = 12,
-  ILIO_KR = 13,
-  ILIO_XMM = 14, /* xmm register number */
-  ILIO_X87 = 15,
-  ILIO_DOUBLEDOUBLE = 16,
-  ILIO_FLOAT128 = 17,
-  ILIO_LNK = 18,
-  ILIO_IRLNK = 19,
-  ILIO_SPLNK = 20,
-  ILIO_DPLNK = 21,
-  ILIO_ARLNK = 22,
-  ILIO_KRLNK = 23,
-  ILIO_QPLNK = 24,
-  ILIO_CSLNK = 25,
-  ILIO_CDLNK = 26,
-  ILIO_CQLNK = 27,
-  ILIO_128LNK = 28,
-  ILIO_256LNK = 29,
-  ILIO_512LNK = 30,
-  ILIO_X87LNK = 31,
-  ILIO_DOUBLEDOUBLELNK = 32,
-  ILIO_FLOAT128LNK = 33
+  ILIO_HP = 8,
+  ILIO_SP = 9,
+  ILIO_DP = 10,
+  ILIO_CS = 11,
+  ILIO_CD = 12,
+  ILIO_AR = 13,
+  ILIO_KR = 14,
+  ILIO_XMM = 15, /* xmm register number */
+  ILIO_X87 = 16,
+  ILIO_DOUBLEDOUBLE = 17,
+  ILIO_FLOAT128 = 18,
+  ILIO_LNK = 19,
+  ILIO_IRLNK = 20,
+  ILIO_HPLNK = 21,
+  ILIO_SPLNK = 22,
+  ILIO_DPLNK = 23,
+  ILIO_ARLNK = 24,
+  ILIO_KRLNK = 25,
+  ILIO_QPLNK = 26,
+  ILIO_CSLNK = 27,
+  ILIO_CDLNK = 28,
+  ILIO_CQLNK = 29,
+  ILIO_128LNK = 30,
+  ILIO_256LNK = 31,
+  ILIO_512LNK = 32,
+  ILIO_X87LNK = 33,
+  ILIO_DOUBLEDOUBLELNK = 34,
+  ILIO_FLOAT128LNK = 35
 } ILIO_KIND;
 
-#define ILIO_MAX 33
+#define ILIO_MAX 35
 #define ILIO_ISLINK(n) ((n) >= ILIO_IRLNK)
 
 /* Reflexive defines */
@@ -183,6 +185,7 @@ typedef enum ILIO_KIND {
 #define ILIO_OFF ILIO_OFF
 #define ILIO_NME ILIO_NME
 #define ILIO_IR ILIO_IR
+#define ILIO_HP ILIO_HP
 #define ILIO_SP ILIO_SP
 #define ILIO_DP ILIO_DP
 #define ILIO_CS ILIO_CS
@@ -195,6 +198,7 @@ typedef enum ILIO_KIND {
 #define ILIO_FLOAT128 ILIO_FLOAT128
 #define ILIO_LNK ILIO_LNK
 #define ILIO_IRLNK ILIO_IRLNK
+#define ILIO_HPLNK ILIO_HPLNK
 #define ILIO_SPLNK ILIO_SPLNK
 #define ILIO_DPLNK ILIO_DPLNK
 #define ILIO_ARLNK ILIO_ARLNK
@@ -220,30 +224,32 @@ typedef enum ILIA_RESULT {
   ILIA_TRM = 0,
   ILIA_LNK = 1,
   ILIA_IR = 2,
-  ILIA_SP = 3,
-  ILIA_DP = 4,
-  ILIA_AR = 5,
-  ILIA_KR = 6,
-  ILIA_CC = 7,
-  ILIA_FCC = 8,
-  ILIA_QP = 9,
-  ILIA_CS = 10,
-  ILIA_CD = 11,
-  ILIA_CQ = 12,
-  ILIA_128 = 13,
-  ILIA_256 = 14,
-  ILIA_512 = 15,
-  ILIA_X87 = 16,
-  ILIA_DOUBLEDOUBLE = 17,
-  ILIA_FLOAT128 = 18
+  ILIA_HP = 3,
+  ILIA_SP = 4,
+  ILIA_DP = 5,
+  ILIA_AR = 6,
+  ILIA_KR = 7,
+  ILIA_CC = 8,
+  ILIA_FCC = 9,
+  ILIA_QP = 10,
+  ILIA_CS = 11,
+  ILIA_CD = 12,
+  ILIA_CQ = 13,
+  ILIA_128 = 14,
+  ILIA_256 = 15,
+  ILIA_512 = 16,
+  ILIA_X87 = 17,
+  ILIA_DOUBLEDOUBLE = 18,
+  ILIA_FLOAT128 = 19
 } ILIA_RESULT;
 
-#define ILIA_MAX 18
+#define ILIA_MAX 19
 
 /* Reflexive defines */
 #define ILIA_TRM ILIA_TRM
 #define ILIA_LNK ILIA_LNK
 #define ILIA_IR ILIA_IR
+#define ILIA_HP ILIA_HP
 #define ILIA_SP ILIA_SP
 #define ILIA_DP ILIA_DP
 #define ILIA_AR ILIA_AR
@@ -410,7 +416,7 @@ inline MSZ MSZ_ILI_OPND(int i, int opn) {
   {                                                                   \
     1 /* SBYTE */, 2 /* SHWORD */, 4 /* SWORD */, 8 /* SLWORD */,     \
       1 /* UBYTE */, 2 /* UHWORD */, 4 /* UWORD */, 8 /* ULWORD */,   \
-      0 /* 0x08  */, 0 /* 0x09   */, 4 /* FWORD */, 8 /* FLWORD */,   \
+      0 /* 0x08  */, 2 /* FHALF  */, 4 /* FWORD */, 8 /* FLWORD */,   \
       0 /* 0x0c  */, 0 /* 0x0d   */, 0 /* 0x0e  */, 8 /* I8     */,   \
       0 /* 0x10  */, 0 /* 0x11   */, 0 /* 0x12  */, 8 /* PTR    */,   \
       0 /* 0x14  */, 0 /* 0x15   */, 16 /* F10  */, 16 /* F16   */,   \
@@ -489,7 +495,7 @@ extern bool share_qjsr_ili; /* defd in iliutil.c */
 /* Get MSZ of an IL_LD or IL_ATOMICLDx instruction */
 #define ILI_MSZ_OF_LD(ilix) (ILI_MSZ_FROM_STC(ILI_OPND((ilix), 3)))
 
-/* Get MSZ of an IL_ST, IL_STSP, IL_STDP, or IL_ATOMICSTx instruction */
+/* Get MSZ of an IL_ST, IL_STHP, IL_STSP, IL_STDP, or IL_ATOMICSTx instruction */
 #define ILI_MSZ_OF_ST(ilix) (ILI_MSZ_FROM_STC(ILI_OPND((ilix), 4)))
 
 #include "iliutil.h"

--- a/tools/flang2/flang2exe/regutil.cpp
+++ b/tools/flang2/flang2exe/regutil.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1993-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1993-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -802,7 +802,7 @@ storedums(int exitbih, int first_rat)
       (void)addilt(0, ad3ili(IL_STA, i, addr, nme));
       break;
     case RATA_IR:
-      (void)addilt(0, ad4ili(IL_ST, i, addr, nme, RAT_MSIZE(rat)));
+        (void)addilt(0, ad4ili(IL_ST, i, addr, nme, RAT_MSIZE(rat)));
       break;
     case RATA_KR:
       (void)addilt(0, ad4ili(IL_STKR, i, addr, nme, MSZ_I8));
@@ -1147,7 +1147,6 @@ _assn_rtemp(int ili, int temp)
   }
 
   switch (IL_RES(opc)) {
-
   case ILIA_IR:
     rtype = RCAND_RTYPE(rcand) = RATA_IR;
     RCAND_MSIZE(rcand) = MSZ_WORD;

--- a/tools/flang2/flang2exe/semutil0.cpp
+++ b/tools/flang2/flang2exe/semutil0.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 1997-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,6 +123,7 @@ getrval(int ilmptr)
 
   case IM_IFUNC:
   case IM_KFUNC:
+  case IM_HFFUNC:
   case IM_RFUNC:
   case IM_DFUNC:
   case IM_CFUNC:
@@ -581,7 +582,6 @@ cngcon(INT oldval, DTYPE oldtyp, DTYPE newtyp)
       }
     }
     break;
-
   case TY_REAL:
     if (from == TY_WORD)
       return oldval;
@@ -643,8 +643,9 @@ cngcon(INT oldval, DTYPE oldtyp, DTYPE newtyp)
     else if (from == TY_CMPLX) {
       oldval = CONVAL1G(oldval);
       xdble(oldval, num);
-    } else if (from == TY_REAL)
+    } else if (from == TY_REAL) {
       xdble(oldval, num);
+    }
     else if (from == TY_HOLL || from == TY_CHAR) {
       if (flg.standard && from == TY_CHAR)
         ERR170("conversion of CHARACTER constant to numeric");

--- a/tools/flang2/flang2exe/upper.cpp
+++ b/tools/flang2/flang2exe/upper.cpp
@@ -145,6 +145,7 @@ static const namelist Datatypes[] = {
     "Logical2",  "L2",  TY_SLOG,   "Logical4",   "L4", TY_LOG,
     "Logical8",  "L8",  TY_LOG8,   "Numeric",    "N",  TY_NUMERIC,
     "Pointer",   "P",   TY_PTR,    "proc",       "p",  TY_PROC,
+    "Real2",     "R2",  TY_HALF,  
     "Real4",     "R4",  TY_REAL,   "Real8",      "R8", TY_DBLE,
     "Real16",    "R16", TY_QUAD,   "Struct",     "S",  TY_STRUCT,
     "Word4",     "W4",  TY_WORD,   "Word8",      "W8", TY_DWORD,

--- a/tools/flang2/utils/ilitp/aarch64/ilitp.n
+++ b/tools/flang2/utils/ilitp/aarch64/ilitp.n
@@ -5271,6 +5271,114 @@ End auto parallel region  of an outliend function sym.
 .AT other null trm
 .CG notCG
 
+.IL HFADD hplnk hplnk
+Half-precision floating-point addition.
+.AT arth comm hp cse
+.CG notCG
+
+.IL HFNEG hplnk
+Half-precision negation.
+.AT arth null hp cse
+.CG notCG
+
+.IL HFSUB hplnk hplnk
+Half-precision floating-point subtraction.
+.AT arth null hp cse
+.CG notCG
+
+.IL HFMUL hplnk hplnk
+Half-precision floating-point multiply.
+.AT arth comm hp cse
+.CG notCG
+
+.IL HFDIV hplnk hplnk
+Half-precision divide.
+.AT arth null hp cse
+.CG notCG
+
+.IL HFCMP hplnk hplnk stc
+Half float compare with result of true or false.
+.AT arth null ir cse
+.CG notCG
+
+.IL HFCMPZ hplnk stc
+Half float compare with zero; result is TRUE or FALSE.
+.AT arth null ir cse
+.CG notCG
+
+.IL DFRHP lnk hp
+Define half precision function result.
+.AT define null hp cse
+.CG terminal asm_nop
+
+.IL HFCON sym
+Half-precision floating-point constant.
+.AT cons null hp cse
+.CG notCG
+
+.IL LDHP arlnk nme stc
+Load half-precision floating value.  'stc' is not used.
+.AT load null hp
+.CG notCG
+
+.IL HP2SP hplnk
+Half precison to single precision conversion.
+.AT arth null sp
+.CG notCG
+
+.IL SP2HP splnk
+Single precison to half precision conversion.
+.AT arth null hp
+.CG notCG
+
+.IL DP2HP dplnk
+Double precison to half precision conversion.
+.AT arth null hp
+.CG notCG
+
+.IL STHP hplnk arlnk nme stc
+Store half precision quantity.  'stc' must be MSZ_F2.
+.AT store null trm
+.CG notCG
+
+.IL ARGHP hplnk lnk
+Defines a half-precision memory argument.
+\'hplnk' points to the register value of the argument.
+\'lnk' points to the next ARG ILI.
+.AT define null lnk
+.CG notCG
+
+.IL CSEHP hplnk
+Half precision register cse.
+.AT arth null hp
+.CG notCG
+
+.IL HFCJMP hplnk hplnk stc sym
+Half precision compare and jump to the label 'sym'
+if the condition, denoted by stc, is true.
+.AT branch null trm dom
+.CG terminal conditional_branch notAILI
+
+.IL HFCJMPZ hplnk stc sym
+Half precision compare with zero and branch to label 'sym'.
+.AT branch null trm dom
+.CG notCG conditional_branch
+
+.IL MVHP hplnk ir
+Move half FP value into specific integer register, ir.
+.AT move null trm
+.CG terminal notAILI 'l'
+
+.IL HFMAX hplnk hplnk
+Half-precision max
+.AT arth comm hp cse
+.CG notCG
+
+.IL HFMIN hplnk hplnk
+Half-precision min
+.AT arth comm hp cse
+.CG notCG
+
 .so ilitp_atomic.n
 
 .so ilitp_longdouble.n

--- a/tools/flang2/utils/ilitp/ilitp.cpp
+++ b/tools/flang2/utils/ilitp/ilitp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,8 +71,8 @@ struct processed_flags {
 // delivers the expansion of a line as a group of consecutive lines.
 std::vector<processed_flags> processed;
 
-/*static*/ ILIINFO ilis[1024]; /* declared external in ili.h  */
-SCHINFO schinfo[1024];
+/*static*/ ILIINFO ilis[1050]; /* declared external in ili.h  */
+SCHINFO schinfo[1050];
 
 static void do_IL_line(int pass);
 static void do_AT_line(void);
@@ -483,6 +483,8 @@ do_IL_line(int pass /* 1 or 2 */)
         k = ILIO_IR;
       if (strcmp(token[i], "kr") == 0)
         k = ILIO_KR;
+      if (strcmp(token[i], "hp") == 0)
+        k = ILIO_HP;
       if (strcmp(token[i], "sp") == 0)
         k = ILIO_SP;
       if (strcmp(token[i], "dp") == 0)
@@ -503,6 +505,8 @@ do_IL_line(int pass /* 1 or 2 */)
         k = ILIO_LNK;
       if (strcmp(token[i], "irlnk") == 0)
         k = ILIO_IRLNK;
+      if (strcmp(token[i], "hplnk") == 0)
+        k = ILIO_HPLNK;
       if (strcmp(token[i], "splnk") == 0)
         k = ILIO_SPLNK;
       if (strcmp(token[i], "dplnk") == 0)
@@ -610,6 +614,8 @@ do_AT_line(void)
     attrb |= (ILIA_LNK << 5);
   else if (strcmp("ir", attr3) == 0)
     attrb |= (ILIA_IR << 5);
+  else if (strcmp("hp", attr3) == 0)
+    attrb |= (ILIA_HP << 5);
   else if (strcmp("sp", attr3) == 0)
     attrb |= (ILIA_SP << 5);
   else if (strcmp("dp", attr3) == 0)

--- a/tools/flang2/utils/ilitp/ppc64le/ilitp.n
+++ b/tools/flang2/utils/ilitp/ppc64le/ilitp.n
@@ -5253,6 +5253,114 @@ End auto parallel region  of an outliend function sym.
 .AT other null trm
 .CG notCG
 
+.IL HFADD hplnk hplnk
+Half-precision floating-point addition.
+.AT arth comm hp cse
+.CG notCG
+
+.IL HFNEG hplnk
+Half-precision negation.
+.AT arth null hp cse
+.CG notCG
+
+.IL HFSUB hplnk hplnk
+Half-precision floating-point subtraction.
+.AT arth null hp cse
+.CG notCG
+
+.IL HFMUL hplnk hplnk
+Half-precision floating-point multiply.
+.AT arth comm hp cse
+.CG notCG
+
+.IL HFDIV hplnk hplnk
+Half-precision divide.
+.AT arth null hp cse
+.CG notCG
+
+.IL HFCMP hplnk hplnk stc
+Half float compare with result of true or false.
+.AT arth null ir cse
+.CG notCG
+
+.IL HFCMPZ hplnk stc
+Half float compare with zero; result is TRUE or FALSE.
+.AT arth null ir cse
+.CG notCG
+
+.IL DFRHP lnk hp
+Define half precision function result.
+.AT define null hp cse
+.CG terminal asm_nop
+
+.IL HFCON sym
+Half-precision floating-point constant.
+.AT cons null hp cse
+.CG notCG
+
+.IL LDHP arlnk nme stc
+Load half-precision floating value.  'stc' is not used.
+.AT load null hp
+.CG notCG
+
+.IL HP2SP hplnk
+Half precison to single precision conversion.
+.AT arth null sp
+.CG notCG
+
+.IL SP2HP splnk
+Single precison to half precision conversion.
+.AT arth null hp
+.CG notCG
+
+.IL DP2HP dplnk
+Double precison to half precision conversion.
+.AT arth null hp
+.CG notCG
+
+.IL STHP hplnk arlnk nme stc
+Store half precision quantity.  'stc' must be MSZ_F2.
+.AT store null trm
+.CG notCG
+
+.IL ARGHP hplnk lnk
+Defines a half-precision memory argument.
+\'hplnk' points to the register value of the argument.
+\'lnk' points to the next ARG ILI.
+.AT define null lnk
+.CG notCG
+
+.IL CSEHP hplnk
+Half precision register cse.
+.AT arth null hp
+.CG notCG
+
+.IL HFCJMP hplnk hplnk stc sym
+Half precision compare and jump to the label 'sym'
+if the condition, denoted by stc, is true.
+.AT branch null trm dom
+.CG terminal conditional_branch notAILI
+
+.IL HFCJMPZ hplnk stc sym
+Half precision compare with zero and branch to label 'sym'.
+.AT branch null trm dom
+.CG notCG conditional_branch
+
+.IL MVHP hplnk ir
+Move half FP value into specific integer register, ir.
+.AT move null trm
+.CG terminal notAILI 'l'
+
+.IL HFMAX hplnk hplnk
+Half-precision max
+.AT arth comm hp cse
+.CG notCG
+
+.IL HFMIN hplnk hplnk
+Half-precision min
+.AT arth comm hp cse
+.CG notCG
+
 .so ilitp_float128.n
 
 .so ilitp_longdouble.n

--- a/tools/flang2/utils/ilitp/x86_64/ilitp.n
+++ b/tools/flang2/utils/ilitp/x86_64/ilitp.n
@@ -6605,6 +6605,114 @@ End auto parallel region of an outlined function sym.
 .AT other null trm
 .CG notCG
 
+.IL HFADD hplnk hplnk
+Half-precision floating-point addition.
+.AT arth comm hp cse
+.CG notCG
+
+.IL HFNEG hplnk
+Half-precision negation.
+.AT arth null hp cse
+.CG notCG
+
+.IL HFSUB hplnk hplnk
+Half-precision floating-point subtraction.
+.AT arth null hp cse
+.CG notCG
+
+.IL HFMUL hplnk hplnk
+Half-precision floating-point multiply.
+.AT arth comm hp cse
+.CG notCG
+
+.IL HFDIV hplnk hplnk
+Half-precision divide.
+.AT arth null hp cse
+.CG notCG
+
+.IL HFCMP hplnk hplnk stc
+Half float compare with result of true or false.
+.AT arth null ir cse
+.CG notCG
+
+.IL HFCMPZ hplnk stc
+Half float compare with zero; result is TRUE or FALSE.
+.AT arth null ir cse
+.CG notCG
+
+.IL DFRHP lnk hp
+Define half precision function result.
+.AT define null hp cse
+.CG terminal asm_nop
+
+.IL HFCON sym
+Half-precision floating-point constant.
+.AT cons null hp cse
+.CG notCG
+
+.IL LDHP arlnk nme stc
+Load half-precision floating value.  'stc' is not used.
+.AT load null hp
+.CG notCG
+
+.IL HP2SP hplnk
+Half precison to single precision conversion.
+.AT arth null sp
+.CG notCG
+
+.IL SP2HP splnk
+Single precison to half precision conversion.
+.AT arth null hp
+.CG notCG
+
+.IL DP2HP dplnk
+Double precison to half precision conversion.
+.AT arth null hp
+.CG notCG
+
+.IL STHP hplnk arlnk nme stc
+Store half precision quantity.  'stc' must be MSZ_F2.
+.AT store null trm
+.CG notCG
+
+.IL ARGHP hplnk lnk
+Defines a half-precision memory argument.
+\'hplnk' points to the register value of the argument.
+\'lnk' points to the next ARG ILI.
+.AT define null lnk
+.CG notCG
+
+.IL CSEHP hplnk
+Half precision register cse.
+.AT arth null hp
+.CG notCG
+
+.IL HFCJMP hplnk hplnk stc sym
+Half precision compare and jump to the label 'sym'
+if the condition, denoted by stc, is true.
+.AT branch null trm dom
+.CG terminal conditional_branch notAILI
+
+.IL HFCJMPZ hplnk stc sym
+Half precision compare with zero and branch to label 'sym'.
+.AT branch null trm dom
+.CG notCG conditional_branch
+
+.IL MVHP hplnk ir
+Move half FP value into specific integer register, ir.
+.AT move null trm
+.CG terminal notAILI 'l'
+
+.IL HFMAX hplnk hplnk
+Half-precision max
+.AT arth comm hp cse
+.CG notCG
+
+.IL HFMIN hplnk hplnk
+Half-precision min
+.AT arth comm hp cse
+.CG notCG
+
 .so ilitp_atomic.n
 
 .IL MFENCE

--- a/tools/flang2/utils/ilmtp/aarch64/ilmtp.n
+++ b/tools/flang2/utils/ilmtp/aarch64/ilmtp.n
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (c) 2010-2018, NVIDIA CORPORATION.  All rights reserved.
+.\" * Copyright (c) 2010-2019, NVIDIA CORPORATION.  All rights reserved.
 .\" *
 .\" * Licensed under the Apache License, Version 2.0 (the "License");
 .\" * you may not use this file except in compliance with the License.
@@ -3696,3 +3696,54 @@ End of reduction clause.
 .IL MP_EMAP SMP
 End of map clause.
 .AT spec trm
+.IL HFLD load lnk
+Load half precision
+.AT spec
+.IL HFST store lnk lnk
+Store half precision
+.AT spec trm
+.IL HFCON cons sym
+Half precision constant
+.OP HFCON r v1
+.IL HFADD arth lnk lnk
+Add half precision
+.OP HFADD r p1 p2
+.IL HFMUL arth lnk lnk
+Multiply half precision
+.OP HFMUL r p1 p2
+.IL HFSUB arth lnk lnk
+Subtract half precision
+.OP HFSUB r p1 p2
+.IL HFDIV arth lnk lnk
+Divide half precision
+.OP HFDIV r p1 p2
+.IL HFNEG arth lnk
+Negate half precision
+.OP HFNEG r p1
+.IL R2HF arth lnk
+Convert single precision to half precision
+.OP SP2HP r p1
+.IL D2HF arth lnk
+Convert double precision to half precision
+.OP DP2HP r p1
+.IL HF2R arth lnk
+Convert half precision to single precision
+.OP HP2SP r p1
+.CL HFFUNC proc n lnk lnk*
+Call half precision function
+.AT spec
+.FL HFFUNC proc n sym lnk*
+Call half precision function
+.AT spec
+.IL HFCMP arth lnk lnk
+Compare half precision
+.AT spec
+.FL HFAIF branch lnk sym1 sym2 sym3
+.AT spec trm
+.OP HFCJMPZ null p1 le v2
+.OP HFCJMPZ null p1 eq v3
+.OP HFCJMPZ null p1 gt v4
+.IL HFMAX arth lnk lnk
+.OP HFMAX r p1 p2
+.IL HFMIN arth lnk lnk
+.OP HFMIN r p1 p2

--- a/tools/flang2/utils/ilmtp/ppc64le/ilmtp.n
+++ b/tools/flang2/utils/ilmtp/ppc64le/ilmtp.n
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (c) 2010-2018, NVIDIA CORPORATION.  All rights reserved.
+.\" * Copyright (c) 2010-2019, NVIDIA CORPORATION.  All rights reserved.
 .\" *
 .\" * Licensed under the Apache License, Version 2.0 (the "License");
 .\" * you may not use this file except in compliance with the License.
@@ -3696,3 +3696,54 @@ End of reduction clause.
 .IL MP_EMAP SMP
 End of map clause.
 .AT spec trm
+.IL HFLD load lnk
+Load half precision
+.AT spec
+.IL HFST store lnk lnk
+Store half precision
+.AT spec trm
+.IL HFCON cons sym
+Half precision constant
+.OP HFCON r v1
+.IL HFADD arth lnk lnk
+Add half precision
+.OP HFADD r p1 p2
+.IL HFMUL arth lnk lnk
+Multiply half precision
+.OP HFMUL r p1 p2
+.IL HFSUB arth lnk lnk
+Subtract half precision
+.OP HFSUB r p1 p2
+.IL HFDIV arth lnk lnk
+Divide half precision
+.OP HFDIV r p1 p2
+.IL HFNEG arth lnk
+Negate half precision
+.OP HFNEG r p1
+.IL R2HF arth lnk
+Convert single precision to half precision
+.OP SP2HP r p1
+.IL D2HF arth lnk
+Convert double precision to half precision
+.OP DP2HP r p1
+.IL HF2R arth lnk
+Convert half precision to single precision
+.OP HP2SP r p1
+.CL HFFUNC proc n lnk lnk*
+Call half precision function
+.AT spec
+.FL HFFUNC proc n sym lnk*
+Call half precision function
+.AT spec
+.IL HFCMP arth lnk lnk
+Compare half precision
+.AT spec
+.FL HFAIF branch lnk sym1 sym2 sym3
+.AT spec trm
+.OP HFCJMPZ null p1 le v2
+.OP HFCJMPZ null p1 eq v3
+.OP HFCJMPZ null p1 gt v4
+.IL HFMAX arth lnk lnk
+.OP HFMAX r p1 p2
+.IL HFMIN arth lnk lnk
+.OP HFMIN r p1 p2

--- a/tools/flang2/utils/ilmtp/x86_64/ilmtp.n
+++ b/tools/flang2/utils/ilmtp/x86_64/ilmtp.n
@@ -3648,3 +3648,54 @@ End of reduction clause.
 .IL MP_EMAP SMP
 End of map clause.
 .AT spec trm
+.IL HFLD load lnk
+Load half precision
+.AT spec
+.IL HFST store lnk lnk
+Store half precision
+.AT spec trm
+.IL HFCON cons sym
+Half precision constant
+.OP HFCON r v1
+.IL HFADD arth lnk lnk
+Add half precision
+.OP HFADD r p1 p2
+.IL HFMUL arth lnk lnk
+Multiply half precision
+.OP HFMUL r p1 p2
+.IL HFSUB arth lnk lnk
+Subtract half precision
+.OP HFSUB r p1 p2
+.IL HFDIV arth lnk lnk
+Divide half precision
+.OP HFDIV r p1 p2
+.IL HFNEG arth lnk
+Negate half precision
+.OP HFNEG r p1
+.IL R2HF arth lnk
+Convert single precision to half precision
+.OP SP2HP r p1
+.IL D2HF arth lnk
+Convert double precision to half precision
+.OP DP2HP r p1
+.IL HF2R arth lnk
+Convert half precision to single precision
+.OP HP2SP r p1
+.CL HFFUNC proc n lnk lnk*
+Call half precision function
+.AT spec
+.FL HFFUNC proc n sym lnk*
+Call half precision function
+.AT spec
+.IL HFCMP arth lnk lnk
+Compare half precision
+.AT spec
+.FL HFAIF branch lnk sym1 sym2 sym3
+.AT spec trm
+.OP HFCJMPZ null p1 le v2
+.OP HFCJMPZ null p1 eq v3
+.OP HFCJMPZ null p1 gt v4
+.IL HFMAX arth lnk lnk
+.OP HFMAX r p1 p2
+.IL HFMIN arth lnk lnk
+.OP HFMIN r p1 p2

--- a/tools/flang2/utils/upper/upperilm.in
+++ b/tools/flang2/utils/upper/upperilm.in
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997-2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 1997-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -622,3 +622,19 @@ MP_BREDUCTION
 MP_EREDUCTION
 MP_REDUCTIONITEM sym sym num
 MP_TARGETMODE num
+HFLD	ilm
+HFST	ilm	ilm
+HFCON	sym
+HFADD	ilm	ilm
+HFMUL	ilm	ilm
+HFSUB	ilm	ilm
+HFDIV	ilm	ilm
+HFNEG	ilm
+HFCMP	ilm	ilm
+R2HF	ilm
+D2HF	ilm
+HF2R	ilm
+HFFUNC	num	sym	ilms
+HFUFUNC/HFFUNC	num	sym	args
+HFMIN  ilm ilm
+HFMAX  ilm ilm


### PR DESCRIPTION
Front-end support for REAL(2)

This change contains the majority of infrastructure
to support real2 handling in the frontend.

There is not backend support for REAL(2) in Flang.

Adding ILMs and ILIs for real2 operations:
ILM: R2HF, HF2R, HFLD, HFST, HFCON, HFADD, HFMUL, HFSUB,
     HFDIV, HFNEG, HFFUNC, HFCMP, HFAIF
ILI: HFADD, HFNEG, HFSUB, HFMUL, HFDIV, HFCMP, DFRHP,
     HFCON, LDHP, HP2SP, SP2HP, STHP, ARGHP, CSEHP,
     HFCMPZ, HFCJMP, HFCJMPZ