### PR TITLE
Implement UNROLL directive

### DIFF
--- a/test/f90_correct/nounroll.f90
+++ b/test/f90_correct/nounroll.f90
@@ -1,0 +1,19 @@
+
+!** Test the NOUNROLL pragma
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s -check-prefix=METADATA
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=ENABLE-METADATA
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+ program tz
+      integer :: i
+      integer :: acc(100)
+      integer :: sz
+      !dir$ nounroll
+      do i=1,sz
+            acc(i) = i
+        end do
+       print *, acc(100)
+ end program
+! METADATA: !"llvm.loop.unroll.disable"
+! ENABLE-METADATA-NOT: !"llvm.loop.unroll.disable
+! CHECK: [[BRNCH:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[BRNCH]], %L.LB
+! CHECK: br i1 {{.*}}, label %[[BRNCH]], label %L.LB

--- a/test/f90_correct/nounroll2.f90
+++ b/test/f90_correct/nounroll2.f90
@@ -1,0 +1,19 @@
+
+!** Test checking no pragma
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -S -emit-llvm -O2 %s -o - | FileCheck %s -check-prefix=CHECK2
+ program tz
+      integer :: i
+
+      integer ::acc(10000)
+       do i=1,10000
+            acc(i) = i
+        end do
+       print *, acc(1000)
+ end program
+
+! CHECK: [[BRNCH:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[BRNCH]], %L.LB
+! CHECK: br i1 {{.*}}, label %[[BRNCH]], label %L.LB
+! CHECK-NOT: !llvm.loop ![0-9]
+! CHECK2: vector.body:{{[' ',\t]+}}; preds = %vector.body, %L.
+! CHECK2: br i1 {{.*}}, label %vector.body, !llvm.loop

--- a/test/f90_correct/unroll.f90
+++ b/test/f90_correct/unroll.f90
@@ -1,0 +1,19 @@
+
+!** Test checking unroll pragma
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s -check-prefix=METADATA
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=ENABLE-METADATA
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+      program tz
+       integer :: i
+       integer ::acc(100)
+       !DIR$ unroll
+       do i=1,100
+            acc(i) = 5
+       end do
+      print *, acc(100)
+      end program
+! METADATA: !"llvm.loop.unroll.enable"
+! ENABLE-METADATA-NOT: !"llvm.loop.unroll.enable"
+! CHECK: [[BRNCH:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[BRNCH]], %L.LB
+! CHECK: br i1 {{.*}}, label %[[BRNCH]], label %L.LB
+

--- a/tools/flang2/flang2exe/bih.h
+++ b/tools/flang2/flang2exe/bih.h
@@ -115,6 +115,9 @@ typedef struct {
       unsigned rpct_confl : 1; /* block contains the RPCT conflict loop */
       unsigned rt_guarded : 1; /* block contains runtime guarded loop */
       unsigned doconc : 1;     /* bih is the head of a do concurrent loop */
+      unsigned fill : 2;
+      unsigned unroll : 1;  /* bih contains the unroll set */
+      unsigned nounroll : 1; /* bih contains the no unroll set*/
     } bits;
   } flags2;
   int lpcntFrom;  /* When a loop count temp is created, record the induction
@@ -228,7 +231,8 @@ typedef struct {
 #define BIH_FTAG(i) bihb.stg_base[i].ftag
 #define BIH_BLKCNT(i) bihb.stg_base[i].blkCnt
 #define BIH_AVLPCNT(i) bihb.stg_base[i].aveLpCnt
-
+#define BIH_UNROLL(i) bihb.stg_base[i].flags2.bits.unroll
+#define BIH_NOUNROLL(i) bihb.stg_base[i].flags2.bits.nounroll
 #define EXEC_COUNT double
 #define UNKNOWN_EXEC_CNT -1.0
 

--- a/tools/flang2/flang2exe/bihutil.cpp
+++ b/tools/flang2/flang2exe/bihutil.cpp
@@ -224,7 +224,8 @@ merge_bih_flags(int to_bih, int fm_bih)
   BIH_LDVOL(to_bih) = BIH_LDVOL(to_bih) | BIH_LDVOL(fm_bih);
   BIH_STVOL(to_bih) = BIH_STVOL(to_bih) | BIH_STVOL(fm_bih);
   BIH_NODEPCHK(to_bih) = BIH_NODEPCHK(to_bih) | BIH_NODEPCHK(fm_bih);
-
+  BIH_UNROLL(to_bih) = BIH_UNROLL(to_bih) | BIH_UNROLL(fm_bih);
+  BIH_NOUNROLL(to_bih) = BIH_NOUNROLL(to_bih) | BIH_NOUNROLL(fm_bih);
   if (BIH_TAIL(fm_bih))
     BIH_TAIL(to_bih) = 1;
   if (BIH_LAST(fm_bih))

--- a/tools/flang2/flang2exe/iltutil.cpp
+++ b/tools/flang2/flang2exe/iltutil.cpp
@@ -331,6 +331,12 @@ dump_ilt(FILE *ff, int bihx)
     fprintf(ff, " UJRES");
   if (BIH_SIMD(bihx))
     fprintf(ff, " SIMD");
+  if (BIH_NOSIMD(bihx))
+    fprintf(ff, " NOSIMD");
+  if (BIH_UNROLL(bihx))
+    fprintf(ff, " UNROLL");
+  if (BIH_NOUNROLL(bihx))
+    fprintf(ff, " NOUNROLL");
   if (BIH_LDVOL(bihx))
     fprintf(ff, " LDVOL");
   if (BIH_STVOL(bihx))

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -265,7 +265,7 @@ typedef enum LL_InstrListFlags {
   CALL_FUNC_PTR_FLAG  = (1 << 1),
   CALL_INTRINSIC_FLAG = (1 << 2),
   HIDDEN_ARG_FLAG     = (1 << 3),
-  SIMD_BACKEDGE_FLAG  = (1 << 4), /**< I_BR only */
+  LOOP_BACKEDGE_FLAG  = (1 << 4), /**< I_BR only */
   FAST_MATH_FLAG      = (1 << 4), /**< I_CALL only */
   VOLATILE_FLAG       = (1 << 4), /**< I_LOAD, I_STORE, I_ATOMICRMW,
                                        I_CMPXCHG only */

--- a/tools/flang2/flang2exe/mwd.cpp
+++ b/tools/flang2/flang2exe/mwd.cpp
@@ -4893,6 +4893,9 @@ db(int block)
   putbit("resid", BIH_RESID(block));
   putbit("ujres", BIH_UJRES(block));
   putbit("simd", BIH_SIMD(block));
+  putbit("unroll", BIH_UNROLL(block));
+  putbit("nounroll", BIH_NOUNROLL(block));
+  putbit("nosimd", BIH_NOSIMD(block));
   putbit("ldvol", BIH_LDVOL(block));
   putbit("stvol", BIH_STVOL(block));
   putbit("task", BIH_TASK(block));

--- a/tools/shared/pragma.c
+++ b/tools/shared/pragma.c
@@ -1168,10 +1168,10 @@ do_sw(void)
     typ = gtok();
     if (typ != T_EQUAL) {
       if (no_specified)
+        bset(DIR_OFFSET(currdir, x[11]), 0x400);
+     else
         bset(DIR_OFFSET(currdir, x[11]), 0x3);
-      else
-        bclr(DIR_OFFSET(currdir, x[11]), 0x3);
-    } else if (gtok() == T_IDENT) {
+     } else if (gtok() == T_IDENT) {
       if (strcmp(ctok, "c") == 0)
         i = 9;
       else if (strcmp(ctok, "n") == 0)


### PR DESCRIPTION
Author: Caroline Concatto <caroline.concatto@arm.com>
This patch implements UNROLL pragma.
However in order for it to work it depends on a previous patch #660  
You can use this directive when you want a loop to be unrolled.
 It must be placed immediately before a DO loop.
It works as:
!dir$ unroll