### PR TITLE
Fix ICE interf:new_symbol_and_link, symbol not found

### DIFF
--- a/test/f90_correct/inc/array_constructor.mk
+++ b/test/f90_correct/inc/array_constructor.mk
@@ -1,0 +1,25 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+build:  $(SRC)/array_constructor.f90
+	-$(RM) array_constructor.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	-$(RM) $(OBJ)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	@echo ------------------------------------ building test $@
+
+	# Do two compilations: one with -default-integer-8, which caused an ICE
+	# before https://github.com/flang-compiler/flang/issues/745 was fixed.
+	$(FC)                     $(FFLAGS) $(LDFLAGS) $(SRC)/array_constructor.f90 check.$(OBJX) -o array_constructor.$(EXESUFFIX)
+	$(FC) -fdefault-integer-8 $(FFLAGS) $(LDFLAGS) $(SRC)/array_constructor.f90 check.$(OBJX) -o array_constructor.defaultint8.$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test array_constructor
+	array_constructor.$(EXESUFFIX)
+	array_constructor.defaultint8.$(EXESUFFIX)
+
+verify: ;
+
+array_constructor.run: run

--- a/test/f90_correct/lit/array_constructor.sh
+++ b/test/f90_correct/lit/array_constructor.sh
@@ -1,0 +1,12 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+#
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/array_constructor.f90
+++ b/test/f90_correct/src/array_constructor.f90
@@ -1,0 +1,29 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+module array_constructor_module
+  implicit none
+
+  integer, private :: i
+
+  integer, parameter :: some_array(3) = (/ (i, i = 4241, 4243) /)
+
+end module array_constructor_module
+
+program test
+  use array_constructor_module
+  implicit none
+
+  integer, parameter :: num = 1
+  integer rslts(num), expect(num)
+  data expect / 12726 /
+
+  ! test that summing elements of an array where the array lives in another
+  ! module produces the correct result.
+  rslts(1) = SUM(some_array)
+  call check(rslts, expect, num)
+
+end program

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -6491,7 +6491,7 @@ dinit_getval1(int ast, DTYPE dtype)
     if (dtype == 0)
       dtype = A_DTYPEG(ast);
     aval = const_eval(ast);
-    ast = mk_cval1(aval, A_DTYPEG(ast));
+    ast = mk_cval(aval, A_DTYPEG(ast));
   }
   if (dtype == 0)
     return ast;


### PR DESCRIPTION
Using a parameter array from a module which is constructed with implied-do
notation resulted in an ICE:

```
INTEGER*8, PARAMETER :: some_array(3) = (/ (i, i = 4241, 4243) /)
```

`const_eval()` computes the value of the index `i` in the implied do of the
array constructor. This function was returning a number literal, which was then
being fed into `mk_cval1()`.  This latter function expects a symbol table entry
when the number is a TY_INT8, and a number literal when it is a TY_INT.

This resulted in the number literal as it appeared in the source being
incorrectly treated as a symbol table index.

The fix is to use `mk_cval` which inserts the constant into the symbol table
and calls `mk_cval1` with what it expects.

This commit adds a test which sums an array which lives in another module and
checks that the sum is correct. `INTEGER` is used with `-fdefault-integer-8`,
which is how the issue was first reported.

Fixes https://github.com/flang-compiler/flang/issues/745