### PR TITLE
Merge updates for OpenMP 4.5 support

### DIFF
--- a/include/flang/Error/errmsg.n
+++ b/include/flang/Error/errmsg.n
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (c) 1994-2018, NVIDIA CORPORATION.  All rights reserved.
+.\" * Copyright (c) 1994-2019, NVIDIA CORPORATION.  All rights reserved.
 .\" *
 .\" * Licensed under the Apache License, Version 2.0 (the "License");
 .\" * you may not use this file except in compliance with the License.
@@ -717,3 +717,4 @@ Please update your licenses to use this feature.
 .MS S 1200 "OpenMP GPU - [$] is used, it is not implemented yet."
 .MS S 1201 "OpenMP GPU - [$] is used with [$], this usage is not implemented yet."
 .MS S 1202 "OpenMP GPU - [$] is used independently than [$], this usage is not implemented yet."
+.MS S 1204 "OpenMP GPU - Internal compiler error. Reason: [$] at [$]"

--- a/tools/flang1/flang1exe/dump.c
+++ b/tools/flang1/flang1exe/dump.c
@@ -1184,6 +1184,8 @@ dast(int astx)
     A_ENDLABP(0, 0);
     putnzint("procbind", A_PROCBINDG(0));
     A_PROCBINDP(0, 0);
+    putnzint("num_threads", A_NPARG(0));
+    A_NPARP(0, 0);
     break;
   case A_MP_TEAMS:
     putnzint("lop", A_LOPG(0));

--- a/tools/flang1/flang1exe/flgdf.h
+++ b/tools/flang1/flang1exe/flgdf.h
@@ -76,6 +76,7 @@ FLG flg = {
     FALSE, /* -nosequence */
     25,    /* errorlimit */
     FALSE, /* don't allow smp directives */
+    FALSE,      /* omptarget - don't allow OpenMP Offload directives */
     0,                                     /* tpcount */
     0,          0, 0, 0, 0, 0, 0, 0, 0, 0, /* tpvalue */
 };

--- a/tools/flang1/flang1exe/global.h
+++ b/tools/flang1/flang1exe/global.h
@@ -214,8 +214,8 @@ typedef struct {
   LOGICAL defaulthpf;
   LOGICAL defaultsequence;
   int errorlimit;
-  LOGICAL omptarget;  /* TRUE => allow omp accel directives */
   LOGICAL smp; /* TRUE => allow smp directives */
+  LOGICAL omptarget;  /* TRUE => allow OpenMP Offload directives */
   int tpcount;
   int tpvalue[TPNVERSION]; /* target processor(s), for unified binary */
   int accmp;

--- a/tools/flang1/flang1exe/lowerilm.c
+++ b/tools/flang1/flang1exe/lowerilm.c
@@ -5215,10 +5215,30 @@ lower_stmt(int std, int ast, int lineno, int label)
     }
 
     if(flg.omptarget) {
+      int ilm_numteams=0, ilm_numthreads=0, ilm_threadlimit=0;
+      if(A_NTEAMSG(ast)) {
+        lower_expression(A_NTEAMSG(ast));
+        ilm_numteams = lower_conv(A_NTEAMSG(ast), DT_INT);
+      } else {
+        ilm_numteams = plower("oS", "ICON", lowersym.intzero);
+      }
+      if(A_THRLIMITG(ast)) {
+        lower_expression(A_THRLIMITG(ast));
+        ilm_threadlimit = lower_conv(A_THRLIMITG(ast), DT_INT);
+      } else {
+        ilm_threadlimit = plower("oS", "ICON", lowersym.intzero);
+      }
+      if(A_NPARG(ast)) {
+        lower_expression(A_NPARG(ast));
+        ilm_numthreads = lower_conv(A_NPARG(ast), DT_INT);
+      } else {
+        ilm_numthreads = plower("oS", "ICON", lowersym.intzero);
+      }
       if(A_LOOPTRIPCOUNTG(ast) != 0) {
         lower_omp_target_tripcount(A_LOOPTRIPCOUNTG(ast), std);
       }
-      plower("on", "MP_TARGETMODE", A_COMBINEDTYPEG(ast));
+      plower("oniii", "MP_TARGETMODE", A_COMBINEDTYPEG(ast), ilm_numteams,
+          ilm_threadlimit, ilm_numthreads);
     }
 
     //pragmatype specifies combined type of target.

--- a/tools/flang1/flang1exe/semutil.c
+++ b/tools/flang1/flang1exe/semutil.c
@@ -1540,7 +1540,7 @@ mklvalue(SST *stkptr, int stmt_type)
        with the same name of induction variables.
     */
     if (stmt_type == 0 && flg.smp && (SCG(sptr) != SC_PRIVATE) && 
-            (sem.expect_cuf_do || (sem.collapsed_acc_do && !sem.seq_acc_do))) {
+            sem.expect_cuf_do ) {
        int newsptr;
        newsptr = insert_sym(sptr);
        DCLDP(newsptr, TRUE);

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -13540,13 +13540,13 @@ mp_create_bscope(int reuse)
     return ast;
   }
 newscope:
-  scope_sptr = getccsym('b', sem.blksymnum++, ST_BLOCK);
+  scope_sptr  = getccssym("uplevel", sem.blksymnum++, ST_BLOCK);
   PARSYMSCTP(scope_sptr, 0);
   PARSYMSP(scope_sptr, 0);
   BLK_SCOPE_SPTR(sem.scope_level) = scope_sptr;
 
   /* create a new uplevel_sptr per outlined region */
-  uplevel_sptr = getccsym('b', sem.blksymnum++, ST_BLOCK);
+  uplevel_sptr = getccssym("uplevel", sem.blksymnum++, ST_BLOCK);
   PARSYMSCTP(uplevel_sptr, 0);
   PARSYMSP(uplevel_sptr, 0);
   PARUPLEVELP(scope_sptr, uplevel_sptr);
@@ -13591,7 +13591,7 @@ enter_lexical_block(int gen_debug)
 
   if (gen_debug) {
     if (!sptr) {
-      sptr = getccsym('b', sem.blksymnum++, ST_BLOCK);
+      sptr = getccssym("uplevel", sem.blksymnum++, ST_BLOCK);
       PARSYMSCTP(sptr, 0);
       PARSYMSP(sptr, 0);
     }

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -5428,10 +5428,7 @@ POWER Modifications
 Enable auto initialization of stack memory to 64bit signaling NaNs.
 
 .XF "218:"
-Temporary flags for testing
-.XB 0x01:
-Enable 'collapsed loop' checking in accelerator compiler.
-This flag will be recycled when it works.
+reserved
 
 .XF "220:"
 Enable tuning code for -Minline.
@@ -5439,6 +5436,26 @@ Enable tuning code for -Minline.
 This sets the maximum caller function size into which to Minline.
 .XF "222:"
 Functions whose size if smaller than this value will get inlined by Minline.
+
+.XF "232:"
+OpenMP Accelerator Model flags for Flang compiler
+.XB 0x01:
+Enable outlining for device functions. Compiler creates a extra function for teams, parallel directives in the device.
+.XB 0x02:
+Disable symbol replacer while saving ILM of outlined function. It is enabled normally for OpenMP GPU offload.
+.XB 0x04:
+Disable skipping openmp cpu reduction code generation. We normally skip it since gpu has different implementation.
+.XB 0x08:
+Enable debug information for GPU code. Experimental
+.XB 0x10:
+Init libomptarget library in the main instead of constructor.
+.XB 0x20:
+Enable codegne for push loop trip count for libomptarget runtime.
+.XB 0x40:
+Enable codegen for spmd kernel init.
+
+.XF "233:"
+reserved
 
 .XF "248:"
 OpenMP Threadprivate TLS/TPvector implementation control.
@@ -5455,19 +5472,3 @@ Set number of bigbuffers for multi-buffer memory management for AMD GPU.
 .XF "251:"
 (NOT available - check declaration in global.h for flg.x[], all compilers)
 
-.XF "232:"
-OpenMP Accelerator Model flags on Flang
-.XB 0x01:
-Enable outlining for device functions. Compiler creates a extra function for teams, parallel directives in the device.
-.XB 0x02:
-Disable symbol replacer while saving ILM of outlined function. It is enabled normally for OpenMP GPU offload.
-.XB 0x04:
-Disable skipping openmp cpu reduction code generation. We normally skip it since gpu has different implementation.
-.XB 0x08:
-Enable debug information for GPU code. Experimental
-.XB 0x10:
-Init libomptarget library in the main instead of constructor.
-.XB 0x20:
-Enable codegne for push loop trip count for libomptarget runtime.
-.XB 0x40:
-Enable codegen for spmd kernel init.

--- a/tools/flang2/flang2exe/aarch64-Linux/flgdf.h
+++ b/tools/flang2/flang2exe/aarch64-Linux/flgdf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2014-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,6 @@ FLG flg = {
     0,          /*  def ptr */
     NULL,       /*  search the standard include */
     false,      /* don't allow smp directives */
-    false,      /* don't allow omptarget OpenMP Offload directives */
+    false,      /* omptarget - don't allow OpenMP Offload directives */
     25,         /* errorlimit */
 };

--- a/tools/flang2/flang2exe/expand.cpp
+++ b/tools/flang2/flang2exe/expand.cpp
@@ -43,8 +43,10 @@
 #include "exp_rte.h"
 #include "dtypeutl.h"
 #include "symfun.h"
-#ifdef OMP_OFFLOAD_LLVM
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
 #include "ompaccel.h"
+#endif
+#ifdef OMP_OFFLOAD_LLVM
 #include "tgtutil.h"
 #include "kmpcutil.h"
 #endif
@@ -459,14 +461,13 @@ eval_ilm(int ilmx)
   opcx = ILM_OPC(ilmpx = (ILM *)(ilmb.ilm_base + ilmx));
 
   if (flg.smp) {
-    if (opcx != IM_MP_MAP && opcx != IM_MP_EMAP)
-      if (IM_TYPE(opcx) != IMTY_SMP && ll_rewrite_ilms(-1, ilmx, 0)) {
-        if (ilmx == 0 && opcx == IM_BOS) {
-          /* Set line no for EPARx */
-          gbl.lineno = ILM_OPND(ilmpx, 1);
-        }
-        return;
+    if (IM_TYPE(opcx) != IMTY_SMP && ll_rewrite_ilms(-1, ilmx, 0)) {
+      if (ilmx == 0 && opcx == IM_BOS) {
+        /* Set line no for EPARx */
+        gbl.lineno = ILM_OPND(ilmpx, 1);
       }
+      return;
+    }
   }
 
   if (EXPDBG(8, 2))
@@ -475,7 +476,7 @@ eval_ilm(int ilmx)
   if (!ll_ilm_is_rewriting())
   {
 #ifdef OMP_OFFLOAD_LLVM
-    if (flg.omptarget && gbl.inomptarget) {
+    if (flg.omptarget && gbl.ompaccel_intarget) {
       if (opcx == IM_MP_BREDUCTION) {
         ompaccel_notify_reduction(true);
         exp_ompaccel_reduction(ilmpx, ilmx);
@@ -639,7 +640,7 @@ eval_ilm(int ilmx)
     /* We do not initialize spmd kernel library since we do not use spmd data
      * sharing model. It does extra work and allocates device on-chip memory.
      * */
-    if (XBIT(232, 0x40) && gbl.inomptarget) {
+    if (XBIT(232, 0x40) && gbl.ompaccel_intarget) {
       ilix = ompaccel_nvvm_get(threadIdX);
       ilix = ll_make_kmpc_spmd_kernel_init(ilix);
       iltb.callfg = 1;

--- a/tools/flang2/flang2exe/expsmp.cpp
+++ b/tools/flang2/flang2exe/expsmp.cpp
@@ -42,7 +42,7 @@
 #include "llassem.h"
 #include "ll_ftn.h"
 #include "llmputil.h"
-#ifdef OMP_OFFLOAD_LLVM
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
 #include "ompaccel.h"
 #include "tgtutil.h"
 #endif
@@ -958,10 +958,16 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
   static SPTR uplevel_sptr;
   static SPTR single_thread;
   static SPTR in_single;
+  static SPTR targetfunc_sptr = SPTR_NULL, targetdevice_func_sptr = SPTR_NULL;
   SPTR nlower, nupper, nstride;
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
+  static int target_ili_num_threads = 0;
+  static int target_ili_num_teams= 0;
+  static int target_ili_thread_limit= 0;
+#endif
   int sz;
   ISZ_T size, num_elements;
-
+  static int isTargetDevice = 0;
   switch (opc) {
   case IM_BPAR:
   case IM_BPARN:
@@ -1009,7 +1015,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
   case IM_BPARN:
   case IM_BPARA:
 #ifdef OMP_OFFLOAD_LLVM
-      if (flg.omptarget && gbl.inomptarget) {
+      if (flg.omptarget && gbl.ompaccel_intarget) {
         exp_ompaccel_bpar(ilmp, curilm, uplevel_sptr, scopeSptr, incrOutlinedCnt);
         break;
       }
@@ -1028,11 +1034,12 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
       int isPar = ILI_OF(ILM_OPND(ilmp, 1));
       SPTR par_label, end_label;
       int iliarg, nthreads, proc_bind;
-      sptr = ll_make_outlined_func(uplevel_sptr, scopeSptr);
-      if (!PARENCLFUNCG(scopeSptr))
-        PARENCLFUNCP(scopeSptr, sptr);
-
-      ll_write_ilm_header(sptr, curilm);
+      {
+        sptr = ll_make_outlined_func_wopc((SPTR)uplevel_sptr, scopeSptr, opc);
+        if (!PARENCLFUNCG(scopeSptr))
+          PARENCLFUNCP(scopeSptr, sptr);
+      }
+        ll_write_ilm_header(sptr, curilm);
       iliarg = ll_load_outlined_args(scopeSptr, sptr, gbl.outlined);
 
       /* if (isPar == 0)
@@ -1094,7 +1101,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
         iltb.callfg = 1;
         chk_block(ili);
       }
-      ili = ll_make_kmpc_fork_call(sptr, 1, &iliarg, OPENMP, -1);
+        ili = ll_make_kmpc_fork_call(sptr, 1, &iliarg, OPENMP, -1);
       iltb.callfg = 1;
       chk_block(ili);
 
@@ -1189,7 +1196,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
   case IM_BTEAMS:
   case IM_BTEAMSN:
 #ifdef OMP_OFFLOAD_LLVM
-      if(flg.omptarget && gbl.inomptarget) {
+      if(flg.omptarget && gbl.ompaccel_intarget) {
         exp_ompaccel_bteams(ilmp, curilm, outlinedCnt, uplevel_sptr, scopeSptr, incrOutlinedCnt);
         break;
       }
@@ -1207,11 +1214,12 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
     if (outlinedCnt == 1) {
       SPTR par_label;
       int iliarg, nteams, n_limit;
-      sptr = ll_make_outlined_func((SPTR)uplevel_sptr, scopeSptr);
+      {
+        sptr = ll_make_outlined_func_wopc((SPTR)uplevel_sptr, scopeSptr, opc);
+      }
       if (!PARENCLFUNCG(scopeSptr))
         PARENCLFUNCP(scopeSptr, sptr);
-
-      ll_write_ilm_header(sptr, curilm);
+        ll_write_ilm_header(sptr, curilm);
       iliarg = ll_load_outlined_args(scopeSptr, sptr, gbl.outlined);
 
       par_label = getlab();
@@ -1242,7 +1250,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
   case IM_BTARGET:
 #ifdef OMP_OFFLOAD_LLVM
       if (flg.omptarget) {
-        exp_ompaccel_btarget(ilmp, curilm, uplevel_sptr, scopeSptr, incrOutlinedCnt);
+        exp_ompaccel_btarget(ilmp, curilm, uplevel_sptr, scopeSptr, incrOutlinedCnt, &targetfunc_sptr, &isTargetDevice);
         break;
       }
 #endif
@@ -1260,54 +1268,59 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
     BIH_QJSR(expb.curbih) = true;
     BIH_NOMERGE(expb.curbih) = true;
     if (outlinedCnt == 1) {
-      int isPar = ILI_OF(ILM_OPND(ilmp, 1));
-      int par_label, end_label, iliarg;
-      sptr = ll_make_outlined_func((SPTR)uplevel_sptr, scopeSptr);
+      isTargetDevice = ILI_OF(ILM_OPND(ilmp, 1));
+      targetfunc_sptr = ll_make_outlined_func_wopc((SPTR)uplevel_sptr, scopeSptr, opc);
       if (!PARENCLFUNCG(scopeSptr))
-        PARENCLFUNCP(scopeSptr, sptr);
-      ll_write_ilm_header(sptr, curilm);
-      iliarg = ll_load_outlined_args(scopeSptr, sptr, gbl.outlined);
-
-      /* if (isPar == 0)
-             call host_version(.....)
-             goto do_end;
-         par_label:
-             call target_offload (....., target_version_func_ptr,.... )
-         do_label:
-       */
-
-      par_label = getlab();
-      end_label = getlab();
-
-      ili = ll_make_outlined_call2(sptr, iliarg);
-      iltb.callfg = 1;
-      chk_block(ili);
+        PARENCLFUNCP(scopeSptr, targetfunc_sptr);
+      ll_write_ilm_header(targetfunc_sptr, curilm);
     }
     ccff_info(MSGOPENMP, "OMP020", gbl.findex, gbl.lineno,
               "Target region activated", NULL);
     break;
   case IM_ETARGET:
-#ifdef OMP_OFFLOAD_LLVM
-      if(flg.omptarget) {
-        exp_ompaccel_etarget(ilmp, curilm, outlinedCnt, (SPTR)uplevel_sptr, decrOutlinedCnt);
-        break;
-      }
-#endif
     if (outlinedCnt == 1) {
       ilm_outlined_pad_ilm(curilm);
     }
     decrOutlinedCnt();
-    if (outlinedCnt >= 1)
+    if (outlinedCnt >= 1) {
       ll_rewrite_ilms(-1, curilm, 0);
-
+      break;
+    }
     if (gbl.outlined)
       expb.sc = SC_AUTO;
+
+    SPTR par_label, end_label;
+    int iliarg;
+
+#ifdef OMP_OFFLOAD_LLVM
+    if(flg.omptarget) {
+      assert(targetfunc_sptr != SPTR_NULL,
+           "Outlined function of target region is not found.", GBL_CURRFUNC, ERR_Fatal);
+      // In Flang, We outline the region once, and offload it in the device
+      // We don't generate outlined function for the host. so we don't have host fallback.
+      exp_ompaccel_etarget(ilmp, curilm, targetfunc_sptr, outlinedCnt, (SPTR) uplevel_sptr, decrOutlinedCnt);
+      break;
+    }
+#endif
+
+    {
+      assert(targetfunc_sptr != SPTR_NULL,
+           "Outlined function of target region is not found.", GBL_CURRFUNC, ERR_Fatal);
+      // When OpenMP Offload is not enabled, we simply call host outlined function.
+      iliarg = ll_load_outlined_args(scopeSptr, targetfunc_sptr, gbl.outlined);
+      ili = ll_make_outlined_call2(targetfunc_sptr, iliarg);
+      iltb.callfg = 1;
+      chk_block(ili);
+      wr_block();
+      cr_block();
+    }
+    targetfunc_sptr = SPTR_NULL;
     ccff_info(MSGOPENMP, "OMP021", gbl.findex, gbl.lineno,
               "Target region terminated", NULL);
     break;
   case IM_EPAR:
 #ifdef OMP_OFFLOAD_LLVM
-      if (flg.omptarget && gbl.inomptarget) {
+      if (flg.omptarget && gbl.ompaccel_intarget) {
         exp_ompaccel_epar(ilmp, curilm, outlinedCnt, decrOutlinedCnt);
         break;
       }
@@ -1512,7 +1525,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
     if (outlinedCnt >= 1)
       break;
 #ifdef OMP_OFFLOAD_LLVM
-      if (flg.omptarget && gbl.inomptarget) {
+      if (flg.omptarget && gbl.ompaccel_intarget) {
         exp_ompaccel_mploop(ilmp, curilm);
         break;
       }
@@ -2666,10 +2679,9 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
   case IM_BTARGETDATA:
   case IM_TARGETENTERDATA:
   case IM_TARGETEXITDATA:
-#ifdef OMP_OFFLOAD_LLVM
-      if(flg.omptarget)
-        exp_ompaccel_targetdata(ilmp, curilm, opc);
-#endif
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
+    if(!flg.omptarget)
+      break;
     dotarget = ILI_OF(ILM_OPND(ilmp, 1));
     beg_label = getlab();
     end_label = getlab();
@@ -2682,14 +2694,18 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
     cr_block();
     exp_label(beg_label);
 
-    /* .... TODO: call to runtime target data here  */
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
+    if(!IS_OMP_DEVICE_CG)
+      exp_ompaccel_targetdata(ilmp, curilm, opc);
+#endif
 
     exp_label(end_label);
-
+#endif
     break;
   case IM_ETARGETDATA:
-#ifdef OMP_OFFLOAD_LLVM
-      if(flg.omptarget)
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
+    if(!flg.omptarget) break;
+    if(!IS_OMP_DEVICE_CG)
         exp_ompaccel_etargetdata(ilmp, curilm);
       break;
 #endif
@@ -2778,31 +2794,38 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
   case IM_ETASKFIRSTPRIV:
     break;
 #endif
-#ifdef OMP_OFFLOAD_LLVM
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
     case IM_MP_MAP:
-      if (flg.omptarget) {
+      if(!flg.omptarget) break;
         exp_ompaccel_map(ilmp, curilm, outlinedCnt);
-      }
       break;
     case IM_MP_TARGETLOOPTRIPCOUNT:
-      if (flg.omptarget)
-        exp_ompaccel_looptripcount(ilmp, curilm);
+      if(!flg.omptarget) break;
+      exp_ompaccel_looptripcount(ilmp, curilm);
       break;
     case IM_MP_EMAP:
-      if(flg.omptarget)
+      if(!flg.omptarget) break;
         exp_ompaccel_emap(ilmp, curilm);
       break;
     case IM_MP_REDUCTIONITEM:
-      if (flg.omptarget && gbl.inomptarget)
+      if (flg.omptarget && gbl.ompaccel_intarget)
         exp_ompaccel_reductionitem(ilmp, curilm);
       break;
     case IM_MP_TARGETMODE:
       ompaccel_tinfo_set_mode_next_target((OMP_TARGET_MODE)ILM_OPND(ilmp, 1));
+      target_ili_num_teams = ILI_OF(ILM_OPND(ilmp, 2));
+      target_ili_thread_limit = ILI_OF(ILM_OPND(ilmp, 3));
+      target_ili_num_threads = ILI_OF(ILM_OPND(ilmp, 4));
       break;
     case IM_MP_BREDUCTION:
       break;
     case IM_MP_EREDUCTION:
       break;
+    break;
+    case IM_MP_END_DIR:
+      break;
+    case IM_MP_BEGIN_DIR:
+break;
 #endif
     default:
       interr("exp_smp: unsupported opc", opc, ERR_Severe);
@@ -2882,7 +2905,7 @@ static int
 addMpBcsNest(void)
 {
   int ili;
-  ili = makeCall("_mp_bcs_nest", IL_JSR, 0);
+  ili = makeCall("_mp_bcs_nest_red", IL_JSR, 0);
   return ili;
 }
 
@@ -2890,7 +2913,7 @@ static int
 addMpEcsNest(void)
 {
   int ili;
-  ili = makeCall("_mp_ecs_nest", IL_JSR, 0);
+  ili = makeCall("_mp_ecs_nest_red", IL_JSR, 0);
   return ili;
 }
 
@@ -3029,7 +3052,8 @@ decrOutlinedCnt(void)
 {
   outlinedCnt--;
   if (outlinedCnt == 0) {
-    ll_write_ilm_end();
+      ll_write_ilm_end();
+    unsetRewritingILM();
   }
   return outlinedCnt;
 }

--- a/tools/flang2/flang2exe/kmpcutil.cpp
+++ b/tools/flang2/flang2exe/kmpcutil.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2016-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -630,7 +630,7 @@ ll_make_kmpc_generic_ptr_int(int kmpc_api)
   DTYPE arg_types[2] = {DT_CPTR, DT_INT};
   args[1] = gen_null_arg();
 #ifdef OMP_OFFLOAD_LLVM
-  if (gbl.inomptarget)
+  if (gbl.ompaccel_intarget)
     args[0] = ompaccel_nvvm_get_gbl_tid();
   else
 #endif
@@ -1496,7 +1496,7 @@ ll_make_kmpc_atomic_read(int *opnd, DTYPE dtype)
   return 0;
 }
 
-#ifdef OMP_OFFLOAD_LLVM
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
 
 static DTYPE
 create_dtype_funcprototype()

--- a/tools/flang2/flang2exe/kmpcutil.h
+++ b/tools/flang2/flang2exe/kmpcutil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2016-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,7 +160,7 @@ enum {
   KMPC_API_PUSH_PROC_BIND,
   KMPC_API_ATOMIC_RD,
   KMPC_API_ATOMIC_WR,
-  /* OpenMP Accelerator RT (libomptarget-nvptx) - non standard - */
+  /* Begin - OpenMP Accelerator RT (libomptarget-nvptx) - non standard - */
   KMPC_API_PUSH_TARGET_TRIPCOUNT,
   KMPC_API_FOR_STATIC_INIT_SIMPLE_SPMD,
   KMPC_API_SPMD_KERNEL_INIT,
@@ -169,6 +169,7 @@ enum {
   KMPC_API_SHUFFLE_I64,
   KMPC_API_NVPTX_PARALLEL_REDUCE_NOWAIT_SIMPLE_SPMD,
   KMPC_API_NVPTX_END_REDUCE_NOWAIT,
+  /* End - OpenMP Accelerator RT (libomptarget-nvptx) - non standard - */
   KMPC_API_N_ENTRIES /* <-- Always last */
 };
 
@@ -444,7 +445,7 @@ void reset_kmpc_ident_dtype(void);
 
 /* OpenMP Accelerator RT - non standard */
 /* Only Available for linomptarget-nvptx device runtime */
-#ifdef OMP_OFFLOAD_LLVM
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
 /**
    \brief cuda special register shuffling for int 32 or int 64
  */

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -709,7 +709,7 @@ ll_convert_dtype_with_addrspace(LL_Module *module, DTYPE dtype, int addrspace)
   return convert_dtype(module, dtype, addrspace);
 }
 
-static int
+bool
 llis_integral_kind(DTYPE dtype)
 {
   switch (DTY(dtype)) {
@@ -745,13 +745,13 @@ llis_integral_kind(DTYPE dtype)
   return 0;
 }
 
-INLINE static bool
+bool
 llis_pointer_kind(DTYPE dtype)
 {
   return (DTY(dtype) == TY_PTR);
 }
 
-static bool
+bool
 llis_array_kind(DTYPE dtype)
 {
   switch (DTY(dtype)) {
@@ -772,13 +772,13 @@ llis_dummied_arg(SPTR sptr)
          (llis_pointer_kind(DTYPEG(sptr)) || llis_array_kind(DTYPEG(sptr)));
 }
 
-INLINE static bool
+bool
 llis_vector_kind(DTYPE dtype)
 {
   return (DTY(dtype) == TY_VECT);
 }
 
-static bool
+bool
 llis_struct_kind(DTYPE dtype)
 {
   switch (DTY(dtype)) {
@@ -794,7 +794,7 @@ llis_struct_kind(DTYPE dtype)
   return false;
 }
 
-static bool
+bool
 llis_function_kind(DTYPE dtype)
 {
   switch (DTY(dtype)) {
@@ -4074,7 +4074,7 @@ get_ftn_dummy_lltype(int sptr)
     const int midnum = MIDNUMG(sptr);
     LL_Type *llt = make_generic_dummy_lltype();
 #ifdef OMP_OFFLOAD_LLVM
-    const bool is_nvvm = gbl.isnvvmcodegen && PASSBYVALG(midnum);
+    const bool is_nvvm = gbl.ompaccel_isdevice && PASSBYVALG(midnum);
 #else
     const bool is_nvvm = false;
 #endif

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -1561,6 +1561,13 @@ void write_type(LL_Type *ll_type);
 /// \param aop   an ATOMIC_RMW_OP value
 LL_InstrListFlags ll_instr_flags_from_aop(ATOMIC_RMW_OP aop);
 
+bool llis_integral_kind(DTYPE dtype);
+bool llis_pointer_kind(DTYPE dtype);
+bool llis_array_kind(DTYPE dtype);
+bool llis_vector_kind(DTYPE dtype);
+bool llis_struct_kind(DTYPE dtype);
+bool llis_function_kind(DTYPE dtype);
+
 #ifdef OMP_OFFLOAD_LLVM
 /**
    \brief Create a file to write the device code if it has not already been created,

--- a/tools/flang2/flang2exe/mwd.cpp
+++ b/tools/flang2/flang2exe/mwd.cpp
@@ -1136,6 +1136,10 @@ dsym(int sptr)
       putbit("ompaccel-host", OMPACCSTRUCTG(0));
       OMPACCSTRUCTP(0, 0);
 #endif
+#ifdef OMPACCLITERALG
+    putbit("ompaccel-literal", OMPACCLITERALG(0));
+    OMPACCLITERALP(0, 0);
+#endif
 #ifdef SOCPTRG
     socptr = SOCPTRG(0);
     putnzint("socptr", SOCPTRG(0));
@@ -1544,6 +1548,10 @@ dsym(int sptr)
 #ifdef PARREFLOADG
     putbit("parrefload", PARREFLOADG(0));
     PARREFLOADP(0, 0);
+#endif
+#ifdef OMPTEAMPRIVATEG
+    putbit("team-private", OMPTEAMPRIVATEG(0));
+    OMPTEAMPRIVATEP(0, 0);
 #endif
 /*
         putbit( "#", #G(0) );		#P(0,0);

--- a/tools/flang2/flang2exe/ompaccel.cpp
+++ b/tools/flang2/flang2exe/ompaccel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,9 @@
 
 /**
  *  \file
- *  \brief ompaccel.c - OpenMP GPU Offload for NVVM Targets. It uses
- * libomptarget
+ *  \brief ompaccel.c - OpenMP Target Accelerator
  */
-#ifdef OMP_OFFLOAD_LLVM
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
 
 #include "kmpcutil.h"
 #include "error.h"
@@ -50,15 +49,16 @@
 #include "llassem.h"
 #include "ll_ftn.h"
 #include "symfun.h"
-#include "../../flang1/flang1exe/global.h"
 
-#define NOT_IMPLEMENTED(_pragma) \
-  error((error_code_t)1200, ERR_Fatal, 0, _pragma, NULL)
-#define NOT_IMPLEMENTED_CANTCOMBINED(_pragma, _pragma2) \
-  error((error_code_t)1201, ERR_Fatal, 0, _pragma, _pragma2)
-#define NOT_IMPLEMENTED_NEEDCOMBINED(_pragma, _pragma2) \
-  error((error_code_t)1202, ERR_Fatal, 0, _pragma, _pragma2)
-
+void
+_ompaccelInternalFail(const char *message, const char *location)
+{
+  error((error_code_t)1204, ERR_Fatal, 0, message, location);
+}
+void
+_ompaccelInternalFailures(const char *location, int numargs, char *format, ...)
+{
+}
 /* Initial Max target region */
 #define INC_EXP 2
 int tinfo_size = 50;
@@ -66,8 +66,10 @@ int tinfo_size_reductions = 10;
 
 int num_tinfos = 0;
 OMPACCEL_TINFO **tinfos;
-OMPACCEL_TINFO *current_tinfo = nullptr;
+OMPACCEL_TINFO *current_tinfo = NULL;
 OMP_TARGET_MODE NextTargetMode = mode_none_target;
+
+static OMPACCEL_TINFO *tinfo_create(SPTR func_sptr, SPTR device_sptr, int max_nargs, ILM_OP opc);
 
 const char *nvvm_target_triple;
 void
@@ -101,7 +103,7 @@ _long_unsigned(int lilix, int *dt, bool *punsigned, DTYPE dtype)
     *dt = 4;
   }
 
-  // todo ompaccel I don't know how to handle others
+  // todo ompaccel: don't know how to handle others
 
   switch (DTY(dtype)) {
   case TY_UINT:
@@ -178,18 +180,14 @@ mk_ompaccel_load(int ili, DTYPE dtype, int nme)
         return ad3ili(IL_LDKR, ili, nme, MSZ_F8);
       else
         return ad3ili(IL_LDSP, ili, nme, MSZ_F8);
-      break;
     case DT_DBLE:
       return ad3ili(IL_LDDP, ili, nme, MSZ_DBLE);
-      break;
     case DT_CMPLX:
       return ad3ili(IL_LDDCMPLX, ili, nme, MSZ_F16);
-      break;
     case DT_NONE:
       return ad3ili(IL_LD, ili, nme, MSZ_WORD);
-      break;
     default:
-      return 0;
+      ompaccelInternalFail("unknown type");
       break;
     }
   }
@@ -210,24 +208,18 @@ mk_ompaccel_store(int ili_value, DTYPE dtype, int nme, int ili_address)
     switch (dtype) {
     case DT_LOG:
       return ad4ili(IL_ST, ili_value, ili_address, nme, MSZ_WORD);
-      break;
     case DT_INT:
       return ad4ili(IL_ST, ili_value, ili_address, nme, MSZ_WORD);
-      break;
     case DT_REAL:
       return ad4ili(IL_STSP, ili_value, ili_address, nme, MSZ_F4);
-      break;
     case DT_DBLE:
       return ad4ili(IL_STDP, ili_value, ili_address, nme, MSZ_DBLE);
-      break;
     case DT_INT8:
       return ad4ili(IL_STKR, ili_value, ili_address, nme, MSZ_I8);
-      break;
     case DT_NONE:
       return ad4ili(IL_ST, ili_value, ili_address, nme, MSZ_WORD);
-      break;
     default:
-      return 0;
+      ompaccelInternalFail("unknown type");
       break;
     }
   }
@@ -309,7 +301,8 @@ mk_ompaccel_shift(int ili1, DTYPE dtype1, int ili2, DTYPE dtype2)
     else if (dt == 2)
       opc = IL_KURSHIFT;
   }
-  assert(opc != IL_NONE, "Correct IL is not found.", 0, ERR_Fatal);
+  if (opc == IL_NONE)
+    ompaccelInternalFail("Correct ILI is not found.");
   return ad2ili(opc, ili1, ili2);
 }
 
@@ -338,7 +331,8 @@ mk_ompaccel_compare(int ili1, DTYPE dtype1, int ili2, DTYPE dtype2, int CC)
     else if (dt == 2)
       opc = IL_UKCMP;
   }
-  assert(opc != IL_NONE, "Correct IL is not found.", 0, ERR_Fatal);
+  if (opc == IL_NONE)
+    ompaccelInternalFail("Correct ILI is not found.");
   return ad3ili(opc, ili1, ili2, CC);
 }
 
@@ -378,7 +372,8 @@ mk_ompaccel_add(int ili1, DTYPE dtype1, int ili2, DTYPE dtype2)
         opc = IL_UKADD;
     }
   }
-  assert(opc != IL_NONE, "Correct IL is not found.", 0, ERR_Fatal);
+  if (opc == IL_NONE)
+    ompaccelInternalFail("Correct ILI is not found.");
   return ad2ili(opc, ili1, ili2);
 } /* mk_ompaccel_add */
 
@@ -419,7 +414,8 @@ mk_ompaccel_mul(int ili1, DTYPE dtype1, int ili2, DTYPE dtype2)
         opc = IL_UKMUL;
     }
   }
-  assert(opc != IL_NONE, "Correct IL is not found.", 0, ERR_Fatal);
+  if (opc == IL_NONE)
+    ompaccelInternalFail("Correct ILI is not found.");
   return ad2ili(opc, ili1, ili2);
 } /* mk_ompaccel_mul */
 
@@ -462,7 +458,7 @@ mk_ompaccel_function_end(SPTR func_sptr)
   RFCNTP(endlab, 1);
   CCSYMP(endlab, 1);
   ILIBLKP(endlab, bihx);
-  BIH_LABEL(bihx) = SPTR(endlab);
+  BIH_LABEL(bihx) = (SPTR)endlab;
 }
 
 static SPTR
@@ -471,6 +467,7 @@ mk_ompaccel_function(char *name, int n_params, const SPTR *param_sptrs,
 {
   /* Create a function symbol along with parameters */
   int dpdscp, bihx;
+  int i;
   SPTR func_sptr, sym;
   func_sptr = getsymbol(name);
   TASKFNP(func_sptr, FALSE);
@@ -493,7 +490,7 @@ mk_ompaccel_function(char *name, int n_params, const SPTR *param_sptrs,
   NEED(aux.dpdsc_avl, aux.dpdsc_base, int, aux.dpdsc_size,
        aux.dpdsc_size + n_params + 100);
 
-  for (int i = 0; i < n_params; ++i) {
+  for (i = 0; i < n_params; ++i) {
     sym = param_sptrs[i];
     aux.dpdsc_base[dpdscp++] = sym;
   }
@@ -532,7 +529,8 @@ mk_reduction_op(int redop, int lili, DTYPE dtype1, int rili, DTYPE dtype2)
   case 3:
     return mk_ompaccel_mul(lili, dtype1, rili, dtype2);
   default:
-    static_assert(true, "Rest of reduction operators are not implemented yet.");
+    ompaccelInternalFail(
+        "Rest of reduction operators are not implemented yet.");
     break;
   }
   return 0;
@@ -561,7 +559,7 @@ open_OMP_OFFLOAD_LLVM_file()
 {
   FILE *F;
   F = fopen(gbl.ompaccfilename, "w");
-  if (F == nullptr) {
+  if (F == NULL) {
 #if DEBUG
     fprintf(stderr, "Trying to open temp file %s\n", gbl.ompaccfilename);
 #endif
@@ -592,8 +590,10 @@ create_sregs(const char *name)
 void
 ompaccel_init()
 {
+#ifdef OMP_OFFLOAD_LLVM
   /* Create file to write device code */
   open_OMP_OFFLOAD_LLVM_file();
+#endif
   /* Create target pool */
   tinfos = (OMPACCEL_TINFO **)sccrelal(
       (char *)tinfos, ((BIGUINT64)((tinfo_size) * sizeof(OMPACCEL_TINFO *))));
@@ -602,6 +602,7 @@ ompaccel_init()
 void
 ompaccel_initsyms()
 {
+#if   OMP_OFFLOAD_LLVM
   /* Create thread id sreg symbols */
   init_nvvm_syms = create_sregs(NVVM_SREG[threadIdX]);
   create_sregs(NVVM_SREG[threadIdY]);
@@ -624,15 +625,16 @@ ompaccel_initsyms()
   /* Create llvm intrinsics symbols */
   init_nvvm_intrinsics = create_nvvm_sym(NVVM_INTRINSICS[barrier0], DT_NONE);
   create_nvvm_sym(NVVM_INTRINSICS[barrier], DT_NONE);
+#endif
 }
 
 int
 ompaccel_nvvm_get(nvvm_sregs sreg)
 {
-  SPTR sptr = SPTR(init_nvvm_syms + sreg);
-  ll_make_ftn_outlined_params(sptr, 0, nullptr);
+  SPTR sptr = (SPTR)(init_nvvm_syms + sreg);
+  ll_make_ftn_outlined_params(sptr, 0, NULL);
   ll_process_routine_parameters(sptr);
-  return ll_ad_outlined_func2(IL_DFRIR, IL_JSR, sptr, 0, nullptr);
+  return ll_ad_outlined_func2(IL_DFRIR, IL_JSR, sptr, 0, NULL);
 }
 
 int
@@ -643,9 +645,9 @@ ompaccel_nvvm_mk_barrier(nvvm_barriers btype)
     sptr = (SPTR)(init_nvvm_intrinsics + barrier0);
     ll_make_ftn_outlined_params(sptr, 0, 0);
     ll_process_routine_parameters(sptr);
-    return ll_ad_outlined_func2(IL_NONE, IL_JSR, sptr, 0, nullptr);
+    return ll_ad_outlined_func2(IL_NONE, IL_JSR, sptr, 0, NULL);
   }
-  static_assert(true, "Other nvvm intrinsics are not implemented yet.");
+  ompaccelInternalFail("Other nvvm intrinsics are not implemented yet.");
 }
 
 int
@@ -669,7 +671,91 @@ ompaccel_nvvm_get_gbl_tid()
 void
 ompaccel_tinfo_current_set_mode(OMP_TARGET_MODE type)
 {
+  if (current_tinfo == NULL)
+    ompaccelInternalFail("Current target info is empty");
   current_tinfo->mode = type;
+}
+
+static OMPACCEL_TINFO *
+_ompaccel_tinfo_get_byside(int func_sptr)
+{
+  int i;
+  for (i = 0; i < num_tinfos; ++i) {
+    if (tinfos[i]->device_sptr == func_sptr) {
+      return tinfos[i];
+    }
+  }
+  return NULL;
+}
+
+OMPACCEL_TINFO *
+ompaccel_tinfo_get_by_device(int device_func_sptr)
+{
+  return _ompaccel_tinfo_get_byside(device_func_sptr);
+}
+
+SPTR
+ompaccel_tinfo_get_nested_side(int func_sptr)
+{
+  OMPACCEL_TINFO *ctinfo = _ompaccel_tinfo_get_byside(func_sptr);
+  if (ctinfo == NULL)
+    ompaccelInternalFail("The tinfo is empty");
+  if (ctinfo->child_tinfos == NULL)
+    //    ompaccelInternalFail("The nested tinfo is empty");
+    return SPTR_NULL;
+  return ctinfo->child_tinfos[0]->device_sptr;
+}
+
+void
+ompaccel_tinfo_register_func(SPTR sptr, SPTR device_sptr, SPTR stblk_sptr,
+                             int iskernel, ILM_OP opc)
+{
+  int i, max_nargs, n_args;
+  OMPACCEL_TINFO *current_tinfo = NULL;
+  const LLUplevel *uplevel;
+  SPTR arg_sptr;
+
+  uplevel = llmp_has_uplevel(stblk_sptr);
+  max_nargs = uplevel != NULL ? uplevel->vals_count : 0;
+
+  // check whether is it registered before
+  if(gbl.ompaccel_isdevice) {
+    /* if it's parallel region or outlining elimination is active for teams
+      * we return child tinfo of the current tinfo.
+      * we assume that child tinfo is already added at outlining function for host */
+    if(!(outlined_is_eliminated(IM_BTEAMS) &&
+      (opc == IM_BPAR || opc == IM_BPARD || opc == IM_BPARN || opc == IM_BPARA))) {
+      current_tinfo = ompaccel_tinfo_get_by_device(GBL_CURRFUNC);
+      if (current_tinfo != NULL) {
+        current_tinfo = current_tinfo->child_tinfos[0];
+        current_tinfo->device_sptr = device_sptr;
+      }
+    }
+  } else if(ompaccel_tinfo_has(GBL_CURRFUNC) && ompaccel_tinfo_get(GBL_CURRFUNC)->n_child){
+    current_tinfo = ompaccel_tinfo_get(GBL_CURRFUNC)->child_tinfos[0];
+    if(current_tinfo != NULL)
+      current_tinfo->func_sptr = sptr;
+  }
+  // if it's not registered, create a new one.
+  if(current_tinfo == NULL)
+    current_tinfo = tinfo_create(sptr, device_sptr, max_nargs, opc);
+
+  for (i = 0; i < max_nargs; ++i) {
+    arg_sptr = (SPTR)uplevel->vals[i];
+    if (!arg_sptr && !ompaccel_tinfo_current_is_registered(arg_sptr))
+      continue;
+    if (SCG(arg_sptr) == SC_PRIVATE)
+      continue;
+#ifdef OMP_OFFLOAD_LLVM
+    if (DESCARRAYG(arg_sptr))
+      continue;
+#endif
+    if (!iskernel && !OMPACCDEVSYMG(arg_sptr))
+      arg_sptr = ompaccel_tinfo_parent_get_devsptr(arg_sptr);
+    ompaccel_tinfo_current_add_sym(arg_sptr, SPTR_NULL, 0);
+
+    n_args++;
+  }
 }
 
 void
@@ -681,29 +767,62 @@ ompaccel_tinfo_set_mode_next_target(OMP_TARGET_MODE type)
 OMP_TARGET_MODE
 ompaccel_tinfo_current_target_mode()
 {
+  if (current_tinfo == NULL)
+    ompaccelInternalFail("Current target info is empty");
   return current_tinfo->mode;
 }
 
-OMPACCEL_TINFO *
-ompaccel_tinfo_create(SPTR func_sptr, int max_nargs)
+static void
+tinfo_add_parent(OMPACCEL_TINFO *info) {
+  OMPACCEL_TINFO *pinfo;
+  /* if host func sptr, we should search parent by device */
+  if (info->func_sptr == SPTR_NULL) {
+    //code falls int ohere if teams outlining elimination.
+    pinfo = ompaccel_tinfo_get_by_device(gbl.currsub);
+    pinfo = pinfo->child_tinfos[0];
+  } else
+    pinfo = ompaccel_tinfo_get(gbl.currsub);
+  if(pinfo == NULL)
+    ompaccelInternalFail("Parent tinfo is not found. ");
+  int sz = pinfo->sz_child == 0 ? 10 : pinfo->sz_child * INC_EXP;
+  NEED(pinfo->n_child + 1, pinfo->child_tinfos, OMPACCEL_TINFO*, pinfo->sz_child, sz);
+  info->parent_tinfo = pinfo;
+  pinfo->child_tinfos[pinfo->n_child] = info;
+  pinfo->n_child++;
+}
+
+static OMPACCEL_TINFO *
+tinfo_create(SPTR func_sptr, SPTR device_sptr, int max_nargs, ILM_OP opc)
 {
   OMPACCEL_TINFO *info;
-  if (DBGBIT(61, 0x10) && gbl.dbgfil != nullptr)
+  if (DBGBIT(61, 0x10) && gbl.dbgfil != NULL)
     fprintf(gbl.dbgfil, "#target add request for sptr:%d [%s]\n", func_sptr,
             SYMNAME(func_sptr));
 
   NEW(info, OMPACCEL_TINFO, 1);
   info->func_sptr = func_sptr;
+  info->device_sptr = device_sptr;
   info->n_symbols = 0;
   if (max_nargs != 0) {
     NEW(info->symbols, OMPACCEL_SYM, max_nargs);
     NEW(info->quiet_symbols, OMPACCEL_SYM, max_nargs);
   } else {
-    info->symbols = nullptr;
-    info->quiet_symbols = nullptr;
+    info->symbols = NULL;
+    info->quiet_symbols = NULL;
   }
   info->sz_symbols = info->sz_quiet_symbols = max_nargs;
+#ifdef OMP_OFFLOAD_LLVM
   info->mode = NextTargetMode;
+#endif
+  if (opc != N_ILM) {
+    if (opc == IM_BTARGET)
+      info->mode = NextTargetMode;
+    else if (opc == IM_BTEAMS || opc == IM_BTEAMSN)
+      info->mode = mode_outlinedfunc_teams;
+    else if (opc == IM_BPAR || opc == IM_BPARA || opc == IM_BPARD ||
+             opc == IM_BPARN)
+      info->mode = mode_outlinedfunc_parallel;
+  }
   NextTargetMode = mode_none_target;
   info->nowait = false;
   info->n_quiet_symbols = 0;
@@ -716,18 +835,53 @@ ompaccel_tinfo_create(SPTR func_sptr, int max_nargs)
   tinfos[num_tinfos++] = info;
 
   /* linking */
-  if (current_tinfo != nullptr)
-    info->parent_tinfo = current_tinfo;
-  else
-    info->parent_tinfo = nullptr;
+  info->parent_tinfo = NULL;
+  info->child_tinfos = NULL;
+  info->sz_child = 0;
+  switch(opc) {
+    case N_ILM:
+    case IM_BTARGET:
+    case IM_BTARGETDATA:
+    case IM_TARGETENTERDATA:
+    case IM_TARGETEXITDATA:
+    case IM_TARGETUPDATE:
+      //todo implement their parent info, for now we don't need.
+      break;
+  case IM_BTEAMS:
+  case IM_BTEAMSN:
+    /* teams must be tightly nested to target */
+    tinfo_add_parent(info);
+    break;
+  case IM_BPAR:
+  case IM_BPARA:
+  case IM_BPARN:
+  case IM_BPARD:
+    /* If it's in target region, add parent */
+    if(gbl.ompaccel_intarget)
+      tinfo_add_parent(info);
+    break;
+  default:
+    ompaccelInternalFail("Can't create tinfo for this directive.");
+    break;
+  }
+
+  info->isProcessed = false;
+  info->n_child = 0;
   current_tinfo = info;
   return info;
+}
+
+OMPACCEL_TINFO *
+ompaccel_tinfo_create(SPTR func_sptr, int max_nargs)
+{
+  return tinfo_create(func_sptr, SPTR_NULL, max_nargs, N_ILM);
 }
 
 bool
 ompaccel_tinfo_has(int func_sptr)
 {
-  for (int i = 0; i < num_tinfos; ++i) {
+  int i;
+  for (i = 0; i < num_tinfos; ++i) {
     if (tinfos[i]->func_sptr == func_sptr) {
       return true;
     }
@@ -744,7 +898,7 @@ ompaccel_tinfo_get(int func_sptr)
       return tinfos[i];
     }
   }
-  return nullptr;
+  return NULL;
 }
 
 SPTR
@@ -775,11 +929,12 @@ ompaccel_create_device_symbol(SPTR sptr, int count)
   }
   // assume it's base of allocatable descriptor
   if (strncmp(SYMNAME(sptr), ".Z", 2) == 0) {
-    for (int j = 0; j < current_tinfo->n_quiet_symbols; ++j)
+    int j;
+    for (j = 0; j < current_tinfo->n_quiet_symbols; ++j)
       if (MIDNUMG(current_tinfo->quiet_symbols[j].host_sym) == sptr)
         sptr_alloc = current_tinfo->quiet_symbols[j].host_sym;
     byval = false;
-    DTYPEP(sym, DTYPE(DTYPEG(sptr_alloc) + 1));
+    DTYPEP(sym, (DTYPE)(DTYPEG(sptr_alloc) + 1));
     sptr_alloc = ((SPTR)0);
 
   } else {
@@ -807,7 +962,7 @@ INLINE static SPTR
 get_devsptr(OMPACCEL_TINFO *tinfo, SPTR host_symbol)
 {
   int i;
-  if (tinfo == nullptr)
+  if (tinfo == NULL)
     return host_symbol;
 
   for (i = 0; i < tinfo->n_symbols; ++i) {
@@ -842,16 +997,29 @@ get_devsptr2(OMPACCEL_TINFO *tinfo, SPTR host_symbol)
 OMPACCEL_TINFO *
 ompaccel_tinfo_current_get_targetdata()
 {
-  OMPACCEL_TINFO *tinfo = current_tinfo;
-  while (tinfo != nullptr) {
-    if (tinfo->mode == mode_target_data_region)
-      return tinfo;
-    if (tinfo->parent_tinfo == nullptr)
+  int i, current_tinfo_idx = -1;
+  OMPACCEL_TINFO *tinfo = NULL;
+  for (i = 0; i < num_tinfos; ++i)
+    if (tinfos[i]->func_sptr == current_tinfo->func_sptr) {
+      current_tinfo_idx = i;
       break;
-    tinfo = tinfo->parent_tinfo;
+    }
+  if (current_tinfo_idx == -1)
+    ompaccelInternalFail("Current tinfo is not found. ");
+
+  for (i = 0; i <= current_tinfo_idx; ++i) {
+    if (tinfos[i]->mode == mode_target_data_region)
+      /* If the target info is processed, we should look more deeper.
+       * There may be nested target data. */
+      if (!tinfos[i]->isProcessed) {
+        tinfos[i]->isProcessed = true;
+        tinfo = tinfos[i];
+        break;
+      }
   }
-  ompaccel_msg_interr("XXX", "Beginning of 'target data' is not found. ");
-  return nullptr;
+  if (tinfo == NULL)
+    ompaccelInternalFail("Beginning of 'target data' is not found. ");
+  return tinfo;
 }
 
 OMPACCEL_TINFO *
@@ -865,7 +1033,7 @@ ompaccel_tinfo_current_get_dev_dtype(DTYPE org_dtype)
 {
   int i;
   DTYPE dev_dtype = org_dtype;
-  if (current_tinfo != nullptr) {
+  if (current_tinfo != NULL) {
     for (i = 0; i < current_tinfo->n_quiet_symbols; ++i) {
       if (DTYPEG(current_tinfo->quiet_symbols[i].host_sym) == org_dtype) {
         dev_dtype = DTYPEG(current_tinfo->quiet_symbols[i].device_sym);
@@ -880,7 +1048,7 @@ ompaccel_tinfo_current_get_dev_dtype(DTYPE org_dtype)
       }
     }
   }
-  if (DBGBIT(61, 2) && gbl.dbgfil != nullptr) {
+  if (DBGBIT(61, 2) && gbl.dbgfil != NULL) {
     if (org_dtype != dev_dtype) {
       fprintf(gbl.dbgfil, "[ompaccel] REPLACED org_dtype:%d --> dev_dtype:%d",
               org_dtype, dev_dtype);
@@ -893,7 +1061,7 @@ SPTR
 ompaccel_tinfo_parent_get_devsptr(SPTR host_symbol)
 {
   int i;
-  if (current_tinfo->parent_tinfo == nullptr)
+  if (current_tinfo->parent_tinfo == NULL)
     return host_symbol;
   for (i = 0; i < current_tinfo->parent_tinfo->n_quiet_symbols; ++i) {
     if (current_tinfo->parent_tinfo->quiet_symbols[i].host_sym == host_symbol) {
@@ -907,7 +1075,7 @@ bool
 ompaccel_tinfo_current_is_registered(SPTR host_symbol)
 {
   int i;
-  if (current_tinfo == nullptr || !host_symbol)
+  if (current_tinfo == NULL || !host_symbol)
     return false;
 
   for (i = 0; i < current_tinfo->n_symbols; ++i) {
@@ -922,16 +1090,15 @@ SPTR
 ompaccel_tinfo_current_get_devsptr(SPTR host_symbol)
 {
   SPTR device_symbol;
-  if (current_tinfo == nullptr || !host_symbol)
+  if (current_tinfo == NULL || !host_symbol)
     return host_symbol;
 
   device_symbol = get_devsptr(current_tinfo, host_symbol);
 
-  if (device_symbol == host_symbol && current_tinfo->parent_tinfo != nullptr)
+  if (device_symbol == host_symbol && current_tinfo->parent_tinfo != NULL)
     device_symbol = get_devsptr2(current_tinfo->parent_tinfo, host_symbol);
 
-  if ((DBGBIT(61, 2)) && gbl.dbgfil != nullptr &&
-      device_symbol != host_symbol) {
+  if ((DBGBIT(61, 2)) && gbl.dbgfil != NULL && device_symbol != host_symbol) {
     fprintf(gbl.dbgfil,
             "[ompaccel] REPLACED host_symbol:%d[%s] --> device_symbol:%d[%s]",
             host_symbol, SYMNAME(host_symbol), device_symbol,
@@ -966,8 +1133,8 @@ void
 ompaccel_tinfo_current_add_reductionitem(SPTR private_sym, SPTR shared_sym,
                                          int redop)
 {
-  if (current_tinfo == nullptr)
-    ompaccel_msg_interr("XXX", "Current target info is not found.\n");
+  if (current_tinfo == NULL)
+    ompaccelInternalFail("Current target info is not found.\n");
 
   current_tinfo->reduction_symbols[current_tinfo->n_reduction_symbols]
       .private_sym = private_sym;
@@ -1000,8 +1167,8 @@ void
 ompaccel_tinfo_current_addupdate_mapitem(SPTR host_symbol, int map_type)
 {
   SPTR midsptr;
-  if (current_tinfo == nullptr)
-    ompaccel_msg_interr("XXX", "Current target info is not found\n");
+  if (current_tinfo == NULL)
+    ompaccelInternalFail("The tinfo is not found");
 
   // check whether it is allocatable or not
   if (SCG(host_symbol) == SC_BASED) {
@@ -1055,7 +1222,7 @@ INLINE static void
 dumptargetsym(OMPACCEL_SYM targetsym)
 {
   const char *dev_sptr_name, *org_sptr_name;
-  if (gbl.dbgfil == nullptr)
+  if (gbl.dbgfil == NULL)
     return;
 
   dev_sptr_name =
@@ -1097,7 +1264,7 @@ dumptargetsym(OMPACCEL_SYM targetsym)
 INLINE static void
 dumptargetreduction(OMPACCEL_RED_SYM targetred)
 {
-  if (gbl.dbgfil == nullptr)
+  if (gbl.dbgfil == NULL)
     return;
   switch (targetred.redop) {
   case 1:
@@ -1136,17 +1303,15 @@ dumptargetreduction(OMPACCEL_RED_SYM targetred)
           targetred.private_sym, SYMNAME(targetred.private_sym));
 }
 
-void
-dumpomptarget(OMPACCEL_TINFO *tinfo)
+static void
+dumptargetmode(OMPACCEL_TINFO *tinfo)
 {
-  if (tinfo == nullptr)
+  if (tinfo == NULL)
     return;
-  if (gbl.dbgfil == nullptr)
+  if (gbl.dbgfil == NULL)
     return;
-
   switch (tinfo->mode) {
   case mode_none_target:
-
     fprintf(gbl.dbgfil, " <mode none>");
     break;
   case mode_target:
@@ -1179,33 +1344,68 @@ dumpomptarget(OMPACCEL_TINFO *tinfo)
   case mode_target_data_exit_region:
     fprintf(gbl.dbgfil, " <target data exit>");
     break;
+  case mode_outlinedfunc_teams:
+    fprintf(gbl.dbgfil, " <outlined teams>");
+    break;
+  case mode_outlinedfunc_parallel:
+    fprintf(gbl.dbgfil, " <outlined parallel>");
+    break;
   }
+}
+
+void
+dumpomptarget(OMPACCEL_TINFO *tinfo)
+{
+  int j;
+  if (tinfo == NULL)
+    return;
+  if (gbl.dbgfil == NULL)
+    return;
+
+  dumptargetmode(tinfo);
   fprintf(gbl.dbgfil, " \n");
-  //}
 
   if ((tinfo->mode != mode_target_data_region) &&
       (tinfo->mode != mode_target_data_enter_region) &&
       (tinfo->mode != mode_target_data_exit_region)) {
+    int functype = -1;
+#if   defined(OMP_OFFLOAD_LLVM)
     if (OMPACCFUNCKERNELG(tinfo->func_sptr))
-      fprintf(gbl.dbgfil, " (__global__) ");
+      functype = 1;
     else if (OMPACCFUNCDEVG(tinfo->func_sptr))
+      functype = 0;
+#endif
+    if (functype == 1)
+      fprintf(gbl.dbgfil, " (__global__) ");
+    else if (functype == 0)
       fprintf(gbl.dbgfil, " (__device__) ");
     else
-      fprintf(gbl.dbgfil, " ??? ");
-    fprintf(gbl.dbgfil, "%s\t sptr: %d \n", SYMNAME(tinfo->func_sptr),
+      fprintf(gbl.dbgfil, " (attribute not found) ");
+    fprintf(gbl.dbgfil, "[Host func] %s sptr: %d ", SYMNAME(tinfo->func_sptr),
             tinfo->func_sptr);
+    if (tinfo->device_sptr != NOSYM)
+      fprintf(gbl.dbgfil, "\t[Device func] %s sptr: %d",
+              SYMNAME(tinfo->device_sptr), tinfo->device_sptr);
+    fprintf(gbl.dbgfil, "\n");
+    if (tinfo->parent_tinfo != NULL)
+      fprintf(gbl.dbgfil, "\t  [Parent] %s sptr: %d ",
+              SYMNAME(tinfo->parent_tinfo->func_sptr),
+              tinfo->parent_tinfo->func_sptr);
+    fprintf(gbl.dbgfil, "\n");
+  } else {
+    fprintf(gbl.dbgfil, "Processed: %s\n", tinfo->isProcessed ? "YES" : "NO");
   }
 
   fprintf(gbl.dbgfil, " ** Active Symbols ** \n");
-  for (int j = 0; j < tinfo->n_symbols; ++j) {
+  for (j = 0; j < tinfo->n_symbols; ++j) {
     dumptargetsym(tinfo->symbols[j]);
   }
   fprintf(gbl.dbgfil, " ** Passive Symbols ** \n");
-  for (int j = 0; j < tinfo->n_quiet_symbols; ++j) {
+  for (j = 0; j < tinfo->n_quiet_symbols; ++j) {
     dumptargetsym(tinfo->quiet_symbols[j]);
   }
   fprintf(gbl.dbgfil, " ** Reductions ** \n");
-  for (int j = 0; j < tinfo->n_reduction_symbols; ++j) {
+  for (j = 0; j < tinfo->n_reduction_symbols; ++j) {
     dumptargetreduction(tinfo->reduction_symbols[j]);
   }
   fprintf(gbl.dbgfil, "\n");
@@ -1222,7 +1422,50 @@ dumpomptargets()
     dumpomptarget(tinfos[i]);
   }
 }
+static void
+dumpfuncinfo(OMPACCEL_TINFO *tinfo)
+{
+  if (gbl.dbgfil == NULL)
+    return;
+  fprintf(gbl.dbgfil, "[Outlined] %s sptr: %d \t[Target] %s sptr: %d \n",
+          SYMNAME(tinfo->func_sptr), tinfo->func_sptr,
+          SYMNAME(tinfo->device_sptr), tinfo->device_sptr);
+}
 
+static void
+dumptinfochild(OMPACCEL_TINFO *tp, int cn)
+{
+  int i;
+  if (cn != 0) {
+    int k;
+    fprintf(gbl.dbgfil, "|");
+    for (k = 0; k < cn; ++k)
+      fprintf(gbl.dbgfil, "   ");
+  }
+  fprintf(gbl.dbgfil, "+-- ");
+  dumptargetmode(tp);
+  dumpfuncinfo(tp);
+  ++cn;
+  for (i = 0; i < tp->n_child; ++i) {
+    dumptinfochild(tp->child_tinfos[i], cn);
+  }
+}
+
+void
+dumpomptargetstree()
+{
+  int i, j;
+  if (gbl.dbgfil == NULL)
+    return;
+  fprintf(gbl.dbgfil,
+          "------------OpenMP Target Region Tree ---------------\n");
+  for (i = 0; i < num_tinfos; ++i) {
+    if (tinfos[i]->parent_tinfo != NULL)
+      continue;
+    dumptinfochild(tinfos[i], 0);
+    fprintf(gbl.dbgfil, "\n");
+  }
+}
 void
 dumpomptargetsymbols()
 {
@@ -1244,21 +1487,10 @@ dumpomptargetsymbols()
 void
 dumptargetsymbols(OMPACCEL_SYM *targetsyms, int n)
 {
-  for (int i = 0; i < n; ++i) {
+  int i;
+  for (i = 0; i < n; ++i) {
     dumptargetsym(targetsyms[i]);
   }
-}
-
-void
-ompaccel_msg_interr(char *id, const char *message)
-{
-  interr(message, MSGOMPACCEL, ERR_Fatal);
-}
-
-void
-ompaccel_msg_info(char *id, const char *message)
-{
-  ccff_info(MSGOMPACCEL, id, gbl.findex, gbl.lineno, message, NULL);
 }
 
 bool
@@ -1295,6 +1527,7 @@ SPTR
 ompaccel_nvvm_emit_reduce(OMPACCEL_RED_SYM *ReductionItems, int NumReductions)
 {
   int ili, bili, rili;
+  int i;
   SPTR sptrFn, sptrRhs, sptrReduceData, func_params[2];
   DTYPE dtypeReductionItem, dtypeReduceData;
   int nmeReduceData, nmeRhs;
@@ -1313,7 +1546,7 @@ ompaccel_nvvm_emit_reduce(OMPACCEL_RED_SYM *ReductionItems, int NumReductions)
   sptrFn = mk_ompaccel_function(name, 2, func_params, true);
   cr_block();
 
-  for (int i = 0; i < NumReductions; ++i) {
+  for (i = 0; i < NumReductions; ++i) {
     dtypeReductionItem = DTYPEG(ReductionItems[i].shared_sym);
 
     bili = mk_ompaccel_ldsptr(sptrReduceData);
@@ -1357,6 +1590,7 @@ ompaccel_nvvm_emit_shuffle_reduce(OMPACCEL_RED_SYM *ReductionItems,
                                   int NumReductions, SPTR sptrFnReduce)
 {
   int ili, rili, bili;
+  int i;
   SPTR sptrFn, sptrRhs, sptrReduceData, sptrShuffleReturn, sptrLaneOffset,
       func_params[4];
   DTYPE dtypeReductionItem, dtypeReduceData, dtypeRHS;
@@ -1385,7 +1619,7 @@ ompaccel_nvvm_emit_shuffle_reduce(OMPACCEL_RED_SYM *ReductionItems,
   dtypeRHS = mk_ompaccel_array_dtype(dtypeReduceData, NumReductions);
   sptrRhs = mk_ompaccel_addsymbol(".rhs", dtypeRHS, SC_LOCAL, ST_ARRAY);
 
-  for (int i = 0; i < NumReductions; ++i) {
+  for (i = 0; i < NumReductions; ++i) {
 
     dtypeReductionItem = DTYPEG(ReductionItems[i].shared_sym);
     sptrShuffleReturn =
@@ -1455,6 +1689,7 @@ ompaccel_nvvm_emit_inter_warp_copy(OMPACCEL_RED_SYM *ReductionItems,
                                    int NumReductions)
 {
   int ili, rili;
+  int i;
   SPTR sptrFn, sptrReduceData, sptrWarpNum, sptrShmem, sptrWarpId,
       sptrMasterWarp, sptrRedItem, sptrRedItemAddress, func_params[2];
   SPTR lFirstLane, lBarrier, lFirstWarp, lFinalBarrier;
@@ -1504,7 +1739,7 @@ ompaccel_nvvm_emit_inter_warp_copy(OMPACCEL_RED_SYM *ReductionItems,
   sptrRedItemAddress =
       mk_ompaccel_addsymbol(".reductionitemaddr", DT_ADDR, SC_LOCAL, ST_VAR);
 
-  for (int i = 0; i < NumReductions; ++i) {
+  for (i = 0; i < NumReductions; ++i) {
     cr_block();
     dtypeReductionItem = DTYPEG(ReductionItems[i].shared_sym);
     rili = mk_ompaccel_ldsptr(sptrReduceData);
@@ -1743,8 +1978,8 @@ exp_ompaccel_mploop(ILM *ilmp, int curilm)
   loop_args_t loop_args;
 #if LLVM_YKT
   /* frontend generates two MPLOOP ILM, one for distribute, other for parallel
-   * If it is combined construct like ttdpf, I don't need to do something
-   * special for distribute I need to pass different scheduling type to device
+   * If it is combined construct like ttdpf, we don't need to do something
+   * special for distribute; we need to pass different scheduling type to device
    * runtime.
    */
   if (mp_sched_to_kmpc_sched(ILM_OPND(ilmp, 7)) == KMP_DISTRIBUTE_STATIC) {
@@ -1814,7 +2049,8 @@ exp_ompaccel_mploop(ILM *ilmp, int curilm)
 
 void
 exp_ompaccel_btarget(ILM *ilmp, int curilm, SPTR uplevel_sptr, SPTR scopeSptr,
-                     int(incrOutlinedCnt()))
+                     int(incrOutlinedCnt()), SPTR *targetfunc_sptr,
+                     int *isTargetDevice)
 {
   int ili, outlinedCnt;
   SPTR sptr;
@@ -1836,7 +2072,7 @@ exp_ompaccel_btarget(ILM *ilmp, int curilm, SPTR uplevel_sptr, SPTR scopeSptr,
   if (outlinedCnt == 1) {
     /* inomptarget used to figure out whether other directives, statements are
      * in target region or not */
-    gbl.inomptarget = true;
+    gbl.ompaccel_intarget = true;
     /* Outline function, create sptr as ptx kernel, duplicate all the sptrs*/
     sptr = ll_make_outlined_ompaccel_func(uplevel_sptr, scopeSptr, TRUE);
     /* set global outlined function with the latest */
@@ -1848,6 +2084,9 @@ exp_ompaccel_btarget(ILM *ilmp, int curilm, SPTR uplevel_sptr, SPTR scopeSptr,
   }
   ccff_info(MSGOPENMP, "OMP020", gbl.findex, gbl.lineno,
             "Target region activated for offload", NULL);
+  *targetfunc_sptr = sptr;
+  *isTargetDevice = ILI_OF(ILM_OPND(ilmp, 1));
+  return;
 }
 
 static void
@@ -1863,48 +2102,51 @@ exp_ompaccel_ereduction(ILM *ilmp, int curilm)
 }
 
 void
-exp_ompaccel_etarget(ILM *ilmp, int curilm, int outlinedCnt, SPTR uplevel_sptr,
-                     int(decrOutlinedCnt()))
+exp_ompaccel_etarget_combined(ILM *ilmp, int curilm, SPTR targetfunc_sptr,
+                              int outlinedCnt, SPTR uplevel_sptr,
+                              int(decrOutlinedCnt()), int num_teams,
+                              int thread_limit, int num_threads, int device_id)
 {
   int ili;
-  if (outlinedCnt == 1) {
-    ilm_outlined_pad_ilm(curilm);
-  }
-  outlinedCnt = decrOutlinedCnt();
-  if (outlinedCnt >= 1) {
-    ll_rewrite_ilms(-1, curilm, 0);
-    return;
-  }
-  if (gbl.outlined)
-    expb.sc = SC_AUTO;
+  const OMP_TARGET_MODE mode = ompaccel_tinfo_current_target_mode();
+  ili = ll_make_tgt_target_teams_parallel(targetfunc_sptr, device_id,
+                                          uplevel_sptr, num_teams, thread_limit,
+                                          num_threads, mode);
+  iltb.callfg = 1;
+  chk_block(ili);
+  gbl.ompaccel_intarget = false;
+}
 
+void
+exp_ompaccel_etarget(ILM *ilmp, int curilm, SPTR targetfunc_sptr,
+                     int outlinedCnt, SPTR uplevel_sptr, int(decrOutlinedCnt()))
+{
+  int ili;
   if (ompaccel_tinfo_current_target_mode() == mode_target) {
-    ili = ll_make_tgt_target(gbl.ompoutlinedfunc, OMPACCEL_DEFAULT_DEVICEID,
+    ili = ll_make_tgt_target(targetfunc_sptr, OMPACCEL_DEFAULT_DEVICEID,
                              uplevel_sptr);
   } else if (ompaccel_tinfo_current_target_mode() == mode_target_parallel_for ||
              ompaccel_tinfo_current_target_mode() ==
                  mode_target_parallel_for_simd) {
     // Create kernel with single team.
-    ili = ll_make_tgt_target_teams(
-        gbl.ompoutlinedfunc, OMPACCEL_DEFAULT_DEVICEID, uplevel_sptr, 1, 0);
+    ili = ll_make_tgt_target_teams(targetfunc_sptr, OMPACCEL_DEFAULT_DEVICEID,
+                                   uplevel_sptr, 1, 0);
   } else {
-    ili = ll_make_tgt_target_teams(
-        gbl.ompoutlinedfunc, OMPACCEL_DEFAULT_DEVICEID, uplevel_sptr, 0, 0);
+    ili = ll_make_tgt_target_teams(targetfunc_sptr, OMPACCEL_DEFAULT_DEVICEID,
+                                   uplevel_sptr, 0, 0);
   }
 
   iltb.callfg = 1;
   chk_block(ili);
 
-  gbl.inomptarget = false;
-
-  ccff_info(MSGOPENMP, "OMP021", gbl.findex, gbl.lineno,
-            "Target region terminated", NULL);
+  gbl.ompaccel_intarget = false;
 }
 
 void
 exp_ompaccel_reduction(ILM *ilmp, int curilm)
 {
   int ili, bili, nmeReduceData, sizeRed = 0;
+  int i;
   SPTR lAssignReduction, sptrReduceData, sptrReductionItem;
   DTYPE dtypeReduceData, dtypeReductionItem;
   dtypeReduceData = mk_ompaccel_array_dtype(
@@ -1914,7 +2156,7 @@ exp_ompaccel_reduction(ILM *ilmp, int curilm)
       mk_ompaccel_addsymbol(".reduceData", dtypeReduceData, SC_LOCAL, ST_ARRAY);
 
   cr_block();
-  for (int i = 0; i < ompaccel_tinfo_current_get()->n_reduction_symbols; ++i) {
+  for (i = 0; i < ompaccel_tinfo_current_get()->n_reduction_symbols; ++i) {
     sptrReductionItem =
         ompaccel_tinfo_current_get()->reduction_symbols[i].shared_sym;
     dtypeReductionItem = DTYPEG(sptrReductionItem);
@@ -1955,7 +2197,7 @@ exp_ompaccel_reduction(ILM *ilmp, int curilm)
   chk_block(ili);
 
   // Load reduced items to the origina laddress
-  for (int i = 0; i < ompaccel_tinfo_current_get()->n_reduction_symbols; ++i) {
+  for (i = 0; i < ompaccel_tinfo_current_get()->n_reduction_symbols; ++i) {
     bili = mk_address(sptrReduceData);
     sptrReductionItem =
         ompaccel_tinfo_current_get()->reduction_symbols[i].private_sym;
@@ -2115,7 +2357,7 @@ exp_ompaccel_targetdata(ILM *ilmp, int curilm, ILM_OP opc)
   int dotarget;
   SPTR beg_label, end_label;
   ompaccel_symreplacer(false);
-  ompaccel_tinfo_create(OMPACCEL_DATA_FUNCTION, OMPACCEL_DATA_MAX_SYM);
+  tinfo_create(OMPACCEL_DATA_FUNCTION, SPTR_NULL, OMPACCEL_DATA_MAX_SYM, opc);
   if (opc == IM_TARGETEXITDATA)
     ompaccel_tinfo_current_set_mode(mode_target_data_exit_region);
   else if (opc == IM_TARGETENTERDATA)

--- a/tools/flang2/flang2exe/ompaccel.h
+++ b/tools/flang2/flang2exe/ompaccel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,27 @@
 
 #define OMPACCEL_DATA_FUNCTION NOSYM
 #define OMPACCEL_DATA_MAX_SYM 50
+// TODO ompaccel make them dynamic at some point.
+#define OMP_SHMEM_SIZE (48 * 1024)
+// TODO ompaccel Decide an offset.
+#define OMP_MAX_SCALARS_INSHMEM 1000
+#define OMP_GET_SHMEM_OFFSET \
+  (OMP_SHMEM_SIZE - (OMP_MAX_SCALARS_INSHMEM)*size_of(DT_ADDR))
+
+#if   OMP_OFFLOAD_LLVM
+/* OpenMP Offload for Flang compiler */
+/* Find if the func_sptr whether it is a kernel or not. */
+#define IS_OMP_DEVICE_KERNEL(func_sptr) (OMPACCFUNCKERNELG(func_sptr))
+/* Find if the func_sptr whether device function or not. */
+#define IS_OMP_DEVICE_FUNC(func_sptr) (OMPACCFUNCDEVG(func_sptr))
+/* Find whether we build ILI for OpenMP target or not.*/
+#define IS_OMP_DEVICE_CG                     \
+  (flg.omptarget && gbl.ompaccel_isdevice && \
+   (IS_OMP_DEVICE_FUNC(GBL_CURRFUNC) | IS_OMP_DEVICE_KERNEL(GBL_CURRFUNC)))
+#else
+#define IS_OMP_DEVICE_FUNC 0
+#define IS_OMP_DEVICE_CG 0
+#endif
 
 typedef struct {
   SPTR shared_sym;
@@ -44,9 +65,9 @@ typedef struct {
 } OMPACCEL_RED_FUNCS;
 
 typedef struct {
-  SPTR host_sym;    /* host symbol */
-  SPTR device_sym;  /* device symbol */
-  int map_type;     /* map type */
+  SPTR host_sym;   /* host symbol */
+  SPTR device_sym; /* device symbol */
+  int map_type;    /* map type */
 } OMPACCEL_SYM;
 
 /* Target Info is the main struct which keeps all the information about target
@@ -55,20 +76,29 @@ typedef struct {
  * each target data construct creates a target info. */
 typedef struct _OMPACCEL_TARGET OMPACCEL_TINFO;
 
-struct _OMPACCEL_TARGET{
-  SPTR func_sptr;                         /*  Kernel or device function sptr          */
-  OMPACCEL_SYM *symbols;                  /*  Keeps host and device symbols along with map-type */
-  int n_symbols;                          /*  Number of parameters         */
-  int sz_symbols;                         /*  Size of symbols array */
-  OMPACCEL_SYM *quiet_symbols;            /*  Keeps sc_based symbols. They don't be passed to the device */
-  int n_quiet_symbols;                    /*  Number of quiet_symbols */
-  int sz_quiet_symbols;                   /*  Size of quite_symbols */
-  OMP_TARGET_MODE mode;                   /*  Combined construct mode */
-  OMPACCEL_TINFO* parent_tinfo;           /*  Parent tinfo is used for nested outlining in device. */
-  bool nowait;                            /*  async      */
-  int n_reduction_symbols;                /*  Number of reduction symbols */
-  OMPACCEL_RED_SYM *reduction_symbols;    /*  Reduction symbols along with the reduction operator */
-  OMPACCEL_RED_FUNCS reduction_funcs;     /*  Auxiliary functions for reduction */
+struct _OMPACCEL_TARGET {
+  SPTR func_sptr;   /*  Outlined function (it's device function for flang) */
+  SPTR device_sptr; /*  Device function sptr */
+  OMPACCEL_SYM
+      *symbols;   /*  Keeps host and device symbols along with map-type */
+  int n_symbols;  /*  Number of parameters         */
+  int sz_symbols; /*  Size of symbols array */
+  OMPACCEL_SYM *quiet_symbols; /*  Keeps sc_based symbols. They don't be passed
+                                  to the device */
+  int n_quiet_symbols;         /*  Number of quiet_symbols */
+  int sz_quiet_symbols;        /*  Size of quite_symbols */
+  OMP_TARGET_MODE mode;        /*  Combined construct mode */
+  OMPACCEL_TINFO
+      *parent_tinfo; /*  Parent tinfo is used for nested outlining in device. */
+  OMPACCEL_TINFO **child_tinfos;       /*  List of child tinfo */
+  int n_child;                         /*  Number of child */
+  int sz_child;                        /*  Size of child array */
+  bool nowait;                         /*  async      */
+  int n_reduction_symbols;             /*  Number of reduction symbols */
+  OMPACCEL_RED_SYM *reduction_symbols; /*  Reduction symbols along with the
+                                          reduction operator */
+  OMPACCEL_RED_FUNCS reduction_funcs;  /*  Auxiliary functions for reduction */
+  bool isProcessed; /*  It is used to keep track of target data begin. */
 };
 
 static bool isOmpaccelRegistered = false;
@@ -193,9 +223,15 @@ void ompaccel_init(void);
 OMPACCEL_TINFO *ompaccel_tinfo_create(SPTR, int);
 
 /**
-   \brief Get target and data info of function
+   \brief Get target and data info of function. Search by host function
  */
 OMPACCEL_TINFO *ompaccel_tinfo_get(int);
+
+/**
+   \brief Get target and data info of function. Search by device function
+ */
+OMPACCEL_TINFO *ompaccel_tinfo_get_by_device(int);
+
 /**
    \brief Return whether parameter function sptr has target info or not.
  */
@@ -256,11 +292,19 @@ DTYPE ompaccel_tinfo_current_get_dev_dtype(DTYPE);
 SPTR ompaccel_tinfo_parent_get_devsptr(SPTR);
 
 /**
+   \brief Registers the outlined function to tinfo.
+ */
+void ompaccel_tinfo_register_func(SPTR, SPTR, SPTR, int, ILM_OP);
+
+/**
+   \brief Registers the outlined function to tinfo.
+ */
+SPTR ompaccel_tinfo_get_nested_side(SPTR);
+/**
    \brief Create device symbol from the host symbol.
    Parameter count can be anything.
  */
-SPTR
-ompaccel_create_device_symbol(SPTR sptr, int count);
+SPTR ompaccel_create_device_symbol(SPTR sptr, int count);
 
 /* OpenMP ACCEL - Target Information data structure */
 
@@ -277,14 +321,10 @@ void dumpomptarget(OMPACCEL_TINFO *);
  */
 void dumpomptargets(void);
 
-/* ################################################ */
-/* OpenMP ACCEL - Error messages                    */
-/* ################################################ */
-#define OMPACCELMESSAGE "OpenMP Accelerator Model:"
-void ompaccel_msg_interr(char *, const char *);
-void ompaccel_msg_err(char *, const char *);
-void ompaccel_msg_warn(char *, const char *);
-void ompaccel_msg_info(char *, const char *);
+/**
+   \brief Dump tree of openmp target regions.
+ */
+void dumpomptargetstree(void);
 
 /* ################################################ */
 /* OpenMP ACCEL - Expander                          */
@@ -317,11 +357,22 @@ void exp_ompaccel_eteams(ILM *ilmp, int, int, int(decrOutlinedCnt()));
 /**
    \brief Expand ILM and emit code for btarget
  */
-void exp_ompaccel_btarget(ILM *, int, SPTR, SPTR, int(incrOutlinedCnt()));
+void exp_ompaccel_btarget(ILM *, int, SPTR, SPTR, int(incrOutlinedCnt()),
+                          SPTR *, int *);
 /**
    \brief Expand ILM and emit code for etarget
  */
-void exp_ompaccel_etarget(ILM *, int, int, SPTR, int(decrOutlinedCnt()));
+void exp_ompaccel_etarget(ILM *, int, SPTR, int, SPTR, int(decrOutlinedCnt()));
+
+/**
+   \brief Expand ILM and emit code for etarget
+ */
+void exp_ompaccel_etarget_combined(ILM *ilmp, int curilm, SPTR targetfunc_sptr,
+                                   int outlinedCnt, SPTR uplevel_sptr,
+                                   int(decrOutlinedCnt()), int num_teams,
+                                   int thread_limit, int num_threads,
+                                   int device_id);
+
 /**
    \brief Expand ILM and emit code for reduction
  */
@@ -350,8 +401,45 @@ void exp_ompaccel_targetdata(ILM *, int, ILM_OP);
    \brief Expand ILM and emit code for etargetdata
  */
 void exp_ompaccel_etargetdata(ILM *, int);
+/**
+   \brief Expand ILM and emit code for etargetdata
+ */
+void exp_ompaccel_begin_dir(ILM *, int);
+/**
+   \brief Expand ILM and emit code for etargetdata
+ */
+void exp_ompaccel_end_dir(ILM *, int);
 
 int mk_ompaccel_store(int ili_value, DTYPE dtype, int nme, int ili_address);
 
 void init_test();
+
+/* ################################################ */
+/* OpenMP ACCEL - Utils                             */
+/* ################################################ */
+
+void _ompaccelInternalFail(const char *message, const char *location);
+void _ompaccelInternalFailures(const char *location, int numargs, char *format,
+                               ...);
+
+#ifdef DEBUG
+#define ompaccelInternalFail(message)                                   \
+  do {                                                                  \
+    char buffer[10000];                                                 \
+    sprintf(buffer, "File:%s Line %d, Function:%s", __FILE__, __LINE__, \
+            __FUNCTION__);                                              \
+    _ompaccelInternalFail(message, buffer);                             \
+  } while (0)
+#define ompaccelInternalFailure(format, ...)                                \
+  char buffer[10000];                                                       \
+  sprintf(buffer,                                                           \
+          "[OpenMP-Offload] Error: [%s] at [File:%s Line %d, Function:%s]", \
+          format, __FILE__, __LINE__, __FUNCTION__);                        \
+  interrf(ERR_Fatal, buffer, ##__VA_ARGS__);
+
+#else
+#define ompaccelInternalFail(message)
+#define ompaccelInternalFailures(numargs, ...)
+#endif
+
 #endif

--- a/tools/flang2/flang2exe/outliner.h
+++ b/tools/flang2/flang2exe/outliner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,20 @@ extern FILE *par_file1;
 extern FILE *par_file2;
 extern FILE *par_curfile;
 
+/* For OpenMP target accelerator,
+ * the compilers outlines the same region multiple times.
+ * Therefore outliner has following states.  */
+typedef enum
+{
+  outliner_not_active = 0,        /* Not outlining, temp files are empty */
+  outliner_active_host_par1 = 1,  /* Host outlining, building ILI from parfile1 ilm */
+  outliner_active_host_par2 = 2,  /* Host outlining, building ILI from parfile2 ilm */
+  outliner_active_switchfile = 3,      /* Outlining recurs */
+  outliner_reset = 4,             /* Reset files, go back to main ilm file.  */
+  outliner_error = 5
+} outliner_states_t;
+
+
 int ll_has_cuda_constructor(void);
 void ll_save_cuda_constructor(void);
 
@@ -43,7 +57,7 @@ bool ll_ilm_is_rewriting(void);
 /**
    \brief ...
  */
-char *ll_get_outlined_funcname(int fileno, int lineno);
+char *ll_get_outlined_funcname(int fileno, int lineno, bool isompacce);
 
 /**
    \brief ...
@@ -120,8 +134,30 @@ int ll_make_outlined_call(int func_sptr, int arg1, int arg2, int arg3);
    \brief Create function and parameter list for an outlined function
    \param stblk_sptr  references the arguments for the function to be outlined
    \param scope_sptr  references the scope
+   \param opc current opc
+ */
+SPTR ll_make_outlined_func_wopc(SPTR stblk_sptr, SPTR scope_sptr, ILM_OP opc);
+
+/**
+   \brief Create function and parameter list for an outlined function
+   \param stblk_sptr  references the arguments for the function to be outlined
+   \param scope_sptr  references the scope
  */
 SPTR ll_make_outlined_func(SPTR stblk_sptr, SPTR scope_sptr);
+
+/**
+   \brief Create function and parameter list for an outlined function
+   \param stblk_sptr  references the arguments for the function to be outlined
+   \param scope_sptr  references the scope
+ */
+SPTR ll_make_outlined_func_target_device(SPTR stblk_sptr, SPTR scope_sptr, ILM_OP opc);
+
+/**
+   \brief Create function for OpenMP target and parameter list for an outlined function
+   \param stblk_sptr  references the arguments for the function to be outlined
+   \param scope_sptr  references the scope
+ */
+SPTR ll_make_outlined_omptarget_func(SPTR stblk_sptr, SPTR scope_sptr, ILM_OP opc);
 
 /**
    \brief ...
@@ -201,7 +237,7 @@ int llvm_ilms_rewrite_mode(void);
    These variables should be used to make the uplevel struct when making a call
    to this outlined region.
  */
-void dump_parsyms(int sptr);
+void dump_parsyms(int sptr, int isTeams);
 
 /**
    \brief ...
@@ -236,7 +272,7 @@ void ll_reset_outlined_func(void);
 /**
    \brief ...
  */
-void ll_set_outlined_currsub(void);
+void ll_set_outlined_currsub(bool);
 
 /**
    \brief ...
@@ -313,7 +349,7 @@ void update_acc_with_fn(int fnsptr);
  */
 ISZ_T getTaskSharedSize(SPTR scope_sptr);
 
-#ifdef OMP_OFFLOAD_LLVM
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
 /**
    \brief Create an outlining function, which has function parameter for each symbol.
  */
@@ -345,4 +381,13 @@ bool ompaccel_is_reduction_region();
 int mk_function_call(DTYPE, int, DTYPE *, int *, SPTR);
 #endif
 
+/**
+   \brief test whether do outlining elision for the current opc or not.
+ */
+bool outlined_is_eliminated(ILM_OP opc);
+
+/**
+   \brief test whether recompile the ILMs or not.
+ */
+bool outlined_need_recompile();
 #endif /* OUTLINER_H_ */

--- a/tools/flang2/flang2exe/ppc64le-Linux/flgdf.h
+++ b/tools/flang2/flang2exe/ppc64le-Linux/flgdf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2014-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,6 @@ FLG flg = {
     0,          /*  def ptr */
     NULL,       /*  search the standard include */
     false,      /* don't allow smp directives */
-    false,      /* don't allow omptarget OpenMP Offload directives */
+    false,      /* omptarget - don't allow OpenMP Offload directives */
     25,         /* errorlimit */
 };

--- a/tools/flang2/flang2exe/tgtutil.cpp
+++ b/tools/flang2/flang2exe/tgtutil.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
  * \brief tgtutil.c - Various definitions for the libomptarget runtime
  *
  */
-#ifdef OMP_OFFLOAD_LLVM
+#if defined(OMP_OFFLOAD_LLVM) || defined(OMP_OFFLOAD_PGI)
 
 #define _GNU_SOURCE // for vasprintf()
 #include <stdio.h>
@@ -51,6 +51,7 @@
 #include "llassem.h"
 #include "symfun.h"
 
+#define MXIDLEN 100
 #define MXIDLEN 100
 static int dataregion = 0;
 
@@ -86,6 +87,7 @@ static const struct tgt_api_entry_t tgt_api_calls[] = {
     [TGT_API_REGISTER_LIB] = {"__tgt_register_lib", 0, DT_NONE},
     [TGT_API_TARGET] = {"__tgt_target", 0, DT_INT},
     [TGT_API_TARGET_TEAMS] = {"__tgt_target_teams", 0, DT_INT},
+    [TGT_API_TARGET_TEAMS_PARALLEL] = {"__tgt_target_teams_parallel", 0, DT_INT},
     [TGT_API_TARGET_DATA_BEGIN] = {"__tgt_target_data_begin", 0, DT_NONE},
     [TGT_API_TARGET_DATA_END] = {"__tgt_target_data_end", 0, DT_NONE}};
 #endif
@@ -118,7 +120,9 @@ ld_sptr(SPTR sptr)
     int ili = mk_address(sptr);
     if (ILI_OPC(ili) == IL_LDA)
       nme = ILI_OPND(ili, 2);
-    if (sz == 8)
+    if(DTYPEG(sptr) == DT_DBLE)
+      return ad3ili(IL_LDDP, ili, nme, MSZ_I8);
+    else if (sz == 8)
       return ad3ili(IL_LDKR, ili, nme, MSZ_I8);
     else
       return ad3ili(IL_LD, ili, nme, mem_size(DTY(DTYPEG(sptr))));
@@ -479,7 +483,8 @@ ll_make_tgt_register_lib2()
   nme = addnme(NT_VAR, sptr, 0, 0);
 
   offset = 0;
-  i = DTY(DTYPE(dtype_devimage + 1));
+
+  i = DTyAlgTyMember(dtype_devimage);
   addr = ad_acon(sptr, offset);
   ilix =
       ad4ili(IL_ST, ad_acon(tptr3, 0), addr,
@@ -518,7 +523,7 @@ ll_make_tgt_register_lib2()
   nme = addnme(NT_VAR, sptr2, 0, 0);
 
   offset = 0;
-  i = DTY(DTYPE(dtype_bindesc + 1));
+  i = DTyAlgTyMember(dtype_bindesc);
   addr = ad_acon(sptr2, offset);
   ilix =
       ad4ili(IL_ST, ad_icon(1), addr, addnme(NT_MEM, (SPTR)PSMEMG(i), nme, 0),
@@ -554,163 +559,192 @@ ll_make_tgt_register_lib2()
   return mk_tgt_api_call(TGT_API_REGISTER_LIB, 1, arg_types, args);
 }
 
-void
-tgt_target_fill_params(SPTR arg_base_sptr, SPTR arg_size_sptr, SPTR args_sptr,
-                       SPTR args_maptypes_sptr, OMPACCEL_TINFO *targetinfo)
+static int
+_tgt_target_fill_base(SPTR sptr, bool isImplicit, DTYPE* ld_dtype) {
+  DTYPE dtype = DTYPEG(sptr);
+  int ilix;
+  *ld_dtype = DT_ADDR;
+  if (llis_pointer_kind(dtype)) {
+    ilix = ad3ili(IL_LDA, ad_acon(sptr, 0),
+                  addnme(NT_VAR, sptr, (INT)0, 0), MSZ_PTR);
+  } else if (llis_vector_kind(dtype)) {
+    ompaccelInternalFail("Vector data type is not implemented, cannot be passed to target region. ");
+  } else if (llis_struct_kind(dtype)) {
+    ompaccelInternalFail("Struct data type is not implemented, cannot be passed to target region. ");
+  } else if (llis_function_kind(dtype)) {
+    ompaccelInternalFail("Function data type is not implemented, cannot be passed to target region. ");
+  } else if (llis_integral_kind(dtype) || dtype == DT_DBLE) {
+    if (isImplicit) {
+      ilix = ld_sptr(sptr);
+      *ld_dtype = dtype;
+    } else
+      ilix = ad_acon(sptr, 0);
+  } else if (llis_array_kind(dtype)) {
+    ilix = ad_acon(sptr, 0);
+  }  else {
+    ompaccelInternalFail("Unknown data type");
+  }
+  return ilix;
+}
+
+static int
+_tgt_target_fill_size(SPTR sptr, int map_type)
 {
-  int param_ili, i, j, index, nme_args, nme_size, nme_base, nme_types, nme, ili,
-      size, sili;
-  DTYPE dtype;
-  SPTR param_sptr, midnum_sptr;
+  DTYPE dtype = DTYPEG(sptr);
+  int ilix, rilix;
   ADSC *ad;
-  LOGICAL ismidnum;
-  /* fill the arrays */
-  /* Build the list: (size, sptr) pairs. */
-  nme_args = addnme(NT_VAR, args_sptr, 0, 0);
-  nme_size = addnme(NT_VAR, arg_size_sptr, 0, 0);
-  nme_base = addnme(NT_VAR, arg_base_sptr, 0, 0);
-  nme_types = addnme(NT_VAR, args_maptypes_sptr, 0, 0);
 
-  for (i = 0; i < targetinfo->n_symbols; ++i) {
-    param_sptr = targetinfo->symbols[i].host_sym;
-
-    /* Check whether it is a midnum */
-    ismidnum = FALSE;
-    for (j = 0; j < targetinfo->n_quiet_symbols; ++j) {
-      int midnum_sptr = MIDNUMG(targetinfo->quiet_symbols[j].host_sym);
-      if (midnum_sptr == param_sptr || HASHLKG(midnum_sptr) == param_sptr) {
-        ismidnum = TRUE;
-        param_sptr = targetinfo->quiet_symbols[j].host_sym;
-        break;
-      }
-    }
-
-    dtype = DTYPEG(param_sptr);
-
-    if (ismidnum) {
-      midnum_sptr = MIDNUMG(param_sptr);
-      param_ili = ad3ili(IL_LDA, ad_acon(midnum_sptr, 0),
-                         addnme(NT_VAR, midnum_sptr, (INT)0, 0), MSZ_PTR);
-
-      /* assign arg */
-      nme = add_arrnme(NT_ARR, args_sptr, nme_args, 0, ad_icon(i), FALSE);
-      ili = ad4ili(IL_STA, param_ili, ad_acon(args_sptr, i * TARGET_PTRSIZE),
-                   nme, MSZ_I8);
-      chk_block(ili);
-
-      /* assign base */
-      nme = add_arrnme(NT_ARR, arg_base_sptr, nme_base, 0, ad_icon(i), FALSE);
-      ili = ad4ili(IL_STA, param_ili,
-                   ad_acon(arg_base_sptr, i * TARGET_PTRSIZE), nme, MSZ_I8);
-      chk_block(ili);
-    } else if ((STYPEG(param_sptr) == ST_ARRAY) ||
-               PASSBYVALG(targetinfo->symbols[i].device_sym) == 0) {
-      param_ili = ad_acon(param_sptr, 0);
-      /* assign arg */
-      nme = add_arrnme(NT_ARR, args_sptr, nme_args, 0, ad_icon(i), FALSE);
-      ili = ad3ili(IL_STA, param_ili, ad_acon(args_sptr, i * TARGET_PTRSIZE),
-                   nme);
-      chk_block(ili);
-      /* assign base */
-      // todo ompaccel find the real base. For now, I assume users request
-      // entire array mapping
-      nme = add_arrnme(NT_ARR, arg_base_sptr, nme_base, 0, ad_icon(i), FALSE);
-
-      ili = ad3ili(IL_STA, param_ili,
-                   ad_acon(arg_base_sptr, i * TARGET_PTRSIZE), nme);
-      chk_block(ili);
+  if(llis_pointer_kind(dtype)) {
+    if (map_type & OMP_TGT_MAPTYPE_IMPLICIT) {
+      ilix = ad_kconi(0);
+    } else
+      ompaccelInternalFail("Pointer data type is not implemented, cannot be passed to target region. ");
+  } else if (llis_vector_kind(dtype)) {
+    ompaccelInternalFail("Vector data type is not implemented, cannot be passed to target region. ");
+  } else if (llis_struct_kind(dtype)) {
+    ompaccelInternalFail("Struct data type is not implemented, cannot be passed to target region. ");
+  } else if (llis_function_kind(dtype)) {
+    ompaccelInternalFail("Function data type is not implemented, cannot be passed to target region. ");
+  } else if (llis_integral_kind(dtype) || dtype == DT_DBLE) {
+    ilix = ad_kconi(size_of(dtype));
+  } else if(llis_array_kind(dtype)) {
+    if(map_type & OMP_TGT_MAPTYPE_IMPLICIT) {
+      ilix = ad_kconi(0);
     } else {
-      param_ili = ld_sptr(param_sptr);
-
-      /* assign arg */
-      nme = add_arrnme(NT_ARR, args_sptr, nme_args, 0, ad_icon(i), FALSE);
-      ili = mk_ompaccel_store(param_ili, DTYPEG(param_sptr), nme,
-                              ad_acon(args_sptr, i * TARGET_PTRSIZE));
-      chk_block(ili);
-
-      /* assign base */
-      nme = add_arrnme(NT_ARR, arg_base_sptr, nme_base, 0, ad_icon(i), FALSE);
-      ili = mk_ompaccel_store(param_ili, DTYPEG(param_sptr), nme,
-                              ad_acon(arg_base_sptr, i * TARGET_PTRSIZE));
-      chk_block(ili);
-    }
-
-    /* assign map type */
-    int map_type = 0;
-    if (ismidnum) {
-      if (targetinfo->quiet_symbols[j].map_type == 0) {
-        targetinfo->quiet_symbols[j].map_type =
-            OMP_TGT_MAPTYPE_IMPLICIT | OMP_TGT_MAPTYPE_TARGET_PARAM;
-        if (DTY(dtype) != TY_ARRAY)
-          targetinfo->quiet_symbols[j].map_type |= OMP_TGT_MAPTYPE_LITERAL;
-      }
-      map_type = targetinfo->quiet_symbols[j].map_type;
-      targetinfo->symbols[i].map_type = map_type;
-    } else {
-      if (targetinfo->symbols[i].map_type == 0) {
-        targetinfo->symbols[i].map_type =
-            OMP_TGT_MAPTYPE_IMPLICIT | OMP_TGT_MAPTYPE_TARGET_PARAM;
-        if (DTY(dtype) != TY_ARRAY)
-          targetinfo->symbols[i].map_type |= OMP_TGT_MAPTYPE_LITERAL;
-      }
-      map_type = targetinfo->symbols[i].map_type;
-    }
-    nme =
-        add_arrnme(NT_ARR, args_maptypes_sptr, nme_types, 0, ad_icon(i), FALSE);
-    ili = ad4ili(IL_ST, ad_icon(map_type),
-                 ad_acon(args_maptypes_sptr, i * TARGET_PTRSIZE), nme, MSZ_I8);
-    chk_block(ili);
-
-    /* assign size */
-    if (DTY(dtype) == TY_ARRAY && (map_type & OMP_TGT_MAPTYPE_IMPLICIT)) {
-      size = ad_icon(0);
-    } else if (DTY(dtype) == TY_ARRAY) {
       ad = AD_DPTR(dtype);
-      if (SCG(param_sptr) == SC_STATIC) {
+      if (SCG(sptr) == SC_STATIC) {
+        ISZ_T size;
         int j, numdim = AD_NUMDIM(ad);
         size = 1;
         for (j = 0; j < numdim; ++j) {
           size = size * CONVAL2G(AD_UPBD(ad, j)) - CONVAL2G(AD_LWBD(ad, j)) + 1;
         }
-        size = size_of(DTYPE(dtype + 1)) * size;
-        size = ad_icon(size);
+        size = size_of((DTYPE)DTyAlgTyMember(dtype)) * size;
+        ilix = ad_icon(size);
       } else {
         int numdim = AD_NUMDIM(ad);
         int j;
-        size = ad_icon(1);
+        ilix = ad_kconi(1);
         // todo ompaccel we do not support partial arrays here.
         for (j = 0; j < numdim; ++j) {
           if (AD_UPBD(ad, j) != 0) {
-            sili = ad2ili(IL_ISUB, ld_sptr((SPTR) AD_UPBD(ad, j)), ld_sptr((SPTR) AD_LWBD(ad, j)));
-            sili = ad2ili(IL_IADD, sili, ad_icon(1));
+            SPTR ub = (SPTR) AD_UPBD(ad, j);
+            SPTR lb = (SPTR) AD_LWBD(ad, j);
+            rilix = ad2ili(IL_KSUB, ld_sptr(ub), ld_sptr(lb));
+            rilix = ad2ili(IL_KADD, rilix, ad_kconi(1));
           } else
-            sili = ad2ili(IL_IADD, ad_icon(0), ad_icon(1));
-          size = ad2ili(IL_IMUL, size, sili);
+            rilix = ad2ili(IL_KADD, ad_kconi(0), ad_kconi(1));
+          ilix = ad2ili(IL_KMUL, ilix, rilix);
         }
-        size = ad2ili(IL_IMUL, size, ad_icon(size_of(DTYPE(dtype + 1))));
+        ilix = ad2ili(IL_KMUL, ilix, ad_kconi(size_of((DTYPE)(dtype + 1))));
       }
-    } else {
-      size = ad_icon(size_of(dtype));
     }
-    nme = add_arrnme(NT_ARR, arg_size_sptr, nme_size, 0, ad_icon(i), FALSE);
-    ili = ad4ili(IL_ST, size, ad_acon(arg_size_sptr, i * TARGET_PTRSIZE), nme,
+  }else {
+    ompaccelInternalFail("Unknown data type");
+  }
+  return ilix;
+}
+
+
+static int
+_tgt_target_fill_maptype(SPTR sptr, int maptype, int isMidnum, int midnum_maptype) {
+  int final_maptype = 0;
+  /*todo ompaccel there are many cases to be covered. It is not completed yet. */
+  if(isMidnum)
+    final_maptype |= midnum_maptype;
+  else if(maptype == 0)
+    final_maptype = OMP_TGT_MAPTYPE_IMPLICIT;
+  else
+    final_maptype = maptype;
+
+  DTYPE dtype = DTYPEG(sptr);
+  if(final_maptype & OMP_TGT_MAPTYPE_IMPLICIT) {
+    if (llis_pointer_kind(dtype)) {
+
+    } else if (llis_array_kind(dtype)) {
+
+    } else if (llis_vector_kind(dtype)) {
+      ompaccelInternalFail("Don't know how to implicitly define map type for vector data type ");
+    } else if (llis_integral_kind(dtype) || dtype == DT_DBLE) {
+      final_maptype |= OMP_TGT_MAPTYPE_LITERAL;
+    } else if (llis_function_kind(dtype)) {
+      ompaccelInternalFail("Don't know how to implicitly define map type for function data type ");
+    } else if (llis_struct_kind(dtype)) {
+      ompaccelInternalFail("Don't know how to implicitly define map type for struct data type ");
+    } else {
+      ompaccelInternalFail("Unknown data type");
+    }
+  }
+  final_maptype |= OMP_TGT_MAPTYPE_TARGET_PARAM;
+  return final_maptype;
+}
+
+void
+tgt_target_fill_params(SPTR arg_base_sptr, SPTR arg_size_sptr, SPTR args_sptr,
+                       SPTR args_maptypes_sptr, OMPACCEL_TINFO *targetinfo)
+{
+  int i, j, ilix, iliy;
+  OMPACCEL_SYM midnum_sym;
+  DTYPE param_dtype, load_dtype;
+  SPTR param_sptr;
+  LOGICAL isPointer, isMidnum, isImplicit;
+  /* fill the arrays */
+  /* Build the list: (size, sptr) pairs. */
+
+  for (i = 0; i < targetinfo->n_symbols; ++i) {
+    int nme_args, nme_size, nme_base, nme_types;
+    nme_args = add_arrnme(NT_ARR, args_sptr, addnme(NT_VAR, args_sptr, 0, 0), 0, ad_icon(i), FALSE);
+    nme_size = add_arrnme(NT_ARR, arg_size_sptr, addnme(NT_VAR, arg_size_sptr, 0, 0), 0, ad_icon(i), FALSE);
+    nme_base = add_arrnme(NT_ARR, arg_base_sptr, addnme(NT_VAR, arg_base_sptr, 0, 0), 0, ad_icon(i), FALSE);
+    nme_types = add_arrnme(NT_ARR, args_maptypes_sptr, addnme(NT_VAR, args_maptypes_sptr, 0, 0), 0, ad_icon(i), FALSE);
+
+    isMidnum = FALSE;
+    param_sptr = targetinfo->symbols[i].host_sym;
+    param_dtype = DTYPEG(param_sptr);
+    isPointer = llis_pointer_kind(param_dtype);
+
+    /* This is for fortran allocatable arrays.
+     * We keep the base symbol as a quiet symbol that has the map type info.
+     * When the symbol is a pointer, it's base symbol might be in the quiet symbol list.
+     * Then we should look for its map type.
+     */
+    if(isPointer) {
+      for (j = 0; j < targetinfo->n_quiet_symbols; ++j) {
+        SPTR midnum_sptr = MIDNUMG(targetinfo->quiet_symbols[j].host_sym);
+        if (midnum_sptr == param_sptr || HASHLKG(midnum_sptr) == param_sptr) {
+          midnum_sym = targetinfo->quiet_symbols[j];
+          isMidnum = TRUE;
+          break;
+        }
+      }
+    }
+    /* assign map type */
+    targetinfo->symbols[i].map_type = _tgt_target_fill_maptype(param_sptr, targetinfo->symbols[i].map_type, isMidnum, midnum_sym.map_type);
+    ilix = ad4ili(IL_ST, ad_icon(targetinfo->symbols[i].map_type),
+                  ad_acon(args_maptypes_sptr, i * TARGET_PTRSIZE), nme_types, MSZ_I8);
+    chk_block(ilix);
+
+    /* Find the base */
+    isImplicit = targetinfo->symbols[i].map_type & OMP_TGT_MAPTYPE_IMPLICIT;
+    iliy = _tgt_target_fill_base(param_sptr, isImplicit, &load_dtype);
+    /* Assign args */
+    ilix = mk_ompaccel_store(iliy, load_dtype, nme_args, ad_acon(args_sptr, i * TARGET_PTRSIZE));
+    chk_block(ilix);
+    /* assign args_base */
+    ilix = mk_ompaccel_store(iliy, load_dtype, nme_base, ad_acon(arg_base_sptr, i * TARGET_PTRSIZE));
+    chk_block(ilix);
+
+    /* assign size */
+    if(isMidnum)
+      ilix = _tgt_target_fill_size(midnum_sym.host_sym, targetinfo->symbols[i].map_type);
+    else
+      ilix = _tgt_target_fill_size(param_sptr, targetinfo->symbols[i].map_type);
+    ilix = ad4ili(IL_STKR, ilix, ad_acon(arg_size_sptr, i * TARGET_PTRSIZE), nme_size,
                  TARGET_PTRSIZE == 8 ? MSZ_I8 : MSZ_WORD);
-    chk_block(ili);
+    chk_block(ilix);
   }
 }
 
-/* Dump the values being stored in the uplevel argument */
-static void
-dumpUplevel(int uplevel_sptr)
-{
-  int i;
-  FILE *fp = gbl.dbgfil ? gbl.dbgfil : stdout;
-
-  fprintf(fp, "********* UPLEVEL Struct *********\n");
-  for (i = DTY(DTYPE(DTYPEG(uplevel_sptr) + 1)); i > NOSYM; i = SYMLKG(i))
-    fprintf(fp, "==> %s %s\n", SYMNAME(i), stb.tynames[DTY(DTYPEG(i))]);
-  fprintf(fp, "**********\n\n");
-}
 
 void
 change_target_func_smbols(int outlined_func_sptr, int stblk_sptr)
@@ -748,19 +782,22 @@ ll_make_tgt_target(SPTR outlined_func_sptr, int64_t device_id, SPTR stblk_sptr)
   SPTR sptr, arg_base_sptr, arg_size_sptr, args_sptr, args_maptypes_sptr;
   char *name, *rname;
   OMPACCEL_TINFO *targetinfo;
+  int ili_hostptr;
 
   rname = SYMNAME(outlined_func_sptr);
   NEW(name, char, 100);
 
   targetinfo = ompaccel_tinfo_get(outlined_func_sptr);
-
+#if OMP_OFFLOAD_LLVM
   sptr = init_tgt_target_syms(rname);
+  ili_hostptr = ad_acon(sptr, 0);
+#endif
   if (targetinfo->n_symbols == 0) {
     int locargs[7];
     DTYPE locarg_types[] = {DT_INT8, DT_ADDR, DT_INT, DT_ADDR,
                             DT_ADDR, DT_ADDR, DT_ADDR};
     locargs[6] = ad_icon(device_id);
-    locargs[5] = ad_acon(sptr, 0);
+    locargs[5] = ili_hostptr;
     locargs[4] = ad_icon(targetinfo->n_symbols);
     locargs[3] = gen_null_arg();
     locargs[2] = gen_null_arg();
@@ -787,7 +824,7 @@ ll_make_tgt_target(SPTR outlined_func_sptr, int64_t device_id, SPTR stblk_sptr)
     DTYPE locarg_types[] = {DT_INT8, DT_ADDR, DT_INT, DT_ADDR,
                             DT_ADDR, DT_ADDR, DT_ADDR};
     locargs[6] = ad_icon(device_id);
-    locargs[5] = ad_acon(sptr, 0);
+    locargs[5] = ili_hostptr;
     locargs[4] = ad_icon(targetinfo->n_symbols);
     locargs[3] = ad_acon(arg_base_sptr, 0);
     locargs[2] = ad_acon(args_sptr, 0);
@@ -811,10 +848,13 @@ ll_make_tgt_target_teams(SPTR outlined_func_sptr, int64_t device_id,
   SPTR sptr, arg_base_sptr, arg_size_sptr, args_sptr, args_maptypes_sptr;
   char *name, *rname;
   OMPACCEL_TINFO *targetinfo = ompaccel_tinfo_get(outlined_func_sptr);
-  int nargs = targetinfo->n_symbols;
+  int ili_hostptr, nargs = targetinfo->n_symbols;
   rname = SYMNAME(outlined_func_sptr);
   NEW(name, char, 100);
+#if OMP_OFFLOAD_LLVM
   sptr = init_tgt_target_syms(rname);
+  ili_hostptr = ad_acon(sptr, 0);
+#endif
 
   sprintf(name, "%s_base", rname);
   arg_base_sptr = make_array_sptr(name, DT_CPTR, nargs);
@@ -833,7 +873,7 @@ ll_make_tgt_target_teams(SPTR outlined_func_sptr, int64_t device_id,
   DTYPE locarg_types[] = {DT_INT8, DT_ADDR, DT_INT, DT_ADDR, DT_ADDR,
                           DT_ADDR, DT_ADDR, DT_INT, DT_INT};
   locargs[8] = ad_icon(device_id);
-  locargs[7] = ad_acon(sptr, 0);
+  locargs[7] = ili_hostptr;
   locargs[6] = ad_icon(nargs);
   locargs[5] = ad_acon(arg_base_sptr, 0);
   locargs[4] = ad_acon(args_sptr, 0);
@@ -852,6 +892,56 @@ ll_make_tgt_target_teams(SPTR outlined_func_sptr, int64_t device_id,
 }
 
 int
+ll_make_tgt_target_teams_parallel(SPTR outlined_func_sptr, int64_t device_id,
+                         SPTR stblk_sptr, int32_t num_teams,
+                         int32_t thread_limit, int32_t num_threads, int32_t mode)
+{
+  SPTR sptr, arg_base_sptr, arg_size_sptr, args_sptr, args_maptypes_sptr;
+  char *name, *rname;
+  OMPACCEL_TINFO *targetinfo = ompaccel_tinfo_get(outlined_func_sptr);
+  int ili_hostptr, nargs = targetinfo->n_symbols;
+  rname = SYMNAME(outlined_func_sptr);
+  NEW(name, char, 100);
+  ili_hostptr = ad1ili(IL_ACON, get_acon(outlined_func_sptr, 0));
+
+  sprintf(name, "%s_base", rname);
+  arg_base_sptr = make_array_sptr(name, DT_CPTR, nargs);
+  sprintf(name, "%s_size", rname);
+  arg_size_sptr = make_array_sptr(name, DT_INT8, nargs);
+  sprintf(name, "%s_args", rname);
+  args_sptr = make_array_sptr(name, DT_CPTR, nargs);
+  sprintf(name, "%s_type", rname);
+  args_maptypes_sptr = make_array_sptr(name, DT_INT8, nargs);
+
+  tgt_target_fill_params(arg_base_sptr, arg_size_sptr, args_sptr,
+                         args_maptypes_sptr, targetinfo);
+
+  // prepare argument for tgt target
+  int locargs[11];
+  DTYPE locarg_types[] = {DT_INT8, DT_ADDR, DT_INT, DT_ADDR, DT_ADDR,
+                          DT_ADDR, DT_ADDR, DT_INT, DT_INT, DT_INT, DT_INT};
+  locargs[10] = ad_icon(device_id);
+  locargs[9] = ili_hostptr;
+  locargs[8] = ad_icon(nargs);
+  locargs[7] = ad_acon(arg_base_sptr, 0);
+  locargs[6] = ad_acon(args_sptr, 0);
+  locargs[5] = ad_acon(arg_size_sptr, 0);
+  locargs[4] = ad_acon(args_maptypes_sptr, 0);
+  locargs[3] = num_teams;
+  locargs[2] = thread_limit;
+  locargs[1] = num_threads;
+  locargs[0] = ad_icon(mode);
+
+  change_target_func_smbols(outlined_func_sptr, stblk_sptr);
+
+  // call the RT
+  int call_ili =
+      mk_tgt_api_call(TGT_API_TARGET_TEAMS_PARALLEL, 11, locarg_types, locargs);
+
+  return call_ili;
+}
+
+int
 ll_make_tgt_target_data_begin(int device_id, OMPACCEL_TINFO *targetinfo)
 {
   int call_ili, nargs;
@@ -861,7 +951,7 @@ ll_make_tgt_target_data_begin(int device_id, OMPACCEL_TINFO *targetinfo)
   int locargs[6];
   DTYPE locarg_types[] = {DT_INT8, DT_INT, DT_ADDR, DT_ADDR, DT_ADDR, DT_ADDR};
 
-  if (targetinfo == nullptr) {
+  if (targetinfo == NULL) {
     interr("Map item list is not found", 0, ERR_Fatal);
   }
   nargs = targetinfo->n_symbols;
@@ -902,9 +992,9 @@ ll_make_tgt_target_data_end(int device_id, OMPACCEL_TINFO *targetinfo)
 
   int locargs[6];
   DTYPE
-  locarg_types[] = {DT_INT8, DT_INT, DT_ADDR, DT_ADDR, DT_ADDR, DT_ADDR};
+      locarg_types[] = {DT_INT8, DT_INT, DT_ADDR, DT_ADDR, DT_ADDR, DT_ADDR};
 
-  if (targetinfo == nullptr) {
+  if (targetinfo == NULL) {
     interr("Map item list is not found", 0, ERR_Fatal);
   }
 

--- a/tools/flang2/flang2exe/tgtutil.h
+++ b/tools/flang2/flang2exe/tgtutil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ enum {
   TGT_API_TARGET_NOWAIT,
   TGT_API_TARGET_TEAMS,
   TGT_API_TARGET_TEAMS_NOWAIT,
+  TGT_API_TARGET_TEAMS_PARALLEL,
+  TGT_API_TARGET_TEAMS_PARALLEL_NOWAIT,
   TGT_API_TARGET_DATA_BEGIN,
   TGT_API_TARGET_DATA_BEGIN_DEPEND,
   TGT_API_TARGET_DATA_BEGIN_NOWAIT,
@@ -82,6 +84,11 @@ int ll_make_tgt_target(SPTR, int64_t, SPTR);
    \brief Start offload for target teams region
  */
 int ll_make_tgt_target_teams(SPTR, int64_t, SPTR, int32_t, int32_t);
+
+/**
+   \brief Start offload for target teams region
+ */
+int ll_make_tgt_target_teams_parallel(SPTR, int64_t, SPTR, int32_t, int32_t, int32_t, int32_t);
 
 /**
    \brief Start target data begin.

--- a/tools/flang2/flang2exe/upper.cpp
+++ b/tools/flang2/flang2exe/upper.cpp
@@ -3261,7 +3261,9 @@ read_symbol(void)
       up = llmp_create_uplevel_bykey(parsyms);
       up->parent = parent;
       for (i = 0; i < parsymsct; ++i) {
-        llmp_add_shared_var(up, getnum());
+	/* todo this should be removed as it's wrong.
+	 * Keep it until tested. */
+	llmp_add_shared_var(up, getnum());
       }
     }
 

--- a/tools/flang2/flang2exe/x86_64-Linux/flgdf.h
+++ b/tools/flang2/flang2exe/x86_64-Linux/flgdf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ FLG flg = {
     0,          /*  def ptr */
     NULL,       /*  search the standard include */
     false,      /* don't allow smp directives */
-    false,      /* don't allow omptarget OpenMP Offload directives */
+    false,      /* omptarget - don't allow OpenMP Offload directives */
     25,         /* errorlimit */
     false,      /* trans_inv */
 #ifdef TARGET_X86

--- a/tools/flang2/utils/ilmtp/aarch64/ilmtp.n
+++ b/tools/flang2/utils/ilmtp/aarch64/ilmtp.n
@@ -3662,10 +3662,13 @@ First stc is the pragma identifier, 2nd stc is the scope, 3rd stc is the policy 
 First link is the symbol link.
 Links point to the arguments.
 .AT spec trm
-.IL MP_TARGETMODE SMP stc
+.IL MP_TARGETMODE SMP stc lnk lnk lnk
 End of Target register.
 .nf
 stc Combined costruct mode
+lnk link to num_teams clause if exists
+lnk link to thread_limit clause if exists
+lnk link to num_threads clause if exists
 .AT spec trm
 .IL MP_TARGETLOOPTRIPCOUNT SMP sym
 loop trip count for target region
@@ -3696,12 +3699,17 @@ End of reduction clause.
 .IL MP_EMAP SMP
 End of map clause.
 .AT spec trm
+.IL MP_BEGIN_DIR SMP
+Begin directive
+.AT spec trm
+.IL MP_END_DIR SMP
+End directive
+.AT spec trm
 .IL HFLD load lnk
 Load half precision
 .AT spec
 .IL HFST store lnk lnk
 Store half precision
-.AT spec trm
 .IL HFCON cons sym
 Half precision constant
 .OP HFCON r v1

--- a/tools/flang2/utils/ilmtp/ppc64le/ilmtp.n
+++ b/tools/flang2/utils/ilmtp/ppc64le/ilmtp.n
@@ -3662,10 +3662,13 @@ First stc is the pragma identifier, 2nd stc is the scope, 3rd stc is the policy 
 First link is the symbol link.
 Links point to the arguments.
 .AT spec trm
-.IL MP_TARGETMODE SMP stc
+.IL MP_TARGETMODE SMP stc lnk lnk lnk
 End of Target register.
 .nf
 stc Combined costruct mode
+lnk link to num_teams clause if exists
+lnk link to thread_limit clause if exists
+lnk link to num_threads clause if exists
 .AT spec trm
 .IL MP_TARGETLOOPTRIPCOUNT SMP sym
 loop trip count for target region
@@ -3696,12 +3699,17 @@ End of reduction clause.
 .IL MP_EMAP SMP
 End of map clause.
 .AT spec trm
+.IL MP_BEGIN_DIR SMP
+Begin directive
+.AT spec trm
+.IL MP_END_DIR SMP
+End directive
+.AT spec trm
 .IL HFLD load lnk
 Load half precision
 .AT spec
 .IL HFST store lnk lnk
 Store half precision
-.AT spec trm
 .IL HFCON cons sym
 Half precision constant
 .OP HFCON r v1

--- a/tools/flang2/utils/ilmtp/x86_64/ilmtp.n
+++ b/tools/flang2/utils/ilmtp/x86_64/ilmtp.n
@@ -3614,10 +3614,13 @@ First stc is the pragma identifier, 2nd stc is the scope, 3rd stc is the policy 
 First link is the symbol link.
 Links point to the arguments.
 .AT spec trm
-.IL MP_TARGETMODE SMP stc
+.IL MP_TARGETMODE SMP stc lnk lnk lnk
 End of Target register.
 .nf
 stc Combined costruct mode
+lnk link to num_teams clause if exists
+lnk link to thread_limit clause if exists
+lnk link to num_threads clause if exists
 .AT spec trm
 .IL MP_TARGETLOOPTRIPCOUNT SMP sym
 loop trip count for target region
@@ -3647,6 +3650,12 @@ End of reduction clause.
 .AT spec trm
 .IL MP_EMAP SMP
 End of map clause.
+.AT spec trm
+.IL MP_BEGIN_DIR SMP
+Begin directive
+.AT spec trm
+.IL MP_END_DIR SMP
+End directive
 .AT spec trm
 .IL HFLD load lnk
 Load half precision

--- a/tools/flang2/utils/symtab/symtab.n
+++ b/tools/flang2/utils/symtab/symtab.n
@@ -394,6 +394,8 @@ Other Fields
 .SE RFCNT w13
 Number of references of this label.
 This includes references in
+.SE RFCNTDEV w14
+Number of references of this label for openmp device code.
 .cw ASSIGN
 and assigned
 .cw GOTO
@@ -1248,6 +1250,8 @@ Set as text startup item
 Set as constructor
 .FL IS_INTERFACE f120
 Set if the symbol is a Fortran interface
+.FL OMPTEAMPRIVATE f121
+Team private symbol
 .SE PRIORITY w27
 If CONSTRUCTORG() or DESTRUCTORG() is true, then this has
 the value 0-65535 for the priority value.

--- a/tools/flang2/utils/upper/upperilm.in
+++ b/tools/flang2/utils/upper/upperilm.in
@@ -621,7 +621,7 @@ MP_EMAP
 MP_BREDUCTION
 MP_EREDUCTION
 MP_REDUCTIONITEM sym sym num
-MP_TARGETMODE num
+MP_TARGETMODE num ilm ilm ilm
 HFLD	ilm
 HFST	ilm	ilm
 HFCON	sym
@@ -646,3 +646,5 @@ UXLNEQV8   ilm ilm
 UXLEQV8    ilm ilm
 UXLAND8    ilm ilm
 UXLNOT8    ilm
+MP_BEGIN_DIR
+MP_END_DIR

--- a/tools/flang2/utils/upper/upperl.c
+++ b/tools/flang2/utils/upper/upperl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2007-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -510,7 +510,7 @@ putdecls()
   fprintf(outfile, "\n");
 } /* putdecls */
 
-#define MAXCOMBO 110
+#define MAXCOMBO 120
 #define MAXSTRING 100
 
 char operation[MAXSTRING];

--- a/tools/shared/llmputil.h
+++ b/tools/shared/llmputil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2015-2019, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,6 +96,7 @@ typedef enum {
   mode_target,
   mode_target_teams,
   mode_target_teams_distribute,
+  mode_target_teams_distribute_simd,
   mode_target_teams_distribute_parallel_for,
   mode_target_teams_distribute_parallel_for_simd,
   mode_target_parallel,
@@ -104,6 +105,8 @@ typedef enum {
   mode_target_data_enter_region,
   mode_target_data_exit_region,
   mode_target_data_region,
+  mode_outlinedfunc_teams,
+  mode_outlinedfunc_parallel,
 } OMP_TARGET_MODE;
 
 /* Obtain a previously created task object, where scope_sptr is the BMPSCOPE

--- a/tools/shared/utils/global.h
+++ b/tools/shared/utils/global.h
@@ -146,9 +146,10 @@ typedef struct {
   bool denorm; /* enforce denorm for the current subprogram */
   int outlined;   /* is outlined function .*/
   int usekmpc;    /* use KMPC runtime. turned on for -ta=multicore for llvm. */
-#ifdef OMP_OFFLOAD_LLVM
-  bool isnvvmcodegen; /* set when generating code for device */
-  bool inomptarget;
+#if defined(OMP_OFFLOAD_PGI) || defined(OMP_OFFLOAD_LLVM)
+  bool ompaccel_intarget;  /* set when expander is in the openmp target construct */
+  bool ompaccel_isdevice;  /* set when generating code for openmp target device */
+  SPTR teamPrivateArgs;    /* keeps sptr that holds team private array */
 #endif
 } GBL;
 
@@ -210,7 +211,7 @@ typedef struct {
   char *stdinc; /* NULL => use std include; 1 ==> do not look in
                  * std dir; o.w., use value as the std dir */
   bool smp;  /* TRUE => allow smp directives */
-  bool omptarget;  /** TRUE => allow omp accel directives */
+  LOGICAL omptarget;  /* TRUE => allow OpenMP Offload directives */
   int errorlimit;
   bool trans_inv; /* global equiv to -Mx,7,0x10000 */
   int tpcount;


### PR DESCRIPTION
Summary:
  - Remove state machine in the outliner.
  - Fix deadlock in reductions with print/write statements.
  - Fix issue with privatization.
  - Add support for team private scalar variables.
  - Remove outlining of teams construct.
  - Remove outlining of parallel construct.
  - Remove unused xflag definitions from Flang.

Adapted RFCNT information for multiple outlining.
    The number of references of the label sptr is
    changed at the first expand. At the second
    expand of the same ILM, expander treats the
    label sptr according to its changed RFCNT
    value. It results wrong ILI generating. This
    patch creates a new symbol feature, that's
    RFCNTDEV, and saves the original RFCNT
    value into RFCNTDEV. At the second expand,
    it replaces original value from RFCNTDEV
    into RFCNT.

Enhancements to the uplevel struct passed to the
outlined functions.

Add OpenMP directive based multiple outliner.
    Previously implemented as a state machine at
    the outliner, was based on the temporary ILM
    files. It turns out it is an insufficient
    mechanism. Because there are multiple
    outlined functions in the same temp ILM file,
    compiler needs to multiple outlining for
    ones that are in OpenMP target region. For
    example:

    This patch removes state-machine in outliner,
    and introduce recompilation in process_input
    function in the main file.

Fix deadlock with write statements in OpenMP reduce
    When a function that contains an OpenMP
    reduction is called within a write Fortran
    statement and the code is executed by
    multiple threads, it causes a deadlock. The
    problem happens because the compiler
    generates a lock `_mp_bcs/ecs_nest` for the
    write statement to make them thread safe;
    the same lock is also used to implement the
    OpenMP reduction. When the reduction is
    called within a print statement the same
    nested lock is being acquired twice by
    multiple threads causing the deadlock. The
    solution is to use different locks for write
    statements and reductions. This introduces
    a new set of locks (`_mp_bcs/ecs_nest_red`)
    for the reduction in the runtime.

Privatization while generating device code.
    Privatization was implemented in several
    places on the compiler; iliutil is one of
    them that generates ILI to load private
    data. Function is_llvm_local_private finds
    out whether the sptr is local private
    or not, it returns true if the current
    function and enclosed function of the sptr
    are the same. However, it fails here while
    generating code for device, because we
    generate two functions sptr for host and
    device in OpenMP. The problem here is that
    the enclosed function of the sptr is the host
    outlined function while GBL_CURRFUNC is the
    device outlined function. In order to make a
    correct comparison, we need to find out host
    function sptr of GBL_CURRFUNC and compare
    it with enclosed function of the sptr.

Handle private sptr when there is no outlining
    Currently the compiler doesn't process
    private sptr. For example, it doesn't
    init SNAME field when there is no
    outlining. However, privatization is possible
    with "!$omp do" or "!$omp distribute" which
    don't require outlining.
    This fix process private sptr even if there is
    no outlining.

Support for team private scalar variables.
    Team private variables should be private to
    the team, but shared accross threads withing
    a team. In our OpenMP model, we associated
    CTAs with the teams. Therefore, shared memory
    is the perfect place to create and keep
    scalars values if they are scalar. Non-scalar
    team private variables is not support yet.

Outlining elimination for teams construct.
    This change implements outlining elimination
    for the teams construct. The aim of doing
    it, outlining prevents compiler and runtime
    further optimization. we should avoid as
    much as we can. Introduced a mechanism that
    finds the enclosed function of the symbol
    in ilitutil.c.

Other features:
    - New optimization - Outlining elimination
      for parallel construct. It can be enabled
      with -Mx,233,0x10
    - Fixed for outlining elimination for teams
      construct. It was passing wrong function
      pointer to _kmpc_fork_call.
    - Fix setting gbl.ompaccel_intarget, that
      is set if the region is inside of target
      construct, while compiling code for the
      target device.
    - Moved PARENCLFUNC feature setting into
      host expanding. It helps to find encolosed
      function info for symbols that are created
      in the outlined functions.

    - New API "__tgt_target_teams_parallel" is
      added in nvomp RTL. This change implements
      its associated codegen in compiler
    - Improved TARGETMODE ILM, that is located
      just before BTARGET. Now TARGETMODE
      has num_teams, thread_limit, num_threads
      beside combined construct mode. We use
      all this information while generating call
      "__tgt_target_teams_parallel".