### PR TITLE
In order to prevent mysterious crashes during parallel building process, build static modules in separate include-static directory

### DIFF
--- a/runtime/flang/CMakeLists.txt
+++ b/runtime/flang/CMakeLists.txt
@@ -465,6 +465,11 @@ add_flang_library(flang_static
   )
 set_property(TARGET flang_static PROPERTY OUTPUT_NAME flang)
 
+set_target_properties(flang_static
+  PROPERTIES
+  Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include-static
+)
+
 set(SHARED_LIBRARY TRUE)
 add_flang_library(flang_shared
   ${FTN_INTRINSICS_DESC_INDEP}


### PR DESCRIPTION
This patch fixes mysterious build-time problem with parallel builds we were facing for way too long.
