### PR TITLE
Force #undef HUGE in runtime/libpgmath/lib/x86_64/libm_amd.h

### DIFF
--- a/runtime/libpgmath/lib/x86_64/libm_amd.h
+++ b/runtime/libpgmath/lib/x86_64/libm_amd.h
@@ -89,6 +89,8 @@ typedef unsigned long long __UINT8_T;
 # define TLOSS          5
 # define PLOSS          6
 
+/* The BSDs (and probably macOS) define HUGE in math.h.  */
+# undef HUGE
 # define HUGE           3.40282347e+38F
 
 #endif


### PR DESCRIPTION
Prevents preprocessor redefined warnings on the BSDs. macOS probably also suffers from this issue.

I've noticed this for a while now in the OpenBSD package builds; just finally getting around to doing something about it.