### PR TITLE
Fixing NCAR test problems with error tolerance lower than E-12.

### DIFF
--- a/test/ncar_kernels/CAM5_mg2_pgi/src/micro_mg_cam.F90
+++ b/test/ncar_kernels/CAM5_mg2_pgi/src/micro_mg_cam.F90
@@ -5,7 +5,11 @@
 ! Generated at: 2015-03-31 09:44:40
 ! KGEN version: 0.4.5
 
-
+#ifdef __aarch64__
+#define  _TOL 1.E-12
+#else
+#define  _TOL 1.E-14
+#endif
 
     MODULE micro_mg_cam
         !---------------------------------------------------------------------------------
@@ -146,7 +150,7 @@
           if(present(tolerance)) then
              check%tolerance = tolerance
           else
-              check%tolerance = 1.E-14
+              check%tolerance = _TOL
           endif
           if(present(minvalue)) then
              check%minvalue = minvalue
@@ -559,7 +563,7 @@
             ! Allocate all the dummies with MG sizes.
             ! Pack input variables that are not updated during substeps.
             ! Allocate input variables that are updated during substeps.
-                        tolerance = 1.E-14
+                        tolerance = _TOL
                         CALL kgen_init_check(check_status, tolerance)
                         CALL kgen_read_real_r8_dim2_alloc(packed_t, kgen_unit)
                         CALL kgen_read_real_r8_dim2_alloc(packed_q, kgen_unit)

--- a/test/ncar_kernels/PORT_binterp/src/kernel_binterp.F90
+++ b/test/ncar_kernels/PORT_binterp/src/kernel_binterp.F90
@@ -1,3 +1,9 @@
+#ifdef __aarch64__
+#define _TOL 1.E-12
+#else
+#define _TOL 0.0
+#endif
+
     MODULE resolvers
 
     ! RESOLVER SPECS
@@ -173,7 +179,7 @@
 
 
     ! STATE VERIFICATION
-    IF ( ALL( outstate_itab == itab ) ) THEN
+    IF ( ALL(( abs(outstate_itab - itab) ) .LT. _TOL )) THEN
         WRITE(*,*) "itab is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_itab
         !WRITE(*,*) "KERNEL: ", itab
@@ -191,7 +197,7 @@
         WRITE(*,*) "Mean value of original outstate_itab is ", sum(outstate_itab)/real(size(outstate_itab))
         WRITE(*,*) ""
     END IF
-    IF ( ALL( outstate_refr == refr ) ) THEN
+    IF ( ALL(( abs(outstate_refr - refr) ) .LT. _TOL )) THEN
         WRITE(*,*) "refr is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_refr
         !WRITE(*,*) "KERNEL: ", refr
@@ -209,7 +215,7 @@
         WRITE(*,*) "Mean value of original outstate_refr is ", sum(outstate_refr)/real(size(outstate_refr))
         WRITE(*,*) ""
     END IF
-    IF ( ALL( outstate_cext == cext ) ) THEN
+    IF ( ALL(( abs(outstate_cext - cext) ) .LT. _TOL )) THEN
         WRITE(*,*) "cext is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_cext
         !WRITE(*,*) "KERNEL: ", cext
@@ -234,7 +240,8 @@
           end do
         end do
     END IF
-    IF ( ALL( outstate_utab == utab ) ) THEN
+
+    IF ( ALL(( abs(outstate_utab -  utab) ) .LT. _TOL )) THEN
         WRITE(*,*) "utab is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_utab
         !WRITE(*,*) "KERNEL: ", utab
@@ -252,7 +259,7 @@
         WRITE(*,*) "Mean value of original outstate_utab is ", sum(outstate_utab)/real(size(outstate_utab))
         WRITE(*,*) ""
     END IF
-    IF ( ALL( outstate_refitabsw == refitabsw ) ) THEN
+    IF ( ALL(( abs(outstate_refitabsw - refitabsw) ) .LT. _TOL )) THEN
         WRITE(*,*) "refitabsw is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_refitabsw
         !WRITE(*,*) "KERNEL: ", refitabsw
@@ -270,7 +277,7 @@
         WRITE(*,*) "Mean value of original outstate_refitabsw is ", sum(outstate_refitabsw)/real(size(outstate_refitabsw))
         WRITE(*,*) ""
     END IF
-    IF ( ALL( outstate_refrtabsw == refrtabsw ) ) THEN
+    IF ( ALL(( abs(outstate_refrtabsw - refrtabsw) ) .LT. _TOL )) THEN
         WRITE(*,*) "refrtabsw is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_refrtabsw
         !WRITE(*,*) "KERNEL: ", refrtabsw
@@ -288,7 +295,7 @@
         WRITE(*,*) "Mean value of original outstate_refrtabsw is ", sum(outstate_refrtabsw)/real(size(outstate_refrtabsw))
         WRITE(*,*) ""
     END IF
-    IF ( ALL( outstate_ttab == ttab ) ) THEN
+    IF ( ALL(( abs(outstate_ttab - ttab) ) .LT. _TOL )) THEN
         WRITE(*,*) "ttab is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_ttab
         !WRITE(*,*) "KERNEL: ", ttab
@@ -306,7 +313,7 @@
         WRITE(*,*) "Mean value of original outstate_ttab is ", sum(outstate_ttab)/real(size(outstate_ttab))
         WRITE(*,*) ""
     END IF
-    IF ( ALL( outstate_refi == refi ) ) THEN
+    IF ( ALL(( abs(outstate_refi - refi )) .LT. _TOL)) THEN
         WRITE(*,*) "refi is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_refi
         !WRITE(*,*) "KERNEL: ", refi
@@ -324,7 +331,7 @@
         WRITE(*,*) "Mean value of original outstate_refi is ", sum(outstate_refi)/real(size(outstate_refi))
         WRITE(*,*) ""
     END IF
-    IF ( outstate_ncol == ncol ) THEN
+    IF ( (abs(outstate_ncol - ncol) ) .LT. _TOL ) THEN
         WRITE(*,*) "ncol is IDENTICAL."
         WRITE(*,*) "STATE : ", outstate_ncol
         WRITE(*,*) "KERNEL: ", ncol
@@ -334,7 +341,7 @@
         WRITE(*,*) "STATE : ", outstate_ncol
         WRITE(*,*) "KERNEL: ", ncol
     END IF
-    IF ( ALL( outstate_jtab == jtab ) ) THEN
+    IF ( ALL(( abs(outstate_jtab - jtab) ) .LT. _TOL )) THEN
         WRITE(*,*) "jtab is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_jtab
         !WRITE(*,*) "KERNEL: ", jtab
@@ -352,7 +359,7 @@
         WRITE(*,*) "Mean value of original outstate_jtab is ", sum(outstate_jtab)/real(size(outstate_jtab))
         WRITE(*,*) ""
     END IF
-    IF ( ALL( outstate_extpsw == extpsw ) ) THEN
+    IF ( ALL(( abs(outstate_extpsw - extpsw) ) .LT. _TOL )) THEN
         WRITE(*,*) "extpsw is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_extpsw
         !WRITE(*,*) "KERNEL: ", extpsw

--- a/test/ncar_kernels/PORT_reftra_sw/src/kernel_reftra_sw.F90
+++ b/test/ncar_kernels/PORT_reftra_sw/src/kernel_reftra_sw.F90
@@ -1,3 +1,8 @@
+#ifdef __aarch64__
+#define _TOL 1.E-12
+#else
+#define _TOL 0.0
+#endif
     MODULE resolvers
 
     ! RESOLVER SPECS
@@ -127,7 +132,7 @@
    
 
     ! STATE VERIFICATION
-    IF ( ALL( outstate_ztradc == ztradc ) ) THEN
+    IF ( ALL(( abs(outstate_ztradc - ztradc) ) .LT. _TOL) ) THEN
         WRITE(*,*) "ztradc is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_ztradc
         !WRITE(*,*) "KERNEL: ", ztradc
@@ -145,7 +150,7 @@
         WRITE(*,*) "Mean value of original outstate_ztradc is ", sum(outstate_ztradc)/real(size(outstate_ztradc))
         WRITE(*,*) ""
     END IF
-    IF ( ALL( outstate_zrefdc == zrefdc ) ) THEN
+    IF ( ALL(( abs(outstate_zrefdc - zrefdc) ) .LT. _TOL)) THEN
         WRITE(*,*) "zrefdc is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_zrefdc
         !WRITE(*,*) "KERNEL: ", zrefdc
@@ -163,7 +168,7 @@
         WRITE(*,*) "Mean value of original outstate_zrefdc is ", sum(outstate_zrefdc)/real(size(outstate_zrefdc))
         WRITE(*,*) ""
     END IF
-    IF ( ALL( outstate_ztrac == ztrac ) ) THEN
+    IF ( ALL(( abs(outstate_ztrac - ztrac) ) .LT. _TOL)) THEN
         WRITE(*,*) "ztrac is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_ztrac
         !WRITE(*,*) "KERNEL: ", ztrac
@@ -181,7 +186,7 @@
         WRITE(*,*) "Mean value of original outstate_ztrac is ", sum(outstate_ztrac)/real(size(outstate_ztrac))
         WRITE(*,*) ""
     END IF
-    IF ( ALL( outstate_zrefc == zrefc ) ) THEN
+    IF ( ALL(( abs(outstate_zrefc - zrefc) ) .LT. _TOL) ) THEN
         WRITE(*,*) "zrefc is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_zrefc
         !WRITE(*,*) "KERNEL: ", zrefc

--- a/test/ncar_kernels/PORT_sw_spcvmc/inc/t1.mk
+++ b/test/ncar_kernels/PORT_sw_spcvmc/inc/t1.mk
@@ -61,7 +61,7 @@ build: ${ALL_OBJS}
 kernel_driver.o: $(SRC_DIR)/kernel_driver.f90 rrtmg_sw_rad.o kgen_utils.o rrtmg_sw_reftra.o rrsw_kg28.o rrsw_kg25.o rrsw_kg19.o parrrsw.o rrsw_tbl.o rrsw_kg21.o rrsw_kg23.o rrsw_con.o rrsw_wvn.o rrsw_kg27.o rrsw_kg24.o rrsw_kg16.o rrsw_vsn.o shr_kind_mod.o rrsw_kg17.o rrsw_kg20.o rrsw_kg29.o rrsw_kg22.o rrtmg_sw_taumol.o rrtmg_sw_vrtqdr.o rrsw_kg26.o rrsw_kg18.o rrtmg_sw_spcvmc.o
 	${FC} ${FC_FLAGS} -c -o $@ $<
 
-rrtmg_sw_rad.o: $(SRC_DIR)/rrtmg_sw_rad.f90 kgen_utils.o rrtmg_sw_spcvmc.o shr_kind_mod.o parrrsw.o
+rrtmg_sw_rad.o: $(SRC_DIR)/rrtmg_sw_rad.F90 kgen_utils.o rrtmg_sw_spcvmc.o shr_kind_mod.o parrrsw.o
 	${FC} ${FC_FLAGS} -c -o $@ $<
 
 rrtmg_sw_reftra.o: $(SRC_DIR)/rrtmg_sw_reftra.f90 kgen_utils.o shr_kind_mod.o rrsw_vsn.o rrsw_tbl.o

--- a/test/ncar_kernels/PORT_sw_spcvmc/src/rrtmg_sw_rad.F90
+++ b/test/ncar_kernels/PORT_sw_spcvmc/src/rrtmg_sw_rad.F90
@@ -5,6 +5,12 @@
 ! Generated at: 2015-07-31 20:35:44
 ! KGEN version: 0.4.13
 
+#ifdef __aarch64__
+#define  _TOL 1.E-12
+#else
+#define  _TOL 1.E-14
+#endif
+
 
 
     MODULE rrtmg_sw_rad
@@ -505,7 +511,7 @@
             !          ! Transfer up and down, clear and total sky fluxes to output arrays.
             !          ! Vertical indexing goes from bottom to top
             !end do
-            tolerance = 1.E-14
+            tolerance = _TOL
             CALL kgen_init_check(check_status, tolerance)
             READ(UNIT=kgen_unit) istart
             READ(UNIT=kgen_unit) iend


### PR DESCRIPTION
The NCAR test use selected_real_kind(12), therefore the  tolerance tests should also compare values until E-12.
This patch adds a tolerance  value TOL according to the architecture.
 The consequence is to make the tests more robust