### PR TITLE
Enable build when OMP_OFFLOAD_LLVM and OMP_OFFLOAD_PGI are both

### DIFF
--- a/tools/flang2/flang2exe/ompaccel.cpp
+++ b/tools/flang2/flang2exe/ompaccel.cpp
@@ -2412,7 +2412,6 @@ init_test()
   init_tgtutil();
 }
 
-#endif
 /* Expander - OpenMP Accelerator Model */
  
 
@@ -2475,3 +2474,5 @@ ompaccel_tinfo_get_current_parent_devsptr(SPTR sptr)
   }
   return SPTR_NULL;
 }
+
+#endif


### PR DESCRIPTION
not defined, for example the official OpenBSD package.