### PR TITLE
LLVM9 debuginfo change

### DIFF
--- a/tools/flang2/flang2exe/ll_structure.cpp
+++ b/tools/flang2/flang2exe/ll_structure.cpp
@@ -400,6 +400,7 @@ compute_ir_feature_vector(LLVMModuleRef module, enum LL_IRVersion vers)
 
   module->ir.version = vers;
   InitializeDIFlags(&module->ir);
+  InitializeDISPFlags(&module->ir);
   if (XBIT(120, 0x200)) {
     module->ir.dwarf_version = LL_DWARF_Version_2;
   } else if (XBIT(120, 0x4000)) {

--- a/tools/flang2/flang2exe/ll_structure.cpp
+++ b/tools/flang2/flang2exe/ll_structure.cpp
@@ -399,8 +399,6 @@ compute_ir_feature_vector(LLVMModuleRef module, enum LL_IRVersion vers)
     module->ir.is_spir = 1;
 
   module->ir.version = vers;
-  InitializeDIFlags(&module->ir);
-  InitializeDISPFlags(&module->ir);
   if (XBIT(120, 0x200)) {
     module->ir.dwarf_version = LL_DWARF_Version_2;
   } else if (XBIT(120, 0x4000)) {

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -396,6 +396,15 @@ ll_feature_three_argument_ctor_and_dtor(const LL_IRFeatures *feature)
   return feature->version >= LL_Version_9_0;
 }
 
+/**
+   \brief Version 9.0 debug metadata
+ */
+INLINE static bool
+ll_feature_debug_info_ver90(const LL_IRFeatures *feature)
+{
+  return feature->version >= LL_Version_9_0;
+}
+
 INLINE static bool
 ll_feature_use_distinct_metadata(const LL_IRFeatures *feature)
 {
@@ -486,6 +495,7 @@ ll_feature_no_file_in_namespace(const LL_IRFeatures *feature)
 #define ll_feature_debug_info_ver80(f) ((f)->version >= LL_Version_8_0)
 #define ll_feature_three_argument_ctor_and_dtor(f) \
   ((f)->version >= LL_Version_9_0)
+#define ll_feature_debug_info_ver90(f) ((f)->version >= LL_Version_9_0)
 #define ll_feature_use_distinct_metadata(f) ((f)->version >= LL_Version_3_8)
 #define ll_feature_subprogram_not_in_cu(f) ((f)->version >= LL_Version_3_9)
 #define ll_feature_from_global_to_md(f) ((f)->version >= LL_Version_4_0)

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1035,6 +1035,28 @@ static const MDTemplate Tmpl_DISubprogram[] = {
   { "scopeLine",                UnsignedField }
 };
 
+static const MDTemplate Tmpl_DISubprogram_90[] = {
+  { "DISubprogram", TF, 18 },
+  { "tag",                      DWTagField, FlgHidden },
+  { "file",                     NodeField },
+  { "scope",                    NodeField },
+  { "name",                     StringField },
+  { "displayName",              StringField, FlgHidden },
+  { "linkageName",              StringField },
+  { "line",                     UnsignedField },
+  { "type",                     NodeField },
+  { "virtuality",               DWVirtualityField },
+  { "virtualIndex",             UnsignedField },
+  { "containingType",           NodeField },
+  { "flags",                    UnsignedField }, /* TBD: DIFlag... */
+  { "spFlags",                  UnsignedField }, /* TBD: DISPFlag... */
+  { "function",                 ValueField, FlgHidden },
+  { "templateParams",           NodeField },
+  { "declaration",              NodeField },
+  { "unit",                     NodeField },
+  { "scopeLine",                UnsignedField }
+};
+
 static const MDTemplate Tmpl_DISubprogram_70[] = {
   { "DISubprogram", TF, 20 },
   { "tag",                      DWTagField, FlgHidden },
@@ -1992,6 +2014,11 @@ emitDISubprogram(FILE *out, LLVMModuleRef mod, const LL_MDNode *mdnode,
                  unsigned mdi)
 {
   if (!ll_feature_debug_info_pre34(&mod->ir)) {
+    if (ll_feature_debug_info_ver90(&mod->ir)) {
+      // 9.0, spFlags field introduced and many other fields migrated there.
+      emitTmpl(out, mod, mdnode, mdi, Tmpl_DISubprogram_90);
+      return;
+    }
     if (ll_feature_debug_info_ver70(&mod->ir)) {
       // 7.0, 'variables:' was removed
       emitTmpl(out, mod, mdnode, mdi, Tmpl_DISubprogram_70);

--- a/tools/flang2/flang2exe/lldebug.h
+++ b/tools/flang2/flang2exe/lldebug.h
@@ -277,14 +277,6 @@ void lldbg_set_func_ptr(LL_DebugInfo *db, LL_Value *func_ptr);
  */
 void lldbg_update_arrays(LL_DebugInfo *db, int lastDType, int newSz);
 
-/// \brief Initialize the DIFLAG values
-/// The values may vary depending on the LLVM branch being used
-void InitializeDIFlags(const LL_IRFeatures *feature);
-
-/// \brief Initialize the DISPFLAG values
-/// The values may vary depending on the LLVM branch being used
-void InitializeDISPFlags(const LL_IRFeatures *feature);
-
 void lldbg_reset_module(LL_DebugInfo *db);
 
 #endif /* LLDEBUG_H_ */

--- a/tools/flang2/flang2exe/lldebug.h
+++ b/tools/flang2/flang2exe/lldebug.h
@@ -281,6 +281,10 @@ void lldbg_update_arrays(LL_DebugInfo *db, int lastDType, int newSz);
 /// The values may vary depending on the LLVM branch being used
 void InitializeDIFlags(const LL_IRFeatures *feature);
 
+/// \brief Initialize the DISPFLAG values
+/// The values may vary depending on the LLVM branch being used
+void InitializeDISPFlags(const LL_IRFeatures *feature);
+
 void lldbg_reset_module(LL_DebugInfo *db);
 
 #endif /* LLDEBUG_H_ */


### PR DESCRIPTION
LLVM9 Changes
LLVM9 moves some bitfields from the DIFlags to a subprogram-specific field called DISPFlags. Teach flang2 to emit these, whilst staying backwards compatible. 