### PR TITLE
Unit tests for NORM2

### DIFF
--- a/test/f90_correct/inc/norm2.mk
+++ b/test/f90_correct/inc/norm2.mk
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+EXE=norm2.$(EXESUFFIX)
+
+build:  $(SRC)/norm2.F90
+	-$(RM) norm2.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	-$(RM) $(OBJ)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	@echo ------------------------------------ building test $@
+	$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/norm2.F90 check.$(OBJX) -o norm2.$(EXESUFFIX)
+	$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/norm2.F90 check.$(OBJX) -r8 -o norm2R8.$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test norm2
+	norm2.$(EXESUFFIX)
+	norm2R8.$(EXESUFFIX)
+
+verify: ;
+
+norm2.run: run

--- a/test/f90_correct/inc/norm2_double_precision.mk
+++ b/test/f90_correct/inc/norm2_double_precision.mk
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+EXE=norm2_double_precision.$(EXESUFFIX)
+
+build:  $(SRC)/norm2_double_precision.F90
+	-$(RM) norm2_double_precision.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	-$(RM) $(OBJ)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	@echo ------------------------------------ building test $@
+	$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/norm2_double_precision.F90 check.$(OBJX) -o norm2_double_precision.$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test Norm2 Double Precicion
+	norm2_double_precision.$(EXESUFFIX)
+
+verify: ;
+
+norm2_double_precision.run: run

--- a/test/f90_correct/inc/norm2_error.mk
+++ b/test/f90_correct/inc/norm2_error.mk
@@ -1,0 +1,29 @@
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build: clean
+	@echo ------------------------------------ building test $(TEST)
+#	-@$(CP) $(SRC)/$(TEST).f90  .
+	-$(FC) -c $(FCFLAGS) $(SRC)/$(TEST).f90 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ test $(TEST) not expected to execute
+
+verify:
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f90 $(TEST).rslt $(FC)
+
+clean:
+	-@$(RM) $(TEST).rslt $(TEST).$(OBJX) *.mod $(TEST).$(EXE)
+

--- a/test/f90_correct/inc/norm2_function.mk
+++ b/test/f90_correct/inc/norm2_function.mk
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+EXE=norm2_function.$(EXESUFFIX)
+
+build:  $(SRC)/norm2_function.F90
+	-$(RM) norm2_function.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	-$(RM) $(OBJ)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	@echo ------------------------------------ building test $@
+	$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/norm2_function.F90 check.$(OBJX) -o norm2_function.$(EXESUFFIX)
+	$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/norm2.F90 check.$(OBJX) -r8 -o norm2R8_function.$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test norm2_function
+	norm2_function.$(EXESUFFIX)
+	norm2R8_function.$(EXESUFFIX)
+
+verify: ;
+
+norm2_function.run: run

--- a/test/f90_correct/inc/norm2_single_precision.mk
+++ b/test/f90_correct/inc/norm2_single_precision.mk
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+EXE=norm2_single_precision.$(EXESUFFIX)
+
+build:  $(SRC)/norm2_single_precision.F90
+	-$(RM) norm2_single_precision.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	-$(RM) $(OBJ)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	@echo ------------------------------------ building test $@
+	$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/norm2_single_precision.F90 check.$(OBJX) -o norm2_single_precision.$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test Norm2 Single Precicion
+	norm2_single_precision.$(EXESUFFIX)
+
+verify: ;
+
+norm2_single_precision.run: run

--- a/test/f90_correct/lit/norm2.sh
+++ b/test/f90_correct/lit/norm2.sh
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/norm2_double_precision.sh
+++ b/test/f90_correct/lit/norm2_double_precision.sh
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+# Due to: https://github.com/flang-compiler/flang/issues/837
+
+# XFAIL: *
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/norm2_error.sh
+++ b/test/f90_correct/lit/norm2_error.sh
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/norm2_function.sh
+++ b/test/f90_correct/lit/norm2_function.sh
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/norm2_single_precision.sh
+++ b/test/f90_correct/lit/norm2_single_precision.sh
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/norm2.F90
+++ b/test/f90_correct/src/norm2.F90
@@ -1,0 +1,87 @@
+! Copyright (c) 2019, Arm Ltd.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+program test
+
+implicit none
+
+  real, parameter :: tolerance = 1.E-12
+  integer, parameter :: expec (2) = [1, 1]
+  integer :: res(2)
+  integer :: sz, i
+  real :: x1(5) = [real::1, 2, 3, 4, 5]
+  real :: x2(6) = [real:: 1, 2, 3, 4, 5, 999999999]
+  real, allocatable :: x3(:)
+  real, dimension (-2:2) :: x4
+  real :: matrix2(3,3) = reshape((/1,2,3,1,2,3,1,2,3/), (/3,3/))
+  real :: resultsA(10)
+  real :: resultsB(10)
+  real :: resultsC
+
+  ! Tests array constructor as argument
+  resultsA(1) = norm2(x1)
+  resultsB(1) = norm2(x2(1:5))
+  resultsC = norm2([real:: 1, 2, 3, 4, 5])
+
+  ! Tests allocatable array as argument
+  sz = 3
+  allocate (x3(sz))
+  do i=1, sz
+    x3(i) = i*i
+  enddo
+  resultsA(2) = norm2(x3)
+  resultsB(2) = sqrt(dot_product(x3, x3))
+
+  ! Test dim
+  resultsA(3:5) = norm2(matrix2, 1)
+  resultsB(3) = sqrt(dot_product(matrix2(:,1), matrix2(:,1)))
+  resultsB(4) = sqrt(dot_product(matrix2(:,2), matrix2(:,2)))
+  resultsB(5) = sqrt(dot_product(matrix2(:,3), matrix2(:,3)))
+  resultsA(6:8) = norm2(matrix2, 2)
+  resultsB(6) = sqrt(dot_product(matrix2(1,:), matrix2(1,:)))
+  resultsB(7) = sqrt(dot_product(matrix2(2,:), matrix2(2,:)))
+  resultsB(8) = sqrt(dot_product(matrix2(3,:), matrix2(3,:)))
+
+  x4 = [real :: -1, -2, 0, 10, 100]
+  ! Test Adjustable Arrays
+  resultsA(9) = norm2(x4,1)
+  resultsB(9) = sqrt(dot_product(x4, x4))
+
+  ! Test assumed shape
+  resultsA(10) = norm2(x4(1:2))
+  resultsB(10) = sqrt(dot_product(x4(1:2), x4(1:2)))
+
+  if (abs(resultsA(1) - resultsB(1)) < tolerance) then
+    if (abs(resultsB(1) - resultsC) < tolerance) then
+       res(1) = 1
+       print *, 'arrays tests match'
+    else
+      res(1) = -1
+      print *, 'arrays tests mismatch'
+    endif
+  else
+    res(1) = -2
+    print *, 'arrays tests mismatch'
+  endif
+
+  if(all(abs(resultsA(2:10)-resultsB(2:10)) < tolerance)) then
+    res(2) = 1
+    print *, 'expect vs results match'
+  else
+    res(2) = -1
+    print *, 'expect vs results mismatch'
+  end if
+
+  call check(res, expec, 2)
+end program

--- a/test/f90_correct/src/norm2_double_precision.F90
+++ b/test/f90_correct/src/norm2_double_precision.F90
@@ -1,0 +1,49 @@
+! Copyright (c) 2019, Arm Ltd.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+
+program test
+  use ISO_FORTRAN_ENV
+  implicit none
+  integer, parameter :: expec = 1
+  integer :: res
+
+  res = norm2Double()
+  call check(res, expec, 1)
+
+contains
+
+function norm2Double()
+  implicit none
+  integer, parameter :: wp = REAL64
+  real, parameter :: tolerance = 1.0E-12
+  integer, parameter :: n = (Maxexponent(1.0_wp)/2)-1
+  real(wp), parameter :: r = Radix(1.0_wp)
+  real(wp), parameter :: big = r**n
+  real(wp) :: x5(4) = [big, big, big, big]
+  real(wp), parameter :: expectDouble = 3.8921198074991259E+307_wp
+  real(wp) :: resultDouble
+  integer :: norm2Double
+
+  resultDouble = norm2(x5)
+  if(abs(resultDouble - expectDouble) < tolerance) then
+    norm2Double = 1
+    print *, 'Double precision test match'
+  else
+    norm2Double = -1
+    print *, 'Double precision test mismatch'
+  end if
+end function
+
+end program

--- a/test/f90_correct/src/norm2_error.f90
+++ b/test/f90_correct/src/norm2_error.f90
@@ -1,0 +1,77 @@
+! Copyright (c) 2019, Arm Ltd.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+
+subroutine s1 ! error
+  implicit none
+  integer :: x(10)
+  real :: results
+  integer :: i
+
+  do i=1,10
+    x(i) = i
+  enddo
+  !{error "PGF90-S-0074-Illegal number or type of arguments to norm2 - keyword argument x"}
+  results = norm2(x)
+end
+
+subroutine s2 ! error
+  implicit none
+  real :: y(10)
+  real :: results
+  integer :: i
+  do i=1,10
+    y(i)=i
+  end do
+  !{error "PGF90-S-0423-Constant DIM= argument is out of range"}
+  results = norm2(y, 2)
+end
+
+subroutine s3
+  implicit none
+  real :: z(10)
+  real :: results
+  integer :: i
+  do i=1,10
+    z(i)=i
+  end do
+  !{error "PGF90-S-0074-Illegal number or type of arguments to norm2 - keyword argument position 3"}
+  results = norm2(z, 1, 0)
+end
+
+subroutine s4
+  implicit none
+  real :: z(10)
+  real :: results
+  integer :: i
+  do i=1,10
+    z(i)=i
+  end do
+  !{error "PGF90-S-0074-Illegal number or type of arguments to norm2 - 0 argument(s) present, 1-3 argument(s) expected"}
+  results = norm2()
+end
+
+subroutine s5
+  implicit none
+  !{error "PGF90-S-0155-Intrinsic not supported in initialization: norm2"}
+  real :: results = norm2([real :: 2, 3, 4, 5])
+end
+
+  call s1
+  call s2
+  call s3
+  call s4
+  call s4
+  call s5
+end

--- a/test/f90_correct/src/norm2_function.F90
+++ b/test/f90_correct/src/norm2_function.F90
@@ -33,7 +33,7 @@ implicit none
 
   ! Test for adjustable array
   expectA(2) = sqrt(dot_product(x, x))
-  resultsA(2) = norm2AdjutableArray(n, x)
+  resultsA(2) = norm2AdjustableArray(n, x)
 
   ! Test for assumed size
   expectA(3) = sqrt(dot_product(x(1:2), x(1:2)))
@@ -76,13 +76,13 @@ function norm2ComputeDummy(sz, inData)
 end function
 
 
-function norm2AdjutableArray(sz, inData)
+function norm2AdjustableArray(sz, inData)
   implicit none
   integer :: sz
   real, dimension(sz) :: inData
-  real :: norm2AdjutableArray
+  real :: norm2AdjustableArray
 
-  norm2AdjutableArray = norm2(inData)
+  norm2AdjustableArray = norm2(inData)
 end function
 
 function norm2AssumedSize(inData)

--- a/test/f90_correct/src/norm2_function.F90
+++ b/test/f90_correct/src/norm2_function.F90
@@ -1,0 +1,97 @@
+! Copyright (c) 2019, Arm Ltd.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+
+program test
+implicit none
+  real, parameter :: tolerance = 1.0E-12
+  integer, parameter :: n = 3
+  integer, parameter :: expc (2) = [1, 1]
+  integer :: res(2)
+  real :: x(n)
+  real :: resultsA(3)
+  real :: expectA(3)
+  integer i
+
+  do i=1, n
+    x(i) = i*i
+  enddo
+  ! Test for assumed size
+  expectA(1) = sqrt(dot_product(x, x))
+  resultsA(1) = norm2ComputeDummy(n, x)
+
+  ! Test for adjustable array
+  expectA(2) = sqrt(dot_product(x, x))
+  resultsA(2) = norm2AdjutableArray(n, x)
+
+  ! Test for assumed size
+  expectA(3) = sqrt(dot_product(x(1:2), x(1:2)))
+  resultsA(3) = norm2AssumedSize(x(1:2))
+
+  if(all(abs(resultsA - expectA) < tolerance)) then
+    res(1) = 1
+    print *, 'expect vs results match'
+  else
+    res(1) = -1
+    print *, 'expect vs results mismatch'
+  end if
+
+  res(2) = checkLocal(norm2(x), expectA(1))
+  call check(res, expc, 2)
+contains
+
+function checkLocal(norm2In, expectIn)
+  implicit none
+  real :: norm2In
+  real :: expectIn
+  integer :: checkLocal
+
+  if (abs(norm2In-expectIn)< tolerance) then
+    print *, 'expect vs results match'
+    checkLocal = 1
+  else
+    print *, 'expect vs results mismatch'
+    checkLocal = -1
+  end if
+end function
+
+function norm2ComputeDummy(sz, inData)
+  implicit none
+  integer :: sz
+  real, dimension(*) :: inData
+  real :: norm2ComputeDummy
+
+  norm2ComputeDummy = norm2(inData(1:sz))
+end function
+
+
+function norm2AdjutableArray(sz, inData)
+  implicit none
+  integer :: sz
+  real, dimension(sz) :: inData
+  real :: norm2AdjutableArray
+
+  norm2AdjutableArray = norm2(inData)
+end function
+
+function norm2AssumedSize(inData)
+  implicit none
+  real, dimension(:) :: inData
+  real :: norm2AssumedSize
+
+  norm2AssumedSize = norm2(inData)
+end function
+
+end program
+

--- a/test/f90_correct/src/norm2_single_precision.F90
+++ b/test/f90_correct/src/norm2_single_precision.F90
@@ -1,0 +1,49 @@
+! Copyright (c) 2019, Arm Ltd.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+
+program test
+  use ISO_FORTRAN_ENV
+  implicit none
+  integer, parameter :: expec = 1
+  integer :: res
+
+  res = norm2Single()
+  call check(res, expec, 1)
+
+contains
+
+function norm2Single()
+  implicit none
+  integer, parameter :: wp = REAL32
+  real, parameter :: tolerance = 1.0E-12
+  integer, parameter :: n = Maxexponent(1.0_wp) - 3
+  real(wp), parameter :: r = Radix(1.0_wp)
+  real(wp), parameter :: big = r**n
+  real(wp) :: x5(3) = [big, big, big]
+  real(wp) resultSingle
+  real(wp), parameter :: expectSingle =  7.36732922E+37_wp
+  integer :: norm2Single
+
+  resultSingle = norm2(x5)
+
+  if(abs(resultSingle - expectSingle) < tolerance) then
+    norm2Single = 1
+    print *, 'Single precision test  match'
+  else
+    norm2Single = -1
+    print *, 'Single precision test  mismatch'
+  end if
+end function
+end program


### PR DESCRIPTION
This patch adds unit tests for NORM2.
norm2.F90: Contains basic unit tests.
norm2_function.F90: Tests for return value as norm2 and for various kinds of arrays as argument.
norm2_single_precision.F90: Tests overflow with single-precision
norm2_double_precision.F90: Tests overflow with double-precision. Currently XFAILed due to #837
norm2_error.f90: Error tests for invalid input and arguments to norm2.

Signed-off-by: Caroline Concatto <caroline.concatto@arm.com>