### PR TITLE
Fix ICE in ArithmeticIF for INT*8 type

### DIFF
--- a/test/f90_correct/inc/arithmetic_if.mk
+++ b/test/f90_correct/inc/arithmetic_if.mk
@@ -1,0 +1,26 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+	
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+	-$(FC) -c -i8 $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX).i8
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX).i8 check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX).i8
+
+
+run: 
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+	$(TEST).$(EXESUFFIX).i8
+
+verify: ;
+

--- a/test/f90_correct/lit/arithmetic_if.sh
+++ b/test/f90_correct/lit/arithmetic_if.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/arithmetic_if.f90
+++ b/test/f90_correct/src/arithmetic_if.f90
@@ -1,0 +1,31 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! tests arithmetic if codegen
+
+function aif(x, expect)
+  integer :: x
+  integer :: expect(3)
+  integer :: res
+  if(x) 5,15,25
+5   res = expect(1)
+    goto 35
+15  res = expect(2)
+    goto 35
+25  res = expect(3)
+35  aif = res
+end function
+
+program main
+  integer, parameter :: val1=10
+  integer, parameter :: val2=20
+  integer, parameter :: val3=30
+  integer :: res(3)
+  integer :: expect(3) = (/10,20,30/)
+  res(1) = aif(-1, expect)
+  res(2) = aif(0, expect)
+  res(3) = aif(1, expect)
+  call check(res, expect, 3)
+end program

--- a/tools/flang2/flang2exe/exp_ftn.cpp
+++ b/tools/flang2/flang2exe/exp_ftn.cpp
@@ -3416,6 +3416,8 @@ exp_bran(ILM_OP opc, ILM *ilmp, int curilm)
        IL_FCJMP, MSZ_F4},
       {IL_DCJMPZ, IL_CSEDP, DT_DBLE, IL_STDP, IL_LDDP, IL_DCMPZ, IL_DSUB,
        IL_DCJMP, MSZ_F8},
+      {IL_HFCJMPZ, IL_CSEHP, DT_HALF, IL_STHP, IL_LDHP, IL_HFCMPZ, IL_HFSUB,
+       IL_HFCJMP, MSZ_F2},
       {IL_KCJMPZ, IL_CSEKR, DT_INT8, IL_STKR, IL_LDKR, IL_KCMPZ, IL_KSUB,
        IL_KCJMP, MSZ_I8},
   };
@@ -3452,6 +3454,9 @@ exp_bran(ILM_OP opc, ILM *ilmp, int curilm)
     goto comaif;
   case IM_DAIF: /* double arithmetic IF */
     type = 2;
+    goto comaif;
+  case IM_HFAIF: /* half precision arithmetic IF */
+    type = 3;
   comaif:
     /* arithmetic if processing */
     ilix = ILM_RESULT(ILM_OPND(ilmp, 1));

--- a/tools/flang2/flang2exe/ili.h
+++ b/tools/flang2/flang2exe/ili.h
@@ -427,6 +427,7 @@ inline MSZ MSZ_ILI_OPND(int i, int opn) {
 /* Synonyms (beware conflicting case values) */
 #define MSZ_WORD MSZ_SWORD
 #define MSZ_BYTE MSZ_UBYTE
+#define MSZ_F2 MSZ_FHALF
 #define MSZ_F4 MSZ_FWORD
 #define MSZ_F8 MSZ_FLWORD
 #define MSZ_DBLE MSZ_FLWORD

--- a/tools/shared/atomic_common.h
+++ b/tools/shared/atomic_common.h
@@ -21,6 +21,7 @@ typedef enum MSZ {
   MSZ_SHWORD = 0x01, /* signed 16-bit short */
   MSZ_UBYTE = 0x04,  /* unsigned byte */
   MSZ_UHWORD = 0x05, /* unsigned 16-bit short */
+  MSZ_FHALF = 0x09, /* 16-bit half precision float */
 
   /* Codes for types larger than two bytes. These are all distinct values
    * suitable for use as case labels in switches.  The holes in this sequence


### PR DESCRIPTION
When half precision reals were introduced the table (aif) used in the
ILI codegen for ArithmeticIF was increased in size and the offset for
INT*8 increased by one. But the entry for half precision was not
inserted, this causes an ICE for INT*8 type. The fix is to introduce
the entry for the half precision type before the INT*8 type.

Fix for https://github.com/flang-compiler/flang/issues/844