### PR TITLE
Fix issue #544: integer constant must have integer type

### DIFF
--- a/tools/flang2/flang2exe/llassem_common.h
+++ b/tools/flang2/flang2exe/llassem_common.h
@@ -77,7 +77,7 @@ void init_Mcuda_compiled(void);
 /**
    \brief ...
  */
-void put_addr(SPTR sptr, ISZ_T off, DTYPE dtype);
+void put_addr(SPTR sptr, ISZ_T off, DTYPE dtype, char *cptr);
 
 /**
    \brief ...


### PR DESCRIPTION
LLVM IR generation needs to account for cases
where bare integers need to be interpreted as
pointers. Use 'inttoptr' llvm IR keyword in
such cases.