### PR TITLE
Support for -gdwarf-5 in flang2

### DIFF
--- a/test/debug_info/gdwarf_4.f90
+++ b/test/debug_info/gdwarf_4.f90
@@ -1,0 +1,7 @@
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !"Dwarf Version", i32 4
+
+program main
+  print *, "hello world !!"
+end program main

--- a/test/debug_info/gdwarf_5.f90
+++ b/test/debug_info/gdwarf_5.f90
@@ -1,0 +1,7 @@
+!RUN: %flang -gdwarf-5 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !"Dwarf Version", i32 5
+
+program main
+  print *, "hello world !!"
+end program main

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -3220,9 +3220,9 @@ allocated locals on Mac OS X.
 .XB 0x800000:
 Do not emit artificial dwarf entries for compiler-created arguments to function/subroutine.
 .XB 0x1000000
-AVAILABLE
+Set the dwarf version to 4.
 .XB 0x2000000
-AVAILABLE
+Set the dwarf version to 5.
 .XB 0x4000000:
 Do not generate include file tables.
 .XB 0x8000000h

--- a/tools/flang2/flang2exe/ll_structure.cpp
+++ b/tools/flang2/flang2exe/ll_structure.cpp
@@ -394,10 +394,12 @@ compute_ir_feature_vector(LLVMModuleRef module, enum LL_IRVersion vers)
     module->ir.dwarf_version = LL_DWARF_Version_2;
   } else if (XBIT(120, 0x4000)) {
     module->ir.dwarf_version = LL_DWARF_Version_3;
+  } else if (XBIT(120, 0x1000000)) {
+    module->ir.dwarf_version = LL_DWARF_Version_4;
+  } else if (XBIT(120, 0x2000000)) {
+    module->ir.dwarf_version = LL_DWARF_Version_5;
   } else if (true) { // FIXME - need a new bit
     module->ir.dwarf_version = LL_DWARF_Version_4;
-  } else {
-    module->ir.dwarf_version = LL_DWARF_Version_5;
   }
 
   if (ll_feature_versioned_dw_tag(&module->ir)) {
@@ -434,6 +436,8 @@ ll_feature_dwarf_version(const LL_IRFeatures *feature)
     return 3;
   case LL_DWARF_Version_4:
     return 4;
+  case LL_DWARF_Version_5:
+    return 5;
   }
 }
 

--- a/tools/flang2/flang2exe/ll_structure.cpp
+++ b/tools/flang2/flang2exe/ll_structure.cpp
@@ -398,7 +398,7 @@ compute_ir_feature_vector(LLVMModuleRef module, enum LL_IRVersion vers)
     module->ir.dwarf_version = LL_DWARF_Version_4;
   } else if (XBIT(120, 0x2000000)) {
     module->ir.dwarf_version = LL_DWARF_Version_5;
-  } else if (true) { // FIXME - need a new bit
+  } else { // DWARF 4 is the default
     module->ir.dwarf_version = LL_DWARF_Version_4;
   }
 


### PR DESCRIPTION
Summary:
  flang2 doesnt produce dwarf version 5 for -gdwarf-5.

  Currently when -gdwarf-5 is passed to flang (driver), that doesnt
pass any corresponding (-x 120) option as it passes in case of
-gdwarf-2/3. flang2 binary picks -gdwarf-4 by default.
   # flang -gdwarf-5 test.f90
   # llvm-dwarfdump a.out | grep version
0x00000000: Compile Unit: length = 0x0000008e version = 0x0004

  Now flang2 will identify gdwarf-4 and gdwarf-5 by -x 120 0x1000000
and -x 120 0x2000000, flang(driver) need to pass these option to flang

  flang-driver changes will be pushed separately. After that -gdwarf-5
will work from glang driver.

Testing:
  - check-llvm
  - check-debuginfo

Change-Id: Ibb70438f0a024bb7a6425d8b022c9353d138fa98