### PR TITLE
[DebugInfo]: Corrected emission of isOptimized flag.

### DIFF
--- a/test/debug_info/isopt-flag.f90
+++ b/test/debug_info/isopt-flag.f90
@@ -1,0 +1,8 @@
+!RUN: %flang -O0 -g -S -emit-llvm %s -o - | FileCheck %s --check-prefix=FALSE
+!RUN: %flang -O2 -g -S -emit-llvm %s -o - | FileCheck %s --check-prefix=TRUE
+
+!FALSE: isOptimized: false
+!TRUE: isOptimized: true
+
+SUBROUTINE sub()
+END SUBROUTINE

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -263,7 +263,7 @@ get_filedesc_mdnode(LL_DebugInfo *db, int index)
 static LL_MDRef
 lldbg_create_compile_unit_mdnode(LL_DebugInfo *db, int lang_tag, char *filename,
                                  char *sourcedir, char *producer, int main,
-                                 int optimized, char *compflags, int vruntime,
+                                 bool optimized, char *compflags, int vruntime,
                                  LL_MDRef *enum_types_list,
                                  LL_MDRef *retained_types_list,
                                  LL_MDRef *subprograms_list, LL_MDRef *gv_list,
@@ -1557,7 +1557,8 @@ lldbg_emit_compile_unit(LL_DebugInfo *db)
   if (LL_MDREF_IS_NULL(db->comp_unit_mdnode)) {
     lang_tag = DW_LANG_Fortran90;
     db->comp_unit_mdnode = lldbg_create_compile_unit_mdnode(
-        db, lang_tag, get_filename(1), get_currentdir(), db->producer, 1, 0, "",
+        db, lang_tag, get_filename(1), get_currentdir(), db->producer, 1,
+        flg.opt >= 1/*isOptimized Flag*/, "",
         0, &db->llvm_dbg_enum, &db->llvm_dbg_retained, &db->llvm_dbg_sp,
         &db->llvm_dbg_gv, &db->llvm_dbg_imported);
   }


### PR DESCRIPTION
flang is generating "isOptimized" flag as false in LLVM IR. Regardless of the whether it's an optimized build "-O2 -g or -O3 -g" or Un-optimized build "-g" or "-O0 -g".

**Incorrect behaviour** -
$flang -O3 -g -S -emit-llvm main.f90 -o- | awk /isOptimized/
 $ isOptimized: false
 flang -O0 -g -S -emit-llvm main.f90 -o- | awk /isOptimized/
 $ isOptimized: false
**Corrected behavior** -
$flang -O3 -g -S -emit-llvm main.f90 -o- | awk /isOptimized/
 $ isOptimized: true
$flang -O0 -g -S -emit-llvm main.f90 -o- | awk /isOptimized/
 $ isOptimized: false