### PR TITLE
flang generated executable shows wrong value for character type in debugger

### DIFF
--- a/test/debug_info/character.f90
+++ b/test/debug_info/character.f90
@@ -1,0 +1,10 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !DILocalVariable(name: "cvar", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: [[TYPE:![0-9]+]])
+!CHECK: [[TYPE]] = !DIBasicType(tag: DW_TAG_string_type, name: "character",
+
+
+program main
+  character :: cvar
+  cvar = 'a'
+end program main

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -2883,13 +2883,16 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
       offset[0] = 0;
       offset[1] = 0;
       cu_mdnode = ll_get_md_null();
-#if defined(FLANG_LLVM_EXTENSIONS)
+      /* 
+       * In case of character Metadata node with tag DW_TAG_string_type
+       * should always be generated, it helps debuggers to differentiate
+       * fortran character type over fortran integer(kind=1) type.
+       */
       if (ll_feature_from_global_to_md(&db->module->ir) &&
           (DTY(dtype) == TY_CHAR))
         type_mdnode = lldbg_create_string_type_mdnode(
             db, sz, align, stb.tynames[DTY(dtype)], dwarf_encoding(dtype));
       else
-#endif
         type_mdnode = lldbg_create_basic_type_mdnode(
             db, cu_mdnode, stb.tynames[DTY(dtype)], ll_get_md_null(), 0, sz,
             align, offset, 0, dwarf_encoding(dtype));


### PR DESCRIPTION
For fortran character type DW_TAG_string_type should be generated, in
absence of this, debugger doesnt differentiate between character(kind=1)
and integer(kind=1). Due to this debugger displays value as an integer.

ex.
-------------
actual output
-------------
(gdb) p cvar
$1 = 97
-------------
expected output
-------------
(gdb) p cvar
$1 = 'a'
-------------

Required code was present under macro FLANG_LLVM_EXTENSIONS.
The code is now free'd from macro.

Testing:
  - make check-flang