### PR TITLE
[DebugInfo]: Fix for missing DISPFlagOptimized in debug metadata

### DIFF
--- a/test/debug_info/optimized-flag.f90
+++ b/test/debug_info/optimized-flag.f90
@@ -1,0 +1,8 @@
+!RUN: %flang -O0 -g -S -emit-llvm %s -o - | FileCheck %s --check-prefix=UNOPT
+!RUN: %flang -O2 -g -S -emit-llvm %s -o - | FileCheck %s --check-prefix=OPT
+
+!UNOPT-NOT: DISPFlagOptimized
+!OPT: DISPFlagOptimized
+
+SUBROUTINE sub()
+END SUBROUTINE

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -424,7 +424,7 @@ lldbg_create_subprogram_mdnode(
     LL_DebugInfo *db, LL_MDRef context, const char *routine,
     const char *mips_linkage_name, LL_MDRef def_context, int line,
     LL_MDRef type_mdnode, int is_local, int is_definition, int virtuality,
-    int vindex, int spFlags, int flags, int is_optimized,
+    int vindex, int spFlags, int flags, bool is_optimized,
     LL_MDRef template_param_mdnode, LL_MDRef decl_desc_mdnode,
     LL_MDRef lv_list_mdnode, int scope)
 {
@@ -2101,7 +2101,7 @@ lldbg_emit_subprogram(LL_DebugInfo *db, SPTR sptr, DTYPE ret_dtype, int findex,
   int vindex = 0;
   int spFlags = 0;
   int flags = 0;
-  int is_optimized = 0;
+  bool is_optimized = flg.opt >= 1;
   int sc = SCG(sptr);
   int is_def;
   int is_local = (sc == SC_STATIC);


### PR DESCRIPTION
For fortran programs -> flang is not emitting, DISPFlagOptimized.
**Incorrect behavior --**
$flang -O3 main.f90 -g -S -emit-llvm -o- | awk /DISPFlagOptimized/
!16 = distinct !DISubprogram(name: "main", scope: !2, file: !3, line: 5, type: !17, scopeLine: 5, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: !2)

While clang does that for every function ->
$ clang -O3 main.c -g -S -emit-llvm -o- | awk /DISPFlagOptimized/
!7 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 5, type: !8, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition | **DISPFlagOptimized**, unit: !0, retainedNodes: !16)

**Corrected behavior --**
$flang -O3 main.f90 -g -S -emit-llvm -o- | awk /DISPFlagOptimized/
!16 = distinct !DISubprogram(name: "main", scope: !2, file: !3, line: 5, type: !17, scopeLine: 5, spFlags: DISPFlagDefinition | **DISPFlagOptimized** | DISPFlagMainSubprogram, unit: !2)