### PR TITLE
Flang generated executable does not show result variable of function.

### DIFF
--- a/test/debug_info/result_var.f90
+++ b/test/debug_info/result_var.f90
@@ -1,0 +1,10 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: call void @llvm.dbg.declare(metadata i32* %rvar_{{[0-9]+}}, metadata [[RESULT:![0-9]+]], metadata !DIExpression())
+!CHECK: [[RESULT]] = !DILocalVariable(name: "rvar"
+
+function func(arg) result(rvar)
+  integer, intent(in) :: arg ! input
+  integer :: rvar ! output
+  rvar = arg + 2
+end function func

--- a/tools/flang1/flang1exe/lowersym.c
+++ b/tools/flang1/flang1exe/lowersym.c
@@ -1081,11 +1081,7 @@ lower_prepare_symbols()
     case ST_ENTRY:
       fval = FVALG(sptr);
       if (fval) {
-        /* Function return variable is available in source. So user
-         * expects it to be visible in debuggers. Let us mark CCSYM
-         * (Compiler Created SYMbol) flag as false.
-         */
-        CCSYMP(fval, 0);
+        CCSYMP(fval, 1);
       }
     default:
       break;

--- a/tools/flang1/flang1exe/lowersym.c
+++ b/tools/flang1/flang1exe/lowersym.c
@@ -1081,7 +1081,11 @@ lower_prepare_symbols()
     case ST_ENTRY:
       fval = FVALG(sptr);
       if (fval) {
-        CCSYMP(fval, 1);
+        /* Function return variable is available in source. So user
+         * expects it to be visible in debuggers. Let us mark CCSYM
+         * (Compiler Created SYMbol) flag as false.
+         */
+        CCSYMP(fval, 0);
       }
     default:
       break;

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -3057,7 +3057,16 @@ set_dilocalvariable_flags(int sptr)
     return DIFLAG_ARTIFICIAL;
   }
 #endif
-  return CCSYMG(sptr) ? DIFLAG_ARTIFICIAL : 0;
+  /* Mark the variable as artificial if (Compiler Created Symbol)
+   * flag is set except in the case of function result variable.
+   * This is done because Function result variable is available
+   * in source. So user expect it to be visible in debugger.
+   */
+  if (CCSYMG(sptr) && (FVALG(GBL_CURRFUNC) != sptr)) {
+    return DIFLAG_ARTIFICIAL;
+  } else {
+    return 0;
+  }
 }
 
 LL_MDRef


### PR DESCRIPTION
Debugger is not able to print function result variable.
---------------
(gdb) list
1       function func(i) result(j)
2           integer, intent(in) :: i ! input
3           integer             :: j ! output
4           j = i**2 + i**3
5        end function func
6
7        program xfunc
8           implicit none
9       integer :: i
10          integer :: func
(gdb) b 4
Breakpoint 2 at 0x201b1a: file funres.f90, line 4.
(gdb) r
Starting program: /dir/funres.fl
[Thread debugging using libthread_db enabled]
Using host libthread_db library
"/lib/x86_64-linux-gnu/libthread_db.so.1".

Breakpoint 1, func (i=3) at 2899_2.f90:4
4           j = i**2 + i**3
(gdb) p j
No symbol "j" in current context.
---------------
This is due to flang marking it as artificial variable. It is fixed now.