### PR TITLE
flang support for pointers to scalar variables during debug info generation

### DIFF
--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -10494,6 +10494,21 @@ create_global_initializer(GBL_LIST *gitem, const char *flag_str,
 }
 
 /**
+   \brief Check if sptr is the midnum of a scalar and scalar has POINTER/ALLOCATABLE attribute
+   \param sptr  A symbol
+ */
+bool
+pointer_scalar_need_debug_info(SPTR sptr)
+{
+  if ((sptr > NOSYM) && REVMIDLNKG(sptr)) {
+    SPTR scalar_sptr = (SPTR)REVMIDLNKG(sptr);
+    if ((POINTERG(scalar_sptr) || ALLOCATTRG(scalar_sptr)) && (STYPEG(scalar_sptr) == ST_VAR))
+      return true;
+  }
+  return false;
+}
+
+/**
    \brief Check if sptr is the midnum of an array and the array has descriptor 
    \param sptr  A symbol
  */
@@ -10873,7 +10888,7 @@ process_extern_variable_sptr(SPTR sptr, ISZ_T off)
 INLINE static void
 addDebugForLocalVar(SPTR sptr, LL_Type *type)
 {
-  if (need_debug_info(sptr)) {
+  if (need_debug_info(sptr) || pointer_scalar_need_debug_info(sptr)) {
     /* Dummy sptrs are treated as local (see above) */
     LL_MDRef param_md = lldbg_emit_local_variable(
         cpu_llvm_module->debug_info, sptr, BIH_FINDEX(gbl.entbih), true);

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -277,4 +277,10 @@ void add_debug_cmnblk_variables(LL_DebugInfo *db, SPTR sptr);
  */
 bool ftn_array_need_debug_info(SPTR sptr);
 
+/**
+   \brief Check if sptr is the midnum of a scalar and scalar has POINTER/ALLOCATABLE attribute
+   \param sptr  A symbol
+ */
+bool pointer_scalar_need_debug_info(SPTR sptr);
+
 #endif

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -2583,23 +2583,11 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
       type_mdnode = db->dtype_array[dtype];
   if (LL_MDREF_IS_NULL(type_mdnode)) {
     if (is_assumed_char(dtype)) {
-#if defined(FLANG_LLVM_EXTENSIONS)
-      if ((!skipDataDependentTypes) &&
-          ll_feature_has_diextensions(&db->module->ir)) {
-        type_mdnode =
+        /* For assumed length string type, always emit !DIStringType metadata
+         * node. Here compiler created local variable holds the string length
+         */
+	 type_mdnode =
             lldbg_create_assumed_len_string_type_mdnode(db, sptr, findex);
-      } else {
-#endif
-        type_mdnode =
-            lldbg_emit_type(db, DT_CPTR, sptr, findex, false, false, false);
-#if defined(FLANG_LLVM_EXTENSIONS)
-        if (!skipDataDependentTypes) {
-#endif
-          dtype_array_check_set(db, dtype, type_mdnode);
-#if defined(FLANG_LLVM_EXTENSIONS)
-        }
-      }
-#endif
     } else
         if (DT_ISBASIC(dtype) && (DTY(dtype) != TY_PTR)) {
 

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -3100,10 +3100,10 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
     } else {
       fwd = ll_get_md_null();
     }
-    if (ftn_array_need_debug_info(sptr)) {
+    if (ftn_array_need_debug_info(sptr) || pointer_scalar_need_debug_info(sptr)) {
       SPTR array_sptr =(SPTR)REVMIDLNKG(sptr);
-      /* Overwrite the symname and flags to represent the user defined array
-       * instead of a compiler generated symbol of array pointer.
+      /* Overwrite the symname and flags to represent the user defined array or
+       * scalar, instead of a compiler generated symbol of array or scalar pointer
        */
       symname = (char *)lldbg_alloc(strlen(SYMNAME(array_sptr)) + 1);
       strcpy(symname, SYMNAME(array_sptr));


### PR DESCRIPTION
This fix handles pointer to scalar variable (of symbol type:ST_VAR) during debug info generation. It address 2 issues.

1. flang is not emitting DW_AT_name attribute for pointer variable DIE, hence inside GDB, "print cqe_int_allocatable_scalar" command fails as shown below
2. flang is emitting DW_TAG_array_type for a pointer variable instead of DW_TAG_pointer_type

Test case: 

program test_cqe
integer, allocatable :: cqe_int_allocatable_scalar
cqe_int_allocatable_scalar=5
print *,cqe_int_allocatable_scalar
print *,"End of printing"
end program test_cqe

sample GDB session:

- without fix :
(gdb) p cqe_int_allocatable_scalar
No symbol "cqe_int_allocatable_scalar" in current context.

- with fix :
(gdb) p cqe_int_allocatable_scalar
$1 = (PTR TO -> ( integer )) 0x21be90
(gdb) p *cqe_int_allocatable_scalar
$2 = 5
