### PR TITLE
flang gen-exec does not show routine variables with parameter attribute

### DIFF
--- a/test/debug_info/enum.f90
+++ b/test/debug_info/enum.f90
@@ -1,0 +1,25 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: call void @llvm.dbg.value(metadata i32 1, metadata [[ENM1:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.value(metadata i32 2, metadata [[ENM2:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.value(metadata i32 5, metadata [[ENM3:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.value(metadata i32 6, metadata [[ENM4:![0-9]+]], metadata !DIExpression())
+!CHECK: [[ENM1]] = !DILocalVariable(name: "red"
+!CHECK: [[ENM2]] = !DILocalVariable(name: "blue"
+!CHECK: [[ENM3]] = !DILocalVariable(name: "black"
+!CHECK: [[ENM4]] = !DILocalVariable(name: "pink"
+
+program main
+  enum, bind(c)
+    enumerator :: red =1, blue, black =5
+    enumerator :: pink
+  endenum
+  integer (kind=8) :: svar1, svar2, svar3, svar4
+  svar1 = red
+  svar2 = blue
+  svar3 = black
+  svar4 = pink
+
+  print *, svar1, svar2, svar3, svar4
+
+end program main

--- a/test/debug_info/parameter.f90
+++ b/test/debug_info/parameter.f90
@@ -1,0 +1,17 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: call void @llvm.dbg.value(metadata i64 99, metadata [[SPAR:![0-9]+]], metadata !DIExpression())
+!CHECK: distinct !DIGlobalVariable(name: "apar"
+!CHECK: [[SPAR]] = !DILocalVariable(name: "spar"
+
+program main
+  integer (kind=8) :: svar
+  integer (kind=8) :: avar(5)
+  integer (kind=8), parameter :: spar = 99
+  integer (kind=8), parameter :: apar(5) = (/99, 98, 97, 96, 95/)
+  svar = spar
+  avar = apar
+
+  print *, svar, avar, spar, apar
+
+end program main

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -1299,8 +1299,8 @@ remove_dead_instrs(void)
 static void process_params(void) {
   unsigned smax = stb.stg_avail;
   for (SPTR sptr = get_symbol_start(); sptr < smax; ++sptr) {
-    if (STYPEG(sptr) == ST_PARAM && should_preserve_param(sptr)) {
-      DTYPE dtype = DTYPEG(sptr);
+    DTYPE dtype = DTYPEG(sptr);
+    if (STYPEG(sptr) == ST_PARAM && should_preserve_param(dtype)) {
       if (DTY(dtype) == TY_ARRAY || DTY(dtype) == TY_STRUCT) {
         /* array and derived types have 'var$ac' constant variable
          * lets use that, by renaming that to 'var'.

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -116,6 +116,7 @@ static char *fn_sig_ptr = NULL;
 static void insert_entry_label(int);
 static void insert_jump_entry_instr(int);
 static void store_return_value_for_entry(OPERAND *, int);
+static void insertLLVMDbgValue(OPERAND *, LL_MDRef, SPTR, LL_Type *);
 
 static int openacc_prefix_sptr = 0;
 static unsigned addressElementSize;
@@ -1293,6 +1294,38 @@ remove_dead_instrs(void)
 }
 
 /**
+   \brief process debug info of variables with parameter attribute.
+ */
+void
+process_params(void)
+{
+  unsigned smax = stb.stg_avail;
+  for (SPTR sptr = get_symbol_start(); sptr < smax; ++sptr) {
+    if (STYPEG(sptr) == ST_PARAM && should_preserve_param(sptr)) {
+      DTYPE dtype = DTYPEG(sptr);
+      if (DTY(dtype) == TY_ARRAY || DTY(dtype) == TY_STRUCT) {
+        /* array and derived types have 'var$ac' constant variable
+         * lets use that, by renaming that to 'var'.
+         */
+	SPTR new_sptr = (SPTR) CONVAL1G(sptr);
+	NMPTRP(new_sptr, NMPTRG(sptr));
+      } else {
+	LL_DebugInfo *di = cpu_llvm_module->debug_info;
+	int fin = BIH_FINDEX(gbl.entbih);
+	LL_Type *type = make_lltype_from_dtype(dtype);
+	OPERAND *ld = make_operand();
+	ld->ot_type = OT_MDNODE;
+	ld->val.sptr = sptr;
+	LL_MDRef lcl = lldbg_emit_local_variable(di, sptr, fin, true);
+
+        /* lets generate llvm.dbg.value intrinsic for it.*/
+	insertLLVMDbgValue(ld, lcl, sptr, type);
+      }
+    }
+  }
+}
+
+/**
    \brief Perform code translation from ILI to LLVM for one routine
  */
 void
@@ -1458,6 +1491,14 @@ restartConcur:
   for (; bih; bih = BIH_NEXT(bih))
     for (ilt = BIH_ILTFIRST(bih); ilt; ilt = ILT_NEXT(ilt))
       build_csed_list(ILT_ILIP(ilt));
+
+  /* process variables with parameter attribute */
+  if (!XBIT(49, 0x10)
+#if defined(OMP_OFFLOAD_PGI) || defined(OMP_OFFLOAD_LLVM)
+      && !gbl.ompaccel_isdevice
+#endif
+     )
+    process_params();
 
   merge_next_block = false;
   bih = BIH_NEXT(0);
@@ -5186,6 +5227,7 @@ insertLLVMDbgValue(OPERAND *load, LL_MDRef mdnode, SPTR sptr, LL_Type *type)
   callOp->next = oper = make_operand();
   oper->ot_type = OT_MDNODE;
   oper->tmps = load->tmps;
+  oper->val = load->val;
   oper->ll_type = type;
   oper->flags |= OPF_WRAPPED_MD;
   oper = make_constval_op(ll_create_int_type(mod, 64), 0, 0);

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -1307,6 +1307,7 @@ static void process_params(void) {
          */
         SPTR new_sptr = (SPTR)CONVAL1G(sptr);
         NMPTRP(new_sptr, NMPTRG(sptr));
+        CCSYMP(new_sptr, 0);
       } else {
         LL_DebugInfo *di = cpu_llvm_module->debug_info;
         int fin = BIH_FINDEX(gbl.entbih);

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -1296,7 +1296,9 @@ remove_dead_instrs(void)
 /**
    \brief process debug info of constants with parameter attribute.
  */
-static void process_params(void) {
+static void
+process_params(void)
+{
   unsigned smax = stb.stg_avail;
   for (SPTR sptr = get_symbol_start(); sptr < smax; ++sptr) {
     DTYPE dtype = DTYPEG(sptr);
@@ -5194,8 +5196,10 @@ gen_gep_index(OPERAND *base_op, LL_Type *llt, int index)
   return gen_gep_op(0, base_op, llt, make_constval32_op(index));
 }
 
-static void insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode, SPTR sptr,
-                                  LL_Type *type) {
+static void
+insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode,
+                      SPTR sptr, LL_Type *type)
+{
   static bool defined = false;
   OPERAND *callOp;
   OPERAND *oper;

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -1490,8 +1490,9 @@ restartConcur:
     for (ilt = BIH_ILTFIRST(bih); ilt; ilt = ILT_NEXT(ilt))
       build_csed_list(ILT_ILIP(ilt));
 
-  /* process variables with parameter attribute */
-  if (!XBIT(49, 0x10)
+  /* Process variables with parameter attribute to generate debug info, if
+     debug is on. */
+  if (!XBIT(49, 0x10) && flg.debug
 #if defined(OMP_OFFLOAD_PGI) || defined(OMP_OFFLOAD_LLVM)
       && !gbl.ompaccel_isdevice
 #endif

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -2198,10 +2198,22 @@ metadata_args_need_struct(void)
  * This function returns true for the types supported
  * in function make_param_op
  */
-bool should_preserve_param(const DTYPE dtype) {
+bool
+should_preserve_param(const DTYPE dtype)
+{
   switch (DTY(dtype)) {
   // handled cases
   case TY_ARRAY:
+    {
+      ADSC *ad = AD_DPTR(dtype);
+      SPTR size_sptr = AD_NUMELM(ad);
+      ISZ_T size = ad_val_of(size_sptr);
+      /* dont preserve zero-sized array, which would be optimized out later */
+      if (size == 0)
+        return false;
+      else
+        return true;
+    }
   case TY_STRUCT:
   case TY_BLOG:
   case TY_SLOG:
@@ -2230,7 +2242,9 @@ bool should_preserve_param(const DTYPE dtype) {
   }
 }
 
-OPERAND *make_param_op(SPTR sptr) {
+OPERAND *
+make_param_op(SPTR sptr)
+{
   OPERAND *oper;
   DTYPE dtype = DTYPEG(sptr);
 

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -2208,7 +2208,7 @@ should_preserve_param(const DTYPE dtype)
       ADSC *ad = AD_DPTR(dtype);
       SPTR size_sptr = AD_NUMELM(ad);
       ISZ_T size = ad_val_of(size_sptr);
-      /* do not preserve zero-sized array, which would be optimized out later */
+      /* Do not preserve zero-sized array, which would be optimized out later */
       if (size == 0)
         return false;
       else

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -2198,10 +2198,9 @@ metadata_args_need_struct(void)
  * This function returns true for the types supported
  * in function make_param_op
  */
-bool should_preserve_param(SPTR sptr) {
-  DTYPE dtype = DTYPEG(sptr);
-
+bool should_preserve_param(const DTYPE dtype) {
   switch (DTY(dtype)) {
+  // handled cases
   case TY_ARRAY:
   case TY_STRUCT:
   case TY_BLOG:
@@ -2219,7 +2218,14 @@ bool should_preserve_param(SPTR sptr) {
   case TY_DCMPLX:
   case TY_CHAR:
     return true;
+  // unsupported cases
+  case TY_WORD:
+  case TY_DWORD:
+  case TY_HOLL:
+  case TY_NCHAR:
+    return false;
   default:
+    assert(0, "should_preserve_param(dtype): unexpected DTYPE", 0, ERR_Fatal);
     return false;
   }
 }
@@ -2227,9 +2233,6 @@ bool should_preserve_param(SPTR sptr) {
 OPERAND *make_param_op(SPTR sptr) {
   OPERAND *oper;
   DTYPE dtype = DTYPEG(sptr);
-
-  assert(should_preserve_param(sptr), "make_param_op(): unexpected sptr", 0,
-         ERR_Fatal);
 
   switch (DTY(dtype)) {
   case TY_BLOG:

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -2198,77 +2198,70 @@ metadata_args_need_struct(void)
  * This function returns true for the types supported
  * in function make_param_op
  */
-bool
-should_preserve_param(SPTR sptr)
-{
-  bool should_preserve = false;
+bool should_preserve_param(SPTR sptr) {
   DTYPE dtype = DTYPEG(sptr);
 
   switch (DTY(dtype)) {
-    case TY_ARRAY:
-    case TY_STRUCT:
-    case TY_BLOG:
-    case TY_SLOG:
-    case TY_LOG:
-    case TY_BINT:
-    case TY_SINT:
-    case TY_INT:
-    case TY_REAL:
-    case TY_INT8:
-    case TY_LOG8:
-    case TY_DBLE:
-    case TY_QUAD:
-    case TY_CMPLX:
-    case TY_DCMPLX:
-    case TY_CHAR:
-      should_preserve = true;
-      break;
+  case TY_ARRAY:
+  case TY_STRUCT:
+  case TY_BLOG:
+  case TY_SLOG:
+  case TY_LOG:
+  case TY_BINT:
+  case TY_SINT:
+  case TY_INT:
+  case TY_REAL:
+  case TY_INT8:
+  case TY_LOG8:
+  case TY_DBLE:
+  case TY_QUAD:
+  case TY_CMPLX:
+  case TY_DCMPLX:
+  case TY_CHAR:
+    return true;
+  default:
+    return false;
   }
-  return should_preserve;
 }
 
-OPERAND *
-make_param_op(SPTR sptr)
-{
+OPERAND *make_param_op(SPTR sptr) {
   OPERAND *oper;
   DTYPE dtype = DTYPEG(sptr);
 
-  assert(should_preserve_param(sptr), "make_param_op(): unexpected sptr",
-         0, ERR_Fatal);
+  assert(should_preserve_param(sptr), "make_param_op(): unexpected sptr", 0,
+         ERR_Fatal);
 
   switch (DTY(dtype)) {
-    case TY_BLOG:
-    case TY_SLOG:
-    case TY_LOG:
-    case TY_BINT:
-    case TY_SINT:
-    case TY_INT:
-    case TY_REAL:
-      oper = make_constval_op(make_lltype_from_dtype(dtype), CONVAL1G(sptr),
-                              CONVAL2G(sptr));
-      break;
-    case TY_INT8:
-    case TY_LOG8:
-      oper = make_constval_op(make_lltype_from_dtype(dtype),
-                              CONVAL2G(CONVAL1G(sptr)),
-                              CONVAL1G(CONVAL1G(sptr)));
-      break;
-    case TY_DBLE:
-      oper = make_constval_op(make_lltype_from_dtype(dtype),
-                              CONVAL1G(CONVAL1G(sptr)),
-                              CONVAL2G(CONVAL1G(sptr)));
-      break;
-    case TY_QUAD:
-    case TY_CMPLX:
-    case TY_DCMPLX:
-      oper = make_constsptr_op((SPTR)CONVAL1G(sptr));
-      break;
-    case TY_CHAR:
-      oper = make_conststring_op((SPTR)CONVAL1G(sptr));
-      break;
-    // TODO: to add support for other types
-    default:
-      break;
+  case TY_BLOG:
+  case TY_SLOG:
+  case TY_LOG:
+  case TY_BINT:
+  case TY_SINT:
+  case TY_INT:
+  case TY_REAL:
+    oper = make_constval_op(make_lltype_from_dtype(dtype), CONVAL1G(sptr),
+                            CONVAL2G(sptr));
+    break;
+  case TY_INT8:
+  case TY_LOG8:
+    oper = make_constval_op(make_lltype_from_dtype(dtype),
+                            CONVAL2G(CONVAL1G(sptr)), CONVAL1G(CONVAL1G(sptr)));
+    break;
+  case TY_DBLE:
+    oper = make_constval_op(make_lltype_from_dtype(dtype),
+                            CONVAL1G(CONVAL1G(sptr)), CONVAL2G(CONVAL1G(sptr)));
+    break;
+  case TY_QUAD:
+  case TY_CMPLX:
+  case TY_DCMPLX:
+    oper = make_constsptr_op((SPTR)CONVAL1G(sptr));
+    break;
+  case TY_CHAR:
+    oper = make_conststring_op((SPTR)CONVAL1G(sptr));
+    break;
+  // TODO: to add support for other types
+  default:
+    break;
   }
 
   return oper;
@@ -2456,15 +2449,14 @@ write_operand(OPERAND *p, const char *punc_string, int flags)
         new_op = make_arg_op(p->val.sptr);
         if (p->ll_type)
           new_op->ll_type = p->ll_type;
+      } else if (STYPEG(p->val.sptr) == ST_PARAM) {
+        new_op = make_param_op(p->val.sptr);
       } else {
-	if (STYPEG(p->val.sptr) == ST_PARAM) {
-	  new_op = make_param_op(p->val.sptr);
-	} else {
-	  new_op = make_var_op(p->val.sptr);
-	  if (p->ll_type)
-	    new_op->ll_type = ll_get_pointer_type(p->ll_type);
-	}
+        new_op = make_var_op(p->val.sptr);
+        if (p->ll_type)
+          new_op->ll_type = ll_get_pointer_type(p->ll_type);
       }
+
       new_op->flags = p->flags;
       write_operand(new_op, "", 0);
       if (metadata_args_need_struct())

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -2208,7 +2208,7 @@ should_preserve_param(const DTYPE dtype)
       ADSC *ad = AD_DPTR(dtype);
       SPTR size_sptr = AD_NUMELM(ad);
       ISZ_T size = ad_val_of(size_sptr);
-      /* dont preserve zero-sized array, which would be optimized out later */
+      /* do not preserve zero-sized array, which would be optimized out later */
       if (size == 0)
         return false;
       else
@@ -2249,6 +2249,9 @@ make_param_op(SPTR sptr)
   DTYPE dtype = DTYPEG(sptr);
 
   switch (DTY(dtype)) {
+  // Below are the supported types, please note that two types TY_ARRAY,
+  // TY_STRUCT present in should_preserve_param but absent here that is
+  // because these two type are handled differently in function process_params.
   case TY_BLOG:
   case TY_SLOG:
   case TY_LOG:

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -1595,7 +1595,7 @@ bool llis_function_kind(DTYPE dtype);
 /**
    \brief return whether param debug info should be preserved
  */
-bool should_preserve_param(SPTR sptr);
+bool should_preserve_param(const DTYPE dtype);
 
 #ifdef OMP_OFFLOAD_LLVM
 /**

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -1597,7 +1597,6 @@ bool llis_function_kind(DTYPE dtype);
  */
 bool should_preserve_param(SPTR sptr);
 
-
 #ifdef OMP_OFFLOAD_LLVM
 /**
    \brief Create a file to write the device code if it has not already been created,

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -1592,6 +1592,12 @@ bool llis_vector_kind(DTYPE dtype);
 bool llis_struct_kind(DTYPE dtype);
 bool llis_function_kind(DTYPE dtype);
 
+/**
+   \brief return whether param debug info should be preserved
+ */
+bool should_preserve_param(SPTR sptr);
+
+
 #ifdef OMP_OFFLOAD_LLVM
 /**
    \brief Create a file to write the device code if it has not already been created,

--- a/tools/flang2/flang2exe/upper.cpp
+++ b/tools/flang2/flang2exe/upper.cpp
@@ -6500,11 +6500,7 @@ lookup_modvar_alias(SPTR sptr)
   return NULL;
 }
 
-SPTR
-get_symbol_start(void)
-{
-  return (SPTR) (oldsymbolcount +1);
-}
+SPTR get_symbol_start(void) { return (SPTR)(oldsymbolcount + 1); }
 
 /**
    \brief Given a alias name of a mod var sptr, create a new alias_syminfo node

--- a/tools/flang2/flang2exe/upper.cpp
+++ b/tools/flang2/flang2exe/upper.cpp
@@ -6500,6 +6500,12 @@ lookup_modvar_alias(SPTR sptr)
   return NULL;
 }
 
+SPTR
+get_symbol_start(void)
+{
+  return (SPTR) (oldsymbolcount +1);
+}
+
 /**
    \brief Given a alias name of a mod var sptr, create a new alias_syminfo node
    and add it to the linked list for later lookup.

--- a/tools/flang2/flang2exe/upper.h
+++ b/tools/flang2/flang2exe/upper.h
@@ -278,4 +278,9 @@ void upper_save_syminfo(void);
  */
 const char *lookup_modvar_alias(SPTR sptr);
 
+/**
+   \brief return start symbol SPTR
+ */
+SPTR get_symbol_start(void);
+
 #endif // UPPER_H_


### PR DESCRIPTION
This patch enables printing of routine scoped variables with parameter
attributes and enum values under debuggers.

- array and derived types with parameter attribute are fixed by
re-naming corresponding array constant values var$ac to var.

- scalar types with parameter attribute are fixed by generating
dbg.value intrinsics.

Example:
```
program main
  integer (kind=8) :: svar
  integer (kind=8) :: avar(5)
  integer (kind=8), parameter :: spar = 99
  integer (kind=8), parameter :: apar(5) = (/99, 98, 97, 96, 95/)
  svar = spar
  avar = apar

  print *, svar, avar, spar, apar

end program main
```

For above test program, now gdb is able to show the value of variables
with parameter attribute.
```
. . . . .
(gdb) p spar
$1 = 99
(gdb) p apar
$2 = (99, 98, 97, 96, 95)
. . . . .
```
Note: #921 should be committed first.

Testing
- make check-flang