### PR TITLE
[DebugInfo]Fix for redundant lexical block in debug info

### DIFF
--- a/test/debug_info/redundant-lexicalblock.f90
+++ b/test/debug_info/redundant-lexicalblock.f90
@@ -1,0 +1,22 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!Ensure that there is no redundant LexicalBlock created with scope
+!pointing to Subprogram.
+!CHECK: ![[SCOPE_NODE:[0-9]+]] = distinct !DISubprogram(name: "sub", {{.*}}, line: [[LINE_NODE:[0-9]+]]
+!CHECK-NOT: !DILexicalBlock(scope: ![[SCOPE_NODE]] {{,*}}, line: [[LINE_NODE]]
+
+!Ensure that there is a LexicalBlock created for the BLOCK statement and
+!the local variable `foo_block` has correct scope information i.e
+!pointing to LexicalBlock.
+!CHECK-DAG: !DILocalVariable(name: "foo_block", scope: ![[BLOCK_NODE:[0-9]+]]
+!CHECK-DAG: ![[BLOCK_NODE]] = !DILexicalBlock(scope: ![[SCOPE_NODE]], {{.*}}, line: 18
+
+SUBROUTINE sub(foo_arg)
+      integer,value :: foo_arg
+      integer :: foo_local
+      foo_local = arg_foo
+      BLOCK      !line number: 18
+             integer :: foo_block
+             foo_block = 4
+      END BLOCK
+END SUBROUTINE

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -1810,7 +1810,9 @@ lldbg_emit_lexical_block(LL_DebugInfo *db, int sptr, int lineno, int findex,
   NEEDB((db->blk_idx + 1), db->blk_tab, BLKINFO, db->blk_tab_size,
         (db->blk_tab_size + 64));
   db->blk_tab[db->blk_idx].mdnode =
-      lldbg_create_block_mdnode(db, parent_blk_mdnode, lineno, 1, findex, ID++);
+      STYPEG(sptr) == ST_BLOCK ? lldbg_create_block_mdnode(db,
+      parent_blk_mdnode, lineno, 1, findex, ID++)
+      : parent_blk_mdnode;
   db->blk_tab[db->blk_idx].sptr = sptr;
   db->blk_tab[db->blk_idx].startline = startline;
   db->blk_tab[db->blk_idx].endline = endline;


### PR DESCRIPTION
Flang was creating a redundant lexical block at the beginning of of every subroutine debug info. This was causing debuggers to incorrectly assume the scope of a variable to be this lexical block.

This patch fixes this incorrect behavior by replacing all the debug info references of this redundant lexical block to the actual subroutine.

Brief explanation and correct behavior can be found here:
http://lists.llvm.org/pipermail/flang-dev/2020-April/000277.html
https://patchwork.ozlabs.org/patch/436971/

After this, GDB is correctly able to show formal arguments for the case of pass by value parameters.