### PR TITLE
[DebugInfo] Corrected debuginfo for modules

### DIFF
--- a/test/debug_info/module.f90
+++ b/test/debug_info/module.f90
@@ -1,0 +1,17 @@
+!RUN: %flang -g %s -S -emit-llvm -o - | FileCheck %s
+
+!CHECK-DAG: DIModule(scope: !{{.*}}, name: "dummy", file: !{{.*}}, line: 9)
+!CHECK-DAG: ![[FOO_NODE:.*]] = {{.*}} !DIGlobalVariable(name: "foo", {{.*}}
+!CHECK-DAG: ![[BAR_NODE:.*]] = {{.*}} !DIGlobalVariable(name: "bar", {{.*}}
+!CHECK-DAG: DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !{{.*}}, entity: ![[FOO_NODE]], file: !{{.*}}, line: 14)
+!CHECK-NOT: DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !{{.*}}, entity: ![[BAR_NODE]], file: !{{.*}}, line: 14)
+
+MODULE dummy !line no. 9
+      INTEGER :: foo
+      INTEGER :: bar
+END MODULE dummy
+
+PROGRAM main
+USE dummy, ONLY: foo
+
+END PROGRAM

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1033,6 +1033,18 @@ static const MDTemplate Tmpl_DIModule[] = {
   //{ "isysroot",               StringField, FlgOptional }
 };
 
+static const MDTemplate Tmpl_DIModule_11[] = {
+  { "DIModule", TF, 5 },
+  { "tag",                      DWTagField, FlgHidden },
+  { "scope",                    NodeField },
+  { "name",                     StringField },
+  { "file",                     NodeField },
+  { "line",                     UnsignedField }
+  //,{ "configMacros",          StringField, FlgOptional },
+  //{ "includePath",            StringField, FlgOptional },
+  //{ "isysroot",               StringField, FlgOptional }
+};
+
 static const MDTemplate Tmpl_DISubprogram[] = {
   { "DISubprogram", TF, 20 },
   { "tag",                      DWTagField, FlgHidden },
@@ -2054,6 +2066,10 @@ emitDINamespace(FILE *out, LLVMModuleRef mod, const LL_MDNode *mdnode,
 static void
 emitDIModule(FILE *out, LLVMModuleRef mod, const LL_MDNode *mdnd, unsigned mdi)
 {
+  if (ll_feature_debug_info_ver11(&mod->ir)) {
+    emitTmpl(out, mod, mdnd, mdi, Tmpl_DIModule_11);
+    return;
+  }
   emitTmpl(out, mod, mdnd, mdi, Tmpl_DIModule);
 }
 

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -360,7 +360,7 @@ lldbg_create_compile_unit_mdnode(LL_DebugInfo *db, int lang_tag, char *filename,
 
 static LL_MDRef
 lldbg_create_module_mdnode(LL_DebugInfo *db, LL_MDRef _, char *name,
-                           LL_MDRef scope, int lineno)
+                           LL_MDRef scope, LL_MDRef file, int lineno)
 {
   LLMD_Builder mdb;
   char *module_name, *pname, *pmname;
@@ -387,6 +387,10 @@ lldbg_create_module_mdnode(LL_DebugInfo *db, LL_MDRef _, char *name,
     llmd_add_i32(mdb, make_dwtag(db, DW_TAG_module)); // tag
     llmd_add_md(mdb, scope);                          // scope
     llmd_add_string(mdb, module_name);                // name
+    if (ll_feature_debug_info_ver11(&db->module->ir)) {
+      llmd_add_md(mdb, file);                         // file
+      llmd_add_i32(mdb, lineno);                      // lineno
+    }
   } else {
     llmd_set_class(mdb, LL_DINamespace);
     llmd_add_i32(mdb, make_dwtag(db, tag));
@@ -1816,7 +1820,8 @@ lldbg_emit_file(LL_DebugInfo *db, int findex)
     lldbg_create_file_mdnode(db, get_filename(findex), get_currentdir(),
                              cu_mnode, findex);
   }
-  return get_file_mdnode(db, findex);
+  return ll_feature_debug_info_need_file_descriptions(&db->module->ir)
+	  ? get_filedesc_mdnode(db, 1) : get_file_mdnode(db, findex);
 }
 
 static LL_MDRef
@@ -2318,13 +2323,15 @@ lldbg_emit_module_mdnode(LL_DebugInfo *db, int sptr)
 {
   LL_MDRef module_mdnode;
 
-  lldbg_emit_file(db, 1);
+  LL_MDRef file_mdnode = lldbg_emit_file(db, 1);
   module_mdnode =
       ll_get_module_debug(db->module->module_debug_map, SYMNAME(sptr));
   if (!LL_MDREF_IS_NULL(module_mdnode))
     return module_mdnode;
+
   return lldbg_create_module_mdnode(db, ll_get_md_null(), SYMNAME(sptr),
-                                    lldbg_emit_compile_unit(db), 1);
+                                    lldbg_emit_compile_unit(db),
+				    file_mdnode, FUNCLINEG(sptr));
 }
 
 void
@@ -3417,7 +3424,7 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
         llObjtodbgAddUnique(*listp, db->gbl_obj_exp_mdnode);
     }
     ll_add_global_debug(db->module, sptr, mdref);
-    if (gbl.rutype == RU_BDATA && sc == SC_CMBLK) {
+    if ((gbl.rutype == RU_SUBR || gbl.rutype == RU_BDATA) && sc == SC_CMBLK) {
       const char *modvar_name;
       if (CCSYMG(MIDNUMG(sptr))) {
         modvar_name = new_debug_name(SYMNAME(ENCLFUNCG(sptr)),


### PR DESCRIPTION
Summary:
Flang was creating DIModule metadata without file and line number
information, as a result GDB is not able to find and print debug
info fortran modules.

This patch extends the flang to emit DIModule with  file and line
number information. This patch is dependent on LLVM 11.0 DIModule
metadata, since older versions of DIModule do not support file
and line information.

Sample GDB output after this:
(gdb) info modules

**File module2.f90:
18:     mod2

File module.f90:
16:     mod1**

LLVM metadata support:
https://reviews.llvm.org/D79484
https://reviews.llvm.org/D80614