### PR TITLE
[DebugInfo] Basic testing infra for debug-info testing

### DIFF
--- a/test/debug_info/lit.local.cfg
+++ b/test/debug_info/lit.local.cfg
@@ -1,0 +1,11 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+#debug info test configuration
+
+config.suffixes = ['.f', '.FOR', '.for', '.f77', '.f90', '.f95', '.F', '.fpp',
+ '.FPP']
+


### PR DESCRIPTION
This patch adds minimal support for debug-info testing
infrastructure.

Post this debug-info related development should use this for
adding incremental test cases for regression and verification.

Discussion GitHub Issue:
https://github.com/flang-compiler/flang/issues/899