### PR TITLE
flang gen-exec doesnt show assumed shape array in debugger

### DIFF
--- a/test/debug_info/assumed_shape.f90
+++ b/test/debug_info/assumed_shape.f90
@@ -1,0 +1,17 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: call void @llvm.dbg.declare(metadata i64* %assume, metadata [[ASSUME:![0-9]+]], metadata !DIExpression())
+!CHECK: [[TYPE:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEMS:![0-9]+]])
+!CHECK: [[ELEMS]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]], [[ELEM3:![0-9]+]], [[ELEM4:![0-9]+]]
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: 1, upperBound: 5)
+!CHECK: [[ELEM2]] = !DISubrange(lowerBound: 1, upperBound: [[N1:![0-9]+]])
+!CHECK: [[N1]] = distinct !DILocalVariable
+!CHECK: [[ELEM3]] = !DISubrange(lowerBound: [[N2:![0-9]+]], upperBound: 9)
+!CHECK: [[N2]] = distinct !DILocalVariable
+!CHECK: [[ELEM4]] = !DISubrange(lowerBound: [[N3:![0-9]+]], upperBound: [[N4:![0-9]+]])
+!CHECK: [[N3]] = distinct !DILocalVariable
+!CHECK: [[N4]] = distinct !DILocalVariable
+subroutine sub(assume,n1,n2,n3,n4)
+  integer(kind=4) :: assume(5,n1,n2:9,n3:n4)
+  assume(1,1,1,1) = 7
+end subroutine sub

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -389,7 +389,8 @@ ll_feature_debug_info_ver90(const LL_IRFeatures *feature)
 /**
    \brief Version 11.0 debug metadata
  */
-INLINE static bool ll_feature_debug_info_ver11(const LL_IRFeatures *feature) {
+INLINE static bool ll_feature_debug_info_ver11(const LL_IRFeatures *feature)
+{
   return feature->version >= LL_Version_11_0;
 }
 

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -146,6 +146,7 @@ typedef enum LL_IRVersion {
   LL_Version_7_0 = 70,
   LL_Version_8_0 = 80,
   LL_Version_9_0 = 90,
+  LL_Version_11_0 = 110,
   LL_Version_trunk = 1023
 } LL_IRVersion;
 
@@ -386,6 +387,13 @@ ll_feature_debug_info_ver90(const LL_IRFeatures *feature)
 }
 
 /**
+   \brief Version 11.0 debug metadata
+ */
+INLINE static bool ll_feature_debug_info_ver11(const LL_IRFeatures *feature) {
+  return feature->version >= LL_Version_11_0;
+}
+
+/**
    \brief Version 9.0 onwards uses 3 field syntax for constructors
    and destructors
  */
@@ -484,6 +492,7 @@ ll_feature_no_file_in_namespace(const LL_IRFeatures *feature)
 #define ll_feature_debug_info_ver70(f) ((f)->version >= LL_Version_7_0)
 #define ll_feature_debug_info_ver80(f) ((f)->version >= LL_Version_8_0)
 #define ll_feature_debug_info_ver90(f) ((f)->version >= LL_Version_9_0)
+#define ll_feature_debug_info_ver11(f) ((f)->version >= LL_Version_11_0)
 #define ll_feature_three_argument_ctor_and_dtor(f) \
   ((f)->version >= LL_Version_9_0)
 #define ll_feature_use_distinct_metadata(f) ((f)->version >= LL_Version_3_8)

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -1232,7 +1232,8 @@ lldbg_create_ftn_subrange_via_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
 }
 
 static LL_MDRef lldbg_create_subrange_mdnode_pre11(LL_DebugInfo *db, ISZ_T lb,
-                                                   ISZ_T ub) {
+                                                   ISZ_T ub)
+{
   DBLINT64 count, low, high;
   DBLINT64 one;
   LLMD_Builder mdb = llmd_init(db->module);
@@ -1261,9 +1262,8 @@ static LL_MDRef lldbg_create_subrange_mdnode_pre11(LL_DebugInfo *db, ISZ_T lb,
 }
 
 static LL_MDRef lldbg_create_subrange_mdnode(LL_DebugInfo *db, LL_MDRef lb,
-                                             LL_MDRef ub) {
-  DBLINT64 count, low, high;
-  DBLINT64 one;
+                                             LL_MDRef ub)
+{
   LLMD_Builder mdb = llmd_init(db->module);
 
   llmd_set_class(mdb, LL_DISubRange);
@@ -1335,7 +1335,7 @@ lldbg_create_local_variable_mdnode(LL_DebugInfo *db, int dw_tag,
                                    LL_MDRef context, char *name,
                                    LL_MDRef fileref, int line, int argnum,
                                    LL_MDRef type_mdnode, int flags,
-                                   LL_MDRef fwd)
+                                   LL_MDRef fwd, int sptr = 0)
 {
   LLMD_Builder mdb = llmd_init(db->module);
 
@@ -1357,6 +1357,11 @@ lldbg_create_local_variable_mdnode(LL_DebugInfo *db, int dw_tag,
   llmd_add_md(mdb, type_mdnode);
   llmd_add_i32(mdb, flags);
   llmd_add_i32(mdb, 0);
+
+  if (sptr && (flags & DIFLAG_ARTIFICIAL)) {
+    llmd_set_distinct(mdb);
+  }
+
   if (fwd)
     return ll_finish_variable(mdb, fwd);
   return llmd_finish(mdb);
@@ -2549,7 +2554,8 @@ lldbg_fwd_local_variable(LL_DebugInfo *db, int sptr, int findex,
  */
 INLINE static void init_subrange_bound_pre11(LL_DebugInfo *db, ISZ_T *cb,
                                              LL_MDRef *bound_sptr, SPTR sptr,
-                                             ISZ_T defVal, int findex) {
+                                             ISZ_T defVal, int findex)
+{
   if (sptr) {
     switch (STYPEG(sptr)) {
     case ST_CONST:
@@ -2572,7 +2578,8 @@ INLINE static void init_subrange_bound_pre11(LL_DebugInfo *db, ISZ_T *cb,
 }
 
 INLINE static void init_subrange_bound(LL_DebugInfo *db, LL_MDRef *bound_sptr,
-                                       SPTR sptr, ISZ_T defVal, int findex) {
+                                       SPTR sptr, ISZ_T defVal, int findex)
+{
   if (sptr) {
     switch (STYPEG(sptr)) {
     case ST_CONST:
@@ -3169,7 +3176,7 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
     }
     var_mdnode = lldbg_create_local_variable_mdnode(
         db, DW_TAG_auto_variable, blk_info->mdnode, symname, file_mdnode, 0, 0,
-        type_mdnode, flags, fwd);
+        type_mdnode, flags, fwd, sptr);
   }
   return var_mdnode;
 }


### PR DESCRIPTION
Note: This modification makes use of recent upgrade to DISubrange
    https://reviews.llvm.org/rGd20bf5a7258d4b6a7f017a81b125275dac1aa166

  Currently flang generates 0 sized DISubrange metadata for assumed sahpe arrays.

  ---------
  test case
  ---------
```
  subroutine sub(assume,n1,n2)
    dimension assume(n1,n2)
  end subroutine sub
```
  -------
  LLVM IR
  -------
```
  !29 = !DILocalVariable(name: "assume", arg: 1, scope: !26, file: !3, type: !30)
  !30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !10, size: 32, align: 32, elements: !31)
  !31 = !{!32, !32}
  !32 = !DISubrange(count: 0, lowerBound: 1)
```
  -------
  This is fixed by upgrading DISubrange as it is upgraded in LLVM to be able to
  dump proper DISubrange for assumed shape array.
  -------
```
  !29 = !DILocalVariable(name: "assume", arg: 1, scope: !26, file: !3, type: !30)
  !30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !10, size: 32, align: 32, elements: !31)
  !31 = !{!32, !36}
  !32 = !DISubrange(lowerBound: 1, upperBound: !33)
  !33 = distinct !DILocalVariable(scope: !34, file: !3, type: !35, flags: DIFlagArtificial)
  !36 = !DISubrange(lowerBound: 1, upperBound: !37)
  !37 = distinct !DILocalVariable(scope: !34, file: !3, type: !35, flags: DIFlagArtificial)
```
  -------