### PR TITLE
flang support for Assumed length string type during debug info generation

### DIFF
--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -12591,6 +12591,26 @@ build_unused_global_define_from_params(void)
 }
 
 /**
+   \brief Helper function: test if the param length exists as compiler created
+          symbol which represents length of any assumed length string argument
+          in the arg list
+   \param length is the compiler created symbol which represents length of
+          assumed length string argument
+ */
+INLINE static bool
+cg_fetch_clen_parent(SPTR length)
+{
+  int i;
+  SPTR parent;
+  for (i = 1; i <= llvm_info.abi_info->nargs; ++i) {
+    parent = llvm_info.abi_info->arg[i].sptr;
+    if ((DTY(DTYPEG(parent)) == TY_CHAR) && (DTYPEG(parent) == DT_ASSCHAR) &&
+        (CLENG(parent) == length)) return true;
+  }
+  return false;
+}
+
+/**
    \brief Helper function: In Fortran, test if \c MIDNUM is not \c SC_DUMMY
    \param sptr   a symbol
  */
@@ -12859,7 +12879,16 @@ process_formal_arguments(LL_ABI_Info *abi)
     assert(llTy->data_type == LL_PTR, "expected a pointer type",
            llTy->data_type, ERR_Fatal);
     /* Emit an @llvm.dbg.declare right after the store. */
-    formalsAddDebug(arg->sptr, i, llTy, true);
+    /* if arg->sptr is the compiler created symbol which represents the length
+     * of assumed length string type, then make the first metadata argument
+     * type of this symbol as address instead of value in the llvm.dbg.declare
+     * intrinsic.
+     */
+    if ((arg->kind == LL_ARG_DIRECT) && CCSYMG(arg->sptr) &&
+	    PASSBYVALG(arg->sptr) && cg_fetch_clen_parent(arg->sptr))
+	formalsAddDebug(arg->sptr, i, llTy, false);
+    else
+	formalsAddDebug(arg->sptr, i, llTy, true);
   }
 }
 

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -2583,23 +2583,11 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
       type_mdnode = db->dtype_array[dtype];
   if (LL_MDREF_IS_NULL(type_mdnode)) {
     if (is_assumed_char(dtype)) {
-#if defined(FLANG_LLVM_EXTENSIONS)
-      if ((!skipDataDependentTypes) &&
-          ll_feature_has_diextensions(&db->module->ir)) {
-        type_mdnode =
+        /* For assumed length string type, always emit !DIStringType metadata
+         * node. Here compiler created local variable holds the string length
+         */
+	 type_mdnode =
             lldbg_create_assumed_len_string_type_mdnode(db, sptr, findex);
-      } else {
-#endif
-        type_mdnode =
-            lldbg_emit_type(db, DT_CPTR, sptr, findex, false, false, false);
-#if defined(FLANG_LLVM_EXTENSIONS)
-        if (!skipDataDependentTypes) {
-#endif
-          dtype_array_check_set(db, dtype, type_mdnode);
-#if defined(FLANG_LLVM_EXTENSIONS)
-        }
-      }
-#endif
     } else
         if (DT_ISBASIC(dtype) && (DTY(dtype) != TY_PTR)) {
 


### PR DESCRIPTION
This fix handle support for Assumed length string type during debug info generation. It has 2 parts.

1. !DIStringType metadata generation, where there is a compiler generated local variable(metadata !28 below) which holds the length of assumed string. lldbg_create_assumed_len_string_type_mdnode() which exists already in flang2 will take care of this. 

2. the dbg.declare for the string length variable looks like (without fix):
call void @llvm.dbg.declare (metadata i64 %.U0001.arg, metadata !28, metadata !29), !dbg !26

But the first metadata in the dbg.declare should have address as shown here:
call void @llvm.dbg.declare (metadata i64* %.U0001.addr, metadata !28, metadata !29), !dbg !26

snippet from IR generated after fix : 
. . .
!28 = !DILocalVariable(scope: !25, arg: 2, file: !3, type: !27, flags: 64)
!29 = !DIExpression()
!30 = !DIStringType(name: "character(*)!2", size: 32, stringLength: !28, stringLengthExpression: !29)
. . .

Dwarf info generated with fix:
. . .                 
0x0000009d:   DW_TAG_string_type [9]
                DW_AT_name [DW_FORM_strp]       ( .debug_str[0x00000074] = "character(*)!2")
                DW_AT_string_length [DW_FORM_ref4]      (cu + 0x0071 => {0x00000071})
. . . 
0x00000071:       DW_TAG_formal_parameter [5]
                    DW_AT_location [DW_FORM_block1]     (DW_OP_fbreg -8)
                    DW_AT_type [DW_FORM_ref4]   (cu + 0x008f => {0x0000008f} "integer*8")
                    DW_AT_artificial [DW_FORM_flag]     (0x01)
. . .

test program:
program assumedLength
   call sub('Hello')
   call sub('Goodbye')
   contains
   subroutine sub(string)
           implicit none
           character(len=*), intent(in) :: string
           print *, string
   end subroutine sub
end program assumedLength