### PR TITLE
Debugger is not able to print correct variable values from modules of library

### DIFF
--- a/test/debug_info/fail.f90
+++ b/test/debug_info/fail.f90
@@ -1,0 +1,7 @@
+! Simple test to check for a failing case.
+
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! CHECK: NULL
+
+subroutine foo
+end subroutine

--- a/test/debug_info/linkage_name.f90
+++ b/test/debug_info/linkage_name.f90
@@ -1,0 +1,12 @@
+
+! RUN: %flang -gdwarf-4  -fpic -c  %s -o %t
+! RUN: llvm-dwarfdump -debug-info %t | FileCheck %s
+! CHECK:  DW_TAG_variable
+! CHECK:  DW_AT_linkage_name ("_lib_8_")
+module lib
+        integer :: var_i = 1
+contains
+        subroutine lib_func
+        var_i = 2
+        end subroutine lib_func
+end module lib

--- a/test/debug_info/lit.local.cfg
+++ b/test/debug_info/lit.local.cfg
@@ -1,0 +1,4 @@
+#debug info test configuration
+
+config.suffixes = ['.f', '.FOR', '.for', '.f77', '.f90', '.f95', '.F', '.fpp',
+ '.FPP']

--- a/test/debug_info/pass.f90
+++ b/test/debug_info/pass.f90
@@ -1,0 +1,7 @@
+! Simple test to check a passing case.
+
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! CHECK: DISubroutine
+
+subroutine foo
+end subroutine

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -2898,7 +2898,7 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
     flags = 0;
   }
   mdref = lldbg_create_global_variable_mdnode(
-      db, scope_mdnode, display_name, SYMNAME(sptr), "", file_mdnode, decl_line,
+      db, scope_mdnode, display_name, SYMNAME(sptr), get_llvm_name(sptr), file_mdnode, decl_line,
       type_mdnode, is_local, DEFDG(sptr) || (sc != SC_EXTERN), value, -1, flags,
       off, sptr, fwd);
 


### PR DESCRIPTION

Test case used:

filename: library-module-main.f90

use lib
call lib_func
if (var_i .ne. 2) call abort
var_i = var_i
end

filename: library-module-lib.f90

module lib
        integer :: var_i = 1
contains
        subroutine lib_func
        var_i = 2
        var_i = var_i
        end subroutine lib_func
end module lib

flang -gdwarf-4  -fpic -c -o library-module-lib.f90.o library-module-lib.f90
flang library-module-lib.f90.o -gdwarf-4  -shared -Wl,-soname,library-module-lib.so -g -lm -o library-module-lib.so
flang -Wl,--no-as-needed library-module-main.f90 library-module-lib.so -gdwarf-4 -g -Wl,-rpath,$ORIGIN -lm -o library-module

gdb -q library-module -ex "start" -ex "b library-module-lib.f90:7" -ex "continue" 

Reading symbols from library-module...
Temporary breakpoint 1 at 0x400854: -qualified MAIN. (2 locations)
Starting program: /home/nitachra/library-module
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Temporary breakpoint 1, main
 (argc=1,
argv=0x7ffffffee208) at /home/nitachra/aocc/llvm-project/flang/runtime/flangmain/flangmain.c:46
46        int i = 0;
Breakpoint 2 at 0x7fffff1f0692: file library-module-lib.f90, line 7.
Continuing.

Breakpoint 2, lib::lib_func () at library-module-lib.f90:7
7               end subroutine lib_func
(gdb) p var_i
$1 = 1
(gdb)

This is because DW_AT_linkage_name is not getting emitted in debug info global
variables. This patch fixes this.

This patch has the dependency on https://github.com/flang-compiler/flang/pull/900/commits/211ee32c223f04178656882c3306b56b3850d046
for adding test case.