### PR TITLE
libflang: Fix strcmp_klen return value type

### DIFF
--- a/runtime/flang/ftncharsup.c
+++ b/runtime/flang/ftncharsup.c
@@ -493,7 +493,7 @@ int Ftn_str_index(  const unsigned char * const a1,
  */
 /* ***********************************************************************/
 
-int64_t
+int
 Ftn_strcmp_klen(    const unsigned char * const a1,
                     const unsigned char * const a2,
                     int64_t a1_len,


### PR DESCRIPTION
Ftn_strcmp_klen return value type should be int like
its similar sibling functions and like the compiler
assumes when generating a call to this function.

Signed-off-by: Itay Bookstein <itay.bookstein@nextsilicon.com>