### PR TITLE
flang gen-exec does not generate DW_AT_associated or DW_AT_allocated

### DIFF
--- a/test/debug_info/allocated.f90
+++ b/test/debug_info/allocated.f90
@@ -1,7 +1,7 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
 !CHECK: !DILocalVariable(name: "arr", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: [[TYPE:![0-9]+]])
-!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}}, allocated: {{![0-9]+}})
 !CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
 !CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 !CHECK: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))

--- a/test/debug_info/allocated.f90
+++ b/test/debug_info/allocated.f90
@@ -1,0 +1,14 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !DILocalVariable(name: "arr", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: [[TYPE:![0-9]+]])
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!CHECK: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+program main
+  integer(kind=4), allocatable :: arr(:, :)
+
+  allocate (arr(10,10))
+  arr(1,1) = 99
+  print *, arr(1,1)
+end program main

--- a/test/debug_info/associated.f90
+++ b/test/debug_info/associated.f90
@@ -1,7 +1,7 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
 !CHECK !DILocalVariable(name: "ptr", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}})
-!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}}, associated: {{![0-9]+}})
 !CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
 !CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 !CHECK: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))

--- a/test/debug_info/associated.f90
+++ b/test/debug_info/associated.f90
@@ -1,0 +1,15 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK !DILocalVariable(name: "ptr", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}})
+!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!CHECK: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+program main
+  integer, target :: arr(10, 10)
+  integer, pointer :: ptr(:, :)
+
+  arr(1,1) = 99
+  ptr => arr
+  print *, ptr(1,1)
+end program main

--- a/test/debug_info/assumed_shape.f90
+++ b/test/debug_info/assumed_shape.f90
@@ -1,0 +1,17 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: call void @llvm.dbg.declare(metadata i64* %assume, metadata [[ASSUME:![0-9]+]], metadata !DIExpression())
+!CHECK: [[TYPE:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEMS:![0-9]+]])
+!CHECK: [[ELEMS]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]], [[ELEM3:![0-9]+]], [[ELEM4:![0-9]+]]
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: 1, upperBound: 5)
+!CHECK: [[ELEM2]] = !DISubrange(lowerBound: 1, upperBound: [[N1:![0-9]+]])
+!CHECK: [[N1]] = distinct !DILocalVariable
+!CHECK: [[ELEM3]] = !DISubrange(lowerBound: [[N2:![0-9]+]], upperBound: 9)
+!CHECK: [[N2]] = distinct !DILocalVariable
+!CHECK: [[ELEM4]] = !DISubrange(lowerBound: [[N3:![0-9]+]], upperBound: [[N4:![0-9]+]])
+!CHECK: [[N3]] = distinct !DILocalVariable
+!CHECK: [[N4]] = distinct !DILocalVariable
+subroutine sub(assume,n1,n2,n3,n4)
+  integer(kind=4) :: assume(5,n1,n2:9,n3:n4)
+  assume(1,1,1,1) = 7
+end subroutine sub

--- a/test/debug_info/dertyp_striding.f90
+++ b/test/debug_info/dertyp_striding.f90
@@ -1,7 +1,7 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
 !CHECK !DILocalVariable(name: "pvar", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}})
-!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 64, align: 64, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 64, align: 64, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}}, associated: {{![0-9]+}})
 !CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]]}
 !CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 program main

--- a/test/debug_info/dertyp_striding.f90
+++ b/test/debug_info/dertyp_striding.f90
@@ -1,0 +1,20 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK !DILocalVariable(name: "pvar", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}})
+!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 64, align: 64, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+program main
+    type dtype
+        integer(kind=8) :: x
+        integer(kind=8) :: y
+        integer(kind=8) :: z
+    end type
+    type(dtype), dimension(10), target :: tvar
+    integer(kind=8), dimension(:), pointer :: pvar => null()
+    tvar(:)%x = 1
+    tvar(:)%y = 2
+    tvar(:)%z = 3
+    pvar => tvar(1:9)%y
+    print *, pvar
+end program

--- a/test/debug_info/ptr_arr_member.f90
+++ b/test/debug_info/ptr_arr_member.f90
@@ -1,0 +1,41 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "dtype", file: {{![0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[MEMS:![0-9]+]])
+!CHECK: [[MEMS]] = !{[[MEM1:![0-9]+]], [[MEM2:![0-9]+]], [[MEM3:![0-9]+]]}
+!CHECK: [[MEM1]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr1", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1:![0-9]+]]
+!CHECK: [[TYPE1]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM1:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref))
+!CHECK: [[ELEM1]] = !{[[ELEM11:![0-9]+]], [[ELEM12:![0-9]+]]}
+!CHECK: [[ELEM11]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 96, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 136, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 40, DW_OP_deref, DW_OP_mul))
+!CHECK: [[ELEM12]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 144, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 184, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 176, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 40, DW_OP_deref, DW_OP_mul))
+!CHECK: [[MEM2]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr2", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1]]
+!CHECK: [[MEM3]] = !DIDerivedType(tag: DW_TAG_member, name: "arralc", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1]]
+
+program main
+
+  type dtype
+     integer, pointer :: arrptr1(:,:)
+     integer, pointer :: arrptr2(:,:)
+     integer, allocatable :: arralc(:,:)
+  end type dtype
+  type(dtype) :: dvar1
+  type(dtype), pointer :: dvar2
+
+  allocate (dvar1%arrptr1 (5,5))
+
+  dvar1%arrptr1 (1,1)= 9
+  dvar1%arrptr1 (2,3)= 8
+  print *, dvar1%arrptr1
+
+  allocate (dvar1%arralc (3,2))
+  dvar1%arralc (1,1)= 29
+  dvar1%arralc (3,2)= 28
+  print *, dvar1%arralc
+
+  allocate (dvar2)
+  allocate (dvar2%arrptr2 (3,4))
+  dvar2%arrptr2 (1,1)= 19
+  dvar2%arrptr2 (2,1)= 18
+  dvar2%arrptr2 (2,3)= 17
+  print *, dvar2%arrptr2
+
+end program main

--- a/test/debug_info/ptr_arr_member.f90
+++ b/test/debug_info/ptr_arr_member.f90
@@ -3,12 +3,13 @@
 !CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "dtype", file: {{![0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[MEMS:![0-9]+]])
 !CHECK: [[MEMS]] = !{[[MEM1:![0-9]+]], [[MEM2:![0-9]+]], [[MEM3:![0-9]+]]}
 !CHECK: [[MEM1]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr1", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1:![0-9]+]]
-!CHECK: [[TYPE1]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM1:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref))
+!CHECK: [[TYPE1]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM1:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref), associated: !DIExpression(DW_OP_push_object_address, DW_OP_deref))
 !CHECK: [[ELEM1]] = !{[[ELEM11:![0-9]+]], [[ELEM12:![0-9]+]]}
 !CHECK: [[ELEM11]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 96, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 136, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 40, DW_OP_deref, DW_OP_mul))
 !CHECK: [[ELEM12]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 144, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 184, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 176, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 40, DW_OP_deref, DW_OP_mul))
-!CHECK: [[MEM2]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr2", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1]]
-!CHECK: [[MEM3]] = !DIDerivedType(tag: DW_TAG_member, name: "arralc", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1]]
+!CHECK: [[MEM2]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr2", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1:![0-9]+]]
+!CHECK: [[MEM3]] = !DIDerivedType(tag: DW_TAG_member, name: "arralc", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE2:![0-9]+]]
+!CHECK: [[TYPE2]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM1:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref), allocated: !DIExpression(DW_OP_push_object_address, DW_OP_deref))
 
 program main
 

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -4532,10 +4532,8 @@ insert_llvm_memcpy(int ilix, int size, OPERAND *dest_op, OPERAND *src_op,
    \param sptr    symbol
    \param llTy    preferred type of \p sptr or \c NULL
  */
-static void
-insert_llvm_dbg_declare(LL_MDRef mdnode, SPTR sptr, LL_Type *llTy,
-                        OPERAND *exprMDOp, OperandFlag_t opflag)
-{
+void insert_llvm_dbg_declare(LL_MDRef mdnode, SPTR sptr, LL_Type *llTy,
+                             OPERAND *exprMDOp, OperandFlag_t opflag) {
   EXFUNC_LIST *exfunc;
   OPERAND *call_op;
   static bool dbg_declare_defined = false;
@@ -4561,15 +4559,19 @@ insert_llvm_dbg_declare(LL_MDRef mdnode, SPTR sptr, LL_Type *llTy,
     } else {
       LL_DebugInfo *di = cpu_llvm_module->debug_info;
       LL_MDRef md;
-      /* Handle the Fortran allocatable array cases. Emit expression
-       * mdnode with sigle argument of DW_OP_deref to workaround known
-       * gdb bug not able to debug array bounds.
-       */
-      if (ftn_array_need_debug_info(sptr)) {
-        const unsigned deref = lldbg_encode_expression_arg(LL_DW_OP_deref, 0);
-        md = lldbg_emit_expression_mdnode(di, 1, deref);
-      } else
+      if (ll_feature_debug_info_ver11(&cpu_llvm_module->ir)) {
         md = lldbg_emit_empty_expression_mdnode(di);
+      } else {
+        /* Handle the Fortran allocatable array cases. Emit expression
+         * mdnode with single argument of DW_OP_deref to workaround known
+         * gdb bug not able to debug array bounds.
+         */
+        if (ftn_array_need_debug_info(sptr)) {
+          const unsigned deref = lldbg_encode_expression_arg(LL_DW_OP_deref, 0);
+          md = lldbg_emit_expression_mdnode(di, 1, deref);
+        } else
+          md = lldbg_emit_empty_expression_mdnode(di);
+      }
       call_op->next->next->next = make_mdref_op(md);
     }
   }
@@ -10920,9 +10922,19 @@ addDebugForLocalVar(SPTR sptr, LL_Type *type)
 {
   if (need_debug_info(sptr)) {
     /* Dummy sptrs are treated as local (see above) */
-    LL_MDRef param_md = lldbg_emit_local_variable(
-        cpu_llvm_module->debug_info, sptr, BIH_FINDEX(gbl.entbih), true);
-    insert_llvm_dbg_declare(param_md, sptr, type, NULL, OPF_NONE);
+    if (ll_feature_debug_info_ver11(&cpu_llvm_module->ir) &&
+        ftn_array_need_debug_info(sptr)) {
+      SPTR array_sptr = (SPTR)REVMIDLNKG(sptr);
+      LL_MDRef array_md =
+          lldbg_emit_local_variable(cpu_llvm_module->debug_info, array_sptr,
+                                    BIH_FINDEX(gbl.entbih), true);
+      insert_llvm_dbg_declare(array_md, SDSCG(array_sptr),
+                              LLTYPE(SDSCG(array_sptr)), NULL, OPF_NONE);
+    } else {
+      LL_MDRef param_md = lldbg_emit_local_variable(
+          cpu_llvm_module->debug_info, sptr, BIH_FINDEX(gbl.entbih), true);
+      insert_llvm_dbg_declare(param_md, sptr, type, NULL, OPF_NONE);
+    }
   }
 }
 

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -277,4 +277,14 @@ void add_debug_cmnblk_variables(LL_DebugInfo *db, SPTR sptr);
  */
 bool ftn_array_need_debug_info(SPTR sptr);
 
+/**
+   \brief Insert <tt>@llvm.dbg.declare</tt> call for debug
+   \param mdnode  metadata node
+   \param sptr    symbol
+   \param llTy    preferred type of \p sptr or \c NULL
+ */
+void insert_llvm_dbg_declare(LL_MDRef mdnode, SPTR sptr, LL_Type *llTy,
+                             OPERAND *exprMDOp, OperandFlag_t opflag);
+
+
 #endif

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -389,7 +389,8 @@ ll_feature_debug_info_ver90(const LL_IRFeatures *feature)
 /**
    \brief Version 11.0 debug metadata
  */
-INLINE static bool ll_feature_debug_info_ver11(const LL_IRFeatures *feature) {
+INLINE static bool ll_feature_debug_info_ver11(const LL_IRFeatures *feature)
+{
   return feature->version >= LL_Version_11_0;
 }
 

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -688,6 +688,8 @@ typedef enum LL_DW_OP_t {
   LL_DW_OP_constu,
   LL_DW_OP_plus_uconst,
   LL_DW_OP_int,
+  LL_DW_OP_push_object_address,
+  LL_DW_OP_mul,
   LL_DW_OP_MAX /**< must be last value */
 } LL_DW_OP_t;
 

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -146,6 +146,7 @@ typedef enum LL_IRVersion {
   LL_Version_7_0 = 70,
   LL_Version_8_0 = 80,
   LL_Version_9_0 = 90,
+  LL_Version_11_0 = 110,
   LL_Version_trunk = 1023
 } LL_IRVersion;
 
@@ -386,6 +387,13 @@ ll_feature_debug_info_ver90(const LL_IRFeatures *feature)
 }
 
 /**
+   \brief Version 11.0 debug metadata
+ */
+INLINE static bool ll_feature_debug_info_ver11(const LL_IRFeatures *feature) {
+  return feature->version >= LL_Version_11_0;
+}
+
+/**
    \brief Version 9.0 onwards uses 3 field syntax for constructors
    and destructors
  */
@@ -484,6 +492,7 @@ ll_feature_no_file_in_namespace(const LL_IRFeatures *feature)
 #define ll_feature_debug_info_ver70(f) ((f)->version >= LL_Version_7_0)
 #define ll_feature_debug_info_ver80(f) ((f)->version >= LL_Version_8_0)
 #define ll_feature_debug_info_ver90(f) ((f)->version >= LL_Version_9_0)
+#define ll_feature_debug_info_ver11(f) ((f)->version >= LL_Version_11_0)
 #define ll_feature_three_argument_ctor_and_dtor(f) \
   ((f)->version >= LL_Version_9_0)
 #define ll_feature_use_distinct_metadata(f) ((f)->version >= LL_Version_3_8)

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -147,6 +147,7 @@ typedef enum LL_IRVersion {
   LL_Version_8_0 = 80,
   LL_Version_9_0 = 90,
   LL_Version_11_0 = 110,
+  LL_Version_12_0 = 120,
   LL_Version_trunk = 1023
 } LL_IRVersion;
 
@@ -395,6 +396,13 @@ INLINE static bool ll_feature_debug_info_ver11(const LL_IRFeatures *feature)
 }
 
 /**
+   \brief Version 12.0 debug metadata
+ */
+INLINE static bool ll_feature_debug_info_ver12(const LL_IRFeatures *feature) {
+  return feature->version >= LL_Version_12_0;
+}
+
+/**
    \brief Version 9.0 onwards uses 3 field syntax for constructors
    and destructors
  */
@@ -494,6 +502,7 @@ ll_feature_no_file_in_namespace(const LL_IRFeatures *feature)
 #define ll_feature_debug_info_ver80(f) ((f)->version >= LL_Version_8_0)
 #define ll_feature_debug_info_ver90(f) ((f)->version >= LL_Version_9_0)
 #define ll_feature_debug_info_ver11(f) ((f)->version >= LL_Version_11_0)
+#define ll_feature_debug_info_ver12(f) ((f)->version >= LL_Version_12_0)
 #define ll_feature_three_argument_ctor_and_dtor(f) \
   ((f)->version >= LL_Version_9_0)
 #define ll_feature_use_distinct_metadata(f) ((f)->version >= LL_Version_3_8)

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1378,7 +1378,7 @@ static const MDTemplate Tmpl_DICompositeType_pre34[] = {
 };
 
 static const MDTemplate Tmpl_DICompositeType[] = {
-  { "DICompositeType", TF, 16 },
+  { "DICompositeType", TF, 18 },
   { "tag",                      DWTagField },
   { "file",                     NodeField },
   { "scope",                    NodeField },
@@ -1394,7 +1394,9 @@ static const MDTemplate Tmpl_DICompositeType[] = {
   { "vtableHolder",             NodeField },
   { "templateParams",           NodeField },
   { "identifier",               StringField },
-  { "dataLocation",             NodeField}
+  { "dataLocation",             NodeField},
+  { "associated",               NodeField},
+  { "allocated",                NodeField}
 };
 
 static const MDTemplate Tmpl_DIFortranArrayType[] = {

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1378,7 +1378,7 @@ static const MDTemplate Tmpl_DICompositeType_pre34[] = {
 };
 
 static const MDTemplate Tmpl_DICompositeType[] = {
-  { "DICompositeType", TF, 15 },
+  { "DICompositeType", TF, 16 },
   { "tag",                      DWTagField },
   { "file",                     NodeField },
   { "scope",                    NodeField },
@@ -1393,7 +1393,8 @@ static const MDTemplate Tmpl_DICompositeType[] = {
   { "runtimeLang",              DWLangField },
   { "vtableHolder",             NodeField },
   { "templateParams",           NodeField },
-  { "identifier",               StringField }
+  { "identifier",               StringField },
+  { "dataLocation",             NodeField}
 };
 
 static const MDTemplate Tmpl_DIFortranArrayType[] = {
@@ -2163,6 +2164,10 @@ ll_dw_op_to_name(LL_DW_OP_t op)
     return "DW_OP_constu";
   case LL_DW_OP_plus_uconst:
     return "DW_OP_plus_uconst";
+  case LL_DW_OP_push_object_address:
+    return "DW_OP_push_object_address";
+  case LL_DW_OP_mul:
+    return "DW_OP_mul";
   default:
     break;
   }

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -1232,7 +1232,8 @@ lldbg_create_ftn_subrange_via_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
 }
 
 static LL_MDRef lldbg_create_subrange_mdnode_pre11(LL_DebugInfo *db, ISZ_T lb,
-                                                   ISZ_T ub) {
+                                                   ISZ_T ub)
+{
   DBLINT64 count, low, high;
   DBLINT64 one;
   LLMD_Builder mdb = llmd_init(db->module);
@@ -1261,9 +1262,8 @@ static LL_MDRef lldbg_create_subrange_mdnode_pre11(LL_DebugInfo *db, ISZ_T lb,
 }
 
 static LL_MDRef lldbg_create_subrange_mdnode(LL_DebugInfo *db, LL_MDRef lb,
-                                             LL_MDRef ub) {
-  DBLINT64 count, low, high;
-  DBLINT64 one;
+                                             LL_MDRef ub)
+{
   LLMD_Builder mdb = llmd_init(db->module);
 
   llmd_set_class(mdb, LL_DISubRange);
@@ -1335,7 +1335,7 @@ lldbg_create_local_variable_mdnode(LL_DebugInfo *db, int dw_tag,
                                    LL_MDRef context, char *name,
                                    LL_MDRef fileref, int line, int argnum,
                                    LL_MDRef type_mdnode, int flags,
-                                   LL_MDRef fwd)
+                                   LL_MDRef fwd, int sptr = 0)
 {
   LLMD_Builder mdb = llmd_init(db->module);
 
@@ -1357,6 +1357,11 @@ lldbg_create_local_variable_mdnode(LL_DebugInfo *db, int dw_tag,
   llmd_add_md(mdb, type_mdnode);
   llmd_add_i32(mdb, flags);
   llmd_add_i32(mdb, 0);
+
+  if (sptr && (flags & DIFLAG_ARTIFICIAL)) {
+    llmd_set_distinct(mdb);
+  }
+
   if (fwd)
     return ll_finish_variable(mdb, fwd);
   return llmd_finish(mdb);
@@ -2549,7 +2554,8 @@ lldbg_fwd_local_variable(LL_DebugInfo *db, int sptr, int findex,
  */
 INLINE static void init_subrange_bound_pre11(LL_DebugInfo *db, ISZ_T *cb,
                                              LL_MDRef *bound_sptr, SPTR sptr,
-                                             ISZ_T defVal, int findex) {
+                                             ISZ_T defVal, int findex)
+{
   if (sptr) {
     switch (STYPEG(sptr)) {
     case ST_CONST:
@@ -2572,7 +2578,8 @@ INLINE static void init_subrange_bound_pre11(LL_DebugInfo *db, ISZ_T *cb,
 }
 
 INLINE static void init_subrange_bound(LL_DebugInfo *db, LL_MDRef *bound_sptr,
-                                       SPTR sptr, ISZ_T defVal, int findex) {
+                                       SPTR sptr, ISZ_T defVal, int findex)
+{
   if (sptr) {
     switch (STYPEG(sptr)) {
     case ST_CONST:
@@ -3169,7 +3176,7 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
     }
     var_mdnode = lldbg_create_local_variable_mdnode(
         db, DW_TAG_auto_variable, blk_info->mdnode, symname, file_mdnode, 0, 0,
-        type_mdnode, flags, fwd);
+        type_mdnode, flags, fwd, sptr);
   }
   return var_mdnode;
 }

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -732,11 +732,15 @@ lldbg_create_ftn_array_type_mdnode(LL_DebugInfo *db, LL_MDRef context, int line,
    \param pts_to
    \param subscripts
    \param data_location
+   \param associated
+   \param allocated
  */
 static LL_MDRef
 lldbg_create_array_type_mdnode(LL_DebugInfo *db, LL_MDRef context, int line,
                                ISZ_T sz, DBLINT64 alignment, LL_MDRef pts_to,
-                               LL_MDRef subscripts, LL_MDRef data_location) {
+                               LL_MDRef subscripts, LL_MDRef data_location,
+                               LL_MDRef associated, LL_MDRef allocated)
+{
   DBLINT64 size;
   LLMD_Builder mdb = llmd_init(db->module);
 
@@ -767,10 +771,22 @@ lldbg_create_array_type_mdnode(LL_DebugInfo *db, LL_MDRef context, int line,
     llmd_add_null(mdb);
     llmd_add_null(mdb);
   }
-  if (ll_feature_debug_info_ver11(&db->module->ir) &&
-      !LL_MDREF_IS_NULL(data_location)) {
-    llmd_add_null(mdb);
-    llmd_add_md(mdb, data_location);
+  if (ll_feature_debug_info_ver11(&db->module->ir)) {
+    if (!LL_MDREF_IS_NULL(data_location)) {
+      llmd_add_null(mdb);
+      llmd_add_md(mdb, data_location);
+    } else {
+      llmd_add_null(mdb);
+      llmd_add_null(mdb);
+    }
+    if (!LL_MDREF_IS_NULL(associated))
+      llmd_add_md(mdb, associated);
+    else
+      llmd_add_null(mdb);
+    if (!LL_MDREF_IS_NULL(allocated))
+      llmd_add_md(mdb, allocated);
+    else
+      llmd_add_null(mdb);
   }
 
   return llmd_finish(mdb);
@@ -2850,6 +2866,9 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
       case TY_ARRAY: {
         LLMD_Builder mdb = llmd_init(db->module);
         LL_MDRef dataloc = ll_get_md_null();
+        LL_MDRef is_live = ll_get_md_null();
+        LL_MDRef associated = ll_get_md_null();
+        LL_MDRef allocated = ll_get_md_null();
         ADSC *ad;
         int i, numdim;
         elem_dtype = DTySeqTyElement(dtype);
@@ -2873,6 +2892,13 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                 const unsigned pushobj = lldbg_encode_expression_arg(
                     LL_DW_OP_push_object_address, 0);
                 dataloc = lldbg_emit_expression_mdnode(db, 2, pushobj, deref);
+                if (ll_feature_debug_info_ver12(&db->module->ir)) {
+                  is_live = lldbg_emit_expression_mdnode(db, 2, pushobj, deref);
+                  if (ALLOCATTRG(sptr))
+                    allocated = is_live;
+                  else
+                    associated = is_live;
+                }
               } else {
                 SPTR datasptr = MIDNUMG(sptr);
                 if (datasptr == NOSYM)
@@ -2893,6 +2919,29 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                       lldbg_emit_local_variable(db, datasptr, findex, true);
                   insert_llvm_dbg_declare(dataloc, datasptr, dataloctype, NULL,
                                           OPF_NONE);
+                  if (ll_feature_debug_info_ver12(&db->module->ir)) {
+                    LL_MDRef file_mdnode;
+                    if (ll_feature_debug_info_need_file_descriptions(
+                            &db->module->ir))
+                      file_mdnode = get_filedesc_mdnode(db, findex);
+                    else
+                      file_mdnode = lldbg_emit_file(db, findex);
+                    BLKINFO *blk_info = get_lexical_block_info(db, sptr, true);
+                    LL_MDRef type_mdnode = lldbg_emit_type(
+                        db, DT_LOG, sptr, findex, false, false, false);
+                    is_live = lldbg_create_local_variable_mdnode(
+                        db, DW_TAG_auto_variable, blk_info->mdnode, NULL,
+                        file_mdnode, 0, 0, type_mdnode, DIFLAG_ARTIFICIAL,
+                        ll_get_md_null(), 1 /*distinct*/);
+
+                    if (ALLOCATTRG(sptr))
+                      allocated = is_live;
+                    else
+                      associated = is_live;
+
+                    insert_llvm_dbg_declare(is_live, datasptr, dataloctype,
+                                            NULL, OPF_NONE);
+                  }
                 }
               }
             }
@@ -2962,14 +3011,14 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         if (ll_feature_debug_info_ver11(&db->module->ir)) {
           type_mdnode = lldbg_create_array_type_mdnode(
               db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode,
-              dataloc);
+              dataloc, associated, allocated);
         } else if (ll_feature_has_diextensions(&db->module->ir)) {
           type_mdnode = lldbg_create_ftn_array_type_mdnode(
               db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode);
         } else
           type_mdnode = lldbg_create_array_type_mdnode(
               db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode,
-              dataloc);
+              dataloc, associated, allocated);
         dtype_array_check_set(db, dtype, type_mdnode);
         break;
       }
@@ -3624,7 +3673,7 @@ lldbg_create_cmblk_gv_mdnode(LL_DebugInfo *db, LL_MDRef cmnblk_mdnode,
   subscripts_mdnode = llmd_finish(mdb);
   type_mdnode = lldbg_create_array_type_mdnode(
       db, ll_get_md_null(), 0, sz, align, elem_type_mdnode, subscripts_mdnode,
-      ll_get_md_null());
+      ll_get_md_null(), ll_get_md_null(), ll_get_md_null());
   display_name = SYMNAME(sptr);
   mdref = lldbg_create_global_variable_mdnode(
       db, cmnblk_mdnode, display_name, SYMNAME(sptr), "", ll_get_md_null(),


### PR DESCRIPTION
        This patch makes use of commited llvm patch
          [DebugInfo] Support for DW_AT_associated and DW_AT_allocated.
          https://reviews.llvm.org/rG2d10258a31a6d05368dfd4442c4aaa7b54614f1e

        This PR has multiple check-ins, first four are already up for review as https://github.com/flang-compiler/flang/pull/901 and #902 . I intend to get only fifth check-in to get reviewed here. once other reviews are completed, the current one will be re-based.

        This fix is needed for allocatable/pointer arrays.

        for pointer array (before allocation/association)
        Before fix
        ------
        (gdb) pt ptr
        type = integer (140737345375288:140737354129776)
        (gdb) p ptr
        value requires 35017956 bytes, which is more than max-value-size
        ------
        After fix
        ------
        (gdb) pt ptr
        type = integer (:)
        (gdb) p ptr
        $1 = <not associated>
        ------
        for allocatable array (before allocation)
        Before fix
        ------
        (gdb) pt arr
        type = integer (140737345375288:140737354129776)
        (gdb) p arr
        value requires 35017956 bytes, which is more than max-value-size
        ------
        After fix
        ------
        (gdb) pt arr
        type = integer, allocatable (:)
        (gdb) p arr
        $1 = <not allocated>
        ------

    Testing:
        - check-flang