### PR TITLE
[runtime] Fix off-by-one error in minimum integers

### DIFF
--- a/runtime/flang/const.c
+++ b/runtime/flang/const.c
@@ -677,10 +677,10 @@ __fort_init_consts()
 
   max_str = (__STR_T) 255;
 
-  min_int1 = -max_int1;
-  min_int2 = -max_int2;
-  min_int4 = -max_int4;
-  min_int8 = -max_int8;
+  min_int1 = -max_int1 - 1;
+  min_int2 = -max_int2 - 1;
+  min_int4 = -max_int4 - 1;
+  min_int8 = -max_int8 - 1;
   min_str = 0;
 
   __fort_shifts[__NONE] = 0;

--- a/test/f90_correct/inc/maxloc14.mk
+++ b/test/f90_correct/inc/maxloc14.mk
@@ -1,0 +1,20 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build: $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/minloc14.mk
+++ b/test/f90_correct/inc/minloc14.mk
@@ -1,0 +1,20 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build: $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/maxloc14.sh
+++ b/test/f90_correct/lit/maxloc14.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/minloc14.sh
+++ b/test/f90_correct/lit/minloc14.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/maxloc14.f90
+++ b/test/f90_correct/src/maxloc14.f90
@@ -1,0 +1,15 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! maxloc with minimum value of integer type as elements
+
+program t
+  integer, dimension(2) :: rslt, expect
+  integer, dimension(2, 2) :: m
+  m = -huge(integer) - 1
+  rslt = maxloc(m, dim = 1)
+  expect = (/1, 1/)
+  call check(rslt, expect, 2)
+end

--- a/test/f90_correct/src/minloc14.f90
+++ b/test/f90_correct/src/minloc14.f90
@@ -1,0 +1,15 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! minloc with maximum value of integer type as elements
+
+program t
+  integer, dimension(2) :: rslt, expect
+  integer, dimension(2, 2) :: m
+  m = huge(integer)
+  rslt = minloc(m, dim = 1, back = .true.)
+  expect = (/2, 2/)
+  call check(rslt, expect, 2)
+end


### PR DESCRIPTION
runtime/flang/const.c defines min_int{1,2,4,8} to be -max_int{1,2,4,8}, which is wrong for the two's complement representation. As a result, the MAXLOC runtime function will compare each element in the input array with an incorrect minimum value. If the array contains -huge(integer)-1, MAXLOC will return an unexpected result.