### PR TITLE
f90_correct: fix rank mismatch in dt17.f90

### DIFF
--- a/test/f90_correct/src/dt17.f90
+++ b/test/f90_correct/src/dt17.f90
@@ -42,7 +42,7 @@
 	  do i = lbound(a,1),ubound(a,1)
 	   do j = lbound(a,2),ubound(a,2)
 	    if(a(i,j)%i .ne. ia(i,j) )then
-	     write(*,'(a,a,i1,a,i1,a,i4,a,i4)') s,'a(',i,',',j,')%i=',a(i,j)%i,' != ',ia(i)
+	     write(*,'(a,a,i1,a,i1,a,i4,a,i4)') s,'a(',i,',',j,')%i=',a(i,j)%i,' != ',ia(i,j)
 	     r = 0
 	    endif
 	    do k = lbound(ja,1),ubound(ja,1)


### PR DESCRIPTION
Line 45 in `test/f90_correct/src/dt17.f90` contains a rank mismatch which causes Flang to emit a warning:
```
F90-W-0155-The number of subscripts is less than the rank of ia (test/f90_correct/src/dt17.f90: 45)
  0 inform,   1 warnings,   0 severes, 0 fatal for check2
```
Its sibling test, `dt17b.f90`, uses the correct rank for `ia` on the same line. Presumably this is just a typo in the first test case; this PR fixes the typo.

Incidentally, gfortran gives an error on this test case:
```
dt17.f90:45:81:

   45 |       write(*,'(a,a,i1,a,i1,a,i4,a,i4)') s,'a(',i,',',j,')%i=',a(i,j)%i,' != ',ia(i)
      |                                                                                 1
Error: Rank mismatch in array reference at (1) (1/2)
```

Is there any reason why Flang only gives a warning and not a severe error?