### PR TITLE
Fix issue #670: Internal compiler error

### DIFF
--- a/test/f90_correct/inc/issue670_00.mk
+++ b/test/f90_correct/inc/issue670_00.mk
@@ -1,0 +1,28 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test issue670_00  ########
+
+
+issue670_00: run
+	
+
+build:  $(SRC)/issue670_00.f90
+	-$(RM) issue670_00.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/issue670_00.f90 -o issue670_00.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) issue670_00.$(OBJX) check.$(OBJX) $(LIBS) -o issue670_00.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test issue670_00
+	issue670_00.$(EXESUFFIX)
+
+verify: ;
+
+issue670_00.run: run
+

--- a/test/f90_correct/inc/issue670_01.mk
+++ b/test/f90_correct/inc/issue670_01.mk
@@ -1,0 +1,28 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test issue670_00  ########
+
+
+issue670_00: run
+	
+
+build:  $(SRC)/issue670_00.f90
+	-$(RM) issue670_00.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/issue670_00.f90 -o issue670_00.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) issue670_00.$(OBJX) check.$(OBJX) $(LIBS) -o issue670_00.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test issue670_00
+	issue670_00.$(EXESUFFIX)
+
+verify: ;
+
+issue670_00.run: run
+

--- a/test/f90_correct/lit/issue670_00.sh
+++ b/test/f90_correct/lit/issue670_00.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/issue670_01.sh
+++ b/test/f90_correct/lit/issue670_01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/issue670_00.f90
+++ b/test/f90_correct/src/issue670_00.f90
@@ -1,0 +1,34 @@
+!* Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+!* See https://llvm.org/LICENSE.txt for license information.
+!* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+!	check correct creation of array parameter constructor
+program main
+  implicit none
+  integer,parameter :: kind_param = 4
+  integer(kind_param),parameter :: x = Z"FF"
+  integer(kind_param) :: n
+  integer(kind_param),parameter :: a(*) = [ Z"d76aa478", Z"e8c7b756"]
+  enum, bind(c)
+     enumerator :: param_foo = Z"2000" ! in C, 0x0200
+     enumerator :: param_bar = Z"4000" ! in C, 0x4000
+  end enum
+  integer :: buffer = 5000, switch = 2
+
+   n = O"034"
+   print *, "n = ",n
+
+   if (buffer > Z"3F") then
+      print *, "Buffer is bigger"
+   end if
+
+   select case (switch)
+      case (Z"01")
+         print *, "bad select case branch"
+         print *, "FAIL"
+      case (Z"02")
+         print *, "Good select case branch"
+         print *, "PASS"
+   end select
+
+ end program main

--- a/test/f90_correct/src/issue670_01.f90
+++ b/test/f90_correct/src/issue670_01.f90
@@ -1,0 +1,7 @@
+!* Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+!* See https://llvm.org/LICENSE.txt for license information.
+!* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+!	check correct creation of array parameter constructor
+ integer, parameter :: a(*) = [1, 2]
+end

--- a/tools/flang1/flang1exe/dinit.c
+++ b/tools/flang1/flang1exe/dinit.c
@@ -396,7 +396,7 @@ dinit_data(VAR *ivl, ACL *ict, int dtype)
         if (ict_rc == 0)
           ict = ict->next;
       } while (num_elem > 0);
-      if (num_elem < 0)
+      if (num_elem < 0 && !ADD_ASSUMSZ(DTYPEG(sptr)))
         errsev(67);
     } else if (ivl->id == Dostart) {
       if (sem.top == &sem.dostack[MAX_DOSTACK]) {

--- a/tools/flang1/flang1exe/semant.c
+++ b/tools/flang1/flang1exe/semant.c
@@ -13286,7 +13286,7 @@ fixup_param_vars(SST *var, SST *init)
     sptr1 = get_param_alias_var(sptr, dtype);
   } else if (DTY(dtype) == TY_ARRAY) {
     ad = AD_DPTR(dtype);
-    if (AD_ASSUMSZ(ad) || AD_ADJARR(ad) || AD_DEFER(ad)) {
+    if (AD_ADJARR(ad) || AD_DEFER(ad)) {
       error(84, 3, gbl.lineno, SYMNAME(sptr),
             "- a named constant array must have constant extents");
       return;

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -1382,6 +1382,7 @@ size_of_array(DTYPE dtype)
   ISZ_T dim_size;
   ISZ_T size = 1;
   ISZ_T d;
+  int ub;
 
   if (dtype) {
 #define DEFAULT_DIM_SIZE 127
@@ -1408,7 +1409,8 @@ size_of_array(DTYPE dtype)
               A_TYPEG(AD_UPAST(ad, i)) != A_CNST) {
             dim_size = DEFAULT_DIM_SIZE;
           } else {
-            dim_size = ad_val_of(sym_of_ast(AD_UPAST(ad, i))) -
+            ub = AD_ASSUMSZ(ad) ? AD_EXTNTAST(ad, i) : AD_UPAST(ad, i);
+            dim_size = ad_val_of(sym_of_ast(ub)) -
                        ad_val_of(sym_of_ast(AD_LWAST(ad, i))) + 1;
           }
           size *= dim_size;


### PR DESCRIPTION
The issue as reported is about the use of BOZ constants,
but the internal compiler error was generated by the handling
of the array constructor in the parameter definition.

This fix from the NVIDIA compiler addresses the issue.

Added two tests as well, from the original issue, and
a cut-down version used internally to identify the fix.