### PR TITLE
Correction of representation of string (character type) constants.

### DIFF
--- a/test/debug_info/conststring.f90
+++ b/test/debug_info/conststring.f90
@@ -1,0 +1,23 @@
+!! This should be enabled only after #888
+!! check if conststrings are stored correctly for special characters
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!! \0 = 0 , " = 34 = 0x22
+!FUTURECHECK: call void @llvm.dbg.value(metadata [10 x i8] c"a\00d\22g     ", metadata [[CONSTR1:![0-9a-f]+]], metadata !DIExpression())
+!FUTURECHECK: call void @llvm.dbg.value(metadata [10 x i8] c"h i~j     ", metadata [[CONSTR2:![0-9a-f]+]], metadata !DIExpression())
+!! \n = 10 \r = 13
+!FUTURECHECK: call void @llvm.dbg.value(metadata [10 x i8] c"k\0Al\0Dm     ", metadata [[CONSTR3:![0-9a-f]+]], metadata !DIExpression())
+!CHECK-LABEL: distinct !DISubprogram(name: "main"
+!FUTURECHECK: [[CONSTR1]] = !DILocalVariable(name: "constr1",
+!FUTURECHECK: [[CONSTR2]] = !DILocalVariable(name: "constr2",
+!FUTURECHECK: [[CONSTR3]] = !DILocalVariable(name: "constr3",
+
+program main
+  character(10),parameter :: constr1 = "a"//achar(0)//"d"//achar(34)//"g"
+  character(10),parameter :: constr2 = "h i~j"
+  character(10),parameter :: constr3 = "k"//achar(10)//"l"//achar(13)//"m"
+
+  print *,constr1
+  print *,constr2
+  print *,constr3
+end

--- a/test/debug_info/conststring.f90
+++ b/test/debug_info/conststring.f90
@@ -3,14 +3,14 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
 !! \0 = 0 , " = 34 = 0x22
-!FUTURECHECK: call void @llvm.dbg.value(metadata [10 x i8] c"a\00d\22g     ", metadata [[CONSTR1:![0-9a-f]+]], metadata !DIExpression())
-!FUTURECHECK: call void @llvm.dbg.value(metadata [10 x i8] c"h i~j     ", metadata [[CONSTR2:![0-9a-f]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.value(metadata [10 x i8] c"a\00d\22g     ", metadata [[CONSTR1:![0-9a-f]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.value(metadata [10 x i8] c"h i~j     ", metadata [[CONSTR2:![0-9a-f]+]], metadata !DIExpression())
 !! \n = 10 \r = 13
-!FUTURECHECK: call void @llvm.dbg.value(metadata [10 x i8] c"k\0Al\0Dm     ", metadata [[CONSTR3:![0-9a-f]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.value(metadata [10 x i8] c"k\0Al\0Dm     ", metadata [[CONSTR3:![0-9a-f]+]], metadata !DIExpression())
 !CHECK-LABEL: distinct !DISubprogram(name: "main"
-!FUTURECHECK: [[CONSTR1]] = !DILocalVariable(name: "constr1",
-!FUTURECHECK: [[CONSTR2]] = !DILocalVariable(name: "constr2",
-!FUTURECHECK: [[CONSTR3]] = !DILocalVariable(name: "constr3",
+!CHECK: [[CONSTR1]] = !DILocalVariable(name: "constr1",
+!CHECK: [[CONSTR2]] = !DILocalVariable(name: "constr2",
+!CHECK: [[CONSTR3]] = !DILocalVariable(name: "constr3",
 
 program main
   character(10),parameter :: constr1 = "a"//achar(0)//"d"//achar(34)//"g"

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -1416,57 +1416,16 @@ make_constsptr_op(SPTR sptr)
 static char *
 ll_get_string_buf(int string_len, char *base, int skip_quotes)
 {
-  char *name = "";
+  char *name;
   char *from, *to;
-  int c, len, newlen;
-
-  len = string_len;
-  from = base;
-  newlen = 3;
-  while (len--) {
-    c = *from++ & 0xff;
-    if (c == '\"' || c == '\\') {
-      newlen += 3;
-    } else if (c >= ' ' && c <= '~') {
-      newlen++;
-    } else if (c == '\n' || c == '\r') {
-      newlen += 3;
-    } else {
-      newlen += 3;
-    }
-  }
-  name = (char *)llutil_alloc((newlen + 3) * sizeof(char));
+  int len;
+  name = (char *)llutil_alloc(string_len * sizeof(char));
   to = name;
-  if (!skip_quotes) {
-    *name = '\"';
-    to++;
-  }
-
   from = base;
   len = string_len;
   while (len--) {
-    c = *from++ & 0xff;
-    if (c == '\"' || c == '\\') {
-      *to++ = '\\';
-      sprintf(to, "%02X", c);
-      to += 2;
-    } else if (c >= ' ' && c <= '~') {
-      *to++ = c;
-    } else if (c == '\n' || c == '\r') {
-      *to++ = '\\';
-      sprintf(to, "%02X", c);
-      to += 2;
-    } else {
-      *to++ = '\\';
-      sprintf(to, "%02X", c);
-      to += 3;
-    }
+    *to++ = *from++;
   }
-
-  if (!skip_quotes) {
-    *to++ = '\"';
-  }
-  *to = '\0';
   return name;
 }
 
@@ -2347,9 +2306,17 @@ write_operand(OPERAND *p, const char *punc_string, int flags)
       if (p->ll_type->sub_types[0]->data_type == LL_I16) {
           print_token(p->string);
       } else {
-          print_token("c\"");
-          print_token(p->string);
-          print_token("\"");
+        char buffer[6];
+        print_token("[");
+        for (int i = 0; i < p->ll_type->sub_elements; i++) {
+          if (i)
+            print_token(", ");
+          print_token("i8 ");
+          char c = p->string[i];
+          sprintf(buffer, "%d", c);
+          print_token(buffer);
+        }
+        print_token(" ] ");
       }
     }
     break;


### PR DESCRIPTION
The current representation fails when character constant has '\0' in between.
Current representation terminates string there which is not correct.
It is fixed by representing character type with I8 type array.

Note: This issue was exposed after support of debug info for parameter
attribute. Below test case would work only after parameter attribute.
After #888 commit FUTURE-CHECK are changed to CHECK in test case.

test case
```
program main
  character(10),parameter :: x = "abc"//achar(0)//"def"
  print *,x
end
```
Current IR
```
call void @llvm.dbg.value (metadata [10 x i8] c"abc\00", metadata !17, metadata !18)
```
Fixed IR
```
call void @llvm.dbg.value (metadata [10 x i8] c"abc\00def   ", metadata !17, metadata !18)
```