### PR TITLE
Fix private flag overwrite in find_def_in_most_recent_scope()

### DIFF
--- a/test/f90_correct/inc/use00.mk
+++ b/test/f90_correct/inc/use00.mk
@@ -1,0 +1,20 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test use00  ########
+
+build:
+	@echo ------------------------------------ building test $(TEST)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	./$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/use00.sh
+++ b/test/f90_correct/lit/use00.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/use00.f90
+++ b/test/f90_correct/src/use00.f90
@@ -1,0 +1,39 @@
+module f_precisions
+  integer, parameter, public :: f_double = selected_real_kind(15, 307)
+end module f_precisions
+
+module box
+  use f_precisions, gp=>f_double
+  private
+  public :: get_gp
+contains
+  subroutine get_gp(out_val)
+    integer, intent(out) :: out_val
+    out_val = gp
+  end subroutine get_gp
+end module box
+
+module Poisson_Solver
+  use f_precisions
+  integer, parameter, public :: gp=f_double
+end module Poisson_Solver
+
+module module_defs
+  use f_precisions
+  integer, parameter, public :: gp=f_double
+end module module_defs
+
+subroutine PSolver(eh)
+  use module_defs ! This has a public gp
+  use box ! This has a private gp
+  use Poisson_Solver, except_gp => gp ! This has a public gp
+  real(gp), intent(out) :: eh ! Should be able to use gp from module_base
+end subroutine PSolver
+
+program main
+  use box
+  use Poisson_Solver
+  integer :: box_gp
+  call get_gp(box_gp)
+  call check(box_gp, gp, 1) ! box's gp and Solver's gp alias the same variable
+end program

--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -503,7 +503,6 @@ find_def_in_most_recent_scope(int sptr, int save_sem_scope_level)
     if (NMPTRG(sptr1) != NMPTRG(sptr))
       continue;
     if (STYPEG(sptr1) == ST_ALIAS && aliased_sym_visible(sptr1)) {
-      PRIVATEP(sptr1, 0);
       HIDDENP(SYMLKG(sptr1), 0);
     }
     if (STYPEG(sptr1) == ST_ALIAS) {


### PR DESCRIPTION
Fixes #890 .

`find_def_in_most_recent_scope()` sets the private bit to 0 when it found an alias. I assume that this is unintended behaviour, as the function is just supposed to find the symbol and not modify it. The private bit for an alias would be misleading, as explained in the comment a few lines later, so it gets cleared, but I don't think it should be cleared forever...

I suggest we save the original value of the flag and restore it at the end of the loop.

@kiranchandramohan , @RichBarton-Arm , please review. I am not sure I got the purpose of the `find_def_in_most_recent_scope()` right, but if I did we could consider doing the exact same thing for "hidden" flag, which gets overwritten in the next line.