### PR TITLE
f90_correct: exclude tests failing with LLVM 10 on OpenPOWER

### DIFF
--- a/test/f90_correct/lit/fc30.sh
+++ b/test/f90_correct/lit/fc30.sh
@@ -7,3 +7,5 @@
 
 # RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
 # RUN: cat %t | FileCheck %S/runmake
+
+# UNSUPPORTED: powerpc64le-host, ppc64le-host

--- a/test/f90_correct/lit/ls07.sh
+++ b/test/f90_correct/lit/ls07.sh
@@ -7,3 +7,5 @@
 
 # RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
 # RUN: cat %t | FileCheck %S/runmake
+
+# UNSUPPORTED: powerpc64le-host, ppc64le-host


### PR DESCRIPTION
While testing flang-compiler/classic-flang-llvm-project#1, @gklimowicz found that two Flang tests were failing with LLVM 10 on OpenPower. We decided to exclude the tests until the test failures are properly investigated and fixed.