### PR TITLE
Fix HTML docs generation

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -141,6 +141,16 @@ if (SPHINX_FOUND)
         "${SPHINX_BASE_DIR}"
         "${SPHINX_HTML_DIR}"
     COMMENT "Building HTML documentation with Sphinx")
+
+   add_dependencies(sphinx-flang
+                    flang1_gen_sphinx_docs
+                    gen_frontend_machar
+                    gen_frontend_parsetable
+                    gen_frontend_symtab
+                    gen_frontend_symini
+                    flang2_gen_sphinx_docs
+                    gen_backend_symtab
+                    gen_backend_symini)
 endif()
 
 if (LLVM_ENABLE_SPHINX)

--- a/docs/doxygen.cfg.in
+++ b/docs/doxygen.cfg.in
@@ -687,7 +687,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error ( stderr) by doxygen. If WARNINGS is set to YES

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,8 @@ Front-end Design
    :maxdepth: 1
 
    flang1/intro
+   flang1/commopt
+   flang1/comms
    flang1/controller
    flang1/scanner
    flang1/parser
@@ -88,6 +90,7 @@ Back-end Internals
    ILI Definitions <flang2/ilitp>
    Intrinsics & Generics <flang2/symini>
    flang2/errmsg
+   flang2/register
 
 Source code
 -----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,8 +34,9 @@ Common
    flang2/coding
    Target Machine <flang1/machar>
    flang2/error
-   flang1/dinit
    flang2/fin
+   flang2/xflag
+   flang2/xref
 
 Front-end Design
 ----------------
@@ -63,6 +64,7 @@ Front-end Internals
 
    Grammar <flang1/grammar>
    flang1/ast
+   flang1/dinit
    flang1/symtab
    Intrinsics & Generics <flang1/symini>
 
@@ -85,6 +87,7 @@ Back-end Internals
 .. toctree::
    :maxdepth: 1
 
+   flang2/dinit
    flang2/symtab
    ILM Definitions <flang2/ilmtp>
    ILI Definitions <flang2/ilitp>

--- a/tools/flang1/flang1exe/CMakeLists.txt
+++ b/tools/flang1/flang1exe/CMakeLists.txt
@@ -131,8 +131,9 @@ add_dependencies(flang1
   )
 
 if (FLANG_INCLUDE_DOCS)
-  add_dependencies(flang1_gen_sphinx_docs
-    flang1
+  file(MAKE_DIRECTORY ${FLANG1_DOC_BIN_DIR})
+  add_dependencies(flang1
+    flang1_gen_sphinx_docs
     )
 endif()
 

--- a/tools/flang1/include/CMakeLists.txt
+++ b/tools/flang1/include/CMakeLists.txt
@@ -12,6 +12,8 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/platform.h
   @ONLY)
 
+file(MAKE_DIRECTORY ${FLANG1_DOC_BIN_DIR})
+
 # Generate error message headers
 
 add_custom_command(

--- a/tools/flang1/utils/n2rst/CMakeLists.txt
+++ b/tools/flang1/utils/n2rst/CMakeLists.txt
@@ -20,6 +20,7 @@ file(MAKE_DIRECTORY ${FLANG1_DOC_BIN_DIR})
 
 add_custom_command(
   OUTPUT ${FLANG1_DOC_BIN_DIR}/ast.rst
+         ${FLANG1_DOC_BIN_DIR}/commopt.rst
          ${FLANG1_DOC_BIN_DIR}/comms.rst
          ${FLANG1_DOC_BIN_DIR}/controller.rst
          ${FLANG1_DOC_BIN_DIR}/dinit.rst
@@ -32,7 +33,8 @@ add_custom_command(
          ${FLANG1_DOC_BIN_DIR}/scanner.rst
          ${FLANG1_DOC_BIN_DIR}/semant.rst
          ${FLANG1_DOC_BIN_DIR}/transform.rst
-  COMMAND ${CMAKE_BINARY_DIR}/bin/fen2rst -v ${FLANG1_DOC_SRC_DIR}/ast.n
+  COMMAND ${CMAKE_BINARY_DIR}/bin/fen2rst -v ${UTILS_AST_DIR}/ast.n
+                                             ${FLANG1_DOC_SRC_DIR}/commopt.n
                                              ${FLANG1_DOC_SRC_DIR}/comms.n
                                              ${FLANG1_DOC_SRC_DIR}/controller.n
                                              ${FLANG1_DOC_SRC_DIR}/dinit.n
@@ -46,7 +48,8 @@ add_custom_command(
                                              ${FLANG1_DOC_SRC_DIR}/semant.n
                                              ${FLANG1_DOC_SRC_DIR}/transform.n
   WORKING_DIRECTORY ${FLANG1_DOC_BIN_DIR}
-  DEPENDS fen2rst ${FLANG1_DOC_SRC_DIR}/ast.n
+  DEPENDS fen2rst ${UTILS_AST_DIR}/ast.n
+                  ${FLANG1_DOC_SRC_DIR}/commopt.n
                   ${FLANG1_DOC_SRC_DIR}/comms.n
                   ${FLANG1_DOC_SRC_DIR}/controller.n
                   ${FLANG1_DOC_SRC_DIR}/dinit.n
@@ -63,6 +66,7 @@ add_custom_command(
 
 add_custom_target(flang1_gen_sphinx_docs
   SOURCES ${FLANG1_DOC_BIN_DIR}/ast.rst
+          ${FLANG1_DOC_BIN_DIR}/commopt.rst
           ${FLANG1_DOC_BIN_DIR}/comms.rst
           ${FLANG1_DOC_BIN_DIR}/controller.rst
           ${FLANG1_DOC_BIN_DIR}/dinit.rst
@@ -76,6 +80,8 @@ add_custom_target(flang1_gen_sphinx_docs
           ${FLANG1_DOC_BIN_DIR}/semant.rst
           ${FLANG1_DOC_BIN_DIR}/transform.rst
   )
+
+add_dependencies(flang1_gen_sphinx_docs gen_frontend_parsetable)
 
 # Local Variables:
 # mode: cmake

--- a/tools/flang1/utils/prstab/CMakeLists.txt
+++ b/tools/flang1/utils/prstab/CMakeLists.txt
@@ -21,7 +21,7 @@ add_executable(prodstr
 # Generate parse tables
 
 add_custom_command(
-  OUTPUT ${UTILS_PARSETABLE_BIN_DIR}/gramdf.h ${UTILS_PARSETABLE_BIN_DIR}/gramsm.h ${UTILS_PARSETABLE_BIN_DIR}/gramtk.h ${UTILS_PARSETABLE_BIN_DIR}/proddf.h ${UTILS_PARSETABLE_BIN_DIR}/tokdf.h ${UTILS_PARSETABLE_BIN_DIR}/gramnt.h
+  OUTPUT ${UTILS_PARSETABLE_BIN_DIR}/gramdf.h ${UTILS_PARSETABLE_BIN_DIR}/gramsm.h ${UTILS_PARSETABLE_BIN_DIR}/gramtk.h ${UTILS_PARSETABLE_BIN_DIR}/proddf.h ${UTILS_PARSETABLE_BIN_DIR}/tokdf.h ${UTILS_PARSETABLE_BIN_DIR}/gramnt.h ${UTILS_PARSETABLE_BIN_DIR}/gram.lis
   # Copy to current build directory, otherwise header will be generated in
   # original directory
   COMMAND ${CMAKE_COMMAND} -E copy ${UTILS_PARSETABLE_DIR}/gram.txt ${UTILS_PARSETABLE_BIN_DIR}
@@ -37,3 +37,4 @@ add_custom_target(gen_frontend_parsetable
 
 add_dependencies(gen_frontend_parsetable lr)
 add_dependencies(gen_frontend_parsetable prodstr)
+add_dependencies(gen_frontend_parsetable gen_frontend_error_headers)

--- a/tools/flang2/flang2exe/CMakeLists.txt
+++ b/tools/flang2/flang2exe/CMakeLists.txt
@@ -146,7 +146,7 @@ add_dependencies(flang2
 
 if (FLANG_INCLUDE_DOCS)
   add_dependencies(flang2
-    gen_sphinx_docs
+    flang2_gen_sphinx_docs
     )
 endif()
 

--- a/tools/flang2/utils/n2rst/CMakeLists.txt
+++ b/tools/flang2/utils/n2rst/CMakeLists.txt
@@ -21,6 +21,7 @@ file(MAKE_DIRECTORY ${FLANG2_DOC_BIN_DIR})
 add_custom_command(
   OUTPUT ${FLANG2_DOC_BIN_DIR}/coding.rst
          ${FLANG2_DOC_BIN_DIR}/controller.rst
+         ${FLANG2_DOC_BIN_DIR}/dinit.rst
          ${FLANG2_DOC_BIN_DIR}/error.rst
          ${FLANG2_DOC_BIN_DIR}/expander.rst
          ${FLANG2_DOC_BIN_DIR}/fin.rst
@@ -29,8 +30,11 @@ add_custom_command(
          ${FLANG2_DOC_BIN_DIR}/ilm.rst
          ${FLANG2_DOC_BIN_DIR}/intro.rst
          ${FLANG2_DOC_BIN_DIR}/register.rst
+         ${FLANG2_DOC_BIN_DIR}/xflag.rst
+         ${FLANG2_DOC_BIN_DIR}/xref.rst
   COMMAND ${CMAKE_BINARY_DIR}/bin/n2rst -v ${FLANG2_DOC_SRC_DIR}/coding.n
                                            ${FLANG2_DOC_SRC_DIR}/controller.n
+                                           ${FLANG2_DOC_SRC_DIR}/dinit.n
                                            ${FLANG2_DOC_SRC_DIR}/error.n
                                            ${FLANG2_DOC_SRC_DIR}/expander.n
                                            ${FLANG2_DOC_SRC_DIR}/fin.n
@@ -39,9 +43,12 @@ add_custom_command(
                                            ${FLANG2_DOC_SRC_DIR}/ilm.n
                                            ${FLANG2_DOC_SRC_DIR}/intro.n
                                            ${FLANG2_DOC_SRC_DIR}/register.n
+                                           ${FLANG2_DOC_SRC_DIR}/xflag.n
+                                           ${FLANG2_DOC_SRC_DIR}/xref.n
   WORKING_DIRECTORY ${FLANG2_DOC_BIN_DIR}
   DEPENDS n2rst ${FLANG2_DOC_SRC_DIR}/coding.n
                 ${FLANG2_DOC_SRC_DIR}/controller.n
+                ${FLANG2_DOC_SRC_DIR}/dinit.n
                 ${FLANG2_DOC_SRC_DIR}/error.n
                 ${FLANG2_DOC_SRC_DIR}/expander.n
                 ${FLANG2_DOC_SRC_DIR}/fin.n
@@ -50,11 +57,14 @@ add_custom_command(
                 ${FLANG2_DOC_SRC_DIR}/ilm.n
                 ${FLANG2_DOC_SRC_DIR}/intro.n
                 ${FLANG2_DOC_SRC_DIR}/register.n
+                ${FLANG2_DOC_SRC_DIR}/xflag.n
+                ${FLANG2_DOC_SRC_DIR}/xref.n
   )
 
 add_custom_target(flang2_gen_sphinx_docs
   SOURCES ${FLANG2_DOC_BIN_DIR}/coding.rst
           ${FLANG2_DOC_BIN_DIR}/controller.rst
+          ${FLANG2_DOC_BIN_DIR}/dinit.rst
           ${FLANG2_DOC_BIN_DIR}/error.rst
           ${FLANG2_DOC_BIN_DIR}/expander.rst
           ${FLANG2_DOC_BIN_DIR}/fin.rst
@@ -63,6 +73,8 @@ add_custom_target(flang2_gen_sphinx_docs
           ${FLANG2_DOC_BIN_DIR}/ilm.rst
           ${FLANG2_DOC_BIN_DIR}/intro.rst
           ${FLANG2_DOC_BIN_DIR}/register.rst
+          ${FLANG2_DOC_BIN_DIR}/xflag.rst
+          ${FLANG2_DOC_BIN_DIR}/xref.rst
   )
 
 # Local Variables:

--- a/tools/flang2/utils/n2rst/CMakeLists.txt
+++ b/tools/flang2/utils/n2rst/CMakeLists.txt
@@ -52,7 +52,7 @@ add_custom_command(
                 ${FLANG2_DOC_SRC_DIR}/register.n
   )
 
-add_custom_target(gen_sphinx_docs
+add_custom_target(flang2_gen_sphinx_docs
   SOURCES ${FLANG2_DOC_BIN_DIR}/coding.rst
           ${FLANG2_DOC_BIN_DIR}/controller.rst
           ${FLANG2_DOC_BIN_DIR}/error.rst


### PR DESCRIPTION
* The `ast.n` file was moved to a different location causing cmake to fail to generate most of the existing documentation.
* Additionally, the unused rst files are now added to the list, so they are now also visible in the generated HTML.
* Sphinx build depends on generating all necessary rst files.
* Directories must be created before putting files into them.
* `gram.lis` file dependency added (thanks @bryanpkc!).
* renamed Cmake target `gen_sphinx_docs` to `flang2_gen_sphinx_docs` (to match existing `flang1_gen_sphinx_docs`)


@RichBarton-Arm , @kiranchandramohan , please review.