### PR TITLE
[flang1] Do not assume unempty derived types

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -260,7 +260,10 @@ config.substitutions.append( ('%test_debuginfo', ' ' + config.llvm_src_root + '/
 config.substitutions.append( ('%itanium_abi_triple', makeItaniumABITriple(config.target_triple)) )
 config.substitutions.append( ('%ms_abi_triple', makeMSABITriple(config.target_triple)) )
 
+config.substitutions.append( ('%flang1', ' ' + config.flang + '1 ') )
+config.substitutions.append( ('%flang2', ' ' + config.flang + '2 ') )
 config.substitutions.append( ('%flang', ' ' + config.flang + ' ') )
+
 # The host triple might not be set, at least if we're compiling flang from
 # an already installed llvm.
 if config.host_triple and config.host_triple != '@LLVM_HOST_TRIPLE@':

--- a/test/sema/aconst_with_null_subict.f90
+++ b/test/sema/aconst_with_null_subict.f90
@@ -1,0 +1,25 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! Reproducer for a flang1 crash in dinit_acl_val2.
+! Ensure that flang1 successfully produces correct symbol table entries for the
+! empty derived type S, the array A, as well as the array constructor [S()].
+
+! RUN: %flang1 %s -opt 0 -q 47 1 | FileCheck %s
+! CHECK: datatype:[[STYPE:[0-9]+]] Derived member:1 size:0
+! CHECK: datatype:[[ATYPE:[0-9]+]] Array type:[[STYPE]] dims:1
+! CHECK: datatype:[[CTYPE:[0-9]+]] Array type:[[STYPE]] dims:1
+! CHECK: Array Local dtype:[[ATYPE]]
+! CHECK-SAME: 1:a
+! CHECK: Array Static dtype:[[CTYPE]]
+! CHECK-SAME: 8:z_c_3$ac
+
+program aconst_with_null_subict
+  type S
+  end type S
+  type(S), dimension(1) :: A = reshape([S()], [1])
+  print *, A
+end program aconst_with_null_subict

--- a/test/sema/lit.local.cfg
+++ b/test/sema/lit.local.cfg
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+config.suffixes = ['.f', '.FOR', '.for', '.f77', '.f90', '.f95', '.F', '.fpp',
+ '.FPP']
+

--- a/tools/flang1/flang1exe/dinit.c
+++ b/tools/flang1/flang1exe/dinit.c
@@ -794,13 +794,9 @@ dinit_acl_val2(int sptr, int dtype, ACL *ict, int op)
       break;
     }
   } else if (ict->id == AC_ACONST) {
-    ACL *subict;
-    int list_dtype;
     if (!cmpat_dtype_with_size(dtype, ict->dtype)) {
       errsev(91);
     }
-    subict = ict->subc;
-    list_dtype = subict->dtype;
     if (!cmpat_dtype_with_size(DDTG(dtype), DDTG(ict->dtype))) {
       errsev(91);
     }


### PR DESCRIPTION
When initializing an ACONST (a constant array or derived type instance), flang1
assumes that the ACL (array constructor list) has a non-NULL subict, which
normally represents the contents of the array or object. But a derived type may
be defined to contain no component part, which causes flang1 to crash when
dereferencing the NULL subict, unnecessarily.