### PR TITLE
Updating X-flag entries for internal command line option "-x 49"

### DIFF
--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -1628,6 +1628,69 @@ reserved
 reserved
 
 .XF "49:"
+.XB 0x1
+reserved
+.XB 0x2
+reserved
+.XB 0x4
+AVAILABLE
+.XB 0x8
+reserved
+.XB 0x10
+reserved
+.XB 0x20
+reserved
+.XB 0x40
+reserved
+.XB 0x80
+reserved
+.XB 0x100
+reserved
+.XB 0x200
+reserved
+.XB 0x400
+AVAILABLE
+.XB 0x800
+AVAILABLE
+.XB 0x1000
+reserved
+.XB 0x2000
+AVAILABLE
+.XB 0x4000
+reserved
+.XB 0x8000
+reserved
+.XB 0x10000
+AVAILABLE
+.XB 0x20000
+reserved
+.XB 0x40000
+reserved
+.XB 0x80000
+AVAILABLE
+.XB 0x100000
+reserved
+.XB 0x200000
+reserved
+.XB 0x400000
+reserved
+.XB 0x800000
+reserved
+.XB 0x1000000
+reserved
+.XB 0x2000000
+AVAILABLE
+.XB 0x4000000
+AVAILABLE
+.XB 0x8000000
+AVAILABLE
+.XB 0x10000000
+reserved
+.XB 0x20000000
+reserved
+.XB 0x40000000
+reserved
+.XB 0x80000000
 reserved
 
 .XF "50:" 

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -1628,68 +1628,78 @@ reserved
 reserved
 
 .XF "49:"
+Behavior modification.
 .XB 0x1
-reserved
+Inhibit transformation passes -- directive processing is done.
 .XB 0x2
-reserved
+Inhibit forall conversion.
 .XB 0x4
-AVAILABLE
+reserved
 .XB 0x8
-reserved
+Inhibit discarding parentheses.
 .XB 0x10
-reserved
+Don't include PARAMETER variables when AST expression simplification is
+performed.
 .XB 0x20
-reserved
+Inhibit communication analyzer and optimizer.
 .XB 0x40
-reserved
+Allow CM fortran's intrinsics.
 .XB 0x80
-reserved
+f77 output (pgftn extensions not allowed; Cray POINTERS allowed).
 .XB 0x100
-reserved
+Target's pointers are 64-bits.
 .XB 0x200
-reserved
+Normally double precision is twice real; this makes it the same as real.
+Similarly for double complex.
 .XB 0x400
-AVAILABLE
+reserved
 .XB 0x800
-AVAILABLE
+reserved
 .XB 0x1000
-reserved
+Emit function & line number information for runtime error handling and for
+communication profiling.
 .XB 0x2000
-AVAILABLE
+reserved
 .XB 0x4000
-reserved
+Source profiling.
 .XB 0x8000
-reserved
+Cray POINTERs not allowed in the output.
+Valid only if the output is f77 (-x 49 0x80).
 .XB 0x10000
-AVAILABLE
+reserved
 .XB 0x20000
-reserved
+Disable invariant communication call hoisting.
 .XB 0x40000
-reserved
+C90 target.
 .XB 0x80000
-AVAILABLE
+reserved
 .XB 0x100000
-reserved
+Don't pass character constants as arguments to pgf90_loc (e.g., when
+the platform is HP).
 .XB 0x200000
-reserved
+Inhibit inlining on following loop.
 .XB 0x400000
-reserved
+F90 output -- kinded constants, pass some intrinsics through.
 .XB 0x800000
-reserved
+Native REAL is REAL8 and CMPLX is CMPLX16.
+Map double precision constants (0.0d0) to real constant format (0.0e0).
 .XB 0x1000000
-reserved
+T3D/T3E target.
 .XB 0x2000000
-AVAILABLE
+reserved
 .XB 0x4000000
-AVAILABLE
+reserved
 .XB 0x8000000
-AVAILABLE
+reserved
 .XB 0x10000000
-reserved
+For POINTERs in commons, place their associated variables near the
+beginning of the common.  This is non/-f90/-f95/-f2003 behavior but was
+our original behavior.
 .XB 0x20000000
-reserved
+In lowerilm, don't use PLD and PST for load/store of pointer variables
 .XB 0x40000000
-reserved
+Return the value of complex functions the same as C (e.g. be XLF compatible)).XB 0x80000000
+Native INTEGER is INTEGER*8 and LOGICAL is LOGICAL*8.
 .XB 0x80000000
 reserved
 


### PR DESCRIPTION
The x flang command line option "-x 49" has missing entries.
This patch includes blanket entries for used sub-options as reserved, leaving others as AVAILABLE.

To get the used options simple script is used as 
```
 # find . -name "*.[ch]" | xargs grep "XBIT(49, " | sed 's/.*XBIT(49, [0x]*\([0-9]*\).*/\1/' | sort -u | sort -n
