### PR TITLE
[DebugInfo] Fixed default emission of ".debug_names" section

### DIFF
--- a/test/debug_info/nametable.f90
+++ b/test/debug_info/nametable.f90
@@ -1,0 +1,15 @@
+!RUN: %flang %s -gdwarf-5 -S -emit-llvm -o - | FileCheck --check-prefix=NOTABLE %s
+!RUN: %flang %s -g -S -emit-llvm -o - | FileCheck --check-prefix=NOTABLE %s
+
+!RUN: %flang %s -gdwarf-5 -gpubnames -S -emit-llvm -o - | FileCheck --check-prefix=TABLE %s
+!RUN: %flang %s -g -gpubnames -S -emit-llvm -o - | FileCheck --check-prefix=TABLE %s
+
+!Ensure that "nameTableKind: None" field is present in DICompileUnit.
+!NOTABLE: !DICompileUnit({{.*}}, nameTableKind: None
+
+!Ensure that "nameTableKind: None" field is NOT present in DICompileUnit.
+!TABLE-NOT: !DICompileUnit({{.*}}, nameTableKind: None
+
+PROGRAM main
+END PROGRAM main
+

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -3303,7 +3303,7 @@ Generating eh_frame.
 .XB 0x20000000:
 Generating eh_frame with .cfi directives: requires 120,0x10000000 to be on
 .XB 0x40000000
-AVAILABLE
+Generate .debug_names/.debug_pubnames section.
 .XB 0x80000000:
 no license check in executable.
 

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -870,7 +870,8 @@ enum FieldType {
   DWVirtualityField,
   DWEncodingField,
   DWEmissionField,
-  SignedOrMDField
+  SignedOrMDField,
+  DebugNameTableKindField
 };
 
 enum FieldFlags {
@@ -962,7 +963,7 @@ static const MDTemplate Tmpl_DICompileUnit[] = {
 
 /* "subprograms" removed from DICompileUnit in LLVM 3.9 */
 static const MDTemplate Tmpl_DICompileUnit_ver39[] = {
-  { "DICompileUnit", TF, 13 },
+  { "DICompileUnit", TF, 14 },
   { "tag",                      DWTagField, FlgHidden },
   { "file",                     NodeField },
   { "language",                 DWLangField },
@@ -975,7 +976,8 @@ static const MDTemplate Tmpl_DICompileUnit_ver39[] = {
   { "globals",                  NodeField },
   { "emissionKind",             DWEmissionField },
   { "imports",                  NodeField },
-  { "splitDebugFilename",       StringField }
+  { "splitDebugFilename",       StringField },
+  { "nameTableKind",            DebugNameTableKindField }
 };
 
 static const MDTemplate Tmpl_DICompileUnit_pre34[] = {
@@ -1562,6 +1564,24 @@ dwarf_emission_name(int value)
 }
 
 /**
+   \brief generate DWARF table kind
+ */
+static const char *
+dwarf_table_name(int value)
+{
+  switch (value) {
+  case 0:
+    return "Default";
+  case 1:
+    return "GNU";
+  case 2:
+    return "None";
+  default:
+    return "None";
+  }
+}
+
+/**
    \brief Write out an an LL_MDRef as a field in a specialised MDNode class
    \param out        file to write to
    \param module       module containing the metadata
@@ -1697,6 +1717,10 @@ write_mdfield(FILE *out, LL_Module *module, int needs_comma, LL_MDRef mdref,
 
     case DWEmissionField:
       fprintf(out, "%s%s: %s", prefix, tmpl->name, dwarf_emission_name(value));
+      break;
+
+    case DebugNameTableKindField:
+      fprintf(out, "%s%s: %s", prefix, tmpl->name, dwarf_table_name(value));
       break;
 
     default:

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -343,6 +343,8 @@ lldbg_create_compile_unit_mdnode(LL_DebugInfo *db, int lang_tag, char *filename,
       llmd_add_i32(mdb, 1); /* emissionMode: FullDebug */
     llmd_add_md(mdb, *imported_entity_list);
     llmd_add_string(mdb, "");
+    if (!XBIT(120, 0x40000000))
+      llmd_add_i32(mdb, 2); /* nameTableKind: None */
   }
 
   llmd_set_distinct(mdb);


### PR DESCRIPTION
Metdata field "nameTableKind" is responsible for generation/emission of
".debug_names" section.
Set it appropriately to avoid generation/emission of ".debug_names" section by default.