### PR TITLE
[DebugInfo] Flang should generate debug location for limited instructions in prolog

### DIFF
--- a/test/debug_info/dwarfdump_prolog.f90
+++ b/test/debug_info/dwarfdump_prolog.f90
@@ -1,0 +1,30 @@
+!RUN: %flang -g %s -o %t
+!RUN: llvm-dwarfdump  --debug-line %t -o - | FileCheck %s
+
+!CHECK: name: "dwarfdump_prolog.f90"
+!CHECK: Address            Line   Column File   ISA Discriminator Flags
+!CHECK: {{0x[0-9a-f]+}}     13      1      1   0             0  is_stmt prologue_end
+!CHECK: {{0x[0-9a-f]+}}     29      1      1   0             0  is_stmt prologue_end
+
+subroutine show (message, array)
+  character (len=*) :: message
+  integer :: array(:)
+
+  print *, message
+  print *, array
+
+end subroutine show
+
+program prolog
+
+  interface
+     subroutine show (message, array)
+       character (len=*) :: message
+       integer :: array(:)
+     end subroutine show
+  end interface
+
+  integer :: array(10) = (/1,2,3,4,5,6,7,8,9,10/)
+
+  call show ("array", array)
+end program prolog

--- a/test/debug_info/dwarfdump_prolog.f90
+++ b/test/debug_info/dwarfdump_prolog.f90
@@ -1,4 +1,4 @@
-!RUN: %flang -g %s -o %t
+!RUN: %flang -g -O0 %s -o %t
 !RUN: llvm-dwarfdump  --debug-line %t -o - | FileCheck %s
 
 !CHECK: name: "dwarfdump_prolog.f90"

--- a/test/debug_info/prolog.f90
+++ b/test/debug_info/prolog.f90
@@ -1,0 +1,37 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! check non debug instructions should not have debug location
+!CHECK: define void @show_
+!CHECK: call void @llvm.dbg.declare
+!CHECK-SAME: , !dbg {{![0-9]+}}
+!CHECK-NOT: bitcast i64* %"array$sd" to i8*, !dbg
+!CHECK: store i64 {{%[0-9]+}}, i64* %z_b_3_{{[0-9]+}}, align 8
+!CHECK: br label
+!CHECK: ret void, !dbg {{![0-9]+}}
+subroutine show (message, array)
+  character (len=*) :: message
+  integer :: array(:)
+
+  print *, message
+  print *, array
+
+end subroutine show
+
+!CHECK: define void @MAIN_
+!CHECK-NOT: bitcast void (...)* @fort_init to void (i8*, ...)*, !dbg {{![0-9]+}}
+!CHECK: call void @llvm.dbg.declare
+!CHECK-SAME: , !dbg {{![0-9]+}}
+!CHECK: ret void, !dbg
+program prolog
+
+  interface
+     subroutine show (message, array)
+       character (len=*) :: message
+       integer :: array(:)
+     end subroutine show
+  end interface
+
+  integer :: array(10) = (/1,2,3,4,5,6,7,8,9,10/)
+
+  call show ("array", array)
+end program prolog

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -2706,7 +2706,9 @@ write_verbose_type(LL_Type *ll_type)
 }
 
 /* whether debug location should be suppressed */
-static bool should_suppress_debug_loc(INSTR_LIST *instrs) {
+static bool
+should_suppress_debug_loc(INSTR_LIST *instrs)
+{
   if (!instrs)
     return false;
 

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -129,6 +129,7 @@ struct LL_DebugInfo {
   LL_MDRef cur_module_mdnode;
   LL_MDRef cur_cmnblk_mdnode;
   int cur_subprogram_lineno;
+  LL_MDRef cur_subprogram_line_mdnode;
   LL_MDRef cur_subprogram_null_loc;
   LL_MDRef cur_line_mdnode;
   PARAMINFO param_stack[PARAM_STACK_SIZE];
@@ -2161,8 +2162,10 @@ lldbg_emit_subprogram(LL_DebugInfo *db, SPTR sptr, DTYPE ret_dtype, int findex,
                                db->import_entity_list->entity_type);
     db->import_entity_list = db->import_entity_list->next;
   }
-    db->cur_subprogram_null_loc =
-        lldbg_create_location_mdnode(db, 0, 0, db->cur_subprogram_mdnode);
+  db->cur_subprogram_null_loc =
+      lldbg_create_location_mdnode(db, 0, 0, db->cur_subprogram_mdnode);
+  db->cur_subprogram_lineno = lineno;
+  db->cur_subprogram_line_mdnode = ll_get_md_null();
   db->param_idx = 0;
   memset(db->param_stack, 0, sizeof(PARAMINFO) * PARAM_STACK_SIZE);
   lldbg_emit_lexical_blocks(db, sptr, findex, targetNVVM);
@@ -2306,6 +2309,10 @@ lldbg_emit_line(LL_DebugInfo *db, int lineno)
       db->cur_line_mdnode =
           lldbg_create_location_mdnode(db, lineno, 1, db->blk_tab[idx].mdnode);
     }
+    // it is not yet column aware so comparing only line
+    if (lineno == db->cur_subprogram_lineno)
+      db->cur_subprogram_line_mdnode = db->cur_line_mdnode;
+
     last_line = lineno;
   }
 }
@@ -3516,3 +3523,6 @@ new_debug_name(const char *str1, const char *str2, const char *str3)
   return (const char *)new_name;
 }
 
+LL_MDRef lldbg_get_subprogram_line(LL_DebugInfo *db) {
+  return db->cur_subprogram_line_mdnode;
+}

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -3523,6 +3523,8 @@ new_debug_name(const char *str1, const char *str2, const char *str3)
   return (const char *)new_name;
 }
 
-LL_MDRef lldbg_get_subprogram_line(LL_DebugInfo *db) {
+LL_MDRef
+lldbg_get_subprogram_line(LL_DebugInfo *db)
+{
   return db->cur_subprogram_line_mdnode;
 }

--- a/tools/flang2/flang2exe/lldebug.h
+++ b/tools/flang2/flang2exe/lldebug.h
@@ -273,4 +273,6 @@ void InitializeDIFlags(const LL_IRFeatures *feature);
 
 void lldbg_reset_module(LL_DebugInfo *db);
 
+/// \brief Get the debug location mdnode of the current procedure.
+LL_MDRef lldbg_get_subprogram_line(LL_DebugInfo *db);
 #endif /* LLDEBUG_H_ */


### PR DESCRIPTION
Due to this wrong debug_line section entry is created with wrong instruction
marked as 'prologue_end'. More details in committed test cases.
This causes debugger not skipping prologue when inserting break-point with
function/subroutine name.
To make breakpoint work as expected, some debugger (GDB) changes were
also required which are already committed as 
commit c2fd7faea8f2c3a267f276ceb6a95f9f537ea7c1
Author: Alok Kumar Sharma <AlokKumar.Sharma@amd.com>
Date:   Thu Aug 20 10:35:27 2020 +0530
