### PR TITLE
[DebugInfo] Internal subprogram variable is not accessible for printing in gdb

### DIFF
--- a/test/debug_info/outervar.f90
+++ b/test/debug_info/outervar.f90
@@ -1,0 +1,14 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: distinct !DIGlobalVariable(name: "prog_i"
+!CHECK-NOT: distinct !DIGlobalVariable(name: "prog_i"
+
+program main
+  integer :: prog_i
+  prog_i = 99
+  call sub()
+contains
+  subroutine sub()
+    print *,prog_i
+  end subroutine sub
+end program main

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -2867,6 +2867,10 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
   bool savedScopeIsGlobal;
   hash_data_t val;
 
+  // Dont emit if it is uplevel variable
+  if (sptr && UPLEVELG(sptr))
+    return;
+
   assert(db, "Debug info not enabled", 0, ERR_Fatal);
   if ((!sptr) || (!DTYPEG(sptr)))
     return;


### PR DESCRIPTION
Currently outer variable are not being shown in debugger.

Please consider below program

````````````````````````````
     1  program main
     2    integer :: prog_i
     3    prog_i = 99
     4    call sub()
     5  contains
     6    subroutine sub()
     7      print *,prog_i
     8    end subroutine sub
     9  end program main

Inside debugger...

(gdb) b 7
Breakpoint 2 at 0x400928: file outervar.f90, line 7.
(gdb) c
Continuing.
Breakpoint 2, main::sub () at outervar.f90:7
7          print *,prog_i
(gdb) p prog_i
$1 = <optimized out>

Now separate variable creation for contained subprogram is suppressed now.