### PR TITLE
Implement UNROLL(n) directive

### DIFF
--- a/test/directives/lit.local.cfg
+++ b/test/directives/lit.local.cfg
@@ -7,5 +7,4 @@
 # Directives test configuration
 
 config.suffixes = ['.f', '.FOR', '.for', '.f77', '.f90', '.f95', '.F', '.fpp',
- '.FPP']
-
+                   '.FPP']

--- a/test/directives/nounroll.f90
+++ b/test/directives/nounroll.f90
@@ -1,0 +1,24 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+!** Test the NOUNROLL pragma
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s -check-prefix=METADATA
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=ENABLE-METADATA
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+program tz
+  integer :: i
+  integer :: acc(100)
+  integer :: sz
+  !dir$ nounroll
+  do i=1,sz
+    acc(i) = i
+  end do
+  print *, acc(100)
+end program
+! METADATA: !"llvm.loop.unroll.disable"
+! ENABLE-METADATA-NOT: !"llvm.loop.unroll.disable
+! CHECK: [[BRNCH:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[BRNCH]], %L.LB
+! CHECK: br i1 {{.*}}, label %[[BRNCH]], label %L.LB

--- a/test/directives/nounroll.f90
+++ b/test/directives/nounroll.f90
@@ -1,24 +1,33 @@
-!
 ! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-!
 
-!** Test the NOUNROLL pragma
-! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s -check-prefix=METADATA
-! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=ENABLE-METADATA
-! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+! Check that the NOUNROLL directive generates the correct metadata.
+!
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK
+!
+! CHECK:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK:      store float
+! CHECK-NOT:  store float
+! CHECK:      br i1 {{.*}}, label %[[LOOP]], label %L.LB
+! CHECK-SAME: !llvm.loop
+! CHECK:      !"llvm.loop.unroll.disable"
+
+! Check that "-Hx,59,2" disables the NOUNROLL directive.
+!
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - \
+! RUN: | FileCheck %s --check-prefix=CHECK-NODIRECTIVE
+!
+! CHECK-NODIRECTIVE-NOT: !llvm.loop
+! CHECK-NODIRECTIVE-NOT: !"llvm.loop.unroll.disable"
+
 program tz
   integer :: i
-  integer :: acc(100)
+  real :: acc(100)
   integer :: sz
   !dir$ nounroll
-  do i=1,sz
-    acc(i) = i
+  do i = 1, sz
+    acc(i) = i * 2.0
   end do
   print *, acc(100)
 end program
-! METADATA: !"llvm.loop.unroll.disable"
-! ENABLE-METADATA-NOT: !"llvm.loop.unroll.disable
-! CHECK: [[BRNCH:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[BRNCH]], %L.LB
-! CHECK: br i1 {{.*}}, label %[[BRNCH]], label %L.LB

--- a/test/directives/nounroll2.f90
+++ b/test/directives/nounroll2.f90
@@ -1,23 +1,30 @@
-!
 ! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-!
 
-!** Test checking no pragma
-! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
-! RUN: %flang -S -emit-llvm -O2 %s -o - | FileCheck %s -check-prefix=CHECK2
+! Check that Flang at -O0 does not unroll the loop, and does not generate any
+! loop unrolling metadata.
+!
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK-O0
+!
+! CHECK-O0:     [[LOOP:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-O0:     store float
+! CHECK-O0-NOT: store float
+! CHECK-O0:     br i1 {{.*}}, label %[[LOOP]], label %L.LB
+! CHECK-O0-NOT: !llvm.loop !{{[0-9]+}}
+
+! Check that LLVM vectorizes the loop automatically at -O2.
+!
+! RUN: %flang -O2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=CHECK-O2
+!
+! CHECK-O2: vector.body:{{[ \t]+}}; preds = %vector.body, %L.
+! CHECK-O2: br i1 {{.*}}, label %vector.body, !llvm.loop
+
 program tz
   integer :: i
-  integer ::acc(10000)
-  do i=1,10000
-    acc(i) = i
+  real ::acc(10000)
+  do i = 1, 10000
+    acc(i) = i * 2.0
   end do
   print *, acc(1000)
 end program
-
-! CHECK: [[BRNCH:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[BRNCH]], %L.LB
-! CHECK: br i1 {{.*}}, label %[[BRNCH]], label %L.LB
-! CHECK-NOT: !llvm.loop ![0-9]
-! CHECK2: vector.body:{{[' ',\t]+}}; preds = %vector.body, %L.
-! CHECK2: br i1 {{.*}}, label %vector.body, !llvm.loop

--- a/test/directives/nounroll2.f90
+++ b/test/directives/nounroll2.f90
@@ -1,0 +1,23 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+!** Test checking no pragma
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -S -emit-llvm -O2 %s -o - | FileCheck %s -check-prefix=CHECK2
+program tz
+  integer :: i
+  integer ::acc(10000)
+  do i=1,10000
+    acc(i) = i
+  end do
+  print *, acc(1000)
+end program
+
+! CHECK: [[BRNCH:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[BRNCH]], %L.LB
+! CHECK: br i1 {{.*}}, label %[[BRNCH]], label %L.LB
+! CHECK-NOT: !llvm.loop ![0-9]
+! CHECK2: vector.body:{{[' ',\t]+}}; preds = %vector.body, %L.
+! CHECK2: br i1 {{.*}}, label %vector.body, !llvm.loop

--- a/test/directives/unroll.f90
+++ b/test/directives/unroll.f90
@@ -1,0 +1,23 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+!** Test checking unroll pragma
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s -check-prefix=METADATA
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=ENABLE-METADATA
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+program tz
+  integer :: i
+  integer ::acc(100)
+  !dir$ unroll
+  do i=1,100
+    acc(i) = 5
+  end do
+  print *, acc(100)
+end program
+! METADATA: !"llvm.loop.unroll.enable"
+! ENABLE-METADATA-NOT: !"llvm.loop.unroll.enable"
+! CHECK: [[BRNCH:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[BRNCH]], %L.LB
+! CHECK: br i1 {{.*}}, label %[[BRNCH]], label %L.LB

--- a/test/directives/unroll.f90
+++ b/test/directives/unroll.f90
@@ -1,23 +1,94 @@
-!
 ! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-!
 
-!** Test checking unroll pragma
-! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s -check-prefix=METADATA
-! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=ENABLE-METADATA
-! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
-program tz
-  integer :: i
-  integer ::acc(100)
+! Check that the UNROLL directive generates correct LLVM IR metadata at -O0.
+! Each subroutine should have distinct metadata, particularly subroutines with
+! different unroll factors specified by the user.
+!
+! RUN: %flang -O0 -S -emit-llvm %s -o - \
+! RUN: | FileCheck %s --check-prefixes=CHECK,CHECK-O0
+
+! Check that LLVM unrolls the first loop fully at -O1, unrolls the other two
+! loops the correct number of times, and disables further unrolling on them.
+!
+! RUN: %flang -O1 -S -emit-llvm %s -o - \
+! RUN: | FileCheck %s --check-prefixes=CHECK,CHECK-O1
+
+! Check that "-Hx,59,2" disables both kinds of UNROLL directives.
+!
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - \
+! RUN: | FileCheck %s --check-prefixes=CHECK,CHECK-DISABLED
+
+subroutine func1(a, b)
+  ! CHECK-LABEL: define void @func1_
+  integer :: m = 10
+  integer :: i, a(m), b(m)
+
   !dir$ unroll
-  do i=1,100
-    acc(i) = 5
+  do i = 1, m
+    b(i) = a(i) + 1
   end do
-  print *, acc(100)
-end program
-! METADATA: !"llvm.loop.unroll.enable"
-! ENABLE-METADATA-NOT: !"llvm.loop.unroll.enable"
-! CHECK: [[BRNCH:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[BRNCH]], %L.LB
-! CHECK: br i1 {{.*}}, label %[[BRNCH]], label %L.LB
+  ! CHECK-O0:           [[BB1:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB1]],
+  ! CHECK-O0:           br i1 {{.*}}, label %[[BB1]]
+  ! CHECK-O0-SAME:      !llvm.loop [[MD_LOOP1:![0-9]+]]
+  ! CHECK-O1-COUNT-10:  store i32
+  ! CHECK-O1-NOT:       store i32
+  ! CHECK-O1-NOT:       br i1 {{.*}}, label %[[BB1]]
+  ! CHECK-O1-NOT:       !llvm.loop !{{[0-9]+}}
+  ! CHECK-O1:           ret void
+  ! CHECK-DISABLED:     [[BB1:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB1]],
+  ! CHECK-DISABLED:     br i1 {{.*}}, label %[[BB1]]
+  ! CHECK-DISABLED-NOT: !llvm.loop !{{[0-9]+}}
+end subroutine func1
+
+subroutine func2(m, a, b)
+  ! CHECK-LABEL: define void @func2_
+  integer :: i, m, a(m), b(m)
+
+  !dir$ unroll(4)
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+  ! CHECK:              [[BB2:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB2]],
+  ! CHECK-O1-COUNT-4:   store i32
+  ! CHECK-O1-NOT:       store i32
+  ! CHECK:              br i1 {{.*}}, label %[[BB2]]
+  ! CHECK-O0-SAME:      !llvm.loop [[MD_LOOP2:![0-9]+]]
+  ! CHECK-O1-SAME:      !llvm.loop [[MD_LOOP2:![0-9]+]]
+  ! CHECK-DISABLED-NOT: !llvm.loop !{{[0-9]+}}
+end subroutine func2
+
+subroutine func3(m, a, b)
+  ! CHECK-LABEL: define void @func3_
+  integer :: i, m, a(m), b(m)
+
+  ! Use an odd factor to make sure it's picked up.
+  !dir$ unroll = 7
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+  ! CHECK:              [[BB3:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB3]],
+  ! CHECK-O1-COUNT-7:   store i32
+  ! CHECK-O1-NOT:       store i32
+  ! CHECK:              br i1 {{.*}}, label %[[BB3]]
+  ! CHECK-O0-SAME:      !llvm.loop [[MD_LOOP3:![0-9]+]]
+  ! CHECK-O1-SAME:      !llvm.loop [[MD_LOOP3:![0-9]+]]
+  ! CHECK-DISABLED-NOT: !llvm.loop !{{[0-9]+}}
+end subroutine func3
+
+! CHECK-O0: [[MD_LOOP1]] = distinct !{[[MD_LOOP1]], [[MD_ENABLE:![0-9]+]]}
+! CHECK-O0: [[MD_ENABLE]] = !{!"llvm.loop.unroll.enable"}
+! CHECK-O0: [[MD_COUNT1:![0-9]+]] = !{!"llvm.loop.unroll.count", i32 4}
+! CHECK-O0: [[MD_LOOP2]] = distinct !{[[MD_LOOP2]], [[MD_COUNT1]]}
+! CHECK-O0: [[MD_COUNT2:![0-9]+]] = !{!"llvm.loop.unroll.count", i32 7}
+! CHECK-O0: [[MD_LOOP3]] = distinct !{[[MD_LOOP3]], [[MD_COUNT2]]}
+
+! CHECK-O1-NOT: !"llvm.loop.unroll.enable"
+! CHECK-O1:     [[MD_LOOP2]] = distinct !{[[MD_LOOP2]], [[MD_DISABLE:![0-9]+]]}
+! CHECK-O1:     [[MD_DISABLE]] = !{!"llvm.loop.unroll.disable"}
+! CHECK-O1:     [[MD_LOOP3]] = distinct !{[[MD_LOOP3]], [[MD_DISABLE]]}
+
+! CHECK-DISABLED-NOT: !"llvm.loop.unroll.enable"
+! CHECK-DISABLED-NOT: !"llvm.loop.unroll.count"
+! CHECK-DISABLED-NOT: !"llvm.loop.unroll.disable"

--- a/test/directives/unroll_override.f90
+++ b/test/directives/unroll_override.f90
@@ -1,0 +1,62 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! When multiple UNROLL directives are specified for the same loop, check
+! that the last one overrides previous ones.
+!
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+
+subroutine func1(m, a, b)
+  ! CHECK-LABEL: define void @func1_
+  integer :: i, m, a(m), b(m)
+
+  !dir$ nounroll
+  !dir$ unroll
+  !dir$ unroll = 10
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+  ! CHECK:       [[BB1:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB1]],
+  ! CHECK:       br i1 {{.*}}, label %[[BB1]]
+  ! CHECK-SAME:  !llvm.loop [[MD_LOOP1:![0-9]+]]
+end subroutine func1
+
+subroutine func2(m, a, b)
+  ! CHECK-LABEL: define void @func2_
+  integer :: i, m, a(m), b(m)
+
+  !dir$ unroll = 10
+  !dir$ nounroll
+  !dir$ unroll
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+  ! CHECK:       [[BB2:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB2]],
+  ! CHECK:       br i1 {{.*}}, label %[[BB2]]
+  ! CHECK-SAME:  !llvm.loop [[MD_LOOP2:![0-9]+]]
+end subroutine func2
+
+subroutine func3(m, a, b)
+  ! CHECK-LABEL: define void @func3_
+  integer :: i, m, a(m), b(m)
+
+  !dir$ unroll
+  !dir$ unroll = 10
+  !dir$ nounroll
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+  ! CHECK:       [[BB3:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB3]],
+  ! CHECK:       br i1 {{.*}}, label %[[BB3]]
+  ! CHECK-SAME:  !llvm.loop [[MD_LOOP3:![0-9]+]]
+end subroutine func3
+
+! Check that metadata are correct.
+!
+! CHECK: [[MD_COUNT:![0-9]+]] = !{!"llvm.loop.unroll.count", i32 10}
+! CHECK: [[MD_LOOP1]] = distinct !{[[MD_LOOP1]], [[MD_COUNT]]}
+! CHECK: [[MD_LOOP2]] = distinct !{[[MD_LOOP2]], [[MD_ENABLE:![0-9]+]]}
+! CHECK: [[MD_ENABLE]] = !{!"llvm.loop.unroll.enable"}
+! CHECK: [[MD_LOOP3]] = distinct !{[[MD_LOOP3]], [[MD_DISABLE:![0-9]+]]}
+! CHECK: [[MD_DISABLE]] = !{!"llvm.loop.unroll.disable"}

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -536,11 +536,9 @@ iteration count.
 .XF "11:" 
 Unrolling
 .XB "0x01:"
-Inhibit completely unrolling a loop (constant loop count);
-for control by directive/pragma
+Enable completely unrolling a loop when the UNROLL directive is used.
 .XB "0x02:"
-Inhibit unrolling a loop with a non-constant loop count;
-for control by directive/pragma
+Enable unrolling a loop by a factor specified via the UNROLL(n) directive.
 .XB "0x04:"
 (I386,X86_64) Ignore the check of the number of variable
 strides.
@@ -567,7 +565,7 @@ containing (outer) loop.
 Enable unrolling of multi-block loops.
 The unroll count is initially default 4 or flg.x[10] if that is set.
 .XB "0x400:"
-(X86_32,X86_64) revert to the old/pre-PRE unrolling thresholds
+Disable unrolling of a loop marked with the NOUNROLL directive.
 .XB "0x800:"
 Do not attempt to increase the threshold for completely unrolling
 an innermost multi-block loops.

--- a/tools/flang2/flang2exe/bih.h
+++ b/tools/flang2/flang2exe/bih.h
@@ -116,6 +116,8 @@ typedef struct {
       unsigned rpct_confl : 1; /* block contains the RPCT conflict loop */
       unsigned rt_guarded : 1; /* block contains runtime guarded loop */
       unsigned doconc : 1;     /* bih is the head of a do concurrent loop */
+      unsigned unroll : 1;  /* bih contains the unroll set */
+      unsigned nounroll : 1; /* bih contains the no unroll set*/
     } bits;
   } flags2;
   int lpcntFrom;  /* When a loop count temp is created, record the induction
@@ -230,6 +232,8 @@ typedef struct {
 #define BIH_FTAG(i) bihb.stg_base[i].ftag
 #define BIH_BLKCNT(i) bihb.stg_base[i].blkCnt
 #define BIH_AVLPCNT(i) bihb.stg_base[i].aveLpCnt
+#define BIH_UNROLL(i) bihb.stg_base[i].flags2.bits.unroll
+#define BIH_NOUNROLL(i) bihb.stg_base[i].flags2.bits.nounroll
 
 #define EXEC_COUNT double
 #define UNKNOWN_EXEC_CNT -1.0

--- a/tools/flang2/flang2exe/bih.h
+++ b/tools/flang2/flang2exe/bih.h
@@ -116,8 +116,9 @@ typedef struct {
       unsigned rpct_confl : 1; /* block contains the RPCT conflict loop */
       unsigned rt_guarded : 1; /* block contains runtime guarded loop */
       unsigned doconc : 1;     /* bih is the head of a do concurrent loop */
-      unsigned unroll : 1;  /* bih contains the unroll set */
-      unsigned nounroll : 1; /* bih contains the no unroll set*/
+      unsigned unroll : 1;     /* bih is a loop to be fully unrolled */
+      unsigned unroll_cnt : 1; /* bih has a user-specified unroll factor */
+      unsigned nounroll : 1;   /* bih is a loop that must not be unrolled */
     } bits;
   } flags2;
   int lpcntFrom;  /* When a loop count temp is created, record the induction
@@ -233,6 +234,7 @@ typedef struct {
 #define BIH_BLKCNT(i) bihb.stg_base[i].blkCnt
 #define BIH_AVLPCNT(i) bihb.stg_base[i].aveLpCnt
 #define BIH_UNROLL(i) bihb.stg_base[i].flags2.bits.unroll
+#define BIH_UNROLL_COUNT(i) bihb.stg_base[i].flags2.bits.unroll_cnt
 #define BIH_NOUNROLL(i) bihb.stg_base[i].flags2.bits.nounroll
 
 #define EXEC_COUNT double

--- a/tools/flang2/flang2exe/bihutil.cpp
+++ b/tools/flang2/flang2exe/bihutil.cpp
@@ -226,6 +226,7 @@ merge_bih_flags(int to_bih, int fm_bih)
   BIH_STVOL(to_bih) = BIH_STVOL(to_bih) | BIH_STVOL(fm_bih);
   BIH_NODEPCHK(to_bih) = BIH_NODEPCHK(to_bih) | BIH_NODEPCHK(fm_bih);
   BIH_UNROLL(to_bih) = BIH_UNROLL(to_bih) | BIH_UNROLL(fm_bih);
+  BIH_UNROLL_COUNT(to_bih) = BIH_UNROLL_COUNT(to_bih) | BIH_UNROLL_COUNT(fm_bih);
   BIH_NOUNROLL(to_bih) = BIH_NOUNROLL(to_bih) | BIH_NOUNROLL(fm_bih);
 
   if (BIH_TAIL(fm_bih))

--- a/tools/flang2/flang2exe/bihutil.cpp
+++ b/tools/flang2/flang2exe/bihutil.cpp
@@ -225,6 +225,8 @@ merge_bih_flags(int to_bih, int fm_bih)
   BIH_LDVOL(to_bih) = BIH_LDVOL(to_bih) | BIH_LDVOL(fm_bih);
   BIH_STVOL(to_bih) = BIH_STVOL(to_bih) | BIH_STVOL(fm_bih);
   BIH_NODEPCHK(to_bih) = BIH_NODEPCHK(to_bih) | BIH_NODEPCHK(fm_bih);
+  BIH_UNROLL(to_bih) = BIH_UNROLL(to_bih) | BIH_UNROLL(fm_bih);
+  BIH_NOUNROLL(to_bih) = BIH_NOUNROLL(to_bih) | BIH_NOUNROLL(fm_bih);
 
   if (BIH_TAIL(fm_bih))
     BIH_TAIL(to_bih) = 1;

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -233,6 +233,8 @@ static int *idxstack = NULL;
 static hashmap_t sincos_map;
 static hashmap_t sincos_imap;
 static LL_MDRef cached_loop_metadata;
+static LL_MDRef cached_unroll_enable_metadata;
+static LL_MDRef cached_unroll_disable_metadata;
 
 static bool CG_cpu_compile = false;
 
@@ -967,6 +969,24 @@ cons_novectorize_metadata(void)
 }
 
 INLINE static LL_MDRef
+cons_nounroll_metadata(void)
+{
+  LL_MDRef lvcomp[1];
+  LL_MDRef loopUnroll;
+  LL_MDRef rv;
+
+  if (LL_MDREF_IS_NULL(cached_unroll_disable_metadata)) {
+   rv = ll_create_flexible_md_node(cpu_llvm_module);
+   lvcomp[0] = ll_get_md_string(cpu_llvm_module, "llvm.loop.unroll.disable");
+   loopUnroll= ll_get_md_node(cpu_llvm_module, LL_PlainMDNode, lvcomp, 1);
+   ll_extend_md_node(cpu_llvm_module, rv, rv);
+   ll_extend_md_node(cpu_llvm_module, rv, loopUnroll);
+   cached_unroll_disable_metadata=rv;
+  }
+  return cached_unroll_disable_metadata;
+}
+
+INLINE static LL_MDRef
 cons_vectorize_metadata(void)
 {
   LL_MDRef lvcomp[2];
@@ -1269,6 +1289,22 @@ cons_no_depchk_metadata(void)
   return cached_loop_metadata;
 }
 
+static LL_MDRef
+cons_unroll_metadata(void) //Calls the metadata for unroll
+{
+  LL_MDRef lvcomp[1];
+  LL_MDRef unroll;
+  if (LL_MDREF_IS_NULL(cached_unroll_enable_metadata)) {
+    lvcomp[0] = ll_get_md_string(cpu_llvm_module, "llvm.loop.unroll.enable");
+    unroll= ll_get_md_node(cpu_llvm_module, LL_PlainMDNode, lvcomp, 1);
+    LL_MDRef md = ll_create_flexible_md_node(cpu_llvm_module);
+    ll_extend_md_node(cpu_llvm_module, md, md);
+    ll_extend_md_node(cpu_llvm_module, md, unroll);
+    cached_unroll_enable_metadata = md;
+  }
+  return cached_unroll_enable_metadata;
+}
+
 INLINE static bool
 ignore_simd_block(int bih)
 {
@@ -1569,6 +1605,10 @@ restartConcur:
     } else {
       clear_rw_nodepchk();
     }
+    if (XBIT(11, 0x3))
+      BIH_UNROLL(bih) = true;
+    else if (XBIT(11, 0x400))
+      BIH_NOUNROLL(bih) = true;
     close_pragma();
 
     for (ilt = BIH_ILTFIRST(bih); ilt; ilt = ILT_NEXT(ilt)) {
@@ -1620,13 +1660,28 @@ restartConcur:
           LL_MDRef loop_md = cons_no_depchk_metadata();
           INSTR_LIST *i = find_last_executable(llvm_info.last_instr);
           if (i) {
-            i->flags |= SIMD_BACKEDGE_FLAG;
+            i->flags |= LOOP_BACKEDGE_FLAG;
+            i->misc_metadata = loop_md;
+          }
+        }
+        if (BIH_UNROLL(bih)) {
+          LL_MDRef loop_md = cons_unroll_metadata();
+          INSTR_LIST *i = find_last_executable(llvm_info.last_instr);
+          if (i) {
+            i->flags |= LOOP_BACKEDGE_FLAG;
+            i->misc_metadata = loop_md;
+          }
+        } else if (BIH_NOUNROLL(bih)) {
+          LL_MDRef loop_md = cons_nounroll_metadata();
+          INSTR_LIST *i = find_last_executable(llvm_info.last_instr);
+          if (i) {
+            i->flags |= LOOP_BACKEDGE_FLAG;
             i->misc_metadata = loop_md;
           }
         }
         if (ignore_simd_block(bih)) {
           LL_MDRef loop_md = cons_novectorize_metadata();
-          llvm_info.last_instr->flags |= SIMD_BACKEDGE_FLAG;
+          llvm_info.last_instr->flags |= LOOP_BACKEDGE_FLAG;
           llvm_info.last_instr->misc_metadata = loop_md;
         }
       } else if ((ILT_ST(ilt) || ILT_DELETE(ilt)) &&
@@ -3101,7 +3156,7 @@ write_instructions(LL_Module *module)
           print_token(llvm_instr_names[i_name]);
           print_space(1);
           write_operands(instrs->operands, 0);
-          if (instrs->flags & SIMD_BACKEDGE_FLAG) {
+          if (instrs->flags & LOOP_BACKEDGE_FLAG) {
             char buf[32];
             LL_MDRef loop_md = instrs->misc_metadata;
             snprintf(buf, 32, ", !llvm.loop !%u", LL_MDREF_value(loop_md));

--- a/tools/flang2/flang2exe/iltutil.cpp
+++ b/tools/flang2/flang2exe/iltutil.cpp
@@ -333,6 +333,10 @@ dump_ilt(FILE *ff, int bihx)
     fprintf(ff, " SIMD");
   if (BIH_NOSIMD(bihx))
     fprintf(ff, " NOSIMD");
+  if (BIH_UNROLL(bihx))
+    fprintf(ff, " UNROLL");
+  if (BIH_NOUNROLL(bihx))
+    fprintf(ff, " NOUNROLL");
   if (BIH_LDVOL(bihx))
     fprintf(ff, " LDVOL");
   if (BIH_STVOL(bihx))

--- a/tools/flang2/flang2exe/iltutil.cpp
+++ b/tools/flang2/flang2exe/iltutil.cpp
@@ -335,6 +335,8 @@ dump_ilt(FILE *ff, int bihx)
     fprintf(ff, " NOSIMD");
   if (BIH_UNROLL(bihx))
     fprintf(ff, " UNROLL");
+  if (BIH_UNROLL_COUNT(bihx))
+    fprintf(ff, " UNROLL_COUNT");
   if (BIH_NOUNROLL(bihx))
     fprintf(ff, " NOUNROLL");
   if (BIH_LDVOL(bihx))

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -265,7 +265,7 @@ typedef enum LL_InstrListFlags {
   CALL_FUNC_PTR_FLAG  = (1 << 1),
   CALL_INTRINSIC_FLAG = (1 << 2),
   HIDDEN_ARG_FLAG     = (1 << 3),
-  SIMD_BACKEDGE_FLAG  = (1 << 4), /**< I_BR only */
+  LOOP_BACKEDGE_FLAG  = (1 << 4), /**< I_BR only */
   FAST_MATH_FLAG      = (1 << 4), /**< I_CALL only */
   VOLATILE_FLAG       = (1 << 4), /**< I_LOAD, I_STORE, I_ATOMICRMW,
                                        I_CMPXCHG only */

--- a/tools/flang2/flang2exe/mwd.cpp
+++ b/tools/flang2/flang2exe/mwd.cpp
@@ -4895,6 +4895,7 @@ db(int block)
   putbit("simd", BIH_SIMD(block));
   putbit("nosimd", BIH_NOSIMD(block));
   putbit("unroll", BIH_UNROLL(block));
+  putbit("unroll_count", BIH_UNROLL_COUNT(block));
   putbit("nounroll", BIH_NOUNROLL(block));
   putbit("ldvol", BIH_LDVOL(block));
   putbit("stvol", BIH_STVOL(block));

--- a/tools/flang2/flang2exe/mwd.cpp
+++ b/tools/flang2/flang2exe/mwd.cpp
@@ -4894,6 +4894,8 @@ db(int block)
   putbit("ujres", BIH_UJRES(block));
   putbit("simd", BIH_SIMD(block));
   putbit("nosimd", BIH_NOSIMD(block));
+  putbit("unroll", BIH_UNROLL(block));
+  putbit("nounroll", BIH_NOUNROLL(block));
   putbit("ldvol", BIH_LDVOL(block));
   putbit("stvol", BIH_STVOL(block));
   putbit("task", BIH_TASK(block));

--- a/tools/shared/pragma.c
+++ b/tools/shared/pragma.c
@@ -1184,37 +1184,27 @@ do_sw(void)
       return true;
     break;
   case SW_UNROLL:
-    /* [no]unroll		-x/y 11 3
-     * [no]unroll = c	-x/y 11 1
-     * [no]unroll = n	-x/y 11 2
-     *     unroll = c:v     -y   11 3  -x    9 v
-     *     unroll = n:v     -y   11 3  -x   10 v
+    /* unroll       -x 11 0x1   -y 11 0x402
+     * unroll = n   -x 11 0x2   -y 11 0x401 -x 9 n
+     * unroll (n)   -x 11 0x2   -y 11 0x401 -x 9 n
+     * nounroll     -x 11 0x400 -y 11 0x3
      */
     typ = gtok();
-    if (typ != T_EQUAL) {
-      if (no_specified)
+    // !dir$ [no]unroll
+    if (typ == T_END) {
+      if (no_specified) { // !dir$ nounroll
         bset(DIR_OFFSET(currdir, x[11]), 0x400);
-      else
-        bset(DIR_OFFSET(currdir, x[11]), 0x3);
-    } else if (gtok() == T_IDENT) {
-      if (strcmp(ctok, "c") == 0)
-        i = 9;
-      else if (strcmp(ctok, "n") == 0)
-        i = 10;
-      else
-        return true;
-      if (no_specified)
-        bset(DIR_OFFSET(currdir, x[11]), i - 8);
-      else if (gtok() != T_COLON)
-        bclr(DIR_OFFSET(currdir, x[11]), i - 8);
-      else if (gtok() != T_INT)
-        return true;
-      else {
-        if (itok <= 0)
-          itok = 1;
-        assn(DIR_OFFSET(currdir, x[i]), (int)itok);
-        bclr(DIR_OFFSET(currdir, x[11]), 3);
+        bclr(DIR_OFFSET(currdir, x[11]), 0x3);
+      } else { // !dir$ unroll
+        bset(DIR_OFFSET(currdir, x[11]), 0x1);
+        bclr(DIR_OFFSET(currdir, x[11]), 0x402);
       }
+    } else if (typ == T_EQUAL || typ == T_LP) {
+      // !dir$ unroll = n or !dir$ unroll(n)
+      int unroll_count = atoi(currp);
+      assn(DIR_OFFSET(currdir, x[9]), unroll_count);
+      bset(DIR_OFFSET(currdir, x[11]), 0x2);
+      bclr(DIR_OFFSET(currdir, x[11]), 0x401);
     } else
       return true;
     break;

--- a/tools/shared/pragma.c
+++ b/tools/shared/pragma.c
@@ -1193,9 +1193,9 @@ do_sw(void)
     typ = gtok();
     if (typ != T_EQUAL) {
       if (no_specified)
-        bset(DIR_OFFSET(currdir, x[11]), 0x3);
+        bset(DIR_OFFSET(currdir, x[11]), 0x400);
       else
-        bclr(DIR_OFFSET(currdir, x[11]), 0x3);
+        bset(DIR_OFFSET(currdir, x[11]), 0x3);
     } else if (gtok() == T_IDENT) {
       if (strcmp(ctok, "c") == 0)
         i = 9;


### PR DESCRIPTION
This PR is based on #742 and cleans it up such that it no longer conflicts with #660 (which is included in this PR). A second commit is added to extend the directive to support user-specified unroll factors, and remove support for the old PGI-style syntax (which cannot be easily supported with `llvm.loop.unroll` metadata AFAICT). The new syntax is similar to what Intel Fortran supports:
```
!dir$ unroll
!dir$ unroll(6)
!dir$ unroll = 6
!dir$ nounroll
```
This PR also clarifies the usage of `XBIT(11)` and updates the test cases to make them more complete and understandable.

This PR needs to be rebased after #660 is accepted.