### PR TITLE
Call check_member() for PD_is_contiguous

### DIFF
--- a/test/f90_correct/inc/is_contiguous.mk
+++ b/test/f90_correct/inc/is_contiguous.mk
@@ -1,0 +1,20 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test is_contiguous  ########
+
+build:
+	@echo ------------------------------------ building test $(TEST)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	./$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/is_contiguous.sh
+++ b/test/f90_correct/lit/is_contiguous.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/is_contiguous.f90
+++ b/test/f90_correct/src/is_contiguous.f90
@@ -1,0 +1,30 @@
+module message
+  type :: msg_type
+    integer, pointer :: arr(:)
+  end type msg_type
+  contains
+  subroutine test(msg, res)
+    type(msg_type) :: msg
+    integer, intent(out) :: res
+    res = is_contiguous(msg%arr)
+  end subroutine
+end module
+
+program prog
+  use message
+
+  integer, parameter :: num = 1
+  integer rslts(num), expect(num)
+  data expect / true /
+
+  type(msg_type) :: my_msg
+  integer :: res_test
+  call test(my_msg, res_test)
+
+  ! test that summing elements of an array where the array lives in another
+  ! module produces the correct result.
+  rslts(1) = res_test
+  call check(rslts, expect, num)
+
+  print *, "PASSED" ! Check that this compiles without error.
+end program prog

--- a/tools/flang1/flang1exe/semfunc.c
+++ b/tools/flang1/flang1exe/semfunc.c
@@ -10309,7 +10309,11 @@ ref_pd(SST *stktop, ITEM *list)
     if (!SDSCG(i)) {
       get_static_descriptor(i);
     }
-    ARG_AST(1) = mk_id(SDSCG(i));
+    if (STYPEG(SDSCG(i)) == ST_MEMBER) {
+      ARG_AST(1) = check_member(ast, mk_id(SDSCG(i)));
+    } else {
+      ARG_AST(1) = mk_id(SDSCG(i));
+    }
     break;
 
   case PD_ranf:


### PR DESCRIPTION
Fixes #936 .

As @mleair explained in [his comment](https://github.com/flang-compiler/flang/issues/936#issuecomment-720657812):

> I believe we missed the call to check_member() in the PD_is_contiguous case of ref_pd() in semfunc.c

This is correct. The reproducer now compiles fine and the other tests are still passing

I added `is_contiguous` test based on the issue's reproducer to prevent regression.

@mleair , @RichBarton-Arm , @kiranchandramohan , please review.