### PR TITLE
Fix gcc-10 compilaton issues

### DIFF
--- a/runtime/flang/ftni64.h
+++ b/runtime/flang/ftni64.h
@@ -27,7 +27,7 @@ typedef unsigned long long _ULONGLONG_T;
 #define I64_MSH(t) t[1]
 #define I64_LSH(t) t[0]
 
-int __ftn_32in64_;
+extern int __ftn_32in64_; // Declared in utilsi64.c
 
 #define VOID void
 

--- a/runtime/libpgmath/lib/x86_64/libm_inlines_amd.h
+++ b/runtime/libpgmath/lib/x86_64/libm_inlines_amd.h
@@ -1940,7 +1940,7 @@ __remainder_piby2f_inline(__UINT8_T ux, double *r, int *region)
 /* This method simulates multi-precision floating-point
    arithmetic and is accurate for all 1 <= x < infinity */
 #define bitsper 36
-  __UINT8_T res[10];
+  __UINT8_T res[10] = { 0 };
   __UINT8_T u, carry, mask, mant, nextbits;
   int first, last, i, rexp, xexp, resexp, ltb, determ, bc;
   double dx;

--- a/tools/flang1/flang1exe/CMakeLists.txt
+++ b/tools/flang1/flang1exe/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
+set_source_files_properties(${UTILS_SYMTAB_BIN_DIR}/symtabdf.c PROPERTIES GENERATED TRUE)
+
 set(SOURCES
   accpp.c
   assem.c
@@ -88,6 +90,7 @@ set(SOURCES
   version.c
   xref.c
   vsub.c
+  ${UTILS_SYMTAB_BIN_DIR}/symtabdf.c
   )
 
 set(COMMON_DEFS

--- a/tools/flang1/flang1exe/lower.h
+++ b/tools/flang1/flang1exe/lower.h
@@ -243,15 +243,20 @@ typedef struct {
   int refd_list;       /* linked list of pointer/offset/section descriptors in the order they
                         * need to be given addresses */
 } lower_symbol_lists;
-STG_DECLARE(lsymlists, lower_symbol_lists);
+
+struct lsymlists_s {
+  STG_MEMBERS(lower_symbol_lists);
+};
+extern struct lsymlists_s lsymlists;
+
 #define LOWER_MEMBER_PARENT(x) lsymlists.stg_base[x].member_parent
 #define LOWER_SYMBOL_REPLACE(x) lsymlists.stg_base[x].symbol_replace
 #define LOWER_POINTER_LIST(x) lsymlists.stg_base[x].pointer_list
 #define LOWER_REFD_LIST(x) lsymlists.stg_base[x].refd_list
 
-int *lower_argument;
-int lower_argument_size;
-int lower_line;
+extern int *lower_argument;
+extern int lower_argument_size;
+extern int lower_line;
 
 /* only one of thenlabel and elselabel should be nonzero;
  * the other is the 'fall through' case */
@@ -259,8 +264,8 @@ typedef struct {
   int thenlabel, elselabel, endlabel;
 } iflabeltype;
 
-int lower_disable_ptr_chk;
-int lower_disable_subscr_chk;
+extern int lower_disable_ptr_chk;
+extern int lower_disable_subscr_chk;
 
 /* types of entries pushed onto the stack */
 #define STKDO 1

--- a/tools/flang1/flang1exe/lowerilm.c
+++ b/tools/flang1/flang1exe/lowerilm.c
@@ -36,6 +36,7 @@ static FILE *lower_ilm_file = NULL;
 int lower_line;
 int lower_disable_ptr_chk = 0;
 int lower_disable_subscr_chk = 0;
+struct lsymlists_s lsymlists;
 
 #define VarBase 0
 #define SourceBase 1

--- a/tools/flang1/flang1exe/optimize.h
+++ b/tools/flang1/flang1exe/optimize.h
@@ -673,7 +673,7 @@ typedef struct {
   STG_DECLARE(astb, OAST);
 } OPT;
 
-OPT opt;
+extern OPT opt;
 
 /*****  optimize.c *****/
 void optshrd_init(void);

--- a/tools/flang1/utils/prstab/prstab.h
+++ b/tools/flang1/utils/prstab/prstab.h
@@ -50,7 +50,7 @@
 
 /* Global Declarations */
 
-struct {
+struct files_s {
   FILE *infile;
   FILE *gramin;
   FILE *tokin;
@@ -59,34 +59,39 @@ struct {
   FILE *datfil;
   FILE *dbgfil;
   FILE *semfil;
-} files;
+};
+extern struct files_s files;
 
-INT *scrtch;
-INT *hashpt;
-CHAR *linech;
-char *filnambuf;
+extern INT *scrtch;
+extern INT *hashpt;
+extern CHAR *linech;
+extern char *filnambuf;
 
-struct {
+struct s4_s {
   INT *item;
   INT *nextt;
-} s4;
+};
+extern struct s4_s s4;
 
-struct {
+struct s1_1_s{
   INT *sstore;
   INT *sthead;
-} s1_1;
+};
+extern struct s1_1_s s1_1;
 
-struct {
+struct lstcom_s {
   INT garbag;
   INT lstptr;
-} lstcom;
+};
+extern struct lstcom_s lstcom;
 
-struct {
+struct qcom_s {
   INT qhead;
   INT qtail;
-} qcom;
+};
+extern struct qcom_s qcom;
 
-struct {
+struct switches_s {
   LOGICAL listsw;
   LOGICAL runosw;
   LOGICAL xrefsw;
@@ -100,13 +105,15 @@ struct {
   LOGICAL dbgcsw;
   LOGICAL dbgdsw;
   LOGICAL dbgesw;
-} switches;
+};
+extern struct switches_s switches;
 
-struct {
+struct adqcom_s {
   INT adequt;
-} adqcom;
+};
+extern struct adqcom_s adqcom;
 
-struct {
+struct g_1_s {
   INT *lftuse;
   INT *rgtuse;
   INT *frsprd;
@@ -118,9 +125,10 @@ struct {
   INT numprd;
   INT goal;
   INT nterms;
-} g_1;
+};
+extern struct g_1_s g_1;
 
-struct {
+struct s_1_s {
   INT nstate;
   INT nxttrn;
   INT nxtred;
@@ -135,25 +143,29 @@ struct {
   INT *basis;
   INT *tran;
   INT *red;
-} s_1;
+};
+extern struct s_1_s s_1;
 
-struct {
+struct string_1_s {
   INT sstptr;
   INT shdptr;
-} string_1;
+};
+extern struct string_1_s string_1;
 
-struct {
+struct readcm_s{
   INT linbuf[81];
   INT curchr;
   INT lineno;
   INT fstchr;
-} readcm;
+};
+extern struct readcm_s readcm;
 
-struct {
+struct ptsem_s {
   INT pnum;
   INT brkflg;
   INT semnum;
-} ptsem;
+};
+extern struct ptsem_s ptsem;
 
 /*
  * a local array line is used to constuct a line of text to be written

--- a/tools/flang1/utils/prstab/prstab1.c
+++ b/tools/flang1/utils/prstab/prstab1.c
@@ -15,6 +15,37 @@
 INT xargc;
 char **xargv;
 
+/* Global Declarations */
+
+struct files_s files;
+
+INT *scrtch;
+INT *hashpt;
+CHAR *linech;
+char *filnambuf;
+
+struct s4_s s4;
+
+struct s1_1_s s1_1;
+
+struct lstcom_s lstcom;
+
+struct qcom_s qcom;
+
+struct switches_s switches;
+
+struct adqcom_s adqcom;
+
+struct g_1_s g_1;
+
+struct s_1_s s_1;
+
+struct string_1_s string_1;
+
+struct readcm_s readcm;
+
+struct ptsem_s ptsem;
+
 int
 main(INT argc, char **argv)
 {

--- a/tools/flang1/utils/symtab/CMakeLists.txt
+++ b/tools/flang1/utils/symtab/CMakeLists.txt
@@ -10,6 +10,7 @@ add_custom_command(
   OUTPUT ${UTILS_SYMTAB_BIN_DIR}/symtab.out.n
          ${UTILS_SYMTAB_BIN_DIR}/symtab.h
          ${UTILS_SYMTAB_BIN_DIR}/symtabdf.h
+         ${UTILS_SYMTAB_BIN_DIR}/symtabdf.c
          ${UTILS_SYMTAB_BIN_DIR}/symnames.h
          ${FLANG1_DOC_BIN_DIR}/symtab.rst
   COMMAND ${CMAKE_BINARY_DIR}/bin/fesymutil ${CMAKE_CURRENT_SOURCE_DIR}/symtab.n
@@ -17,6 +18,7 @@ add_custom_command(
                                       -o -n ${UTILS_SYMTAB_BIN_DIR}/symtab.out.n
                                             ${UTILS_SYMTAB_BIN_DIR}/symtab.h
                                             ${UTILS_SYMTAB_BIN_DIR}/symtabdf.h
+                                            ${UTILS_SYMTAB_BIN_DIR}/symtabdf.c
                                             ${UTILS_SYMTAB_BIN_DIR}/symnames.h
                                          -s ${FLANG1_DOC_BIN_DIR}/symtab.rst
   DEPENDS fesymutil ${CMAKE_CURRENT_SOURCE_DIR}/symtab.n
@@ -27,6 +29,7 @@ add_custom_target(gen_frontend_symtab
   SOURCES ${UTILS_SYMTAB_BIN_DIR}/symtab.out.n
           ${UTILS_SYMTAB_BIN_DIR}/symtab.h
           ${UTILS_SYMTAB_BIN_DIR}/symtabdf.h
+          ${UTILS_SYMTAB_BIN_DIR}/symtabdf.c
           ${UTILS_SYMTAB_BIN_DIR}/symnames.h
           ${FLANG1_DOC_BIN_DIR}/symtab.rst
   )
@@ -86,6 +89,7 @@ add_executable(fesymini
   ${UTILS_SHARED_DIR}/symacc.c
   symini.cpp
   ${UTILS_COMMON_DIR}/utils.cpp
+  ${UTILS_SYMTAB_BIN_DIR}/symtabdf.c
   )
 
 add_dependencies(fesymini gen_frontend_symtab)

--- a/tools/flang1/utils/symtab/CMakeLists.txt
+++ b/tools/flang1/utils/symtab/CMakeLists.txt
@@ -26,7 +26,7 @@ add_custom_command(
   )
 
 add_custom_target(gen_frontend_symtab
-  SOURCES ${UTILS_SYMTAB_BIN_DIR}/symtab.out.n
+  DEPENDS ${UTILS_SYMTAB_BIN_DIR}/symtab.out.n
           ${UTILS_SYMTAB_BIN_DIR}/symtab.h
           ${UTILS_SYMTAB_BIN_DIR}/symtabdf.h
           ${UTILS_SYMTAB_BIN_DIR}/symtabdf.c

--- a/tools/flang1/utils/symtab/symini.cpp
+++ b/tools/flang1/utils/symtab/symini.cpp
@@ -43,7 +43,7 @@
  * out5 -  output file which will contain ILMs (ilmtp.h)
  *---------------------------------------------------------------------*/
 
-STB stb;
+extern STB stb;
 
 /**
  * .IN name pcnt atyp dtype ILM pname arrayf

--- a/tools/flang2/flang2exe/CMakeLists.txt
+++ b/tools/flang2/flang2exe/CMakeLists.txt
@@ -18,6 +18,8 @@ elseif( ${TARGET_ARCHITECTURE} STREQUAL "ppc64le" )
   )
 endif()
 
+set_source_files_properties(${UTILS_SYMTAB_BIN_DIR}/symtabdf.cpp PROPERTIES GENERATED TRUE)
+
 set(SOURCES
   ${ARCH_DEP_FILES}
   bihutil.cpp
@@ -74,6 +76,7 @@ set(SOURCES
   verify.cpp
   ompaccel.cpp
   tgtutil.cpp
+  ${UTILS_SYMTAB_BIN_DIR}/symtabdf.cpp
   )
 
 set(COMMON_DEFS

--- a/tools/flang2/utils/symtab/CMakeLists.txt
+++ b/tools/flang2/utils/symtab/CMakeLists.txt
@@ -10,6 +10,7 @@ add_custom_command(
   OUTPUT ${UTILS_SYMTAB_BIN_DIR}/symtab.out.n
          ${UTILS_SYMTAB_BIN_DIR}/symtab.h
          ${UTILS_SYMTAB_BIN_DIR}/symtabdf.h
+         ${UTILS_SYMTAB_BIN_DIR}/symtabdf.cpp
          ${UTILS_SYMTAB_BIN_DIR}/symnames.h
          ${FLANG2_DOC_BIN_DIR}/symtab.rst
   COMMAND ${CMAKE_BINARY_DIR}/bin/fsymutil ${CMAKE_CURRENT_SOURCE_DIR}/symtab.n
@@ -17,15 +18,17 @@ add_custom_command(
                                      -o -n ${UTILS_SYMTAB_BIN_DIR}/symtab.out.n
                                            ${UTILS_SYMTAB_BIN_DIR}/symtab.h
                                            ${UTILS_SYMTAB_BIN_DIR}/symtabdf.h
+                                           ${UTILS_SYMTAB_BIN_DIR}/symtabdf.cpp
                                            ${UTILS_SYMTAB_BIN_DIR}/symnames.h
                                         -s ${FLANG2_DOC_BIN_DIR}/symtab.rst
   DEPENDS fsymutil ${CMAKE_CURRENT_SOURCE_DIR}/symtab.n ${CMAKE_CURRENT_SOURCE_DIR}/symtab.in.h
   )
 
 add_custom_target(gen_backend_symtab
-  SOURCES ${UTILS_SYMTAB_BIN_DIR}/symtab.out.n
+  DEPENDS ${UTILS_SYMTAB_BIN_DIR}/symtab.out.n
           ${UTILS_SYMTAB_BIN_DIR}/symtab.h
           ${UTILS_SYMTAB_BIN_DIR}/symtabdf.h
+          ${UTILS_SYMTAB_BIN_DIR}/symtabdf.cpp
           ${UTILS_SYMTAB_BIN_DIR}/symnames.h
           ${FLANG2_DOC_BIN_DIR}/symtab.rst
   )
@@ -71,6 +74,7 @@ add_executable(fsymini
   ${UTILS_COMMON_DIR}/utils.cpp
   ${UTILS_SYMTAB_BIN_DIR}/symtab.h
   ${UTILS_SYMTAB_BIN_DIR}/symtabdf.h
+  ${UTILS_SYMTAB_BIN_DIR}/symtabdf.cpp
   ${UTILS_SYMTAB_BIN_DIR}/symnames.h
   )
 

--- a/tools/flang2/utils/symtab/symini.cpp
+++ b/tools/flang2/utils/symtab/symini.cpp
@@ -33,7 +33,7 @@
  * out2 -  generated macros which define the predeclared numbers (pd.h)
  *---------------------------------------------------------------------*/
 
-STB stb;
+extern STB stb;
 
 /**
  * Formats of lines in the symini*.n input file:

--- a/tools/shared/utils/symacc.c
+++ b/tools/shared/utils/symacc.c
@@ -36,11 +36,11 @@
 #endif
 
 #ifdef UTILSYMTAB
-STB stb;
+extern STB stb;
 GBL gbl;
 #else
 extern STB stb;
-extern GBL gbl;
+GBL gbl;
 #endif
 static char buff[132];
 


### PR DESCRIPTION
When trying to build flang using gcc-10 on top of `classic-flang-llvm-project` I came across some issues which were overlooked by gcc-9:
* an uninitialized array in one of `libpgmath`'s files (trivial to fix),
* a number of global symbols defined in header files (resulting in multiple definitions errors).

Regarding the second issue there is at least one case where the error is about a generated variable `STB stb` which lives in `symtabdf.h`, written by a utility program `fesymutil`. 

In the easier case it is quite straightforward to modify the code, so it doesn't give us multiple definition errors with `-fno-common` by just naming the structures and providing `extern` symbols in the header files and then moving their declarations to one of the c files. This approach is presented in `prstab.h` and `prstab1.c`.

Before diving into the other issues (at least one of them coming from a generated file) I wanted to check if it would be acceptable to just add the `-fcommon` flag to workaround the definitions in header files? 

@RichBarton-Arm , @kiranchandramohan , your initial thoughts and comparison with Arm's downstream code would be much appreciated.