### PR TITLE
USE rename should check if renamed sptr is available in the scope

### DIFF
--- a/test/f90_correct/inc/rename00.mk
+++ b/test/f90_correct/inc/rename00.mk
@@ -1,0 +1,20 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test rename00  ########
+
+build:
+	@echo ------------------------------------ building test $(TEST)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	./$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/rename00.sh
+++ b/test/f90_correct/lit/rename00.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/rename00.f90
+++ b/test/f90_correct/src/rename00.f90
@@ -1,0 +1,68 @@
+! Code based on the reproducer from https://github.com/flang-compiler/flang/issues/889
+
+module declare_var
+  integer, parameter, public :: var = 8
+end module declare_var
+
+module declare_var_2
+   use declare_var
+   integer, parameter, public :: var_2 = var
+end module declare_var_2
+
+module declare_type
+  ! Removing this use statement and defining var_2 in this module fixes our issue
+  use declare_var_2
+  type, public :: new_type
+  end type new_type
+end module declare_type
+
+module declare_func
+  use declare_var, only: var_2 => var
+  private ! Removing this fixes the issue
+  public :: func
+  contains
+    pure real(var_2) function func()
+        func = x'eeeeeeee'
+    end function func
+end module declare_func
+
+module declare_var_2_again
+  implicit none
+  private
+  integer, parameter, public :: var_2=4 ! This is the value that should be taken as double precision for real(var_2) inside subrout.
+end module declare_var_2_again
+
+module mod_subrout
+  use declare_var_2_again ! var_2 for real(var_2) should come from this line
+  ! Removing this use statement (and use of func) fixes the issue
+  use declare_func ! returns var_2=8 defined in declare_var
+
+  integer :: result(3)
+  integer :: expect(3)
+  data expect/4, 4, 8/ ! kind(unused_var), var_2 and var_3 - see below for more explanations.
+
+  contains
+    subroutine subrout(subrout_arg)
+      ! Removing this use statement (and use of subrout_arg) fixes the issue
+      use declare_type, only: new_type
+      ! Removing this use statement with rename fixes it
+      use declare_var_2, var_3 => var_2 ! var_2=8 in declare_var_2 so var_3=8
+      type(new_type), intent(inout) :: subrout_arg ! Changing to an intrinsic type fixes the issue
+      real(var_2) :: unused_var
+      ! the value of var_2 should come from declare_var_2_again (equal 4)
+
+      result(1) = kind(unused_var)
+      result(2) = var_2
+      result(3) = var_3
+
+      call check(result, expect, 3)
+
+    end subroutine subrout
+end module mod_subrout
+
+program foo
+  use declare_type
+  use mod_subrout
+  type(new_type) :: t
+  call subrout(t)
+end program

--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -320,6 +320,7 @@ add_use_rename(SPTR local, SPTR global, LOGICAL is_operator)
     SCOPEP(newglobal, curr_scope()->sptr);
     ENCLFUNCP(newglobal, SCOPEG(newglobal));
     DTYPEP(newglobal, DTYPEG(global));
+    STYPEP(newglobal, ST_ALIAS);
     SYMLKP(newglobal, SYMLKG(global));
     HIDDENP(SYMLKG(newglobal), 0);
     pr->lineno = gbl.lineno;

--- a/tools/flang1/flang1exe/semant.c
+++ b/tools/flang1/flang1exe/semant.c
@@ -10445,7 +10445,18 @@ procedure_stmt:
    */
   case RENAME1:
     add_use_stmt();
-    sptr = SST_SYMG(RHS(3));
+    sptr = sptr1 = SST_SYMG(RHS(3));
+    if (test_scope(sptr) == -1) {
+      // If symbol not in scope search for an in-scope symbol with same name.
+      for (sptr1 = first_hash(sptr); sptr1 > NOSYM; sptr1 = HASHLKG(sptr1)) {
+        if (sptr1 == sptr || NMPTRG(sptr) != NMPTRG(sptr1))
+          continue;
+        if (test_scope(sptr1) != -1) {
+          sptr = sptr1;
+          break; // Found it.
+        }
+      }
+    }
     sptr = add_use_rename((int)SST_SYMG(RHS(1)), sptr, 0);
     SST_SYMP(RHS(3), sptr);
     break;


### PR DESCRIPTION
Fixes #889 .

In case the sptr is not in current scope - check if there is a symbol with same name available.
When an `alias` is being `rename`d, the newly created variable on the stack should also be of `ST_ALIAS` type.

I've also added a test based on @RichBarton-Arm 's reproducer.

@RichBarton-Arm , @kiranchandramohan , would you please review and help me set up the other reviewers appropriately?