### PR TITLE
Fix for ICE in atomic instruction generation

### DIFF
--- a/test/llvm_ir_correct/omp_atomic_reduce_ice.f90
+++ b/test/llvm_ir_correct/omp_atomic_reduce_ice.f90
@@ -1,0 +1,49 @@
+
+! RUN: %flang -fopenmp -Hy,69,0x1000 -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -i8 -fopenmp -Hy,69,0x1000 -S -emit-llvm %s -o - | FileCheck %s
+
+subroutine reduce()
+integer :: j
+logical(kind=8) :: error_status = .FALSE.
+!$omp parallel do reduction(.or.: error_status)
+do j=1,100
+end do
+!$omp end parallel do
+end subroutine
+! //CHECK: atomicrmw
+
+subroutine atomic_logical_1(n,val)
+logical(kind=1) :: lg = .FALSE.
+integer :: n, val, i
+!$omp parallel
+do i=1,n
+!$omp atomic
+lg = lg .or. val==n
+end do
+!$omp end parallel
+end subroutine
+! //CHECK: atomicrmw
+
+subroutine atomic_logical_8(n,val)
+logical(kind=8) :: lg = .FALSE.
+integer :: n, val, i
+!$omp parallel
+do i=1,n
+!$omp atomic
+lg = lg .or. val==n
+end do
+!$omp end parallel
+end subroutine
+! //CHECK: atomicrmw
+
+subroutine atomic_integer_1(n,val)
+integer(kind=1) :: lg, val
+integer :: n, i
+!$omp parallel
+do i=1,n
+!$omp atomic
+lg = lg + val
+end do
+!$omp end parallel
+end subroutine
+! //CHECK: atomicrmw

--- a/tools/flang2/flang2exe/iliutil.cpp
+++ b/tools/flang2/flang2exe/iliutil.cpp
@@ -12349,6 +12349,7 @@ mem_size(TY_KIND ty)
   case TY_PTR:
     msz = MSZ_PTR;
     break;
+  case TY_LOG8:
   case TY_INT8:
     msz = MSZ_I8;
     break;
@@ -12373,6 +12374,10 @@ mem_size(TY_KIND ty)
     break;
   case TY_DCMPLX:
     msz = MSZ_F16;
+    break;
+  case TY_BLOG:
+  case TY_BINT:
+    msz = MSZ_SBYTE;
     break;
   case TY_LOG:
     msz = MSZ_WORD;


### PR DESCRIPTION
Using non-standard types (logical or int with kind=1 and logical
with kind=8) in code with atomic instructions were leading to ICEs due
to a switch statement not handling these types. Adding these types to
the switch statement fixes the issue.