### PR TITLE
[DebugInfo] Array debugging support with upgraded DISubrange

### DIFF
--- a/test/debug_info/allocatable_arr_param.f90
+++ b/test/debug_info/allocatable_arr_param.f90
@@ -1,0 +1,41 @@
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK-LABEL: define void @callee_
+!CHECK: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[DLOC:![0-9]+]]
+!CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[ALLOCATED:![0-9]+]]
+!CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
+!CHECK: [[ARRAY]] = !DILocalVariable(name: "array", arg: 1,
+!CHECK-SAME: type: [[TYPE:![0-9]+]]
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type,
+!CHECK-SAME: dataLocation: [[DLOC]], allocated: [[ALLOCATED]]
+
+subroutine callee (array)
+  integer, allocatable :: array(:, :)
+  integer :: local = 4
+
+  do i=LBOUND (array, 2), UBOUND (array, 2), 1
+     do j=LBOUND (array, 1), UBOUND (array, 1), 1
+        write(*, fmt="(i4)", advance="no") array (j, i)
+     end do
+     print *, ""
+  end do
+
+  local = local / 2
+  print *, "local = ", local
+end subroutine callee
+
+program caller
+
+  interface
+     subroutine callee (array)
+       integer, allocatable :: array(:, :)
+     end subroutine callee
+  end interface
+
+  integer, allocatable :: caller_arr(:, :)
+  allocate(caller_arr(10, 10))
+  caller_arr = 99
+  caller_arr(2,2) = 88
+  call callee (caller_arr)
+  print *, ""
+end program caller

--- a/test/debug_info/allocatable_arr_param.f90
+++ b/test/debug_info/allocatable_arr_param.f90
@@ -4,7 +4,8 @@
 !CHECK: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[DLOC:![0-9]+]]
 !CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[ALLOCATED:![0-9]+]]
 !CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
-!CHECK: [[ARRAY]] = !DILocalVariable(name: "array", arg: 1,
+!CHECK: [[ARRAY]] = !DILocalVariable(name: "array",
+!CHECK-SAME: arg: 2,
 !CHECK-SAME: type: [[TYPE:![0-9]+]]
 !CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type,
 !CHECK-SAME: dataLocation: [[DLOC]], allocated: [[ALLOCATED]]

--- a/test/debug_info/allocated.f90
+++ b/test/debug_info/allocated.f90
@@ -1,7 +1,7 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
 !CHECK: !DILocalVariable(name: "arr", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: [[TYPE:![0-9]+]])
-!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}}, allocated: {{![0-9]+}})
 !CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
 !CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 !CHECK: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))

--- a/test/debug_info/allocated.f90
+++ b/test/debug_info/allocated.f90
@@ -1,0 +1,14 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !DILocalVariable(name: "arr", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: [[TYPE:![0-9]+]])
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!CHECK: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+program main
+  integer(kind=4), allocatable :: arr(:, :)
+
+  allocate (arr(10,10))
+  arr(1,1) = 99
+  print *, arr(1,1)
+end program main

--- a/test/debug_info/allocated_nodup.f90
+++ b/test/debug_info/allocated_nodup.f90
@@ -1,0 +1,32 @@
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: distinct !DIGlobalVariable(name: "arr",
+!CHECK-SAME: type: [[TYPE:![0-9]+]]
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: [[DTYPE:![0-9]+]]
+!CHECK: [[DTYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "dtype"
+!CHECK-SAME: elements: [[MEMBERS:![0-9]+]]
+!CHECK: [[MEMBERS]] = !{[[MEM1:![0-9]+]]
+!CHECK: [[MEM1]] = !DIDerivedType(tag: DW_TAG_member, name: "memfunptr",
+!CHECK-SAME: baseType: [[FUNPTRTYPE:![0-9]+]]
+!CHECK: [[FUNPTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[FUNTYPE:![0-9]+]]
+!CHECK: [[FUNTYPE]] = !DISubroutineType(types: [[FUNSIGNATURE:![0-9]+]])
+!CHECK: [[FUNSIGNATURE]] = !{[[DTYPE]]}
+
+module pdt
+  type dtype
+    procedure (func), pointer, nopass :: memfunptr
+    integer, allocatable :: memalcarr(:)
+  end type dtype
+contains
+  function func()
+    class (dtype), allocatable :: func
+  end function func
+end module pdt
+
+program main
+  use pdt
+  type (dtype) arr(3)
+  allocate(arr(1)%memalcarr(10))
+  arr(1)%memalcarr=9
+  print *, arr(1)%memalcarr
+end program main

--- a/test/debug_info/associated.f90
+++ b/test/debug_info/associated.f90
@@ -1,7 +1,7 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
 !CHECK !DILocalVariable(name: "ptr", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}})
-!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}}, associated: {{![0-9]+}})
 !CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
 !CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 !CHECK: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))

--- a/test/debug_info/associated.f90
+++ b/test/debug_info/associated.f90
@@ -1,0 +1,15 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK !DILocalVariable(name: "ptr", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}})
+!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!CHECK: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+program main
+  integer, target :: arr(10, 10)
+  integer, pointer :: ptr(:, :)
+
+  arr(1,1) = 99
+  ptr => arr
+  print *, ptr(1,1)
+end program main

--- a/test/debug_info/assumed_rank.f90
+++ b/test/debug_info/assumed_rank.f90
@@ -4,8 +4,9 @@
 !RUN: %flang -gdwarf-5 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=DWARF5
 
 !DWARF4: call void @llvm.dbg.value(metadata i64* %ararray, metadata [[DLOC:![0-9]+]], metadata !DIExpression())
-!DWARF4: !DILocalVariable(name: "ararray",
-!DWARF4-SAME: type: [[ARTYPE:![0-9]+]]
+!DWARF4: !DILocalVariable(name: "ararray"
+!DWARF4-SAME: arg: 2
+!DWARF4-SAME: type: [[ARTYPE:![0-9]+]])
 !DWARF4: [[ARTYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: !{{[0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[ELEMS:![0-9]+]], dataLocation: [[DLOC:![0-9]+]])
 !DWARF4: [[ELEMS]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]], [[ELEM3:![0-9]+]], [[ELEM4:![0-9]+]], [[ELEM5:![0-9]+]], [[ELEM6:![0-9]+]], [[ELEM7:![0-9]+]]}
 !DWARF4: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
@@ -19,7 +20,8 @@
 
 !DWARF5: call void @llvm.dbg.value(metadata i64* %ararray, metadata [[DLOC:![0-9]+]], metadata !DIExpression())
 !DWARF5: !DILocalVariable(name: "ararray"
-!DWARF5-SAME: type: [[ARTYPE:![0-9]+]]
+!DWARF5-SAME: arg: 2
+!DWARF5-SAME: type: [[ARTYPE:![0-9]+]])
 !DWARF5: [[ARTYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: !{{[0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[ELEMS:![0-9]+]], dataLocation: [[DLOC:![0-9]+]], rank: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 8, DW_OP_deref, DW_OP_constu, 7, DW_OP_and))
 !DWARF5: [[ELEMS]] = !{[[ELEM1:![0-9]+]]}
 !DWARF5: [[ELEM1]] = !DIGenericSubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 80, DW_OP_plus, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 120, DW_OP_plus, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 112, DW_OP_plus, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))

--- a/test/debug_info/assumed_rank.f90
+++ b/test/debug_info/assumed_rank.f90
@@ -1,0 +1,30 @@
+!Check debug info generation for assumed rank arrays with DWARF5 and lower.
+
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=DWARF4
+!RUN: %flang -gdwarf-5 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=DWARF5
+
+!DWARF4: call void @llvm.dbg.value(metadata i64* %ararray, metadata [[DLOC:![0-9]+]], metadata !DIExpression())
+!DWARF4: !DILocalVariable(name: "ararray",
+!DWARF4-SAME: type: [[ARTYPE:![0-9]+]]
+!DWARF4: [[ARTYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: !{{[0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[ELEMS:![0-9]+]], dataLocation: [[DLOC:![0-9]+]])
+!DWARF4: [[ELEMS]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]], [[ELEM3:![0-9]+]], [[ELEM4:![0-9]+]], [[ELEM5:![0-9]+]], [[ELEM6:![0-9]+]], [[ELEM7:![0-9]+]]}
+!DWARF4: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!DWARF4: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!DWARF4: [[ELEM3]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 176, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 216, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 208, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!DWARF4: [[ELEM4]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 224, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 264, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 256, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!DWARF4: [[ELEM5]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 272, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 312, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 304, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!DWARF4: [[ELEM6]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 320, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 360, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 352, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!DWARF4: [[ELEM7]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 368, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 408, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 400, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+
+
+!DWARF5: call void @llvm.dbg.value(metadata i64* %ararray, metadata [[DLOC:![0-9]+]], metadata !DIExpression())
+!DWARF5: !DILocalVariable(name: "ararray"
+!DWARF5-SAME: type: [[ARTYPE:![0-9]+]]
+!DWARF5: [[ARTYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: !{{[0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[ELEMS:![0-9]+]], dataLocation: [[DLOC:![0-9]+]], rank: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 8, DW_OP_deref, DW_OP_constu, 7, DW_OP_and))
+!DWARF5: [[ELEMS]] = !{[[ELEM1:![0-9]+]]}
+!DWARF5: [[ELEM1]] = !DIGenericSubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 80, DW_OP_plus, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 120, DW_OP_plus, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 112, DW_OP_plus, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+
+subroutine sub(ararray)
+  real :: ararray(..)
+  print *, rank(ararray)
+end

--- a/test/debug_info/assumed_shape.f90
+++ b/test/debug_info/assumed_shape.f90
@@ -1,0 +1,17 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: call void @llvm.dbg.declare(metadata i64* %assume, metadata [[ASSUME:![0-9]+]], metadata !DIExpression())
+!CHECK: [[TYPE:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEMS:![0-9]+]])
+!CHECK: [[ELEMS]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]], [[ELEM3:![0-9]+]], [[ELEM4:![0-9]+]]
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: 1, upperBound: 5)
+!CHECK: [[ELEM2]] = !DISubrange(lowerBound: 1, upperBound: [[N1:![0-9]+]])
+!CHECK: [[N1]] = distinct !DILocalVariable
+!CHECK: [[ELEM3]] = !DISubrange(lowerBound: [[N2:![0-9]+]], upperBound: 9)
+!CHECK: [[N2]] = distinct !DILocalVariable
+!CHECK: [[ELEM4]] = !DISubrange(lowerBound: [[N3:![0-9]+]], upperBound: [[N4:![0-9]+]])
+!CHECK: [[N3]] = distinct !DILocalVariable
+!CHECK: [[N4]] = distinct !DILocalVariable
+subroutine sub(assume,n1,n2,n3,n4)
+  integer(kind=4) :: assume(5,n1,n2:9,n3:n4)
+  assume(1,1,1,1) = 7
+end subroutine sub

--- a/test/debug_info/assumed_shape_non_contiguous.f90
+++ b/test/debug_info/assumed_shape_non_contiguous.f90
@@ -3,8 +3,9 @@
 !CHECK: call void @llvm.dbg.value(metadata i64* %array, metadata [[ARRAYDL:![0-9]+]], metadata !DIExpression())
 !CHECK: call void @llvm.dbg.declare(metadata i64* %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
 !CHECK-LABEL: distinct !DICompileUnit(language: DW_LANG_Fortran90,
-!CHECK: [[ARRAY]] = !DILocalVariable(name: "array",
-!CHECK-SAME: type: [[TYPE:![0-9]+]]
+!CHECK: [[ARRAY]] = !DILocalVariable(name: "array"
+!CHECK-SAME: arg: 3
+!CHECK-SAME: type: [[TYPE:![0-9]+]])
 !CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: [[ARRAYDL]])
 !CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
 !CHECK: [[ELEM1]] = !DISubrange(lowerBound: 1, upperBound: {{![0-9]+}}, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))

--- a/test/debug_info/assumed_shape_non_contiguous.f90
+++ b/test/debug_info/assumed_shape_non_contiguous.f90
@@ -1,0 +1,34 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: call void @llvm.dbg.value(metadata i64* %array, metadata [[ARRAYDL:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata i64* %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
+!CHECK-LABEL: distinct !DICompileUnit(language: DW_LANG_Fortran90,
+!CHECK: [[ARRAY]] = !DILocalVariable(name: "array",
+!CHECK-SAME: type: [[TYPE:![0-9]+]]
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: [[ARRAYDL]])
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: 1, upperBound: {{![0-9]+}}, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!CHECK: [[ELEM2]] = !DISubrange(lowerBound: 1, upperBound: {{![0-9]+}}, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+
+subroutine show (message, array)
+  character (len=*) :: message
+  integer :: array(:,:)
+
+  print *, message
+  print *, array
+
+end subroutine show
+
+program test
+
+  interface
+     subroutine show (message, array)
+       character (len=*) :: message
+       integer :: array(:,:)
+     end subroutine show
+  end interface
+
+  integer :: parray(4,4) = reshape((/1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16/),(/4,4/))
+
+  call show ("parray", parray(1:2,1:2))
+end program test

--- a/test/debug_info/assumed_shape_noopt.f90
+++ b/test/debug_info/assumed_shape_noopt.f90
@@ -1,0 +1,32 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | llc -O0 -fast-isel=false -global-isel=false -filetype=obj -o %t
+!RUN: llvm-dwarfdump %t | FileCheck %s
+
+!CHECK-LABEL: DW_TAG_subprogram
+!COM: make sure DLOC's DW_AT_location is available
+!CHECK-LABEL: DW_TAG_subprogram
+  !CHECK: DW_AT_name      ("show")
+    !CHECK:[[DLOC:0x[0-9a-f]+]]: DW_TAG_formal_parameter
+      !CHECK: DW_AT_location
+    !CHECK:[[ARRAY:0x[0-9a-f]+]]: DW_TAG_formal_parameter
+      !CHECK: DW_AT_location
+      !CHECK: DW_AT_type ([[TYPE:0x[0-9a-f]+]]
+    !CHECK: [[TYPE]]: DW_TAG_array_type
+      !CHECK: DW_AT_data_location ([[DLOC]])
+
+subroutine show (array)
+  integer :: array(:,:)
+
+  print *, array
+end subroutine show
+
+program test
+  interface
+     subroutine show (array)
+       integer :: array(:,:)
+     end subroutine show
+  end interface
+
+  integer :: parray(4,4) = reshape((/1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16/),(/4,4/))
+
+  call show (parray(1:2,1:2))
+end program test

--- a/test/debug_info/assumed_size_array.f90
+++ b/test/debug_info/assumed_size_array.f90
@@ -1,0 +1,22 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: call void @llvm.dbg.declare(metadata i64* %array1, metadata [[ARRAY1:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata i64* %array2, metadata [[ARRAY2:![0-9]+]], metadata !DIExpression())
+!CHECK: [[TYPE1:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, align: 32, elements: [[ELEMS1:![0-9]+]])
+!CHECK: [[ELEMS1]] = !{[[ELEM11:![0-9]+]]}
+!CHECK: [[ELEM11]] = !DISubrange(lowerBound: 1)
+!CHECK: [[TYPE2:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, align: 32, elements: [[ELEMS2:![0-9]+]])
+!CHECK: [[ELEMS2]] = !{[[ELEM21:![0-9]+]], [[ELEM22:![0-9]+]]}
+!CHECK: [[ELEM21]] = !DISubrange(lowerBound: 4, upperBound: 9)
+!CHECK: [[ELEM22]] = !DISubrange(lowerBound: 10)
+!CHECK: [[ARRAY1]] = !DILocalVariable(name: "array1"
+!CHECK-SAME: type: [[TYPE1]]
+!CHECK: [[ARRAY2]] = !DILocalVariable(name: "array2"
+!CHECK-SAME: type: [[TYPE2]]
+subroutine sub (array1, array2)
+  integer :: array1 (*)
+  integer :: array2 (4:9, 10:*)
+
+  array1(7:8) = 9
+  array2(5, 10) = 10
+end subroutine

--- a/test/debug_info/cray_ptr_param.f90
+++ b/test/debug_info/cray_ptr_param.f90
@@ -1,0 +1,24 @@
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK-LABEL: define internal void @main_callee
+!CHECK: call void @llvm.dbg.declare(metadata i64* %callee_ptr, metadata [[CALLEE_PTR:![0-9]+]]
+!CHECK: [[CALLEE_PTR]] = !DILocalVariable(name: "callee_ptr", arg: 1
+
+program main
+  pointer (ptr, b)
+  integer :: a(10), b(10)
+  a = (/1,2,3,4,5,6,7,8,9,10/)
+  call callee(ptr)
+  print *, b 
+  print *, a
+  print *, ptr
+contains
+  subroutine callee(callee_ptr)
+    pointer(callee_ptr, callee_pte)
+    integer, allocatable :: callee_pte(:)
+    allocate (callee_pte(10))
+    callee_pte = (/5,4,5,4,5,4,5,4,5,4/)
+    print *,callee_ptr
+    print *,callee_pte
+  end subroutine
+end

--- a/test/debug_info/cray_ptr_param.f90
+++ b/test/debug_info/cray_ptr_param.f90
@@ -2,7 +2,8 @@
 
 !CHECK-LABEL: define internal void @main_callee
 !CHECK: call void @llvm.dbg.declare(metadata i64* %callee_ptr, metadata [[CALLEE_PTR:![0-9]+]]
-!CHECK: [[CALLEE_PTR]] = !DILocalVariable(name: "callee_ptr", arg: 1
+!CHECK: [[CALLEE_PTR]] = !DILocalVariable(name: "callee_ptr"
+!CHECK-SAME: arg: 1
 
 program main
   pointer (ptr, b)

--- a/test/debug_info/dertyp_striding.f90
+++ b/test/debug_info/dertyp_striding.f90
@@ -1,7 +1,7 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
 !CHECK !DILocalVariable(name: "pvar", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}})
-!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 64, align: 64, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 64, align: 64, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}}, associated: {{![0-9]+}})
 !CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]]}
 !CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 program main

--- a/test/debug_info/dertyp_striding.f90
+++ b/test/debug_info/dertyp_striding.f90
@@ -1,0 +1,20 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK !DILocalVariable(name: "pvar", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}})
+!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 64, align: 64, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+program main
+    type dtype
+        integer(kind=8) :: x
+        integer(kind=8) :: y
+        integer(kind=8) :: z
+    end type
+    type(dtype), dimension(10), target :: tvar
+    integer(kind=8), dimension(:), pointer :: pvar => null()
+    tvar(:)%x = 1
+    tvar(:)%y = 2
+    tvar(:)%z = 3
+    pvar => tvar(1:9)%y
+    print *, pvar
+end program

--- a/test/debug_info/module_allocatable_arr.f90
+++ b/test/debug_info/module_allocatable_arr.f90
@@ -1,0 +1,19 @@
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK-LABEL: distinct !DIGlobalVariable(name: "alc_arr"
+!CHECK-SAME: type: [[TYPE:![0-9]+]]
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type,
+!CHECK-SAME: elements: [[ELEMENTS:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref), allocated: !DIExpression(DW_OP_push_object_address, DW_OP_deref)
+!CHECK: [[ELEMENTS]] = !{[[ELEMENT:![0-9]+]]}
+!CHECK: [[ELEMENT]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 96, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 136, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 40, DW_OP_deref, DW_OP_mul))
+
+module mod_allocatable_arr
+  integer, allocatable :: alc_arr(:)
+end module
+
+program main
+  use mod_allocatable_arr
+  allocate (alc_arr(10))
+  alc_arr = 99
+  print *, alc_arr
+end program

--- a/test/debug_info/module_pointer_arr.f90
+++ b/test/debug_info/module_pointer_arr.f90
@@ -1,0 +1,21 @@
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK-LABEL: distinct !DIGlobalVariable(name: "ptr_arr"
+!CHECK-SAME: type: [[TYPE:![0-9]+]]
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type,
+!CHECK-SAME: elements: [[ELEMENTS:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref), associated: !DIExpression(DW_OP_push_object_address, DW_OP_deref)
+!CHECK: [[ELEMENTS]] = !{[[ELEMENT:![0-9]+]]}
+!CHECK: [[ELEMENT]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 96, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 136, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 40, DW_OP_deref, DW_OP_mul))
+
+module mod_pointer_arr
+  integer, pointer :: ptr_arr(:)
+end module
+
+program main
+use mod_pointer_arr
+  integer, target :: tgtarr(20)
+  tgtarr(1:20:2) = 22
+  tgtarr(2:20:2) = 33
+  ptr_arr => tgtarr(1:20:2)
+  print *, ptr_arr
+end program

--- a/test/debug_info/pointer_arr_param.f90
+++ b/test/debug_info/pointer_arr_param.f90
@@ -4,7 +4,8 @@
 !CHECK: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[DLOC:![0-9]+]]
 !CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[ASSOCIATED:![0-9]+]]
 !CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
-!CHECK: [[ARRAY]] = !DILocalVariable(name: "array", arg: 1, 
+!CHECK: [[ARRAY]] = !DILocalVariable(name: "array"
+!CHECK-SAME: arg: 2
 !CHECK-SAME: type: [[TYPE:![0-9]+]]
 !CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type,
 !CHECK-SAME: dataLocation: [[DLOC]], associated: [[ASSOCIATED]]

--- a/test/debug_info/pointer_arr_param.f90
+++ b/test/debug_info/pointer_arr_param.f90
@@ -1,0 +1,44 @@
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK-LABEL: define void @callee_
+!CHECK: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[DLOC:![0-9]+]]
+!CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[ASSOCIATED:![0-9]+]]
+!CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
+!CHECK: [[ARRAY]] = !DILocalVariable(name: "array", arg: 1, 
+!CHECK-SAME: type: [[TYPE:![0-9]+]]
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type,
+!CHECK-SAME: dataLocation: [[DLOC]], associated: [[ASSOCIATED]]
+
+subroutine callee (array)
+  integer, pointer :: array(:, :)
+  integer :: local = 4
+
+  do i=LBOUND (array, 2), UBOUND (array, 2), 1
+     do j=LBOUND (array, 1), UBOUND (array, 1), 1
+        write(*, fmt="(i4)", advance="no") array (j, i)
+     end do
+     print *, ""
+  end do
+
+  local = local / 2
+  print *, "local = ", local
+end subroutine callee
+
+program caller
+
+  interface
+     subroutine callee (array)
+       integer, pointer :: array(:, :)
+     end subroutine callee
+  end interface
+
+  integer, pointer :: caller_arr(:, :)
+  integer, target :: tgt_arr(10,10)
+  tgt_arr = 99
+  tgt_arr(2,2) = 88
+
+  caller_arr => tgt_arr
+  call callee (caller_arr)
+
+  print *, ""
+end program caller

--- a/test/debug_info/pointer_array_openmp.f90
+++ b/test/debug_info/pointer_array_openmp.f90
@@ -1,0 +1,30 @@
+!RUN: %flang -g -fopenmp -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: define internal void @main_sub
+!CHECK: define internal void @__nv_main_sub_
+!CHECK:  call void @llvm.dbg.declare(metadata double** %"res$p
+!CHECK-NEXT:  call void @llvm.dbg.declare(metadata double** %"res$p
+!CHECK-NEXT:  call void @llvm.dbg.declare(metadata [16 x i64]* %"res$sd
+
+program main
+  type :: dtype
+    integer(4) :: fdim
+    real(8), pointer :: fld_ptr(:)
+  end type dtype
+  type(dtype) :: dvar
+  allocate(dvar%fld_ptr(100))
+  call sub(dvar)
+  deallocate(dvar%fld_ptr)
+
+contains
+
+  subroutine sub(arg)
+    type(dtype),intent(inout) :: arg
+    integer:: count               ! indices
+    real(8), pointer :: res(:)
+!$OMP PARALLEL DO PRIVATE (COUNT, RES)
+    do count=1, 100
+      res  => arg%fld_ptr(1:10)
+    end do
+  end subroutine sub
+end program main

--- a/test/debug_info/ptr_arr_member.f90
+++ b/test/debug_info/ptr_arr_member.f90
@@ -1,0 +1,41 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "dtype", file: {{![0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[MEMS:![0-9]+]])
+!CHECK: [[MEMS]] = !{[[MEM1:![0-9]+]], [[MEM2:![0-9]+]], [[MEM3:![0-9]+]]}
+!CHECK: [[MEM1]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr1", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1:![0-9]+]]
+!CHECK: [[TYPE1]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM1:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref))
+!CHECK: [[ELEM1]] = !{[[ELEM11:![0-9]+]], [[ELEM12:![0-9]+]]}
+!CHECK: [[ELEM11]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 96, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 136, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 40, DW_OP_deref, DW_OP_mul))
+!CHECK: [[ELEM12]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 144, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 184, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 176, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 40, DW_OP_deref, DW_OP_mul))
+!CHECK: [[MEM2]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr2", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1]]
+!CHECK: [[MEM3]] = !DIDerivedType(tag: DW_TAG_member, name: "arralc", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1]]
+
+program main
+
+  type dtype
+     integer, pointer :: arrptr1(:,:)
+     integer, pointer :: arrptr2(:,:)
+     integer, allocatable :: arralc(:,:)
+  end type dtype
+  type(dtype) :: dvar1
+  type(dtype), pointer :: dvar2
+
+  allocate (dvar1%arrptr1 (5,5))
+
+  dvar1%arrptr1 (1,1)= 9
+  dvar1%arrptr1 (2,3)= 8
+  print *, dvar1%arrptr1
+
+  allocate (dvar1%arralc (3,2))
+  dvar1%arralc (1,1)= 29
+  dvar1%arralc (3,2)= 28
+  print *, dvar1%arralc
+
+  allocate (dvar2)
+  allocate (dvar2%arrptr2 (3,4))
+  dvar2%arrptr2 (1,1)= 19
+  dvar2%arrptr2 (2,1)= 18
+  dvar2%arrptr2 (2,3)= 17
+  print *, dvar2%arrptr2
+
+end program main

--- a/test/debug_info/ptr_arr_member.f90
+++ b/test/debug_info/ptr_arr_member.f90
@@ -3,12 +3,13 @@
 !CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "dtype", file: {{![0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[MEMS:![0-9]+]])
 !CHECK: [[MEMS]] = !{[[MEM1:![0-9]+]], [[MEM2:![0-9]+]], [[MEM3:![0-9]+]]}
 !CHECK: [[MEM1]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr1", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1:![0-9]+]]
-!CHECK: [[TYPE1]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM1:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref))
+!CHECK: [[TYPE1]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM1:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref), associated: !DIExpression(DW_OP_push_object_address, DW_OP_deref))
 !CHECK: [[ELEM1]] = !{[[ELEM11:![0-9]+]], [[ELEM12:![0-9]+]]}
 !CHECK: [[ELEM11]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 96, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 136, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 40, DW_OP_deref, DW_OP_mul))
 !CHECK: [[ELEM12]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 144, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 184, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 176, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 40, DW_OP_deref, DW_OP_mul))
-!CHECK: [[MEM2]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr2", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1]]
-!CHECK: [[MEM3]] = !DIDerivedType(tag: DW_TAG_member, name: "arralc", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1]]
+!CHECK: [[MEM2]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr2", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE1:![0-9]+]]
+!CHECK: [[MEM3]] = !DIDerivedType(tag: DW_TAG_member, name: "arralc", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE2:![0-9]+]]
+!CHECK: [[TYPE2]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM1:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref), allocated: !DIExpression(DW_OP_push_object_address, DW_OP_deref))
 
 program main
 

--- a/tools/flang1/flang1exe/lowersym.c
+++ b/tools/flang1/flang1exe/lowersym.c
@@ -3703,6 +3703,7 @@ lower_symbol(int sptr)
     if (stype == ST_ARRAY || stype == ST_DESCRIPTOR) {
       putbit("adjustable", ADJARRG(sptr));
       putbit("afterentry", AFTENTG(sptr));
+      putbit("assumedrank", ASSUMRANKG(sptr));
       putbit("assumedshape", ASSUMSHPG(sptr));
       putbit("assumedsize", ASUMSZG(sptr));
       putbit("autoarray",

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -4739,7 +4739,7 @@ insert_llvm_dbg_declare(LL_MDRef mdnode, SPTR sptr, LL_Type *llTy,
     } else {
       LL_DebugInfo *di = cpu_llvm_module->debug_info;
       LL_MDRef md;
-      if (ll_feature_debug_info_ver11(&cpu_llvm_module->ir)) {
+      if (ll_feature_debug_info_ver90(&cpu_llvm_module->ir)) {
         md = lldbg_emit_empty_expression_mdnode(di);
       } else {
         /* Handle the Fortran allocatable array cases. Emit expression
@@ -11104,7 +11104,7 @@ addDebugForLocalVar(SPTR sptr, LL_Type *type)
 {
   if (need_debug_info(sptr)) {
     /* Dummy sptrs are treated as local (see above) */
-    if (ll_feature_debug_info_ver11(&cpu_llvm_module->ir) &&
+    if (ll_feature_debug_info_ver90(&cpu_llvm_module->ir) &&
         ftn_array_need_debug_info(sptr)) {
       SPTR array_sptr = (SPTR)REVMIDLNKG(sptr);
       LL_MDRef array_md =
@@ -12895,7 +12895,8 @@ formalsAddDebug(SPTR sptr, unsigned i, LL_Type *llType, bool mayHide)
       OperandFlag_t flag = (mayHide && CCSYMG(sptr)) ? OPF_HIDDEN : OPF_NONE;
       // For assumed shape and assumed rank array, pass descriptor in place of
       // base address.
-      if ((ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr))
+      if (ll_feature_debug_info_ver90(&cpu_llvm_module->ir) &&
+          (ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr))
         sptr = SDSCG(sptr);
       insert_llvm_dbg_declare(param_md, sptr, llTy, exprMDOp, flag);
     }
@@ -12929,7 +12930,7 @@ process_formal_arguments(LL_ABI_Info *abi)
     bool ftn_byval = false;
 
     assert(arg->sptr, "Unnamed function argument", i, ERR_Fatal);
-    if (!ll_feature_debug_info_ver11(&cpu_llvm_module->ir))
+    if (!ll_feature_debug_info_ver90(&cpu_llvm_module->ir))
       assert(SNAME(arg->sptr) == NULL, "Argument sptr already processed",
              arg->sptr, ERR_Fatal);
     if ((SCG(arg->sptr) != SC_DUMMY) && formalsMidnumNotDummy(arg->sptr)) {

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -12895,6 +12895,10 @@ formalsAddDebug(SPTR sptr, unsigned i, LL_Type *llType, bool mayHide)
       sptr = new_sptr;
     }
     LL_DebugInfo *db = current_module->debug_info;
+    if (ll_feature_debug_info_ver90(&cpu_llvm_module->ir) &&
+        STYPEG(sptr) == ST_ARRAY && CCSYMG(sptr) &&
+        !LL_MDREF_IS_NULL(get_param_mdnode(db, sptr)))
+      return;
     LL_MDRef param_md = lldbg_emit_param_variable(
         db, sptr, BIH_FINDEX(gbl.entbih), i, CCSYMG(sptr));
     if (!LL_MDREF_IS_NULL(param_md)) {
@@ -13962,4 +13966,16 @@ is_vector_x86_mmx(LL_Type *type) {
     return true;
   }
   return false;
+}
+
+int
+get_parnum(SPTR sptr)
+{
+  for (int parnum = 1; parnum <= llvm_info.abi_info->nargs; parnum++) {
+    if (llvm_info.abi_info->arg[parnum].sptr == sptr) {
+      return parnum;
+    }
+  }
+
+  return 0;
 }

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -12893,8 +12893,9 @@ formalsAddDebug(SPTR sptr, unsigned i, LL_Type *llType, bool mayHide)
                               ? NULL
                               : cons_expression_metadata_operand(llTy);
       OperandFlag_t flag = (mayHide && CCSYMG(sptr)) ? OPF_HIDDEN : OPF_NONE;
-      // For the assumed shape array, pass descriptor in place of base address.
-      if (ASSUMSHPG(sptr) && SDSCG(sptr))
+      // For assumed shape and assumed rank array, pass descriptor in place of
+      // base address.
+      if ((ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr))
         sptr = SDSCG(sptr);
       insert_llvm_dbg_declare(param_md, sptr, llTy, exprMDOp, flag);
     }
@@ -12928,10 +12929,9 @@ process_formal_arguments(LL_ABI_Info *abi)
     bool ftn_byval = false;
 
     assert(arg->sptr, "Unnamed function argument", i, ERR_Fatal);
-#if 0
-    assert(SNAME(arg->sptr) == NULL, "Argument sptr already processed",
-           arg->sptr, ERR_Fatal);
-#endif
+    if (!ll_feature_debug_info_ver11(&cpu_llvm_module->ir))
+      assert(SNAME(arg->sptr) == NULL, "Argument sptr already processed",
+             arg->sptr, ERR_Fatal);
     if ((SCG(arg->sptr) != SC_DUMMY) && formalsMidnumNotDummy(arg->sptr)) {
       process_sptr(arg->sptr);
       continue;

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -117,7 +117,6 @@ static char *fn_sig_ptr = NULL;
 static void insert_entry_label(int);
 static void insert_jump_entry_instr(int);
 static void store_return_value_for_entry(OPERAND *, int);
-static void insert_llvm_dbg_value(OPERAND *, LL_MDRef, SPTR, LL_Type *);
 
 static int openacc_prefix_sptr = 0;
 static unsigned addressElementSize;
@@ -5382,9 +5381,8 @@ gen_gep_index(OPERAND *base_op, LL_Type *llt, int index)
   return gen_gep_op(0, base_op, llt, make_constval32_op(index));
 }
 
-static void
-insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode,
-                      SPTR sptr, LL_Type *type)
+void
+insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode, SPTR sptr, LL_Type *type)
 {
   static bool defined = false;
   OPERAND *callOp;
@@ -12895,6 +12893,9 @@ formalsAddDebug(SPTR sptr, unsigned i, LL_Type *llType, bool mayHide)
                               ? NULL
                               : cons_expression_metadata_operand(llTy);
       OperandFlag_t flag = (mayHide && CCSYMG(sptr)) ? OPF_HIDDEN : OPF_NONE;
+      // For the assumed shape array, pass descriptor in place of base address.
+      if (ASSUMSHPG(sptr) && SDSCG(sptr))
+        sptr = SDSCG(sptr);
       insert_llvm_dbg_declare(param_md, sptr, llTy, exprMDOp, flag);
     }
   }
@@ -12927,8 +12928,10 @@ process_formal_arguments(LL_ABI_Info *abi)
     bool ftn_byval = false;
 
     assert(arg->sptr, "Unnamed function argument", i, ERR_Fatal);
+#if 0
     assert(SNAME(arg->sptr) == NULL, "Argument sptr already processed",
            arg->sptr, ERR_Fatal);
+#endif
     if ((SCG(arg->sptr) != SC_DUMMY) && formalsMidnumNotDummy(arg->sptr)) {
       process_sptr(arg->sptr);
       continue;

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -296,4 +296,5 @@ void insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode, SPTR sptr,
                            LL_Type *type);
 
 
+int get_parnum(SPTR sptr);
 #endif

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -286,5 +286,14 @@ bool ftn_array_need_debug_info(SPTR sptr);
 void insert_llvm_dbg_declare(LL_MDRef mdnode, SPTR sptr, LL_Type *llTy,
                              OPERAND *exprMDOp, OperandFlag_t opflag);
 
+/**
+   \brief Insert <tt>@llvm.dbg.value</tt> call for debug
+   \param OPERAND operand
+   \param sptr    symbol
+   \param llTy    preferred type of \p sptr or \c NULL
+ */
+void insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode, SPTR sptr,
+                           LL_Type *type);
+
 
 #endif

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -277,4 +277,14 @@ void add_debug_cmnblk_variables(LL_DebugInfo *db, SPTR sptr);
  */
 bool ftn_array_need_debug_info(SPTR sptr);
 
+/**
+   \brief Insert <tt>@llvm.dbg.declare</tt> call for debug
+   \param mdnode  metadata node
+   \param sptr    symbol
+   \param llTy    preferred type of \p sptr or \c NULL
+ */
+void insert_llvm_dbg_declare(LL_MDRef mdnode, SPTR sptr, LL_Type *llTy,
+                             OPERAND *exprMDOp, OperandFlag_t opflag);
+
+
 #endif

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -147,6 +147,7 @@ typedef enum LL_IRVersion {
   LL_Version_8_0 = 80,
   LL_Version_9_0 = 90,
   LL_Version_11_0 = 110,
+  LL_Version_12_0 = 120,
   LL_Version_trunk = 1023
 } LL_IRVersion;
 
@@ -396,6 +397,13 @@ ll_feature_debug_info_ver11(const LL_IRFeatures *feature)
 }
 
 /**
+   \brief Version 12.0 debug metadata
+ */
+INLINE static bool ll_feature_debug_info_ver12(const LL_IRFeatures *feature) {
+  return feature->version >= LL_Version_12_0;
+}
+
+/**
    \brief Version 9.0 onwards uses 3 field syntax for constructors
    and destructors
  */
@@ -495,6 +503,7 @@ ll_feature_no_file_in_namespace(const LL_IRFeatures *feature)
 #define ll_feature_debug_info_ver80(f) ((f)->version >= LL_Version_8_0)
 #define ll_feature_debug_info_ver90(f) ((f)->version >= LL_Version_9_0)
 #define ll_feature_debug_info_ver11(f) ((f)->version >= LL_Version_11_0)
+#define ll_feature_debug_info_ver12(f) ((f)->version >= LL_Version_12_0)
 #define ll_feature_three_argument_ctor_and_dtor(f) \
   ((f)->version >= LL_Version_9_0)
 #define ll_feature_use_distinct_metadata(f) ((f)->version >= LL_Version_3_8)

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -146,6 +146,7 @@ typedef enum LL_IRVersion {
   LL_Version_7_0 = 70,
   LL_Version_8_0 = 80,
   LL_Version_9_0 = 90,
+  LL_Version_11_0 = 110,
   LL_Version_trunk = 1023
 } LL_IRVersion;
 
@@ -386,6 +387,15 @@ ll_feature_debug_info_ver90(const LL_IRFeatures *feature)
 }
 
 /**
+   \brief Version 11.0 debug metadata
+ */
+INLINE static bool
+ll_feature_debug_info_ver11(const LL_IRFeatures *feature)
+{
+  return feature->version >= LL_Version_11_0;
+}
+
+/**
    \brief Version 9.0 onwards uses 3 field syntax for constructors
    and destructors
  */
@@ -484,6 +494,7 @@ ll_feature_no_file_in_namespace(const LL_IRFeatures *feature)
 #define ll_feature_debug_info_ver70(f) ((f)->version >= LL_Version_7_0)
 #define ll_feature_debug_info_ver80(f) ((f)->version >= LL_Version_8_0)
 #define ll_feature_debug_info_ver90(f) ((f)->version >= LL_Version_9_0)
+#define ll_feature_debug_info_ver11(f) ((f)->version >= LL_Version_11_0)
 #define ll_feature_three_argument_ctor_and_dtor(f) \
   ((f)->version >= LL_Version_9_0)
 #define ll_feature_use_distinct_metadata(f) ((f)->version >= LL_Version_3_8)

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -689,6 +689,8 @@ typedef enum LL_DW_OP_t {
   LL_DW_OP_constu,
   LL_DW_OP_plus_uconst,
   LL_DW_OP_int,
+  LL_DW_OP_push_object_address,
+  LL_DW_OP_mul,
   LL_DW_OP_MAX /**< must be last value */
 } LL_DW_OP_t;
 

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -670,6 +670,7 @@ typedef enum LL_MDClass {
   LL_DIBasicType_string, /* deprecated */
   LL_DIStringType,
   LL_DICommonBlock,
+  LL_DIGenericSubRange,
   LL_MDClass_MAX /**< must be last value and < 64 (6 bits) */
 } LL_MDClass;
 
@@ -700,6 +701,8 @@ typedef enum LL_DW_OP_t {
   LL_DW_OP_int,
   LL_DW_OP_push_object_address,
   LL_DW_OP_mul,
+  LL_DW_OP_over,
+  LL_DW_OP_and,
   LL_DW_OP_MAX /**< must be last value */
 } LL_DW_OP_t;
 

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1378,7 +1378,7 @@ static const MDTemplate Tmpl_DICompositeType_pre34[] = {
 };
 
 static const MDTemplate Tmpl_DICompositeType[] = {
-  { "DICompositeType", TF, 16 },
+  { "DICompositeType", TF, 18 },
   { "tag",                      DWTagField },
   { "file",                     NodeField },
   { "scope",                    NodeField },
@@ -1394,7 +1394,9 @@ static const MDTemplate Tmpl_DICompositeType[] = {
   { "vtableHolder",             NodeField },
   { "templateParams",           NodeField },
   { "identifier",               StringField },
-  { "dataLocation",             NodeField}
+  { "dataLocation",             NodeField},
+  { "associated",               NodeField},
+  { "allocated",                NodeField}
 };
 
 static const MDTemplate Tmpl_DIFortranArrayType[] = {

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -2002,7 +2002,7 @@ static void
 emitDISubRange(FILE *out, LLVMModuleRef mod, const LL_MDNode *mdnode,
                unsigned mdi)
 {
-  if (ll_feature_debug_info_ver11(&mod->ir)) {
+  if (ll_feature_debug_info_ver90(&mod->ir)) {
     emitTmpl(out, mod, mdnode, mdi, Tmpl_DISubrange);
     return;
   }

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1378,7 +1378,7 @@ static const MDTemplate Tmpl_DICompositeType_pre34[] = {
 };
 
 static const MDTemplate Tmpl_DICompositeType[] = {
-  { "DICompositeType", TF, 18 },
+  { "DICompositeType", TF, 19 },
   { "tag",                      DWTagField },
   { "file",                     NodeField },
   { "scope",                    NodeField },
@@ -1396,7 +1396,8 @@ static const MDTemplate Tmpl_DICompositeType[] = {
   { "identifier",               StringField },
   { "dataLocation",             NodeField},
   { "associated",               NodeField},
-  { "allocated",                NodeField}
+  { "allocated",                NodeField},
+  { "rank",                     NodeField}
 };
 
 static const MDTemplate Tmpl_DIFortranArrayType[] = {
@@ -1423,6 +1424,14 @@ static const MDTemplate Tmpl_DISubrange[] = {
   { "lowerBound",               SignedOrMDField },
   { "upperBound",               SignedOrMDField },
   { "stride",                   SignedOrMDField }
+};
+
+static const MDTemplate Tmpl_DIGenericSubrange[] = {
+  { "DIGenericSubrange", TF, 4 },
+  { "tag",                      DWTagField, FlgHidden },
+  { "lowerBound",               SignedOrMDField },
+  { "upperBound",               SignedOrMDField, FlgMandatory },
+  { "stride",                   SignedOrMDField, FlgMandatory }
 };
 
 static const MDTemplate Tmpl_DISubrange_pre37[] = {
@@ -1809,6 +1818,7 @@ static void emitDIGlobalVariableExpression(FILE *, LLVMModuleRef, MDNodeRef,
                                            unsigned);
 static void emitDIImportedEntity(FILE *, LLVMModuleRef, MDNodeRef, unsigned);
 static void emitDICommonBlock(FILE *, LLVMModuleRef, MDNodeRef, unsigned);
+static void emitDIGenericSubRange(FILE *, LLVMModuleRef, MDNodeRef, unsigned);
 
 typedef void (*MDDispatchMethod)(FILE *out, LLVMModuleRef mod, MDNodeRef mdnode,
                                  unsigned mdi);
@@ -1846,6 +1856,7 @@ static MDDispatch mdDispTable[LL_MDClass_MAX] = {
     {emitDIBasicStringType},          // LL_DIBasicType_string - deprecated
     {emitDIStringType},               // LL_DIStringType
     {emitDICommonBlock},              // LL_DICommonBlock
+    {emitDIGenericSubRange},          // LL_DIGenericSubRange
 };
 
 INLINE static void
@@ -2000,6 +2011,13 @@ emitDISubRange(FILE *out, LLVMModuleRef mod, const LL_MDNode *mdnode,
     return;
   }
   emitTmpl(out, mod, mdnode, mdi, Tmpl_DISubrange_pre11);
+}
+
+static void
+emitDIGenericSubRange(FILE *out, LLVMModuleRef mod, const LL_MDNode *mdnode,
+                      unsigned mdi)
+{
+  emitTmpl(out, mod, mdnode, mdi, Tmpl_DIGenericSubrange);
 }
 
 static void
@@ -2170,6 +2188,10 @@ ll_dw_op_to_name(LL_DW_OP_t op)
     return "DW_OP_push_object_address";
   case LL_DW_OP_mul:
     return "DW_OP_mul";
+  case LL_DW_OP_over:
+    return "DW_OP_over";
+  case LL_DW_OP_and:
+    return "DW_OP_and";
   default:
     break;
   }

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1421,7 +1421,7 @@ static const MDTemplate Tmpl_DISubrange[] = {
   { "DISubrange", TF, 4 },
   { "tag",                      DWTagField, FlgHidden },
   { "lowerBound",               SignedOrMDField },
-  { "upperBound",               SignedOrMDField, FlgMandatory },
+  { "upperBound",               SignedOrMDField },
   { "stride",                   SignedOrMDField }
 };
 

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1378,7 +1378,7 @@ static const MDTemplate Tmpl_DICompositeType_pre34[] = {
 };
 
 static const MDTemplate Tmpl_DICompositeType[] = {
-  { "DICompositeType", TF, 15 },
+  { "DICompositeType", TF, 16 },
   { "tag",                      DWTagField },
   { "file",                     NodeField },
   { "scope",                    NodeField },
@@ -1393,7 +1393,8 @@ static const MDTemplate Tmpl_DICompositeType[] = {
   { "runtimeLang",              DWLangField },
   { "vtableHolder",             NodeField },
   { "templateParams",           NodeField },
-  { "identifier",               StringField }
+  { "identifier",               StringField },
+  { "dataLocation",             NodeField}
 };
 
 static const MDTemplate Tmpl_DIFortranArrayType[] = {
@@ -2163,6 +2164,10 @@ ll_dw_op_to_name(LL_DW_OP_t op)
     return "DW_OP_constu";
   case LL_DW_OP_plus_uconst:
     return "DW_OP_plus_uconst";
+  case LL_DW_OP_push_object_address:
+    return "DW_OP_push_object_address";
+  case LL_DW_OP_mul:
+    return "DW_OP_mul";
   default:
     break;
   }

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -3027,10 +3027,9 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                 SPTR datasptr = MIDNUMG(sptr);
                 if (datasptr == NOSYM)
                   datasptr = SYMLKG(sptr);
-                if (SCG(datasptr) == SC_DUMMY) {
-                  // TODO: we want to generate local variable carrying
-                  // datalocation, but enclosing scope is not yet ready.
-                  // we shall solve it separately.
+                if ((SCG(datasptr) == SC_DUMMY) && !db->cur_subprogram_mdnode) {
+                  // If cur_subprogram_md is not yet ready, we are interested
+                  // only in type. datalocation is about value than type. So
                 } else {
                   LL_Type *dataloctype = LLTYPE(datasptr);
                   /* make_lltype_from_sptr() should have added a pointer to
@@ -3635,10 +3634,17 @@ lldbg_emit_param_variable(LL_DebugInfo *db, SPTR sptr, int findex, int parnum,
     file_mdnode = lldbg_emit_file(db, findex);
   is_reference = ((SCG(sptr) == SC_DUMMY) && HOMEDG(sptr) && !PASSBYVALG(sptr));
   dtype = DTYPEG(sptr) ? DTYPEG(sptr) : DT_ADDR;
-  if (ll_feature_debug_info_ver90(&db->module->ir) &&
-      (ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr)) {
-    type_mdnode = lldbg_emit_type(db, dtype, SDSCG(sptr), findex, is_reference,
-                                  true, false, sptr);
+  if (ll_feature_debug_info_ver90(&db->module->ir)) {
+    if ((ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr)) {
+      type_mdnode = lldbg_emit_type(db, dtype, SDSCG(sptr), findex,
+                                    is_reference, true, false, sptr);
+    } else if (ALLOCATTRG(sptr) || POINTERG(sptr)) {
+      type_mdnode = lldbg_emit_type(db, dtype, sptr, findex, is_reference, true,
+                                    false, MIDNUMG(sptr));
+    } else {
+      type_mdnode =
+          lldbg_emit_type(db, dtype, sptr, findex, is_reference, true, false);
+    }
   } else {
     type_mdnode =
         lldbg_emit_type(db, dtype, sptr, findex, is_reference, true, false);

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -180,12 +180,19 @@ static void lldbg_emit_imported_entity(LL_DebugInfo *db, SPTR entity_sptr,
                                        SPTR func_sptr, IMPORT_TYPE entity_type);
 static LL_MDRef lldbg_create_subrange_mdnode(LL_DebugInfo *db, LL_MDRef lb,
                                              LL_MDRef ub, LL_MDRef st);
+static LL_MDRef lldbg_create_generic_subrange_mdnode(LL_DebugInfo *db,
+                                                     LL_MDRef lb, LL_MDRef ub,
+                                                     LL_MDRef st);
 static LL_MDRef lldbg_create_subrange_via_sdsc(LL_DebugInfo *db, int findex,
                                                SPTR sptr, int rank);
 static void lldbg_get_bounds_for_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
                                       int rank, LL_MDRef *lbnd_expr_mdnode,
                                       LL_MDRef *ubnd_expr_mdnode,
                                       LL_MDRef *stride_expr_mdnode);
+
+static void lldbg_get_bounds_for_assumed_rank_sdsc(
+    LL_DebugInfo *db, SPTR sptr, LL_MDRef *lbnd_expr_mdnode,
+    LL_MDRef *ubnd_expr_mdnode, LL_MDRef *stride_expr_mdnode);
 /* ---------------------------------------------------------------------- */
 
 void
@@ -736,12 +743,14 @@ lldbg_create_ftn_array_type_mdnode(LL_DebugInfo *db, LL_MDRef context, int line,
    \param data_location
    \param associated
    \param allocated
+   \param rank
  */
 static LL_MDRef
 lldbg_create_array_type_mdnode(LL_DebugInfo *db, LL_MDRef context, int line,
                                ISZ_T sz, DBLINT64 alignment, LL_MDRef pts_to,
                                LL_MDRef subscripts, LL_MDRef data_location,
-                               LL_MDRef associated, LL_MDRef allocated)
+                               LL_MDRef associated, LL_MDRef allocated,
+                               LL_MDRef rank)
 {
   DBLINT64 size;
   LLMD_Builder mdb = llmd_init(db->module);
@@ -787,6 +796,10 @@ lldbg_create_array_type_mdnode(LL_DebugInfo *db, LL_MDRef context, int line,
       llmd_add_null(mdb);
     if (!LL_MDREF_IS_NULL(allocated))
       llmd_add_md(mdb, allocated);
+    else
+      llmd_add_null(mdb);
+    if (!LL_MDREF_IS_NULL(rank))
+      llmd_add_md(mdb, rank);
     else
       llmd_add_null(mdb);
   }
@@ -1267,7 +1280,6 @@ lldbg_create_ftn_subrange_via_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
   return llmd_finish(mdb);
 }
 
-/* Create subrange mdnode based on array descriptor */
 static void
 lldbg_get_bounds_for_sdsc(LL_DebugInfo *db, int findex, SPTR sptr, int rank,
                           LL_MDRef *lbnd_expr_mdnode,
@@ -1350,6 +1362,58 @@ lldbg_create_subrange_via_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
                                       stride_expr_mdnode);
 }
 
+static void
+lldbg_get_bounds_for_assumed_rank_sdsc(LL_DebugInfo *db, SPTR sptr,
+                                       LL_MDRef *lbnd_expr_mdnode,
+                                       LL_MDRef *ubnd_expr_mdnode,
+                                       LL_MDRef *stride_expr_mdnode)
+{
+  const int F90_Desc_byte_len = 8 * (DESC_HDR_BYTE_LEN - DESC_HDR_TAG);
+  const int F90_DescDim_size = 8 * DESC_DIM_LEN;    /* sizeof(F90_DescDim)*/
+  const int F90_Desc_dim_offset = 8 * DESC_HDR_LEN; /* offsetof(F90_Desc, dim)*/
+  const int ubound_offset_wrt_lbound =
+      8 * (DESC_DIM_UPPER - DESC_DIM_LOWER); /* offsetof(F90_DescDim, ubound)*/
+  const int lstride_offset_wrt_lbound =
+      8 * (DESC_DIM_LMULT - DESC_DIM_LOWER); /* offsetof(F90_DescDim, lstride)*/
+
+  const int target_size_offset = F90_Desc_byte_len;
+  const int lower_offset = F90_Desc_dim_offset;
+  const int upper_offset = lower_offset + ubound_offset_wrt_lbound;
+  const int stride_offset = lower_offset + lstride_offset_wrt_lbound;
+
+  const unsigned v0 =
+      lldbg_encode_expression_arg(LL_DW_OP_int, F90_DescDim_size);
+  const unsigned v1 = lldbg_encode_expression_arg(LL_DW_OP_int, lower_offset);
+  const unsigned v2 = lldbg_encode_expression_arg(LL_DW_OP_int, upper_offset);
+  const unsigned v3 = lldbg_encode_expression_arg(LL_DW_OP_int, stride_offset);
+  const unsigned v4 =
+      lldbg_encode_expression_arg(LL_DW_OP_int, target_size_offset);
+
+  const unsigned add = lldbg_encode_expression_arg(LL_DW_OP_plus_uconst, 0);
+  const unsigned mul = lldbg_encode_expression_arg(LL_DW_OP_mul, 0);
+  const unsigned plus = lldbg_encode_expression_arg(LL_DW_OP_plus, 0);
+  const unsigned constu = lldbg_encode_expression_arg(LL_DW_OP_constu, 0);
+  const unsigned deref = lldbg_encode_expression_arg(LL_DW_OP_deref, 0);
+  const unsigned pushobj =
+      lldbg_encode_expression_arg(LL_DW_OP_push_object_address, 0);
+  const unsigned over = lldbg_encode_expression_arg(LL_DW_OP_over, 0);
+
+  if (lbnd_expr_mdnode)
+    *lbnd_expr_mdnode = lldbg_emit_expression_mdnode(
+        db, 9, pushobj, over, constu, v0, mul, add, v1, plus, deref);
+  if (ubnd_expr_mdnode)
+    *ubnd_expr_mdnode = lldbg_emit_expression_mdnode(
+        db, 9, pushobj, over, constu, v0, mul, add, v2, plus, deref);
+  if (stride_expr_mdnode) {
+    if (zsize_of(DTYPEG(sptr)) > 0)
+      *stride_expr_mdnode = lldbg_emit_expression_mdnode(
+          db, 14, pushobj, over, constu, v0, mul, add, v3, plus, deref, pushobj,
+          add, v4, deref, mul);
+    else
+      *stride_expr_mdnode = ll_get_md_null();
+  }
+}
+
 static LL_MDRef
 lldbg_create_subrange_mdnode_pre11(LL_DebugInfo *db, ISZ_T lb, ISZ_T ub)
 {
@@ -1387,6 +1451,27 @@ lldbg_create_subrange_mdnode(LL_DebugInfo *db, LL_MDRef lb, LL_MDRef ub,
   LLMD_Builder mdb = llmd_init(db->module);
 
   llmd_set_class(mdb, LL_DISubRange);
+  llmd_add_i32(mdb, make_dwtag(db, DW_TAG_subrange_type));
+  llmd_add_md(mdb, lb);
+  if (ub != ll_get_md_null())
+    llmd_add_md(mdb, ub);
+  else
+    llmd_add_null(mdb);
+  if (st != ll_get_md_null())
+    llmd_add_md(mdb, st);
+  else
+    llmd_add_null(mdb);
+
+  return llmd_finish(mdb);
+}
+
+static LL_MDRef
+lldbg_create_generic_subrange_mdnode(LL_DebugInfo *db, LL_MDRef lb, LL_MDRef ub,
+                                     LL_MDRef st)
+{
+  LLMD_Builder mdb = llmd_init(db->module);
+
+  llmd_set_class(mdb, LL_DIGenericSubRange);
   llmd_add_i32(mdb, make_dwtag(db, DW_TAG_subrange_type));
   llmd_add_md(mdb, lb);
   if (ub != ll_get_md_null())
@@ -2882,6 +2967,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         LL_MDRef is_live = ll_get_md_null();
         LL_MDRef associated = ll_get_md_null();
         LL_MDRef allocated = ll_get_md_null();
+        LL_MDRef rank = ll_get_md_null();
         ADSC *ad;
         int i, numdim;
         elem_dtype = DTySeqTyElement(dtype);
@@ -2892,6 +2978,12 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         align[1] = (alignment(dtype) + 1) * 8;
         ad = AD_DPTR(dtype);
         numdim = AD_NUMDIM(ad);
+        if ((!ll_feature_debug_info_ver12(&db->module->ir) ||
+             db->module->ir.dwarf_version < LL_DWARF_Version_5) &&
+            data_sptr && ASSUMRANKG(data_sptr)) {
+          // Set dimension of array to maximum for DWARF version lower than5
+          numdim = 7;
+        }
         if (numdim >= 1 && numdim <= 7) {
           // Generate dataLocation field DW_TAG_array_type for assumed shape
           // arrays, pointers and allocatables. For pointers and allocatables
@@ -2978,73 +3070,113 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
               }
             }
           }
+          // For DWARF version 5 and greater make use of DW_OP_rank and
+          // DW_TAG_generic_subrange for assumed rank array.
+          if (ll_feature_debug_info_ver12(&db->module->ir) &&
+              db->module->ir.dwarf_version >= LL_DWARF_Version_5 && data_sptr &&
+              ASSUMRANKG(data_sptr)) {
+            LL_MDRef lbnd_expr_mdnode, ubnd_expr_mdnode, stride_expr_mdnode;
 
-          for (i = 0; i < numdim; ++i) {
-            SPTR lower_bnd = AD_LWBD(ad, i);
-            SPTR upper_bnd = AD_UPBD(ad, i);
-            if (ll_feature_debug_info_ver11(&db->module->ir)) {
-              LL_MDRef lbv = ll_get_md_null();
-              LL_MDRef ubv = ll_get_md_null();
-              LL_MDRef st = ll_get_md_null();
-              if (ALLOCATTRG(sptr) || POINTERG(sptr)) {
-                /* Create subrange mdnode based on array descriptor */
-                subscript_mdnode =
-                    lldbg_create_subrange_via_sdsc(db, findex, sptr, i);
-              } else if ((SCG(sptr) == SC_DUMMY) && data_sptr &&
-                         db->cur_subprogram_mdnode) {
-                // assumed shape array
-                LL_MDRef s_bnd;
-                init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
-                init_subrange_bound(db, &ubv, upper_bnd, 0, findex);
-                lldbg_get_bounds_for_sdsc(db, findex, data_sptr, i, NULL,
-                                          NULL, &s_bnd);
+            const unsigned pushobj =
+                lldbg_encode_expression_arg(LL_DW_OP_push_object_address, 0);
+            const unsigned v1 = lldbg_encode_expression_arg(LL_DW_OP_int, 8);
+            const unsigned v2 =
+                lldbg_encode_expression_arg(LL_DW_OP_int, 7);
+            const unsigned add =
+                lldbg_encode_expression_arg(LL_DW_OP_plus_uconst, 0);
+            const unsigned deref =
+                lldbg_encode_expression_arg(LL_DW_OP_deref, 0);
+            const unsigned constu =
+                lldbg_encode_expression_arg(LL_DW_OP_constu, 0);
+            const unsigned op_and =
+                lldbg_encode_expression_arg(LL_DW_OP_and, 0);
+            // Get rank of assumed rank array from descriptor
+            rank = lldbg_emit_expression_mdnode(db, 7, pushobj, add, v1, deref,
+                                                constu, v2, op_and);
+            // Generate generic subrange
+            lldbg_get_bounds_for_assumed_rank_sdsc(
+                db, data_sptr, &lbnd_expr_mdnode, &ubnd_expr_mdnode,
+                &stride_expr_mdnode);
+            subscript_mdnode = lldbg_create_generic_subrange_mdnode(
+                db, lbnd_expr_mdnode, ubnd_expr_mdnode, stride_expr_mdnode);
+            llmd_add_md(mdb, subscript_mdnode);
+          } else {
 
-                subscript_mdnode =
-                    lldbg_create_subrange_mdnode(db, lbv, ubv, s_bnd);
-              } else {
-                // explicit shape array, assumed size array
-                init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
-                if (!ll_feature_debug_info_ver12(&db->module->ir) ||
-                    (upper_bnd != SPTR_NULL)) // assumed size
+            for (i = 0; i < numdim; ++i) {
+              SPTR lower_bnd = AD_LWBD(ad, i);
+              SPTR upper_bnd = AD_UPBD(ad, i);
+              if (ll_feature_debug_info_ver11(&db->module->ir)) {
+                LL_MDRef lbv = ll_get_md_null();
+                LL_MDRef ubv = ll_get_md_null();
+                LL_MDRef st = ll_get_md_null();
+                if ((ll_feature_debug_info_ver12(&db->module->ir) &&
+                     db->module->ir.dwarf_version < LL_DWARF_Version_5 &&
+                     data_sptr && ASSUMRANKG(data_sptr)) ||
+                    ALLOCATTRG(sptr) || POINTERG(sptr)) {
+                  /* Create subrange mdnode based on array descriptor */
+                  subscript_mdnode = lldbg_create_subrange_via_sdsc(
+                      db, findex,
+                      (data_sptr && ASSUMRANKG(data_sptr)) ? data_sptr : sptr,
+                      i);
+                } else if ((SCG(sptr) == SC_DUMMY) && data_sptr &&
+                           db->cur_subprogram_mdnode) {
+                  // assumed shape array
+                  LL_MDRef s_bnd;
+                  init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
                   init_subrange_bound(db, &ubv, upper_bnd, 0, findex);
+                  lldbg_get_bounds_for_sdsc(db, findex, data_sptr, i, NULL,
+                                            NULL, &s_bnd);
 
-                subscript_mdnode =
-                    lldbg_create_subrange_mdnode(db, lbv, ubv, st);
-              }
-              llmd_add_md(mdb, subscript_mdnode);
-            } else if (ll_feature_has_diextensions(&db->module->ir)) {
-              // use PGI metadata extensions
-              LL_MDRef lbv;
-              LL_MDRef ubv;
-              if (SDSCG(sptr) && MIDNUMG(sptr) &&
-                  !(lower_bnd && STYPEG(lower_bnd) == ST_CONST &&
-                    upper_bnd && STYPEG(upper_bnd) == ST_CONST)) {
-                /* Create subrange mdnode based on array descriptor */
-                subscript_mdnode =
-                    lldbg_create_ftn_subrange_via_sdsc(db, findex, sptr, i);
-              } else {
-                const ISZ_T M = 1ul << ((sizeof(ISZ_T) * 8) - 1);
-                init_subrange_bound_pre11(db, &lb, &lbv, lower_bnd, 1, findex);
-                init_subrange_bound_pre11(db, &ub, &ubv, upper_bnd, M, findex);
-                subscript_mdnode =
-                    lldbg_create_ftn_subrange_mdnode(db, lb, lbv, ub, ubv);
-              }
-              llmd_add_md(mdb, subscript_mdnode);
-            } else {
-              // cons the old debug metadata
-              if (lower_bnd && STYPEG(lower_bnd) == ST_CONST && upper_bnd &&
-                  STYPEG(upper_bnd) == ST_CONST) {
-                lb = ad_val_of(lower_bnd); /* or get_isz_cval() */
-                if (upper_bnd)
-                  ub = ad_val_of(upper_bnd); /* or get_isz_cval() */
-                else
-                  ub = 0; /* error or zero-size */
-                subscript_mdnode =
-                    lldbg_create_subrange_mdnode_pre11(db, lb, ub);
+                  subscript_mdnode =
+                      lldbg_create_subrange_mdnode(db, lbv, ubv, s_bnd);
+                } else {
+                  // explicit shape array, assumed size array
+                  init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
+                  if (!ll_feature_debug_info_ver12(&db->module->ir) ||
+                      (upper_bnd != SPTR_NULL)) // assumed size
+                    init_subrange_bound(db, &ubv, upper_bnd, 0, findex);
+
+                  subscript_mdnode =
+                      lldbg_create_subrange_mdnode(db, lbv, ubv, st);
+                }
+                llmd_add_md(mdb, subscript_mdnode);
+              } else if (ll_feature_has_diextensions(&db->module->ir)) {
+                // use PGI metadata extensions
+                LL_MDRef lbv;
+                LL_MDRef ubv;
+                if (SDSCG(sptr) && MIDNUMG(sptr) &&
+                    !(lower_bnd && STYPEG(lower_bnd) == ST_CONST && upper_bnd &&
+                      STYPEG(upper_bnd) == ST_CONST)) {
+                  /* Create subrange mdnode based on array descriptor */
+                  subscript_mdnode =
+                      lldbg_create_ftn_subrange_via_sdsc(db, findex, sptr, i);
+                } else {
+                  const ISZ_T M = 1ul << ((sizeof(ISZ_T) * 8) - 1);
+                  init_subrange_bound_pre11(db, &lb, &lbv, lower_bnd, 1,
+                                            findex);
+                  init_subrange_bound_pre11(db, &ub, &ubv, upper_bnd, M,
+                                            findex);
+                  subscript_mdnode =
+                      lldbg_create_ftn_subrange_mdnode(db, lb, lbv, ub, ubv);
+                }
                 llmd_add_md(mdb, subscript_mdnode);
               } else {
-                subscript_mdnode = lldbg_create_subrange_mdnode_pre11(db, 1, 1);
-                llmd_add_md(mdb, subscript_mdnode);
+                // cons the old debug metadata
+                if (lower_bnd && STYPEG(lower_bnd) == ST_CONST && upper_bnd &&
+                    STYPEG(upper_bnd) == ST_CONST) {
+                  lb = ad_val_of(lower_bnd); /* or get_isz_cval() */
+                  if (upper_bnd)
+                    ub = ad_val_of(upper_bnd); /* or get_isz_cval() */
+                  else
+                    ub = 0; /* error or zero-size */
+                  subscript_mdnode =
+                      lldbg_create_subrange_mdnode_pre11(db, lb, ub);
+                  llmd_add_md(mdb, subscript_mdnode);
+                } else {
+                  subscript_mdnode =
+                      lldbg_create_subrange_mdnode_pre11(db, 1, 1);
+                  llmd_add_md(mdb, subscript_mdnode);
+                }
               }
             }
           }
@@ -3056,14 +3188,14 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         if (ll_feature_debug_info_ver11(&db->module->ir)) {
           type_mdnode = lldbg_create_array_type_mdnode(
               db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode,
-              dataloc, associated, allocated);
+              dataloc, associated, allocated, rank);
         } else if (ll_feature_has_diextensions(&db->module->ir)) {
           type_mdnode = lldbg_create_ftn_array_type_mdnode(
               db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode);
         } else
           type_mdnode = lldbg_create_array_type_mdnode(
               db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode,
-              dataloc, associated, allocated);
+              dataloc, associated, allocated, rank);
         dtype_array_check_set(db, dtype, type_mdnode);
         break;
       }
@@ -3400,8 +3532,12 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
     file_mdnode = get_filedesc_mdnode(db, findex);
   else
     file_mdnode = lldbg_emit_file(db, findex);
-  type_mdnode =
-      lldbg_emit_type(db, DTYPEG(sptr), sptr, findex, false, false, false);
+  if ((ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr))
+    type_mdnode =
+        lldbg_emit_type(db, __POINT_T, sptr, findex, false, false, false);
+  else
+    type_mdnode =
+        lldbg_emit_type(db, DTYPEG(sptr), sptr, findex, false, false, false);
 #ifdef THISG
   if (ENCLFUNCG(sptr) && THISG(ENCLFUNCG(sptr)) == sptr) {
     symname = "this";
@@ -3497,7 +3633,7 @@ lldbg_emit_param_variable(LL_DebugInfo *db, SPTR sptr, int findex, int parnum,
     file_mdnode = lldbg_emit_file(db, findex);
   is_reference = ((SCG(sptr) == SC_DUMMY) && HOMEDG(sptr) && !PASSBYVALG(sptr));
   dtype = DTYPEG(sptr) ? DTYPEG(sptr) : DT_ADDR;
-  if (ASSUMSHPG(sptr) && SDSCG(sptr)) {
+  if ((ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr)) {
     type_mdnode = lldbg_emit_type(db, dtype, SDSCG(sptr), findex, is_reference,
                                   true, false, sptr);
   } else {
@@ -3744,7 +3880,7 @@ lldbg_create_cmblk_gv_mdnode(LL_DebugInfo *db, LL_MDRef cmnblk_mdnode,
   subscripts_mdnode = llmd_finish(mdb);
   type_mdnode = lldbg_create_array_type_mdnode(
       db, ll_get_md_null(), 0, sz, align, elem_type_mdnode, subscripts_mdnode,
-      ll_get_md_null(), ll_get_md_null(), ll_get_md_null());
+      ll_get_md_null(), ll_get_md_null(), ll_get_md_null(), ll_get_md_null());
   display_name = SYMNAME(sptr);
   mdref = lldbg_create_global_variable_mdnode(
       db, cmnblk_mdnode, display_name, SYMNAME(sptr), "", ll_get_md_null(),

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -782,7 +782,7 @@ lldbg_create_array_type_mdnode(LL_DebugInfo *db, LL_MDRef context, int line,
     llmd_add_null(mdb);
     llmd_add_null(mdb);
   }
-  if (ll_feature_debug_info_ver11(&db->module->ir)) {
+  if (ll_feature_debug_info_ver90(&db->module->ir)) {
     if (!LL_MDREF_IS_NULL(data_location)) {
       llmd_add_null(mdb);
       llmd_add_md(mdb, data_location);
@@ -937,12 +937,12 @@ lldbg_create_aggregate_members_type(LL_DebugInfo *db, SPTR first, int findex,
        */
       base_sptr = element;
       if (ALLOCATTRG(element) && SDSCG(element)) {
-        if (!ll_feature_debug_info_ver11(&db->module->ir) && db->gbl_var_sptr) {
+        if (!ll_feature_debug_info_ver90(&db->module->ir) && db->gbl_var_sptr) {
           contains_allocatable = true;
           db->need_dup_composite_type |= true;
         }
       } else {
-        if (!ll_feature_debug_info_ver11(&db->module->ir)) {
+        if (!ll_feature_debug_info_ver90(&db->module->ir)) {
           element = SYMLKG(element);
           assert(element > NOSYM,
                  "lldbg_create_aggregate_members_type: element not exists",
@@ -971,7 +971,7 @@ lldbg_create_aggregate_members_type(LL_DebugInfo *db, SPTR first, int findex,
       member = base_sptr;
       is_desc_member = false;
     }
-    if (!ll_feature_debug_info_ver11(&db->module->ir) && contains_allocatable) {
+    if (!ll_feature_debug_info_ver90(&db->module->ir) && contains_allocatable) {
       db->need_dup_composite_type |= true;
     }
     if (base_sptr && SDSCG(element)) {
@@ -2920,7 +2920,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         /* Fortran arrays with SDSC and MIDNUM attributes have the type of either
          * Pointer to FortranArrayType or FortranArrayType.
          */
-        if (!ll_feature_debug_info_ver11(&cpu_llvm_module->ir)) {
+        if (!ll_feature_debug_info_ver90(&cpu_llvm_module->ir)) {
           if (ftn_array_need_debug_info(sptr)) {
             SPTR array_sptr = (SPTR)REVMIDLNKG(sptr);
             type_mdnode = lldbg_emit_type(db, DTYPEG(array_sptr), array_sptr,
@@ -2978,7 +2978,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         align[1] = (alignment(dtype) + 1) * 8;
         ad = AD_DPTR(dtype);
         numdim = AD_NUMDIM(ad);
-        if ((!ll_feature_debug_info_ver12(&db->module->ir) ||
+        if ((!ll_feature_debug_info_ver90(&db->module->ir) ||
              db->module->ir.dwarf_version < LL_DWARF_Version_5) &&
             data_sptr && ASSUMRANKG(data_sptr)) {
           // Set dimension of array to maximum for DWARF version lower than5
@@ -2988,7 +2988,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
           // Generate dataLocation field DW_TAG_array_type for assumed shape
           // arrays, pointers and allocatables. For pointers and allocatables
           // generate allocated / associated.
-          if (ll_feature_debug_info_ver11(&db->module->ir)) {
+          if (ll_feature_debug_info_ver90(&db->module->ir)) {
             if ((SCG(sptr) == SC_DUMMY) && data_sptr &&
                 db->cur_subprogram_mdnode) {
               // Assumed shape array
@@ -3016,7 +3016,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                 const unsigned pushobj = lldbg_encode_expression_arg(
                     LL_DW_OP_push_object_address, 0);
                 dataloc = lldbg_emit_expression_mdnode(db, 2, pushobj, deref);
-                if (ll_feature_debug_info_ver12(&db->module->ir)) {
+                if (ll_feature_debug_info_ver90(&db->module->ir)) {
                   is_live = lldbg_emit_expression_mdnode(db, 2, pushobj, deref);
                   if (ALLOCATTRG(sptr))
                     allocated = is_live;
@@ -3043,7 +3043,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                       lldbg_emit_local_variable(db, datasptr, findex, true);
                   insert_llvm_dbg_declare(dataloc, datasptr, dataloctype, NULL,
                                           OPF_NONE);
-                  if (ll_feature_debug_info_ver12(&db->module->ir)) {
+                  if (ll_feature_debug_info_ver90(&db->module->ir)) {
                     LL_MDRef file_mdnode;
                     if (ll_feature_debug_info_need_file_descriptions(
                             &db->module->ir))
@@ -3072,7 +3072,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
           }
           // For DWARF version 5 and greater make use of DW_OP_rank and
           // DW_TAG_generic_subrange for assumed rank array.
-          if (ll_feature_debug_info_ver12(&db->module->ir) &&
+          if (ll_feature_debug_info_ver90(&db->module->ir) &&
               db->module->ir.dwarf_version >= LL_DWARF_Version_5 && data_sptr &&
               ASSUMRANKG(data_sptr)) {
             LL_MDRef lbnd_expr_mdnode, ubnd_expr_mdnode, stride_expr_mdnode;
@@ -3105,11 +3105,11 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
             for (i = 0; i < numdim; ++i) {
               SPTR lower_bnd = AD_LWBD(ad, i);
               SPTR upper_bnd = AD_UPBD(ad, i);
-              if (ll_feature_debug_info_ver11(&db->module->ir)) {
+              if (ll_feature_debug_info_ver90(&db->module->ir)) {
                 LL_MDRef lbv = ll_get_md_null();
                 LL_MDRef ubv = ll_get_md_null();
                 LL_MDRef st = ll_get_md_null();
-                if ((ll_feature_debug_info_ver12(&db->module->ir) &&
+                if ((ll_feature_debug_info_ver90(&db->module->ir) &&
                      db->module->ir.dwarf_version < LL_DWARF_Version_5 &&
                      data_sptr && ASSUMRANKG(data_sptr)) ||
                     ALLOCATTRG(sptr) || POINTERG(sptr)) {
@@ -3132,7 +3132,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                 } else {
                   // explicit shape array, assumed size array
                   init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
-                  if (!ll_feature_debug_info_ver12(&db->module->ir) ||
+                  if (!ll_feature_debug_info_ver90(&db->module->ir) ||
                       (upper_bnd != SPTR_NULL)) // assumed size
                     init_subrange_bound(db, &ubv, upper_bnd, 0, findex);
 
@@ -3185,7 +3185,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
             lldbg_emit_type(db, elem_dtype, sptr, findex, false, false, false);
         cu_mdnode = ll_get_md_null();
         subscripts_mdnode = llmd_finish(mdb);
-        if (ll_feature_debug_info_ver11(&db->module->ir)) {
+        if (ll_feature_debug_info_ver90(&db->module->ir)) {
           type_mdnode = lldbg_create_array_type_mdnode(
               db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode,
               dataloc, associated, allocated, rank);
@@ -3231,7 +3231,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         /* TODO: Check that vector datatype is what's expected by LLVM */
         lb = 0;
         ub = DTyVecLength(dtype) - 1;
-        if (ll_feature_debug_info_ver11(&db->module->ir))
+        if (ll_feature_debug_info_ver90(&db->module->ir))
           subscript_mdnode = lldbg_create_subrange_mdnode(
               db, ll_get_md_i64(db->module, lb), ll_get_md_i64(db->module, ub),
               ll_get_md_null());
@@ -3336,7 +3336,7 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
     fwd = ll_get_md_null();
   }
   flags = CCSYMG(sptr) ? DIFLAG_ARTIFICIAL : 0;
-  if (!ll_feature_debug_info_ver11(&db->module->ir)) {
+  if (!ll_feature_debug_info_ver90(&db->module->ir)) {
     if (ftn_array_need_debug_info(sptr)) {
       SPTR array_sptr = (SPTR)REVMIDLNKG(sptr);
       /* Overwrite the display_name and flags to represent the user defined
@@ -3351,7 +3351,7 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
       type_mdnode, is_local, DEFDG(sptr) || (sc != SC_EXTERN), value, -1, flags,
       off, sptr, fwd);
 
-  if (!ll_feature_debug_info_ver11(&db->module->ir)) {
+  if (!ll_feature_debug_info_ver90(&db->module->ir)) {
     if (!LL_MDREF_IS_NULL(db->gbl_obj_mdnode)) {
       if (LL_MDREF_IS_NULL(db->gbl_obj_exp_mdnode)) {
         /* Create a dummy global var expression mdnode to be associated to
@@ -3532,7 +3532,8 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
     file_mdnode = get_filedesc_mdnode(db, findex);
   else
     file_mdnode = lldbg_emit_file(db, findex);
-  if ((ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr))
+  if (ll_feature_debug_info_ver90(&db->module->ir) &&
+      (ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr))
     type_mdnode =
         lldbg_emit_type(db, __POINT_T, sptr, findex, false, false, false);
   else
@@ -3558,7 +3559,8 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
 
     // This is base address of Assumed shape array, need to be used as
     // dataLocation field of DW_TAG_array_type. Make it artificial.
-    if (ASSUMSHPG(sptr) && SDSCG(sptr))
+    if (ll_feature_debug_info_ver90(&db->module->ir) && ASSUMSHPG(sptr) &&
+        SDSCG(sptr))
       flags = DIFLAG_ARTIFICIAL;
 
     BLKINFO *blk_info = get_lexical_block_info(db, sptr, true);
@@ -3570,7 +3572,7 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
     } else {
       fwd = ll_get_md_null();
     }
-    if (ll_feature_debug_info_ver11(&db->module->ir)) {
+    if (ll_feature_debug_info_ver90(&db->module->ir)) {
       if (SDSCG(sptr))
         sptr = SDSCG(sptr);
     } else if (ftn_array_need_debug_info(sptr)) {
@@ -3633,7 +3635,8 @@ lldbg_emit_param_variable(LL_DebugInfo *db, SPTR sptr, int findex, int parnum,
     file_mdnode = lldbg_emit_file(db, findex);
   is_reference = ((SCG(sptr) == SC_DUMMY) && HOMEDG(sptr) && !PASSBYVALG(sptr));
   dtype = DTYPEG(sptr) ? DTYPEG(sptr) : DT_ADDR;
-  if ((ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr)) {
+  if (ll_feature_debug_info_ver90(&db->module->ir) &&
+      (ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr)) {
     type_mdnode = lldbg_emit_type(db, dtype, SDSCG(sptr), findex, is_reference,
                                   true, false, sptr);
   } else {
@@ -3867,7 +3870,7 @@ lldbg_create_cmblk_gv_mdnode(LL_DebugInfo *db, LL_MDRef cmnblk_mdnode,
   ub = dim_ele;
   align[1] = ((alignment(elem_dtype) + 1) * 8);
   align[0] = 0;
-  if (ll_feature_debug_info_ver11(&db->module->ir))
+  if (ll_feature_debug_info_ver90(&db->module->ir))
     subscript_mdnode = lldbg_create_subrange_mdnode(
         db, ll_get_md_i64(db->module, lb), ll_get_md_i64(db->module, ub),
         ll_get_md_null());

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -172,7 +172,8 @@ static LL_MDRef lldbg_create_file_mdnode(LL_DebugInfo *db, char *filename,
 static LL_MDRef lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr,
                                 int findex, bool is_reference,
                                 bool skip_first_dim,
-                                bool skipDataDependentTypes);
+                                bool skipDataDependentTypes,
+                                SPTR data_sptr = SPTR_NULL);
 static LL_MDRef lldbg_fwd_local_variable(LL_DebugInfo *db, int sptr, int findex,
                                          int emit_dummy_as_local);
 static void lldbg_emit_imported_entity(LL_DebugInfo *db, SPTR entity_sptr,
@@ -2733,7 +2734,7 @@ init_subrange_bound(LL_DebugInfo *db, LL_MDRef *bound_sptr, SPTR sptr,
 static LL_MDRef
 lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                 bool is_reference, bool skip_first_dim,
-                bool skipDataDependentTypes)
+                bool skipDataDependentTypes, SPTR data_sptr)
 {
   LL_MDRef cu_mdnode, file_mdnode, type_mdnode;
   LL_MDRef subscripts_mdnode, subscript_mdnode;
@@ -2893,9 +2894,28 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         numdim = AD_NUMDIM(ad);
         if (numdim >= 1 && numdim <= 7) {
           // Generate dataLocation field DW_TAG_array_type for assumed shape
-          // arrays, pointers and allocatables.
+          // arrays, pointers and allocatables. For pointers and allocatables
+          // generate allocated / associated.
           if (ll_feature_debug_info_ver11(&db->module->ir)) {
-            if (ALLOCATTRG(sptr) || POINTERG(sptr)) {
+            if ((SCG(sptr) == SC_DUMMY) && data_sptr &&
+                db->cur_subprogram_mdnode) {
+              // Assumed shape array
+              LL_Type *dataloctype = LLTYPE(data_sptr);
+              /* make_lltype_from_sptr() should have added a pointer to
+               * the type of this local variable. Remove it */
+              if (!dataloctype)
+                dataloctype = make_lltype_from_sptr(data_sptr);
+              if (dataloctype->data_type == LL_PTR)
+                dataloctype = dataloctype->sub_types[0];
+              dataloc = lldbg_emit_local_variable(db, data_sptr, findex, true);
+
+              OPERAND *ld = make_operand();
+              ld->ot_type = OT_MDNODE;
+              ld->val.sptr = data_sptr;
+
+              /* lets generate llvm.dbg.value intrinsic for it.*/
+              insert_llvm_dbg_value(ld, dataloc, data_sptr, dataloctype);
+            } else if (ALLOCATTRG(sptr) || POINTERG(sptr)) {
               // Variables with allocatable/pointer attribute.
               if (SCG(SDSCG(sptr)) == SC_CMBLK ||
                   STYPEG(SDSCG(sptr)) == ST_MEMBER) {
@@ -2970,7 +2990,19 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                 /* Create subrange mdnode based on array descriptor */
                 subscript_mdnode =
                     lldbg_create_subrange_via_sdsc(db, findex, sptr, i);
-              } else { // explicit shape, assumed size, assumed shape array
+              } else if ((SCG(sptr) == SC_DUMMY) && data_sptr &&
+                         db->cur_subprogram_mdnode) {
+                // assumed shape array
+                LL_MDRef s_bnd;
+                init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
+                init_subrange_bound(db, &ubv, upper_bnd, 0, findex);
+                lldbg_get_bounds_for_sdsc(db, findex, data_sptr, i, NULL,
+                                          NULL, &s_bnd);
+
+                subscript_mdnode =
+                    lldbg_create_subrange_mdnode(db, lbv, ubv, s_bnd);
+              } else {
+                // explicit shape array, assumed size array
                 init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
                 if (!ll_feature_debug_info_ver12(&db->module->ir) ||
                     (upper_bnd != SPTR_NULL)) // assumed size
@@ -3387,6 +3419,12 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
            sptr, ERR_Fatal);
   } else {
     int flags = set_dilocalvariable_flags(sptr);
+
+    // This is base address of Assumed shape array, need to be used as
+    // dataLocation field of DW_TAG_array_type. Make it artificial.
+    if (ASSUMSHPG(sptr) && SDSCG(sptr))
+      flags = DIFLAG_ARTIFICIAL;
+
     BLKINFO *blk_info = get_lexical_block_info(db, sptr, true);
     LL_MDRef fwd;
     hash_data_t val;
@@ -3459,8 +3497,13 @@ lldbg_emit_param_variable(LL_DebugInfo *db, SPTR sptr, int findex, int parnum,
     file_mdnode = lldbg_emit_file(db, findex);
   is_reference = ((SCG(sptr) == SC_DUMMY) && HOMEDG(sptr) && !PASSBYVALG(sptr));
   dtype = DTYPEG(sptr) ? DTYPEG(sptr) : DT_ADDR;
-  type_mdnode =
-      lldbg_emit_type(db, dtype, sptr, findex, is_reference, true, false);
+  if (ASSUMSHPG(sptr) && SDSCG(sptr)) {
+    type_mdnode = lldbg_emit_type(db, dtype, SDSCG(sptr), findex, is_reference,
+                                  true, false, sptr);
+  } else {
+    type_mdnode =
+        lldbg_emit_type(db, dtype, sptr, findex, is_reference, true, false);
+  }
   if (unnamed) {
     symname = NULL;
 #ifdef THISG

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -25,6 +25,9 @@
 #include "cgmain.h"
 #include "flang/ADT/hash.h"
 #include "symfun.h"
+#define RTE_C
+#include "rte.h"
+#undef RTE_C
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -174,6 +177,14 @@ static LL_MDRef lldbg_fwd_local_variable(LL_DebugInfo *db, int sptr, int findex,
                                          int emit_dummy_as_local);
 static void lldbg_emit_imported_entity(LL_DebugInfo *db, SPTR entity_sptr,
                                        SPTR func_sptr, IMPORT_TYPE entity_type);
+static LL_MDRef lldbg_create_subrange_mdnode(LL_DebugInfo *db, LL_MDRef lb,
+                                             LL_MDRef ub, LL_MDRef st);
+static LL_MDRef lldbg_create_subrange_via_sdsc(LL_DebugInfo *db, int findex,
+                                               SPTR sptr, int rank);
+static void lldbg_get_bounds_for_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
+                                      int rank, LL_MDRef *lbnd_expr_mdnode,
+                                      LL_MDRef *ubnd_expr_mdnode,
+                                      LL_MDRef *stride_expr_mdnode);
 /* ---------------------------------------------------------------------- */
 
 void
@@ -721,11 +732,12 @@ lldbg_create_ftn_array_type_mdnode(LL_DebugInfo *db, LL_MDRef context, int line,
    \param alignment  alignment of array
    \param pts_to
    \param subscripts
+   \param data_location
  */
 static LL_MDRef
 lldbg_create_array_type_mdnode(LL_DebugInfo *db, LL_MDRef context, int line,
                                ISZ_T sz, DBLINT64 alignment, LL_MDRef pts_to,
-                               LL_MDRef subscripts)
+                               LL_MDRef subscripts, LL_MDRef data_location)
 {
   DBLINT64 size;
   LLMD_Builder mdb = llmd_init(db->module);
@@ -756,6 +768,11 @@ lldbg_create_array_type_mdnode(LL_DebugInfo *db, LL_MDRef context, int line,
   } else {
     llmd_add_null(mdb);
     llmd_add_null(mdb);
+  }
+  if (ll_feature_debug_info_ver11(&db->module->ir) &&
+      !LL_MDREF_IS_NULL(data_location)) {
+    llmd_add_null(mdb);
+    llmd_add_md(mdb, data_location);
   }
 
   return llmd_finish(mdb);
@@ -891,17 +908,19 @@ lldbg_create_aggregate_members_type(LL_DebugInfo *db, SPTR first, int findex,
        */
       base_sptr = element;
       if (ALLOCATTRG(element) && SDSCG(element)) {
-        if (db->gbl_var_sptr) {
+        if (!ll_feature_debug_info_ver11(&db->module->ir) && db->gbl_var_sptr) {
           contains_allocatable = true;
           db->need_dup_composite_type |= true;
         }
       } else {
-        element = SYMLKG(element);
-        assert(element > NOSYM, 
-               "lldbg_create_aggregate_members_type: element not exists",
-               element, ERR_Fatal);
+        if (!ll_feature_debug_info_ver11(&db->module->ir)) {
+          element = SYMLKG(element);
+          assert(element > NOSYM,
+                 "lldbg_create_aggregate_members_type: element not exists",
+                 element, ERR_Fatal);
+          db->need_dup_composite_type = false;
+        }
         is_desc_member = true;
-        db->need_dup_composite_type = false;
       }
     }
     elem_dtype = DTYPEG(element);
@@ -923,7 +942,7 @@ lldbg_create_aggregate_members_type(LL_DebugInfo *db, SPTR first, int findex,
       member = base_sptr;
       is_desc_member = false;
     }
-    if (contains_allocatable) {
+    if (!ll_feature_debug_info_ver11(&db->module->ir) && contains_allocatable) {
       db->need_dup_composite_type |= true;
     }
     if (base_sptr && SDSCG(element)) {
@@ -1232,6 +1251,89 @@ lldbg_create_ftn_subrange_via_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
   return llmd_finish(mdb);
 }
 
+/* Create subrange mdnode based on array descriptor */
+static void
+lldbg_get_bounds_for_sdsc(LL_DebugInfo *db, int findex, SPTR sptr, int rank,
+                          LL_MDRef *lbnd_expr_mdnode,
+                          LL_MDRef *ubnd_expr_mdnode,
+                          LL_MDRef *stride_expr_mdnode)
+{
+
+  /*
+   * Please consider below derived type, which has allocatable array as member.
+   * type dt
+   *  integer :: var1
+   *  integer :: var2
+   *  integer, allocatable :: arr (:,:)
+   * end type dt
+   * Below should be its datalayout,
+   *o0=0      o1       o2                   o3
+   * |--------|--------|--------------------|---------------------|
+   * |<-var1->|<-var2->|<--address of arr-->|<-Descriptor of arr->|
+   *
+   * for allocatable array 'arr' DW_OP_push_object_address produces 'o2' to get
+   * to the descriptor start we need 'o3-o2' which we are calling here
+   * 'descr_offset_wrt_array'.
+   */
+  const int descr_offset_wrt_array =
+      (SCG(SDSCG(sptr)) == SC_CMBLK || STYPEG(SDSCG(sptr)) == ST_MEMBER)
+          ? ADDRESSG(SDSCG(sptr)) - ADDRESSG(sptr)
+          : 0;
+
+  const int F90_Desc_byte_len = 8 * (DESC_HDR_BYTE_LEN - DESC_HDR_TAG);
+  const int F90_DescDim_size = 8 * DESC_DIM_LEN;    /* sizeof(F90_DescDim)*/
+  const int F90_Desc_dim_offset = 8 * DESC_HDR_LEN; /* offsetof(F90_Desc, dim)*/
+  const int ubound_offset_wrt_lbound =
+      8 * (DESC_DIM_UPPER - DESC_DIM_LOWER); /* offsetof(F90_DescDim, ubound)*/
+  const int lstride_offset_wrt_lbound =
+      8 *
+      (DESC_DIM_LMULT - DESC_DIM_LOWER); /* offsetof(F90_DescDim, lstride)*/
+
+  const int target_size_offset = descr_offset_wrt_array + F90_Desc_byte_len;
+  const int lower_offset =
+      descr_offset_wrt_array + F90_Desc_dim_offset + (rank * F90_DescDim_size);
+  const int upper_offset = lower_offset + ubound_offset_wrt_lbound;
+  const int stride_offset = lower_offset + lstride_offset_wrt_lbound;
+
+  const unsigned v1 = lldbg_encode_expression_arg(LL_DW_OP_int, lower_offset);
+  const unsigned v2 = lldbg_encode_expression_arg(LL_DW_OP_int, upper_offset);
+  const unsigned v3 = lldbg_encode_expression_arg(LL_DW_OP_int, stride_offset);
+  const unsigned v4 =
+      lldbg_encode_expression_arg(LL_DW_OP_int, target_size_offset);
+
+  const unsigned add = lldbg_encode_expression_arg(LL_DW_OP_plus_uconst, 0);
+  const unsigned mul = lldbg_encode_expression_arg(LL_DW_OP_mul, 0);
+  const unsigned deref = lldbg_encode_expression_arg(LL_DW_OP_deref, 0);
+  const unsigned pushobj =
+      lldbg_encode_expression_arg(LL_DW_OP_push_object_address, 0);
+
+  if (lbnd_expr_mdnode)
+    *lbnd_expr_mdnode =
+      lldbg_emit_expression_mdnode(db, 4, pushobj, add, v1, deref);
+  if (ubnd_expr_mdnode)
+    *ubnd_expr_mdnode =
+      lldbg_emit_expression_mdnode(db, 4, pushobj, add, v2, deref);
+  if (stride_expr_mdnode) {
+    if (zsize_of(DTYPEG(sptr)) > 0)
+      *stride_expr_mdnode = lldbg_emit_expression_mdnode(
+          db, 9, pushobj, add, v3, deref, pushobj, add, v4, deref, mul);
+    else
+      *stride_expr_mdnode = ll_get_md_null();
+  }
+}
+
+static LL_MDRef
+lldbg_create_subrange_via_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
+                               int rank)
+{
+  LL_MDRef lbnd_expr_mdnode, ubnd_expr_mdnode, stride_expr_mdnode;
+  lldbg_get_bounds_for_sdsc(db, findex, sptr, rank, &lbnd_expr_mdnode,
+                            &ubnd_expr_mdnode, &stride_expr_mdnode);
+
+  return lldbg_create_subrange_mdnode(db, lbnd_expr_mdnode, ubnd_expr_mdnode,
+                                      stride_expr_mdnode);
+}
+
 static LL_MDRef
 lldbg_create_subrange_mdnode_pre11(LL_DebugInfo *db, ISZ_T lb, ISZ_T ub)
 {
@@ -1263,15 +1365,22 @@ lldbg_create_subrange_mdnode_pre11(LL_DebugInfo *db, ISZ_T lb, ISZ_T ub)
 }
 
 static LL_MDRef
-lldbg_create_subrange_mdnode(LL_DebugInfo *db, LL_MDRef lb, LL_MDRef ub)
+lldbg_create_subrange_mdnode(LL_DebugInfo *db, LL_MDRef lb, LL_MDRef ub,
+                             LL_MDRef st)
 {
   LLMD_Builder mdb = llmd_init(db->module);
 
   llmd_set_class(mdb, LL_DISubRange);
   llmd_add_i32(mdb, make_dwtag(db, DW_TAG_subrange_type));
   llmd_add_md(mdb, lb);
-  llmd_add_md(mdb, ub);
-  llmd_add_null(mdb);
+  if (ub != ll_get_md_null())
+    llmd_add_md(mdb, ub);
+  else
+    llmd_add_null(mdb);
+  if (st != ll_get_md_null())
+    llmd_add_md(mdb, st);
+  else
+    llmd_add_null(mdb);
 
   return llmd_finish(mdb);
 }
@@ -2710,20 +2819,22 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         /* Fortran arrays with SDSC and MIDNUM attributes have the type of either
          * Pointer to FortranArrayType or FortranArrayType.
          */
-        if (ftn_array_need_debug_info(sptr)) {
-          SPTR array_sptr = (SPTR)REVMIDLNKG(sptr);
-          type_mdnode = lldbg_emit_type(db, DTYPEG(array_sptr), array_sptr, findex,
-                                        false, false, false);
-          /* Emit FortranArrayType instead of pointer to FortranArrayType
-           * to workaround a known gdb bug not able to debug array bounds.
-           * i.e.
-           * 1) On POWER, gdb 7.x fails to read array bounds either w/ or
-           * w/o the pointer type layer; gdb 8.x only works w/o the pointer
-           * type layer.
-           * 2) On X86, gdb 7.x works either w/ or w/o the pointer type layer,
-           * however, gdb 8.x only works w/o the pointer type layer.
-           */
-          return type_mdnode;
+        if (!ll_feature_debug_info_ver11(&cpu_llvm_module->ir)) {
+          if (ftn_array_need_debug_info(sptr)) {
+            SPTR array_sptr = (SPTR)REVMIDLNKG(sptr);
+            type_mdnode = lldbg_emit_type(db, DTYPEG(array_sptr), array_sptr,
+                                          findex, false, false, false);
+            /* Emit FortranArrayType instead of pointer to FortranArrayType
+             * to workaround a known gdb bug not able to debug array bounds.
+             * i.e.
+             * 1) On POWER, gdb 7.x fails to read array bounds either w/ or
+             * w/o the pointer type layer; gdb 8.x only works w/o the pointer
+             * type layer.
+             * 2) On X86, gdb 7.x works either w/ or w/o the pointer type layer,
+             * however, gdb 8.x only works w/o the pointer type layer.
+             */
+            return type_mdnode;
+          }
         }
         type_mdnode = lldbg_emit_type(db, DTySeqTyElement(dtype), sptr, findex,
                                       false, false, false);
@@ -2751,6 +2862,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
 
       case TY_ARRAY: {
         LLMD_Builder mdb = llmd_init(db->module);
+        LL_MDRef dataloc = ll_get_md_null();
         ADSC *ad;
         int i, numdim;
         elem_dtype = DTySeqTyElement(dtype);
@@ -2762,22 +2874,61 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         ad = AD_DPTR(dtype);
         numdim = AD_NUMDIM(ad);
         if (numdim >= 1 && numdim <= 7) {
+          // Generate dataLocation field DW_TAG_array_type for assumed shape
+          // arrays, pointers and allocatables.
+          if (ll_feature_debug_info_ver11(&db->module->ir)) {
+            if (ALLOCATTRG(sptr) || POINTERG(sptr)) {
+              // Variables with allocatable/pointer attribute.
+              if (SCG(SDSCG(sptr)) == SC_CMBLK ||
+                  STYPEG(SDSCG(sptr)) == ST_MEMBER) {
+                const unsigned deref =
+                    lldbg_encode_expression_arg(LL_DW_OP_deref, 0);
+                const unsigned pushobj = lldbg_encode_expression_arg(
+                    LL_DW_OP_push_object_address, 0);
+                dataloc = lldbg_emit_expression_mdnode(db, 2, pushobj, deref);
+              } else {
+                SPTR datasptr = MIDNUMG(sptr);
+                if (datasptr == NOSYM)
+                  datasptr = SYMLKG(sptr);
+                if (SCG(datasptr) == SC_DUMMY) {
+                  // TODO: we want to generate local variable carrying
+                  // datalocation, but enclosing scope is not yet ready.
+                  // we shall solve it separately.
+                } else {
+                  LL_Type *dataloctype = LLTYPE(datasptr);
+                  /* make_lltype_from_sptr() should have added a pointer to
+                   * the type of this local variable. Remove it */
+                  if (!dataloctype)
+                    dataloctype = make_lltype_from_sptr(datasptr);
+                  if (dataloctype->data_type == LL_PTR)
+                    dataloctype = dataloctype->sub_types[0];
+                  dataloc =
+                      lldbg_emit_local_variable(db, datasptr, findex, true);
+                  insert_llvm_dbg_declare(dataloc, datasptr, dataloctype, NULL,
+                                          OPF_NONE);
+                }
+              }
+            }
+          }
+
           for (i = 0; i < numdim; ++i) {
             SPTR lower_bnd = AD_LWBD(ad, i);
             SPTR upper_bnd = AD_UPBD(ad, i);
             if (ll_feature_debug_info_ver11(&db->module->ir)) {
               LL_MDRef lbv = ll_get_md_null();
               LL_MDRef ubv = ll_get_md_null();
+              LL_MDRef st = ll_get_md_null();
               if (ALLOCATTRG(sptr) || POINTERG(sptr)) {
-                // TODO: This will be handled seaparately
-                // lets set upperBound=0 which with default lowerBound=0 makes
-                // empty array
-                ubv = ll_get_md_i64(db->module, 0);
-                subscript_mdnode = lldbg_create_subrange_mdnode(db, lbv, ubv);
-              } else { // explicit shape, assumed shape arrays
+                /* Create subrange mdnode based on array descriptor */
+                subscript_mdnode =
+                    lldbg_create_subrange_via_sdsc(db, findex, sptr, i);
+              } else {
+                // explicit shape array
                 init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
                 init_subrange_bound(db, &ubv, upper_bnd, 0, findex);
-                subscript_mdnode = lldbg_create_subrange_mdnode(db, lbv, ubv);
+
+                subscript_mdnode =
+                    lldbg_create_subrange_mdnode(db, lbv, ubv, st);
               }
               llmd_add_md(mdb, subscript_mdnode);
             } else if (ll_feature_has_diextensions(&db->module->ir)) {
@@ -2821,12 +2972,17 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
             lldbg_emit_type(db, elem_dtype, sptr, findex, false, false, false);
         cu_mdnode = ll_get_md_null();
         subscripts_mdnode = llmd_finish(mdb);
-        if (ll_feature_has_diextensions(&db->module->ir)) {
+        if (ll_feature_debug_info_ver11(&db->module->ir)) {
+          type_mdnode = lldbg_create_array_type_mdnode(
+              db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode,
+              dataloc);
+        } else if (ll_feature_has_diextensions(&db->module->ir)) {
           type_mdnode = lldbg_create_ftn_array_type_mdnode(
               db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode);
         } else
           type_mdnode = lldbg_create_array_type_mdnode(
-              db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode);
+              db, cu_mdnode, 0, sz, align, elem_type_mdnode, subscripts_mdnode,
+              dataloc);
         dtype_array_check_set(db, dtype, type_mdnode);
         break;
       }
@@ -2864,7 +3020,8 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         ub = DTyVecLength(dtype) - 1;
         if (ll_feature_debug_info_ver11(&db->module->ir))
           subscript_mdnode = lldbg_create_subrange_mdnode(
-              db, ll_get_md_i64(db->module, lb), ll_get_md_i64(db->module, ub));
+              db, ll_get_md_i64(db->module, lb), ll_get_md_i64(db->module, ub),
+              ll_get_md_null());
         else
           subscript_mdnode =
               lldbg_create_subrange_mdnode_pre11(db, lb, DTyVecLength(dtype));
@@ -2966,34 +3123,38 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
     fwd = ll_get_md_null();
   }
   flags = CCSYMG(sptr) ? DIFLAG_ARTIFICIAL : 0;
-  if (ftn_array_need_debug_info(sptr)) {
-    SPTR array_sptr =(SPTR)REVMIDLNKG(sptr);
-    /* Overwrite the display_name and flags to represent the user defined
-     * array instead of a compiler generated symbol of array pointer.
-     */
-    display_name = SYMNAME(array_sptr);
-    flags = 0;
+  if (!ll_feature_debug_info_ver11(&db->module->ir)) {
+    if (ftn_array_need_debug_info(sptr)) {
+      SPTR array_sptr = (SPTR)REVMIDLNKG(sptr);
+      /* Overwrite the display_name and flags to represent the user defined
+       * array instead of a compiler generated symbol of array pointer.
+       */
+      display_name = SYMNAME(array_sptr);
+      flags = 0;
+    }
   }
   mdref = lldbg_create_global_variable_mdnode(
       db, scope_mdnode, display_name, SYMNAME(sptr), "", file_mdnode, decl_line,
       type_mdnode, is_local, DEFDG(sptr) || (sc != SC_EXTERN), value, -1, flags,
       off, sptr, fwd);
 
-  if (!LL_MDREF_IS_NULL(db->gbl_obj_mdnode)) {
-    if (LL_MDREF_IS_NULL(db->gbl_obj_exp_mdnode)) {
-      /* Create a dummy global var expression mdnode to be associated to
-       * the global static object.
-       */
-      db->gbl_obj_exp_mdnode = lldbg_create_global_variable_mdnode(
-          db, scope_mdnode, "", "", "", file_mdnode, 0, type_mdnode, 0, 0,
-          NULL, -1, DIFLAG_ARTIFICIAL, 0, SPTR_NULL, db->gbl_obj_mdnode);
-    }
-    if (db->need_dup_composite_type) {
-      /* erase dtype record to allow duplication for allocatable array type within
-       * derived type.
-       */
-      dtype_array_check_set(db, DTYPEG(sptr), ll_get_md_null());
-      db->need_dup_composite_type = false;
+  if (!ll_feature_debug_info_ver11(&db->module->ir)) {
+    if (!LL_MDREF_IS_NULL(db->gbl_obj_mdnode)) {
+      if (LL_MDREF_IS_NULL(db->gbl_obj_exp_mdnode)) {
+        /* Create a dummy global var expression mdnode to be associated to
+         * the global static object.
+         */
+        db->gbl_obj_exp_mdnode = lldbg_create_global_variable_mdnode(
+            db, scope_mdnode, "", "", "", file_mdnode, 0, type_mdnode, 0, 0,
+            NULL, -1, DIFLAG_ARTIFICIAL, 0, SPTR_NULL, db->gbl_obj_mdnode);
+      }
+      if (db->need_dup_composite_type) {
+        /* erase dtype record to allow duplication for allocatable array type
+         * within derived type.
+         */
+        dtype_array_check_set(db, DTYPEG(sptr), ll_get_md_null());
+        db->need_dup_composite_type = false;
+      }
     }
   }
   db->gbl_var_sptr = SPTR_NULL;
@@ -3186,7 +3347,10 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
     } else {
       fwd = ll_get_md_null();
     }
-    if (ftn_array_need_debug_info(sptr)) {
+    if (ll_feature_debug_info_ver11(&db->module->ir)) {
+      if (SDSCG(sptr))
+        sptr = SDSCG(sptr);
+    } else if (ftn_array_need_debug_info(sptr)) {
       SPTR array_sptr =(SPTR)REVMIDLNKG(sptr);
       /* Overwrite the symname and flags to represent the user defined array
        * instead of a compiler generated symbol of array pointer.
@@ -3477,7 +3641,8 @@ lldbg_create_cmblk_gv_mdnode(LL_DebugInfo *db, LL_MDRef cmnblk_mdnode,
   align[0] = 0;
   if (ll_feature_debug_info_ver11(&db->module->ir))
     subscript_mdnode = lldbg_create_subrange_mdnode(
-        db, ll_get_md_i64(db->module, lb), ll_get_md_i64(db->module, ub));
+        db, ll_get_md_i64(db->module, lb), ll_get_md_i64(db->module, ub),
+        ll_get_md_null());
   else
     subscript_mdnode = lldbg_create_subrange_mdnode_pre11(db, lb, sz);
   llmd_add_md(mdb, subscript_mdnode);
@@ -3486,7 +3651,8 @@ lldbg_create_cmblk_gv_mdnode(LL_DebugInfo *db, LL_MDRef cmnblk_mdnode,
       lldbg_emit_type(db, elem_dtype, sptr, 1, false, false, false);
   subscripts_mdnode = llmd_finish(mdb);
   type_mdnode = lldbg_create_array_type_mdnode(
-      db, ll_get_md_null(), 0, sz, align, elem_type_mdnode, subscripts_mdnode);
+      db, ll_get_md_null(), 0, sz, align, elem_type_mdnode, subscripts_mdnode,
+      ll_get_md_null());
   display_name = SYMNAME(sptr);
   mdref = lldbg_create_global_variable_mdnode(
       db, cmnblk_mdnode, display_name, SYMNAME(sptr), "", ll_get_md_null(),

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -2970,10 +2970,11 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                 /* Create subrange mdnode based on array descriptor */
                 subscript_mdnode =
                     lldbg_create_subrange_via_sdsc(db, findex, sptr, i);
-              } else {
-                // explicit shape array
+              } else { // explicit shape, assumed size, assumed shape array
                 init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
-                init_subrange_bound(db, &ubv, upper_bnd, 0, findex);
+                if (!ll_feature_debug_info_ver12(&db->module->ir) ||
+                    (upper_bnd != SPTR_NULL)) // assumed size
+                  init_subrange_bound(db, &ubv, upper_bnd, 0, findex);
 
                 subscript_mdnode =
                     lldbg_create_subrange_mdnode(db, lbv, ubv, st);

--- a/tools/flang2/flang2exe/lldebug.h
+++ b/tools/flang2/flang2exe/lldebug.h
@@ -275,4 +275,7 @@ void lldbg_reset_module(LL_DebugInfo *db);
 
 /// \brief Get the debug location mdnode of the current procedure.
 LL_MDRef lldbg_get_subprogram_line(LL_DebugInfo *db);
+
+/// \brief Get parameter mdnode for SPTR
+LL_MDRef get_param_mdnode(LL_DebugInfo *db, int sptr);
 #endif /* LLDEBUG_H_ */

--- a/tools/flang2/flang2exe/upper.cpp
+++ b/tools/flang2/flang2exe/upper.cpp
@@ -2007,8 +2007,8 @@ read_symbol(void)
   int val[4], namelen, i, dpdsc, inmod;
   /* flags: */
   int addrtkn, adjustable, afterentry, altname, altreturn, aret, argument,
-      assigned, assumedshape, assumedsize, autoarray, blank, Cfunc, ccsym, clen,
-    cmode, common, constant, count, currsub, decl;
+      assigned, assumedrank, assumedshape, assumedsize, autoarray, blank, Cfunc,
+      ccsym, clen, cmode, common, constant, count, currsub, decl;
   SPTR descriptor;
   int intentin, texture, device, dll, dllexportmod, enclfunc, end, endlab,
     format, func, gsame, gdesc, hccsym, hollerith, init, isdesc, linenum;
@@ -2130,6 +2130,7 @@ read_symbol(void)
     if (stype == ST_ARRAY) {
       adjustable = getbit("adjustable");
       afterentry = getbit("afterentry");
+      assumedrank = getbit("assumedrank");
       assumedshape = getbit("assumedshape"); /* + */
       assumedsize = getbit("assumedsize");
       autoarray = getbit("autoarray");
@@ -2296,6 +2297,7 @@ read_symbol(void)
     }
     ORIGDIMP(newsptr, origdim);
     if (stype == ST_ARRAY) {
+      ASSUMRANKP(newsptr, assumedrank);
       ASSUMSHPP(newsptr, assumedshape);
       ASUMSZP(newsptr, assumedsize);
       ADJARRP(newsptr, adjustable);

--- a/tools/flang2/utils/symtab/symtab.n
+++ b/tools/flang2/utils/symtab/symtab.n
@@ -611,6 +611,8 @@ Set by Expander.
 Assumed size array.
 .FL ADJARR f10
 Adjustable array.
+.FL ASSUMRANK f37
+Assumed-rank array.
 .FL ASSUMSHP f19
 Assumed-shape array.
 .FL AFTENT f20
@@ -716,8 +718,6 @@ This is set in an F90 program for an array that is being used as a
 section descriptor with a non-stride-1 leading dimension;
 in this case, the leftmost subscript must be multiplied by the 
 stride in the section descriptor.
-.FL RESERVED_f37 f37
-reserved
 .FL LSCOPE f41
 If set, the local variable is accessed only in the function's local
 scope; any internal procedure does not access this variable.


### PR DESCRIPTION
This PR supports general array debugging (adjustable array, assumed shape array, assumed size array, allocatable and pointer array and assumed rank array).

It uses multiple upgrades to upstream LLVM which are backported to flang-LLVM as
LLVM11: https://github.com/flang-compiler/classic-flang-llvm-project/pull/14
LLVM10: https://github.com/flang-compiler/classic-flang-llvm-project/pull/8
LLVM9: https://github.com/flang-compiler/llvm/pull/86

Please note that this PR should be able to replace existing flang-LLVM DIFortranSubrage .