### PR TITLE
Do not issue an error when character kind 2 is used

### DIFF
--- a/test/llvm_ir_correct/character_kind2.f90
+++ b/test/llvm_ir_correct/character_kind2.f90
@@ -1,0 +1,14 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! RUN: %flang %s
+
+PROGRAM charlen
+END PROGRAM charlen
+FUNCTION cksum(data)
+CHARACTER(LEN=30):: cksum
+CHARACTER(KIND=2):: data(:)
+END

--- a/tools/flang1/flang1exe/transfrm.c
+++ b/tools/flang1/flang1exe/transfrm.c
@@ -2570,8 +2570,7 @@ trans_freeidx(void)
 LOGICAL
 is_bad_dtype(int dtype)
 {
-  if ((DTYG(dtype) != TY_NCHAR) && (DTYG(dtype) != TY_STRUCT) &&
-      (DTYG(dtype) != TY_UNION))
+  if ((DTYG(dtype) != TY_STRUCT) && (DTYG(dtype) != TY_UNION))
     return FALSE;
   return TRUE;
 }


### PR DESCRIPTION
Fixes https://github.com/flang-compiler/flang/issues/864.

See issue description for details of the problem.

EDIT: In the course of the discussion and with great help from the reviewers it was proven that in fact `character(kind=2)` is using flang's extension `ncharacter` to handle multibyte characters. There are tests checking this basic functionality and we also managed to store an actual Kanji character correctly. So in the end the fix is not to raise internal compiler errors when `character(kind=2)` is used.

Original outdated description:

I tried to apply a minimum patch that will issue an error, as requested. It seems flang has been to some extent deliberately prepared to support `kind = 2`, because there is a dedicated type for it as well as some documentation. I left all the prepared code in, just amending the information where necessary and modifying the critical part to issue an error and explaining the situation in a comment.

I hope this is as expected, @nSircombe?

@RichBarton-Arm , @kiranchandramohan , as usually - kind request to review the patch and set up more reviewers.