### PR TITLE
[test] Minor FileCheck pattern fixes

### DIFF
--- a/test/openmp_examples/lit/runmake
+++ b/test/openmp_examples/lit/runmake
@@ -23,4 +23,4 @@ export PATH=$PATH:$(pwd)
 make -f $MAKE_FILE HOMEQA=$MAKE_FILE_DIR TEST=$test_name OPT="$FLAGS" build 2>&1
 make -f $MAKE_FILE HOMEQA=$MAKE_FILE_DIR TEST=$test_name OPT="$FLAGS" run 2>&1
 make -f $MAKE_FILE HOMEQA=$MAKE_FILE_DIR TEST=$test_name OPT="$FLAGS" verify 2>&1
-# CHECK: {{([1-9][0-9]* tests PASSED\. 0 tests failed|[[:space:]]*PASS(ED)?[[:space:]]*$)}}
+# CHECK: {{^PASS$}}

--- a/test/tools/check_compilation.py
+++ b/test/tools/check_compilation.py
@@ -103,7 +103,8 @@ def getLogErrors(log):
 				terminated = True
 			else:
 				sys.stdout.write (line)
-				sys.stdout.write (" ")
+				if not line.endswith("\n"):
+					sys.stdout.write (" ")
 	return terminated, errorList
 
 def getFileSet(source, logErrors):


### PR DESCRIPTION
Simplify the FileCheck pattern used in test/openmp_examples/lit/runmake; most of the original pattern was never generated and hence misleading. Prevent check_compilation.py from appending an extraneous space when printing a properly newline-terminated string.

I needed the FileCheck pattern change to catch test failures that would be erroneously reported as passing. The original problem has since been fixed (by 2beb1f781af26009535e511aa7e8ac063f86b65d), but I think these changes are still good to have, especially the check_compilation.py fix.