### PR TITLE
[Flang2] Support Prefetch Directive

### DIFF
--- a/test/directives/prefetch.f90
+++ b/test/directives/prefetch.f90
@@ -1,0 +1,23 @@
+! RUN: %flang -O1 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK-PREFETCH
+! RUN: %flang -O1 -S -emit-llvm -Hy,59,0x4 %s -o - | FileCheck %s --check-prefix=CHECK-NOPREFETCH
+
+subroutine prefetch_dir(a1, a2)
+  integer :: a1(4096)
+  integer :: a2(4096)
+
+  do i = 128, (4096 - 128)
+    !$mem prefetch a1, a2(i + 256)
+    a1(i) = a2(i - 127) + a2(i + 127)
+  end do
+end subroutine prefetch_dir
+
+!! Ensure that the offset generated for the prefetch of a2(i + 256) is correct.
+! CHECK-PREFETCH: [[a1:%[0-9]+]] = bitcast i64* %a1 to i8*
+! CHECK-PREFETCH: [[a2:%[0-9]+]] = bitcast i64* %a2 to i8*
+! CHECK-PREFETCH: [[a2base:%[0-9]+]] = getelementptr i8, i8* [[a2]], i64 1020
+! CHECK-PREFETCH: call void @llvm.prefetch{{.*}}(i8* [[a1]], i32 0, i32 3, i32 1)
+! CHECK-PREFETCH: [[i:%[0-9]+]] = shl nuw nsw i64 %indvars.iv, 2
+! CHECK-PREFETCH: [[a2elem:%[0-9]+]] = getelementptr i8, i8* [[a2base]], i64 [[i]]
+! CHECK-PREFETCH: call void @llvm.prefetch{{.*}}(i8* [[a2elem]], i32 0, i32 3, i32 1)
+! CHECK-PREFETCH: declare void @llvm.prefetch{{.*}}
+! CHECK-NOPREFETCH-NOT: @llvm.prefetch

--- a/tools/flang2/flang2exe/exp_ftn.cpp
+++ b/tools/flang2/flang2exe/exp_ftn.cpp
@@ -3972,15 +3972,8 @@ exp_misc(ILM_OP opc, ILM *ilmp, int curilm)
   case IM_PREFETCH:
     ilix = ILI_OF(ILM_OPND(ilmp, 1)); /* address */
     nme = NME_OF(ILM_OPND(ilmp, 1));
-    if (XBIT(39, 0x4000) && TEST_MACH(MACH_AMD_HAMMER)) {
-      ilix = ad3ili(IL_PREFETCHT0, ilix, 0, nme);
-    } else if (TEST_MACH(MACH_AMD_HAMMER)) {
-      ilix = ad3ili(IL_PREFETCHNTA, ilix, 0, NME_UNK);
-    } else if (TEST_MACH(MACH_AMD)) {
-      ilix = ad3ili(IL_PREFETCH, ilix, 0, nme); /* Athlon */
-    } else {
-      ilix = ad3ili(IL_PREFETCHNTA, ilix, 0, nme); /* PIII+ sse */
-    }
+    /* Use the generic LLVM prefetch intrinsic. */
+    ilix = ad3ili(IL_PREFETCH, ilix, 0, nme);
     chk_block(ilix);
     break;
   case IM_FARG:


### PR DESCRIPTION
While Flang can parse a prefetch directive with the following syntax, it
currently ignores the directive:

    !$mem prefetch <var1>[,<var2>[,...]]

This patch teaches flang2 to insert a call to @llvm.prefetch when it sees
the directive.