### PR TITLE
[AST] Do not reorder non-constant operands

### DIFF
--- a/test/llvm_ir_correct/short-circuit-eval.f90
+++ b/test/llvm_ir_correct/short-circuit-eval.f90
@@ -1,0 +1,26 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! Check that short-circuit evaluation of logical expressions work as expected.
+! The two operands should not be reordered if neither is constant.
+!
+! RUN: %flang -S %s -emit-llvm -o - | FileCheck %s
+!
+! CHECK: [[y8:%[0-9]+]] = bitcast i64* %y to i8*
+! CHECK: [[LOP:%[0-9]+]] = icmp eq i8* [[y8]], null
+! CHECK: br i1 [[LOP]], label %L.[[SHORTCUT:.*]], label %L.[[ROP:.*]],
+! CHECK: L.[[ROP]]:
+! CHECK: [[y32:%[0-9]+]] = bitcast i64* %y to i32*
+! CHECK: load i32, i32* [[y32]]
+! CHECK: L.[[SHORTCUT]]:
+
+subroutine setoptional(x, y)
+  integer :: x
+  integer, intent(inout), optional ::y
+  if (present(y) .and. y == 10) then
+    y = x
+  end if
+end subroutine setoptional

--- a/tools/flang1/flang1exe/ast.c
+++ b/tools/flang1/flang1exe/ast.c
@@ -739,10 +739,6 @@ mk_binop(int optype, int lop, int rop, DTYPE dtype)
         rop = tmp;
         c2 = c1;
         c1 = 0;
-      } else if (ncons == 0 && lop > rop) {
-        tmp = lop;
-        lop = rop;
-        rop = tmp;
       }
     }
     break;


### PR DESCRIPTION
Do not reorder non-constant operands, even for commutative opcodes. Doing so breaks short-circuit evaluation
of logical expressions, and can also cause side effects to occur out of order.

This PR includes a reproducer which, when compiled without the patch, would access an optional dummy argument before confirming its presence, leading to a segmentation fault.