### PR TITLE
Fix errors on array initialisation with an implied do loop

### DIFF
--- a/test/f90_correct/inc/array_constructor_nested_implied_do.mk
+++ b/test/f90_correct/inc/array_constructor_nested_implied_do.mk
@@ -1,0 +1,20 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test array_constructor_nested_implied_do  ########
+
+build:
+	@echo ------------------------------------ building test $(TEST)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	./$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/array_constructor_nested_implied_do.sh
+++ b/test/f90_correct/lit/array_constructor_nested_implied_do.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/array_constructor_nested_implied_do.f90
+++ b/test/f90_correct/src/array_constructor_nested_implied_do.f90
@@ -1,0 +1,52 @@
+PROGRAM stress_test_nested_implied_do
+  ! Test that a nested implied do loop can be used to initialize an array.
+  ! Array constructors, and implicit DO loops are detailed in sec. 7.8
+  ! of the Standard.
+  IMPLICIT NONE
+  INTEGER, PARAMETER :: n=4
+  INTEGER, PARAMETER :: m=10
+  INTEGER, PARAMETER :: o=2
+  INTEGER, PARAMETER :: p=3
+  INTEGER :: i, j, k, l
+
+  ! 1 level of nesting
+  INTEGER :: array1(n) = (/ (i, i=1, n) /)
+  INTEGER :: expect1(n)
+  data expect1/1, 2, 3, 4/
+
+  ! 2 levels of nesting
+  INTEGER :: array2(m) = (/ ((i, j=1, i), i=1, n ) /)
+  INTEGER :: expect2(m)
+  data expect2/1, 2, 2, 3, 3, 3, 4, 4, 4, 4/
+
+  ! 3 levels of nesting
+  INTEGER :: array3(m*o) = (/ (((i, j=1, i), i=1,n ), k=1, o) /)
+  INTEGER :: expect3(m*o)
+  data expect3/1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4/
+
+  ! 4 levels of nesting
+  INTEGER :: array4(m*o*p) = (/ ((((i, j=1, i), i=1,n ), k=1, o), l=1, p) /)
+  INTEGER :: expect4(m*o*p)
+  data expect4/1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4,&
+               1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4,&
+               1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4/
+
+  ! 3 levels of nesting and multiple items
+  INTEGER :: array5(3*m*o) = (/ (((i, i+10, i+100, j=1, i), i=1,n ), k=1, o) /)
+  INTEGER :: expect5(3*m*o)
+  data expect5/1, 10, 100,&
+               2, 20, 200, 2, 20, 200,&
+               3, 30, 300, 3, 30, 300, 3, 30, 300,&
+               4, 40, 400, 4, 40, 400, 4, 40, 400, 4, 40, 400,&
+               1, 10, 100,&
+               2, 20, 200, 2, 20, 200,&
+               3, 30, 300, 3, 30, 300, 3, 30, 300,&
+               4, 40, 400, 4, 40, 400, 4, 40, 400, 4, 40, 400/
+
+  call check(array1, expect1, n)
+  call check(array2, expect2, m)
+  call check(array3, expect3, m*o)
+  call check(array4, expect4, m*o*p)
+  call check(array5, expect5, 3*m*o)
+
+END PROGRAM stress_test_nested_implied_do

--- a/tools/flang1/flang1exe/semant.h
+++ b/tools/flang1/flang1exe/semant.h
@@ -620,7 +620,7 @@ typedef enum {
 #define GET_ACL(a) get_acl(a)
 
 typedef struct {   /* STRUCTURE stack entries */
-  char type;       /* 's': STRUCTURE; 'u': UNION; 'm: MAP */
+  char type;       /* 's': STRUCTURE; 'u': UNION; 'm': MAP; 'd': derived type */
   char mem_access; /* 0 - public by default, 'v'=>access private */
   int sptr;        /* Sym ptr to field name list having this structure */
   int dtype;       /* Pointer to structure dtype */

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -7292,7 +7292,7 @@ dinit_varref(SST *stkp)
 {
   VAR *ivl;
   int ast;
-  ITEM *mhd, *p;
+  ITEM *mhd, *p; /* mhd = "member of the whole array" ? */
   int i;
   int ndim;
   int subs[MAXDIMS];

--- a/tools/flang1/utils/prstab/gram.txt
+++ b/tools/flang1/utils/prstab/gram.txt
@@ -931,8 +931,8 @@
 
 <ac item> ::= <expression> |
               <elp> <ac list> , <implied do control> ) |
-	      <expression> : <expression> <opt stride> |
-	      <elp> <ac list> , <expression> )
+              <expression> : <expression> <opt stride> |
+              <elp> <ac list> , <expression> )
 
 <implied do control> ::= <var ref> <idc eq> <etmp exp> , <etmp exp> <etmp e3>
 

--- a/tools/flang2/flang2exe/dinit.cpp
+++ b/tools/flang2/flang2exe/dinit.cpp
@@ -580,7 +580,13 @@ dinit_varref(VAR *ivl, SPTR member, CONST *ict, DTYPE dtype,
       *repeat = 0;
       (void)dinit_varref(ivl, member, ict->subc, dtype, struct_bytes_initd,
                          repeat, base_off);
-      i = *repeat = ad_val_of(AD_NUMELM(AD_DPTR(ict->dtype)));
+      /* Make sure the recursive processing ends, as the nesting has been
+       * collapsed/flattened in eval_array_constructor */
+      if (ict->subc->subc != nullptr && ict->u1.ido.index_var != 0) {
+        interr("nested implied do loop should have been collapsed/flattened", 0, ERR_Warning);
+      }
+      *repeat = num_elem;
+      i = num_elem;
     } else {
       if (ivl && (DTY(DDTG(ivl->u.varref.dtype)) == TY_STRUCT)) {
         if (put_value) {


### PR DESCRIPTION
Fixes https://github.com/flang-compiler/flang/issues/871.

Summary of the changes in this PR:
* The array is resolved after the checks are performed - use a precalculated size and skip size checks performed before the array is ready.
* flang2 also needs to use a precalculated size.
* Add a test checking that the array is correctly initialised.
* Fixed inconsequent spacing in gram.txt and improved comments.

Rationale:
I believe that the root cause for the issue is that the algorithm performs some checks on an implied-do loop before it actually gets properly resolved. I failed to find an error in earlier stages of the implied-do handling and unless it is used to initialize an array the code works fine. I do not feel competent to redesign the whole algorithm of the data initialization, but I managed to find a solution which acts the way we would expect it:
1) It initializes the array correctly in the https://github.com/flang-compiler/flang/issues/871 reproducer.
2) It reports errors if the implied-do loop has insufficient elements.
3) It does not break any tests.

I achieved this by using a correctly calculated size from an earlier stage of the algorithm and relaxing another check (`cmpat_dtype_with_size`), which also couldn't calculate the size correctly.
I realise that this is more of a work-around, a patch applied to handle a particular use case, so I am fully open to suggestions on a better solution.