### PR TITLE
[Flang2] Support for noinline/forceinline pragmas

### DIFF
--- a/test/directives/dir_forceinline.f90
+++ b/test/directives/dir_forceinline.f90
@@ -1,0 +1,32 @@
+!! check for pragma support for forced inlining of functions
+!RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+!RUN: %flang -O2 -S -emit-llvm %s -o - | FileCheck %s
+!RUN: %flang -O3 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: define void @func_forceinline_(){{.*}} #0 {{.*$}}
+!CHECK-NOT: call void @func_forceinline_(), {{.*$}}
+!CHECK: call void @func_noforceinline_(), {{.*$}}
+!CHECK: attributes #0 = { alwaysinline {{.*$}}
+!CHECK-NOT: attributes #1 = { alwaysinline {{.*$}}
+
+!DIR$ FORCEINLINE
+SUBROUTINE func_forceinline
+    INTEGER :: i
+    do i = 0, 5
+            WRITE(*, *) "Hello World"
+    end do
+END SUBROUTINE func_forceinline
+
+!DIR$ NOFORCEINLINE
+SUBROUTINE func_noforceinline
+    INTEGER :: i
+    do i = 0, 5
+            WRITE(*, *) "Hello World"
+    end do
+END SUBROUTINE func_noforceinline
+
+PROGRAM test_inline
+    IMPLICIT NONE
+    call func_forceinline
+    call func_noforceinline
+END PROGRAM test_inline

--- a/test/directives/dir_noinline.f90
+++ b/test/directives/dir_noinline.f90
@@ -1,0 +1,21 @@
+!! check for pragma support for no inlining of functions
+!RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+!RUN: %flang -O2 -S -emit-llvm %s -o - | FileCheck %s
+!RUN: %flang -O3 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: define void @func_noinline_(){{.*}} #0 {{.*$}}
+!CHECK: call void @func_noinline_(), {{.*$}}
+!CHECK: attributes #0 = { noinline {{.*$}}
+
+!DIR$ NOINLINE
+SUBROUTINE func_noinline
+    INTEGER :: i
+    do i = 0, 5
+            WRITE(*, *) "Hello World"
+    end do
+END SUBROUTINE func_noinline
+
+PROGRAM test_inline
+    IMPLICIT NONE
+    call func_noinline
+END PROGRAM test_inline

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -5108,6 +5108,8 @@ Temporary flags
 .XB 0x01:
 Turn on C++ prototype implementation of the gnu visibility attribute 
 "hidden"
+.XB 0x02:
+Enable "alwaysinline" attribute for a function, using "forceinline" pragma
 
 .XF "192:"
 More Accelerator flags

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -13177,10 +13177,14 @@ print_function_signature(int func_sptr, const char *fn_name, LL_ABI_Info *abi,
   if (need_debug_info(SPTR_NULL)) {
     /* 'attributes #0 = { ... }' to be emitted later */
     print_token(" #0");
-  } else if (!XBIT(183, 0x10)) {
+  } else if (!XBIT(183, 0x10) || XBIT(14, 0x8)) {
     /* Nobody sets -x 183 0x10, besides Flang. We're disabling LLVM inlining for
      * proprietary compilers. */
+    /* 2nd XBIT - Apply noinline attribute if the pragma "noinline" is given */
     print_token(" noinline");
+  } else if (XBIT(191, 0x2)) {
+    /* Apply alwaysinline attribute if the pragma "forceinline" is given */
+    print_token(" alwaysinline");
   }
 
   if (func_sptr > NOSYM) {

--- a/tools/shared/pragma.c
+++ b/tools/shared/pragma.c
@@ -412,6 +412,7 @@ p_pragma(char *pg, int pline)
 #define SW_SAVE_USED 69
 #define SW_LIBM 70
 #define SW_SIMD 71
+#define SW_FORCEINLINE 73
 
 struct c {
   char *cmd;
@@ -430,6 +431,7 @@ struct c {
 static struct c table[] = {
     {"align", SW_ALIGN, false, S_NONE, S_NONE},
     {"altcode", SW_ALTCODE, true, S_LOOP, S_LOOP | S_ROUTINE | S_GLOBAL},
+    {"forceinline", SW_FORCEINLINE, true, S_ROUTINE, S_ROUTINE | S_GLOBAL},
     {"assoc", SW_ASSOC, true, S_LOOP, S_LOOP | S_ROUTINE | S_GLOBAL},
     {"bounds", SW_BOUNDS, true, S_ROUTINE, S_ROUTINE | S_GLOBAL},
     {"c", SW_C, false, S_NONE, S_NONE},
@@ -1295,7 +1297,15 @@ do_sw(void)
      * mark routine or all routines as not-to-be-extracted, and therefore
      * not to be inlined
      */
+    bclr(DIR_OFFSET(currdir, x[191]), 0x2);
     bset(DIR_OFFSET(currdir, x[14]), 8);
+    break;
+  case SW_FORCEINLINE:
+    if (no_specified)
+      break;
+    else
+      bclr(DIR_OFFSET(currdir, x[14]), 0x8);
+      bset(DIR_OFFSET(currdir, x[191]), 0x2);
     break;
   case SW_ZEROTRIP:
     if (no_specified)


### PR DESCRIPTION
This PR adds support for `!dir$ noinline` and `!dir$ forceinline` directives along with the test cases for the same.
These directives are usable right before a routine definition.