### PR TITLE
Fixes to address cp2k compilation and runtime issues

### DIFF
--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -544,7 +544,8 @@ find_def_in_most_recent_scope(int sptr, int save_sem_scope_level)
           in private USE or a private module variable */
       if (!is_except_in_scope(scope, sptr1) &&
           !is_private_in_scope(scope, sptr1) &&
-          (STYPEG(ng) == ST_USERGENERIC || !PRIVATEG(ng))) {
+          ((STYPEG(ng) == ST_PROC) ||
+          (STYPEG(ng) == ST_USERGENERIC || !PRIVATEG(ng)))) {
         return sptr1;
       }
     }

--- a/tools/flang1/flang1exe/semfunc.c
+++ b/tools/flang1/flang1exe/semfunc.c
@@ -2098,8 +2098,7 @@ gen_pointer_result(int array_value, int dscptr, int nactuals,
     get_all_descriptors(arr_tmp);
     /* need to have different MIDNUM than arr_value */
     /* otherwise multiple declaration */
-    pvar = sym_get_ptr(arr_tmp);
-    MIDNUMP(arr_tmp, pvar);
+    MIDNUMP(arr_tmp, 0);
     NODESCP(arr_tmp, 0);
     ddt = DDTG(dt);
     if ((DTY(dt) == TY_CHAR && dt != DT_DEFERCHAR) ||
@@ -7411,7 +7410,8 @@ ref_pd(SST *stktop, ITEM *list)
       XFR_ARGAST(3);
       dtype2 = SST_DTYPEG(stkp);
       if (!DT_ISINT(DTY(dtype2 + 1)) ||
-          count != get_int_cval(sym_of_ast(AD_NUMELM(AD_DPTR(dtype2))))) {
+          ((STYPEG(sym_of_ast(AD_NUMELM(AD_DPTR(dtype2)))) == ST_CONST) && 
+          count != get_int_cval(sym_of_ast(AD_NUMELM(AD_DPTR(dtype2)))))) {
         E74_ARG(pdsym, 3, NULL);
         goto call_e74_arg;
       }

--- a/tools/flang1/flang1exe/semgnr.c
+++ b/tools/flang1/flang1exe/semgnr.c
@@ -420,6 +420,7 @@ find_best_generic(int gnr, ITEM *list, int arg_cnt, int try_device,
                                  try_device == 1);
       }
       if (found && func && found != func && *min_argdistance != INF_DISTANCE &&
+          !PRIVATEG(SCOPEG(func)) &&
           !is_conflicted_generic(func_sptrgen, found_sptrgen) &&
           cmp_arg_score(argdistance, min_argdistance, distance_sz) == 0) {
         int len;

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -4777,7 +4777,10 @@ gen_const_expr(int ilix, LL_Type *expected_type)
              expected_type->data_type, ERR_Fatal);
       operand->ll_type = expected_type;
     } else {
-      operand->ll_type = make_lltype_from_dtype(DT_INT);
+       if (expected_type && expected_type->data_type == LL_PTR)
+         operand->ll_type = make_lltype_from_dtype(DT_INT8);
+       else
+         operand->ll_type = make_lltype_from_dtype(DT_INT);
       operand->val.sptr = sptr;
     }
     break;


### PR DESCRIPTION
This patch addresses the compilation and runtime issues of CP2K. Following additional flags are required for successful cp2k compilation and run.
1. -Hx,2,0x400000  - disable pointer optimizations
2. -Hx,47,0x1000000  - to disable calls to streamlined/dgemm-like matmul run-time routines