### PR TITLE
tests: two test cases supporting PR #966

### DIFF
--- a/test/llvm_ir_correct/named_arguments.f90
+++ b/test/llvm_ir_correct/named_arguments.f90
@@ -1,0 +1,41 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! RUN: %flang -S -emit-llvm %s
+
+MODULE operations_module
+   IMPLICIT NONE
+   PUBLIC :: operation
+   PRIVATE
+   INTERFACE operation
+      MODULE PROCEDURE operation_anytype
+   END INTERFACE
+CONTAINS
+   SUBROUTINE operation_anytype(key)
+      REAL(8), INTENT(IN)                :: key
+   END SUBROUTINE operation_anytype
+END MODULE operations_module
+
+MODULE api_module
+   USE operations_module, ONLY: operation_prv => operation
+   IMPLICIT NONE
+   PUBLIC :: operation
+   PRIVATE
+CONTAINS
+   SUBROUTINE operation(key)
+      REAL(8), INTENT(IN)                               :: key
+   END SUBROUTINE operation
+END MODULE api_module
+
+MODULE methods_module
+   USE api_module, ONLY: operation
+   IMPLICIT NONE
+CONTAINS
+   SUBROUTINE method(key_value)
+      REAL(KIND = 8), INTENT(IN)                          :: key_value
+      CALL operation(key = key_value)
+   END SUBROUTINE method
+END MODULE methods_module

--- a/test/llvm_ir_correct/reshape_allocatable_order.f90
+++ b/test/llvm_ir_correct/reshape_allocatable_order.f90
@@ -1,0 +1,17 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! RUN: %flang -S -emit-llvm %s
+
+program test_reshape
+  integer, dimension(4) :: x = [1, 2, 3, 4]
+  integer, dimension(:), allocatable :: order
+  integer, dimension(2) :: other_order = [2, 1]
+  allocate(order(2))
+  order(:) = [2, 1]
+  print *, reshape(x, shape = [2, 2], order = order)
+!!  print *, reshape(x, shape = [2, 2], order = other_order)
+end program


### PR DESCRIPTION
PR #966 has fixed two compile time problems which can be reproduced by the two minimal reproducers introduced by this commit.
