### PR TITLE
Fix hash collision handling routine that didn't work due to a fatal mistake (issue #960).

### DIFF
--- a/tools/flang2/flang2exe/llassem.cpp
+++ b/tools/flang2/flang2exe/llassem.cpp
@@ -5500,11 +5500,11 @@ find_funcptr_name(SPTR sptr)
         goto Continue;
     } while (*sp);
     if (np - sptrnm != len)
-      continue;
+      goto Continue;
     goto Found;
   Continue:
     if (gblsym == FPTR_HASHLK(gblsym))
-      return 0;
+      interr("Broken hash link on sptr:", sptr, ERR_Fatal);
   }
   return 0;
 
@@ -5558,8 +5558,8 @@ llvm_funcptr_store(SPTR sptr, char *ag_name)
 
   sprintf(sptrnm, "%s_%d", get_llvm_name(sptr), sptr);
   hashval = name_to_hash(sptrnm, strlen(sptrnm));
-  fptr_local.hashtb[hashval] = gblsym;
   FPTR_HASHLK(gblsym) = fptr_local.hashtb[hashval];
+  fptr_local.hashtb[hashval] = gblsym;
   FPTR_SYMLK(gblsym) = ptr_local;
   nmptr = add_ag_fptr_name(sptrnm); /* fnptr_local key */
   FPTR_NMPTR(gblsym) = nmptr;


### PR DESCRIPTION
Since the presence of this bug cannot be reliably tested by usual
source code test cases, I've ensured that any malfunction of this algorithm
should result in a fatal ICE. Having this error detection check alone (without
fixing the bug itself) causes certain number of currently used test cases to
fail, this fact alone reveals how well this bug was hidden for years.

Fixes a problem signaled in #960.
