### PR TITLE
Update apt data before installing sphinx

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Check tools
         run: |
+          sudo apt update
           sudo apt install python3-sphinx
           git --version
           cmake --version


### PR DESCRIPTION
Github's default ubuntu image contents might have changed and we need to get the latest ubuntu database to install `sphinx`.