### PR TITLE
Fix the readme to point to the correct flang-dev list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://github.com/flang-compiler/flang/wiki
 We have mailing lists for announcements and developers.
 Here's the link with the sign-up information:
 
-http://lists.flang-compiler.org/mailman/listinfo
+https://lists.llvm.org/cgi-bin/mailman/listinfo/flang-dev
 
 We have a flang-compiler channel on Slack.  Slack is invitation only but anyone can join.  Here's the link:
 


### PR DESCRIPTION
The readme still points to the old flang-dev list. The link times out for me now. Point it to the new flang-dev list page.