### PR TITLE
add asprintf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 
 VERSION
+.vscode

--- a/tools/flang2/flang2exe/CMakeLists.txt
+++ b/tools/flang2/flang2exe/CMakeLists.txt
@@ -22,6 +22,7 @@ set_source_files_properties(${UTILS_SYMTAB_BIN_DIR}/symtabdf.cpp PROPERTIES GENE
 
 set(SOURCES
   ${ARCH_DEP_FILES}
+  asprintf.cpp
   bihutil.cpp
   dinitutl.cpp
   dinit.cpp

--- a/tools/flang2/flang2exe/asprintf.cpp
+++ b/tools/flang2/flang2exe/asprintf.cpp
@@ -1,0 +1,41 @@
+/*
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+/*
+ * asprintf, vasprintf:
+ * MSVC does not implement these, thus we implement them here
+ * GNU-C-compatible compilers implement these with the same names, thus we
+ * don't have to do anything
+ */
+#ifdef _WIN32
+#include "asprintf.h"
+int vasprintf(char **strp, const char *format, va_list ap)
+{
+    int len = vscprintf(format, ap);
+    if (len == -1)
+        return -1;
+    char *str = (char*)malloc((size_t) len + 1);
+    if (!str)
+        return -1;
+    int retval = vsnprintf(str, len + 1, format, ap);
+    if (retval == -1) {
+        free(str);
+        return -1;
+    }
+    *strp = str;
+    return retval;
+}
+
+int asprintf(char **strp, const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    int retval = vasprintf(strp, format, ap);
+    va_end(ap);
+    return retval;
+}
+#endif

--- a/tools/flang2/flang2exe/asprintf.h
+++ b/tools/flang2/flang2exe/asprintf.h
@@ -1,0 +1,40 @@
+/*
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#ifndef ASPRINTF_H
+#define ASPRINTF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdarg.h>
+
+/**
+ * Sets `char **' pointer to be a buffer
+ * large enough to hold the formatted string
+ * accepting a `va_list' args of variadic
+ * arguments.
+ */
+
+int
+vasprintf (char **, const char *, va_list);
+
+/**
+ * Sets `char **' pointer to be a buffer
+ * large enough to hold the formatted
+ * string accepting `n' arguments of
+ * variadic arguments.
+ */
+
+int
+asprintf (char **, const char *, ...);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/tools/flang2/flang2exe/kmpcutil.cpp
+++ b/tools/flang2/flang2exe/kmpcutil.cpp
@@ -33,7 +33,11 @@
 #endif
 #include "cgllvm.h"
 #include "cgmain.h"
+#ifndef _WIN32
 #include <unistd.h>
+#else
+#include "asprintf.h"
+#endif
 #include "regutil.h"
 #include "dtypeutl.h"
 #include "llassem.h"
@@ -527,6 +531,7 @@ build_kmpc_api_name(int kmpc_api, va_list va)
 
     /* Construct the name */
     vasprintf(&nm, KMPC_NAME(kmpc_api), va);
+    assert(NULL != nm, "build_kmpc_api_name: Incorrect return value", 0, ERR_Fatal);
 
     /* If the name has already been allocated, use that to save memory */
     if (hashmap_lookup(names, (hash_key_t)nm, (hash_data_t *)&res)) {


### PR DESCRIPTION
reasons why it's done this way:

1. I prefer to keep header files free of code.
2. windows functionality should not interfere with linux readability. windows should try to "also" work in addition to linux; therefore linux functions should be created on windows as a wrapper.