### PR TITLE
Clean up Windows related macros

### DIFF
--- a/lib/scutil/pgnewfil.c
+++ b/lib/scutil/pgnewfil.c
@@ -78,7 +78,7 @@ addn(char *p, unsigned long val, int n)
 static LONG pgrand = 0;
 static unsigned long pid = 0;
 
-#if defined(USETEMPNAM) || defined(HOST_WIN) || defined(WIN64)
+#if defined(USETEMPNAM) || defined(HOST_WIN) || defined(_WIN64)
 static int next = 0; /* counter of files created */
 
 /*
@@ -132,7 +132,7 @@ gentmp(char *pfx, char *sfx)
     last = NULL;
     for (q = filename; *q; ++q) {
       if (*q == '/'
-#if defined(HOST_WIN) || defined(WINNT) || defined(WIN64)
+#if defined(HOST_WIN) || defined(_WIN32)
           || *(p - 1) != '\\'
 #endif
           ) {
@@ -233,7 +233,7 @@ gentmp(char *pfx, char *sfx)
   }
   p = add(filename, tmpdir);
   if (*(p - 1) != '/'
-#if defined(HOST_WIN) || defined(WINNT) || defined(WIN64)
+#if defined(HOST_WIN) || defined(_WIN32)
       && *(p - 1) != '\\'
 #endif
       )
@@ -349,7 +349,7 @@ pg_makenewdir(char *pfx, char *sfx, int make)
     if (r == -1 && errno == ENOENT) {
       if (make) {
         int err;
-#if defined(HOST_WIN) || defined(WINNT) || defined(WIN64)
+#if defined(HOST_WIN) || defined(_WIN32)
         err = _mkdir(filename);
 #else
         err = mkdir(filename, S_IRWXG | S_IRWXO | S_IXUSR | S_IWUSR | S_IRUSR);

--- a/runtime/flang/alarm3f.c
+++ b/runtime/flang/alarm3f.c
@@ -9,7 +9,7 @@
 
 /*	alarm3f.c - Implements LIB3F alarm subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 #include <signal.h>
 #include "ent3f.h"
 

--- a/runtime/flang/allo.c
+++ b/runtime/flang/allo.c
@@ -237,7 +237,7 @@ I8(__fort_alloc)(__INT_T nelem, dtype kind, size_t len, __STAT_T *stat,
   char msg[80];
   char *p_env;
 
-#if (defined(WIN64) || defined(WIN32))
+#if defined(_WIN32)
 #define ALN_LARGE
 #else
 #undef ALN_LARGE
@@ -397,7 +397,7 @@ I8(__alloc04)(__NELEM_T nelem, dtype kind, size_t len,
     MP_V_STDIO;
   }
 
-#if (defined(WIN64) || defined(WIN32))
+#if defined(_WIN32)
 #define ALN_LARGE
 #else
 #undef ALN_LARGE

--- a/runtime/flang/backspace.c
+++ b/runtime/flang/backspace.c
@@ -64,7 +64,7 @@ _f90io_backspace(__INT_T *unit, __INT_T *bitv, __INT_T *iostat, int swap_bytes)
 
   if (f->nonadvance) {
     f->nonadvance = FALSE;
-#if defined(WINNT)
+#if defined(_WIN32)
     if (__fortio_binary_mode(f->fp))
       __io_fputc('\r', f->fp);
 #endif

--- a/runtime/flang/bcopys.c
+++ b/runtime/flang/bcopys.c
@@ -25,7 +25,7 @@ __fort_bcopysl(char *to, char *fr, size_t cnt, size_t tostr, size_t frstr,
 {
   size_t i, j;
   unsigned long n;
-#if !defined(WIN64)
+#if !defined(_WIN64)
   long k;
 #else
   long long k;

--- a/runtime/flang/besj03f.c
+++ b/runtime/flang/besj03f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define j0 _j0
 #endif
 

--- a/runtime/flang/besj13f.c
+++ b/runtime/flang/besj13f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define j1 _j1
 #endif
 

--- a/runtime/flang/besjn3f.c
+++ b/runtime/flang/besjn3f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define jn _jn
 #endif
 

--- a/runtime/flang/besy03f.c
+++ b/runtime/flang/besy03f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define y0 _y0
 #endif
 

--- a/runtime/flang/besy13f.c
+++ b/runtime/flang/besy13f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define y1 _y1
 #endif
 

--- a/runtime/flang/besyn3f.c
+++ b/runtime/flang/besyn3f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define yn _yn
 #endif
 

--- a/runtime/flang/buffer.c
+++ b/runtime/flang/buffer.c
@@ -12,7 +12,7 @@
 #include "stdioInterf.h"
 #include "fioMacros.h"
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 #define write _write
 #define creat _creat
 #define close _close

--- a/runtime/flang/chdir3f.c
+++ b/runtime/flang/chdir3f.c
@@ -18,7 +18,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define chdir _chdir
 #endif
 

--- a/runtime/flang/chmod3f.c
+++ b/runtime/flang/chmod3f.c
@@ -17,7 +17,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define chmod _chmod
 #endif
 

--- a/runtime/flang/close.c
+++ b/runtime/flang/close.c
@@ -18,7 +18,7 @@
 #endif
 #include "stdioInterf.h"
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 #define unlink _unlink
 #define access _access
 #endif
@@ -38,7 +38,7 @@ __fortio_close(FIO_FCB *f, int flag)
 
   if (f->nonadvance) {
     f->nonadvance = FALSE;
-#if defined(WINNT)
+#if defined(_WIN32)
     if (__fortio_binary_mode(f->fp))
       __io_fputc('\r', f->fp);
 #endif
@@ -61,7 +61,7 @@ __fortio_close(FIO_FCB *f, int flag)
       else
         __fort_unlink(f->name);
     }
-#ifdef WINNT
+#if defined(_WIN32)
     else if (f->status == FIO_SCRATCH)
       unlink(f->name);
 #endif

--- a/runtime/flang/cnfg.c
+++ b/runtime/flang/cnfg.c
@@ -80,7 +80,7 @@ __fortio_scratch_name(char *filename, int unit)
   extern char *__io_tempnam();
   char *nm;
 
-#if defined(WINNT)
+#if defined(_WIN32)
   if (getenv("TMP") == 0)
     nm = __io_tempnam("C:\\", "FTN");
   else
@@ -88,13 +88,13 @@ __fortio_scratch_name(char *filename, int unit)
   strcpy(filename, nm);
   if (nm)
     free(nm);
-#else /*WINNT*/
+#else /* _WIN32 */
 
   nm = __io_tempnam((char *)0, "FTN");
   strcpy(filename, nm);
   if (nm)
     free(nm);
 
-#endif /*WINNT*/
+#endif /* _WIN32 */
 
 }

--- a/runtime/flang/cnfg.h
+++ b/runtime/flang/cnfg.h
@@ -17,7 +17,7 @@ typedef struct {
   int ftn_true;       /* -1 ==> VAX; 1 => unix */
 } FIO_CNFG;
 
-#ifdef WINNT
+#if defined(_WIN32)
 
 extern char *__get_fio_cnfg_default_name(void);
 extern int __get_fio_cnfg_true_mask(void);

--- a/runtime/flang/const.c
+++ b/runtime/flang/const.c
@@ -125,7 +125,7 @@ __INT_T ENTCOMN(TYPE, type)[] = {
     17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,
     32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43};
 
-#if defined(WINNT) && !defined(WIN64) && !defined(WIN32)
+#if defined(_WIN32)
 char *
 __get_fort_type_addr(void)
 {
@@ -423,7 +423,7 @@ __get_size_of(int* idx)
   return __fort_size_of[*idx];
 }
 
-#ifdef WINNT
+#if defined(_WIN32)
 
 /* pg access routines for data shared between windows dlls */
 
@@ -658,7 +658,7 @@ __get_fort_zed(void)
   return __fort_zed;
 }
 
-#endif /* WINNT */
+#endif /* _WIN32 */
 
 void
 __fort_init_consts()
@@ -766,7 +766,7 @@ __fort_init_consts()
 /*
  * Always emit the comms for non-windows systems.
  */
-#ifdef WINNT
+#if defined(_WIN32)
 /*
  * Emit the comms for win if pg.dll is not used -- PGDLL is defined
  * if we need to revert to pg.dll.

--- a/runtime/flang/curdir.c
+++ b/runtime/flang/curdir.c
@@ -18,7 +18,7 @@
 #define MAXPATHLEN 1024
 #endif
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 #define getcwd _getcwd
 #endif
 

--- a/runtime/flang/dbesj03f.c
+++ b/runtime/flang/dbesj03f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define j0 _j0
 #endif
 

--- a/runtime/flang/dbesj13f.c
+++ b/runtime/flang/dbesj13f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define j1 _j1
 #endif
 

--- a/runtime/flang/dbesjn3f.c
+++ b/runtime/flang/dbesjn3f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define jn _jn
 #endif
 

--- a/runtime/flang/dbesy03f.c
+++ b/runtime/flang/dbesy03f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define y0 _y0
 #endif
 

--- a/runtime/flang/dbesy13f.c
+++ b/runtime/flang/dbesy13f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define y1 _y1
 #endif
 

--- a/runtime/flang/dbesyn3f.c
+++ b/runtime/flang/dbesyn3f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define yn _yn
 #endif
 

--- a/runtime/flang/delfilesqq3f.c
+++ b/runtime/flang/delfilesqq3f.c
@@ -8,7 +8,7 @@
 /* clang-format off */
 
 /*	delfilesqq3f.c - Implements DFLIB delfilesqq subprogram.  */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 #include <string.h>
@@ -17,7 +17,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 extern char *__fstr2cstr();
 int ENT3F(DELFILESQQ, delfilesqq)(DCHAR(ffiles) DCLEN(ffiles))
 {

--- a/runtime/flang/descIntrins.c
+++ b/runtime/flang/descIntrins.c
@@ -18,10 +18,10 @@
 #include <string.h>
 #include "fioMacros.h"
 /* macros for entries */
-#if defined(WINNT) && !defined(WIN64) && !defined(UXOBJS) && !defined(CROBJS)
+#if defined(_WIN32) && !defined(_WIN64) && !defined(UXOBJS) && !defined(CROBJS)
 #pragma global - x 121 0x20000
 #define ENTFTN_MS(UC) WIN_EXP __attribute__((stdcall)) UC
-#elif defined(WINNT) && defined(WIN64)
+#elif defined(_WIN32)
 #define ENTFTN_MS I8
 #endif
 
@@ -282,7 +282,7 @@ ENTFTN(KINDEXX, kindexx_cr_nm)
 
 #endif
 
-#if defined(WINNT)
+#if defined(_WIN32)
 
 /* functions here follow the msfortran/mscall conventions */
 

--- a/runtime/flang/drandm3f.c
+++ b/runtime/flang/drandm3f.c
@@ -12,7 +12,7 @@
 #include "ent3f.h"
 
 /* drand48, srand48 are not currently available on win64 */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 #include <stdlib.h>
 

--- a/runtime/flang/ent3f.h
+++ b/runtime/flang/ent3f.h
@@ -18,7 +18,7 @@
 #undef CLEN
 
 /* macros for entries */
-#if defined(WINNT) && !defined(WIN64) && !defined(UXOBJS)
+#if defined(_WIN32) && !defined(_WIN64) && !defined(UXOBJS)
 
 #pragma global - x 121 0x20000
 #define ENT3F(UC, LC) __attribute__((stdcall)) UC
@@ -37,7 +37,7 @@
 
 #endif
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 #define j0 _j0
 #define j1 _j1
 #define jn _jn

--- a/runtime/flang/entry.c
+++ b/runtime/flang/entry.c
@@ -14,16 +14,16 @@
 #include "stdioInterf.h"
 #include "fioMacros.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 WIN_IMP __INT_T LINENO[];
-#elif defined(C90) || defined(WINNT)
+#elif defined(C90)
 __INT_T LINENO[1];
 char *__get_fort_lineno_addr(void);
 #else
 extern __INT_T LINENO[];
 #endif
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 #define write _write
 #endif
 
@@ -51,7 +51,7 @@ static int __fort_trac_mflag;
 static int __fort_prof_mflag;
 int __fort_entry_mflag;
 
-#ifdef WINNT
+#if defined(_WIN32)
 /* pg access for dlls */
 char *
 __get_fort_lineno_addr(void)

--- a/runtime/flang/fdate3f.c
+++ b/runtime/flang/fdate3f.c
@@ -14,7 +14,7 @@
 #include <time.h>
 #include "utils3f.h"
 
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32)
 WIN_MSVCRT_IMP char *WIN_CDECL ctime(const time_t *);
 #endif
 

--- a/runtime/flang/findfileqq3f.c
+++ b/runtime/flang/findfileqq3f.c
@@ -16,7 +16,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 extern char *__fstr2cstr();
 int ENT3F(FINDFILEQQ, findfileqq)(DCHAR(fname), DCHAR(fvarname),

--- a/runtime/flang/fioMacros.h
+++ b/runtime/flang/fioMacros.h
@@ -25,20 +25,9 @@
 
 /* special argument pointers */
 
-#if defined(TARGET_WIN) || defined(WIN64) || defined(WIN32)
+#if defined(TARGET_WIN) || defined(_WIN32)
 WIN_IMP __INT_T ENTCOMN(0, 0)[4];
 WIN_IMP __STR_T ENTCOMN(0C, 0c)[1];
-#elif defined(WINNT)
-__INT_T ENTCOMN(0, 0)[4];
-__STR_T ENTCOMN(0C, 0c)[1];
-char *__get_fort_01_addr(void);
-char *__get_fort_02_addr(void);
-char *__get_fort_03_addr(void);
-char *__get_fort_04_addr(void);
-char *__get_fort_0c_addr(void);
-char *__get_fort_me_addr(void);
-char *__get_fort_np_addr(void);
-
 #else
 #if defined(DESC_I8)
 extern __INT4_T ENTCOMN(0, 0)[];
@@ -78,9 +67,9 @@ extern __STR_T ENTCOMN(0C, 0c)[];
 
 /* local mode flag declaration and test macro */
 
-#if defined(TARGET_WIN) || defined(WIN64) || defined(WIN32)
+#if defined(TARGET_WIN) || defined(_WIN32)
 WIN_IMP __INT_T ENTCOMN(LOCAL_MODE, local_mode)[1];
-#elif defined(WINNT) || defined(C90)
+#elif defined(C90)
 __INT_T ENTCOMN(LOCAL_MODE, local_mode)[1];
 #else
 #if defined(DESC_I8)
@@ -221,7 +210,7 @@ void __fort_set_second(double d);
 #define __DIST_ENTRY_AWAIT(reqn)
 #define __DIST_ENTRY_AWAIT_DONE(reqn)
 
-#ifdef WINNT
+#if defined(_WIN32)
 /* prototypes for HPF */
 
 /* The PG compilers cannot yet create dlls that share data. For
@@ -540,10 +529,8 @@ extern int __fort_entry_mflag;
 #define __CORMEM_M1 0x58ad5e3
 #define __CORMEM_M2 0x61f072b
 
-#if   defined(TARGET_WIN) || defined(WIN64) || defined(WIN32)
+#if   defined(TARGET_WIN) || defined(_WIN32)
 WIN_IMP __INT_T *CORMEM;
-#elif defined(WINNT)
-extern __INT_T *CORMEM;
 #else
 #if defined(DESC_I8)
 extern __INT4_T CORMEM[];
@@ -556,7 +543,7 @@ extern __INT_T CORMEM[];
 #define NPLIMIT 0
 #endif /* NPLIMIT */
 
-#if defined(TARGET_WIN) || defined(WIN64) || defined(WIN32)
+#if defined(TARGET_WIN) || defined(_WIN32)
 void __CORMEM_SCAN(void);
 #else
 #define __CORMEM_SCAN()                                                        \

--- a/runtime/flang/fiodf.c
+++ b/runtime/flang/fiodf.c
@@ -13,7 +13,7 @@
 
 FIO_TBL fioFcbTbls = {0};
 
-#ifdef WINNT
+#if defined(_WIN32)
 FIO_FCB *
 __get_hpfio_fcbs(void)
 {

--- a/runtime/flang/fmtwrite.c
+++ b/runtime/flang/fmtwrite.c
@@ -2686,7 +2686,7 @@ fw_write_record(void)
         f->nonadvance = FALSE; /* do it now */
         if (!(g->suppress_crlf)) {
 /* append carriage return */
-#if defined(WINNT)
+#if defined(_WIN32)
           if (__fortio_binary_mode(f->fp))
             __io_fputc('\r', f->fp);
 #endif

--- a/runtime/flang/fork3f.c
+++ b/runtime/flang/fork3f.c
@@ -9,7 +9,7 @@
 
 /*	fork3f.c - Implements LIB3F fork subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
@@ -33,4 +33,4 @@ int ENT3F(FORK, fork)()
     return pid;
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/fortDt.h
+++ b/runtime/flang/fortDt.h
@@ -265,7 +265,7 @@ typedef __CPLX16_T __BIGCPLX_T;
 
 /* pointer-sized integer */
 
-#if   defined(WIN64)
+#if defined(_WIN64)
 
 typedef long long __POINT_T;
 

--- a/runtime/flang/fpcvt.c
+++ b/runtime/flang/fpcvt.c
@@ -7,7 +7,7 @@
 
 #include <string.h>
 #include <ctype.h>
-#if !defined(WIN64)
+#if !defined(_WIN64)
 #include <fenv.h>
 #endif
 #include "fioMacros.h"
@@ -723,7 +723,7 @@ __fortio_strtod(char *s, char **p)
  * (0 is before first digit).  *sign is sign.
  */
 
-#if defined(WIN64)
+#if defined(_WIN64)
 #define FE_TONEAREST 0
 #define FE_DOWNWARD 1024
 #define FE_UPWARD 2048

--- a/runtime/flang/fstat3f.c
+++ b/runtime/flang/fstat3f.c
@@ -17,7 +17,7 @@
 
 int ENT3F(FSTAT, fstat)(int *lu, int *statb)
 {
-#ifdef WIN32
+#if defined(_WIN32)
   struct _stat32 b;
   char *p;
   int i;
@@ -100,7 +100,7 @@ int ENT3F(FSTAT, fstat)(int *lu, int *statb)
   statb[8] = b.st_atime;
   statb[9] = b.st_mtime;
   statb[10] = b.st_ctime;
-#if !defined(WINNT)
+#if !defined(_WIN32)
   statb[11] = b.st_blksize;
   statb[12] = b.st_blocks;
 #else

--- a/runtime/flang/fstat643f.c
+++ b/runtime/flang/fstat643f.c
@@ -17,7 +17,7 @@
 
 int ENT3F(FSTAT64, fstat64)(int *lu, long long *statb)
 {
-#if defined(TARGET_WIN) || defined(WIN32) || defined(WIN64)
+#if defined(TARGET_WIN) || defined(_WIN32)
   /*
    * The __int64_t members in the _stat64 are 8-byte aligned, thus the
    * st_size member is at offset 24. On WIN32, 64-bit ints are 4-byte

--- a/runtime/flang/ftni64.h
+++ b/runtime/flang/ftni64.h
@@ -46,7 +46,7 @@ typedef union {
     I64_LSH(int64d.i) = l;                                                     \
     return int64d.lv;                                                          \
   }
-#elif defined(WIN64)
+#elif defined(_WIN64)
 /* Someday, should only care if TM_I8 is defined */
 #define __I8RET_T long long
 #define UTL_I_I64RET(m, l)                                                     \

--- a/runtime/flang/fullpathqq3f.c
+++ b/runtime/flang/fullpathqq3f.c
@@ -15,7 +15,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 extern char *__fstr2cstr();
 int ENT3F(FULLPATHQQ, fullpathqq)(DCHAR(fname),

--- a/runtime/flang/gerror3f.c
+++ b/runtime/flang/gerror3f.c
@@ -17,7 +17,7 @@
 
 #define Ftn_errmsg __fortio_errmsg
 
-#if !defined(WIN64) && !defined(WIN32)
+#if !defined(_WIN32)
 extern char *strerror(); /* SVR4 only ? */
 #endif
 

--- a/runtime/flang/getcwd3f.c
+++ b/runtime/flang/getcwd3f.c
@@ -15,7 +15,7 @@
 #include "utils3f.h"
 #include "mpalloc.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 #define GETCWDM _getcwd /* getcwd deprecated in Windows in VC 2005 */
 #else
 #define GETCWDM getcwd

--- a/runtime/flang/getdat3f.c
+++ b/runtime/flang/getdat3f.c
@@ -9,7 +9,7 @@
 
 /*	getdat3f.c - Implements getdat subroutine.  */
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 #include <windows.h>
 #include "ent3f.h"

--- a/runtime/flang/getdrivedirqq3f.c
+++ b/runtime/flang/getdrivedirqq3f.c
@@ -16,7 +16,7 @@
 #include "utils3f.h"
 #include "mpalloc.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 #define GETCWDM _getcwd /* getcwd deprecated in Windows in VC 2005 */
 #else
 #define GETCWDM getcwd

--- a/runtime/flang/getfileinfoqq3f.c
+++ b/runtime/flang/getfileinfoqq3f.c
@@ -8,7 +8,7 @@
 /* clang-format off */
 
 /*	getfileinfoqq3f.c - Implements DFLIB getfileinfoqq subprogram.  */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 #include <string.h>
@@ -17,7 +17,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 extern char *__fstr2cstr();
 extern void __GetTimeToSecondsSince1970(ULARGE_INTEGER *fileTime,
                                         unsigned int *out);

--- a/runtime/flang/getfileinfoqqi83f.c
+++ b/runtime/flang/getfileinfoqqi83f.c
@@ -8,7 +8,7 @@
 /* clang-format off */
 
 /*	getfileinfoqq3f.c - Implements DFLIB getfileinfoqq subprogram.  */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 #include <string.h>
@@ -21,7 +21,7 @@
 #define FILE$LAST -2
 #define FILE$ERROR -3
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 extern char *__fstr2cstr();
 extern void __GetTimeToSecondsSince1970(ULARGE_INTEGER *fileTime,
                                         unsigned int *out);

--- a/runtime/flang/getgid3f.c
+++ b/runtime/flang/getgid3f.c
@@ -9,11 +9,11 @@
 
 /*	getgid3f.c - Implements LIB3F getgid subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 #include  <unistd.h>
 #include "ent3f.h"
 
 int ENT3F(GETGID, getgid)() { return getgid(); }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/getlog3f.c
+++ b/runtime/flang/getlog3f.c
@@ -9,7 +9,7 @@
 
 /*	getlog3f.c - Implements LIB3F getlog subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 #include "ent3f.h"
 #include "utils3f.h"
@@ -24,4 +24,4 @@ void ENT3F(GETLOG, getlog)(DCHAR(nm) DCLEN(nm))
   __fcp_cstr(CADR(nm), CLEN(nm), p);
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/gettim3f.c
+++ b/runtime/flang/gettim3f.c
@@ -9,7 +9,7 @@
 
 /*	gettim3f.c - Implements gettim subroutine.  */
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 #include <windows.h>
 #include "ent3f.h"

--- a/runtime/flang/getuid3f.c
+++ b/runtime/flang/getuid3f.c
@@ -9,11 +9,11 @@
 
 /*	getuid3f.c - Implements LIB3F getuid subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 #include "ent3f.h"
 #include <unistd.h>
 
 int ENT3F(GETUID, getuid)() { return getuid(); }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/getvolinfo3f.c
+++ b/runtime/flang/getvolinfo3f.c
@@ -18,8 +18,8 @@
 typedef char *LPSTR;
 typedef int DWORD;
 
-#if defined(WIN64) || defined(WIN32)
-#if defined(WIN64)
+#if defined(_WIN32)
+#if defined(_WIN64)
 typedef long long LDWORD;
 extern int GetVolumeInformationA();
 #define ENTNAM(ss) _##ss

--- a/runtime/flang/global.h
+++ b/runtime/flang/global.h
@@ -317,7 +317,7 @@ typedef struct {
 #include <errno.h>
 
 extern FIO_TBL fioFcbTbls;
-#ifdef WINNT
+#if defined(_WIN32)
 extern FIO_FCB *__get_fio_fcbs(void);
 #define GET_FIO_FCBS __get_fio_fcbs()
 #else
@@ -365,7 +365,7 @@ extern int __fortio_check_format(void);
 extern int __fortio_eor_crlf(void);
 extern VOID __fortio_fmtinit(void);
 extern VOID __fortio_fmtend(void);
-#if defined(WINNT)
+#if defined(_WIN32)
 #define EOR_CRLF 1
 #else
 #define EOR_CRLF __fortio_eor_crlf()

--- a/runtime/flang/hand.c
+++ b/runtime/flang/hand.c
@@ -10,7 +10,7 @@
 #include "stdioInterf.h"
 #include "fioMacros.h"
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 #define write _write
 #endif
 
@@ -87,7 +87,7 @@ static void sighand(s) int s;
 
   lcpu = __fort_myprocnum();
   __fort_psignal(lcpu, s); /* print message */
-#if !defined(WIN64) && !defined(WIN32)
+#if !defined(WIN32)
   sleep(1); /* wait for message to clear */
 #endif
   __fort_abort(NULL); /* abort */

--- a/runtime/flang/hostnm3f.c
+++ b/runtime/flang/hostnm3f.c
@@ -9,7 +9,7 @@
 
 /*	hostnm3f.c - Implements LIB3F hostnm subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
@@ -43,4 +43,4 @@ int ENT3F(HOSTNM, hostnm)(DCHAR(nm) DCLEN(nm))
   return i;
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/init.c
+++ b/runtime/flang/init.c
@@ -18,7 +18,7 @@ static int tid = 0;
 
 char *__fort_transnam = "rpm1";
 
-#ifdef WINNT
+#if defined(_WIN32)
 
 /* pg access routines for data shared between windows dlls */
 

--- a/runtime/flang/initpar.c
+++ b/runtime/flang/initpar.c
@@ -35,7 +35,7 @@
 
 #if   defined(TARGET_OSX)
 #include <crt_externs.h>
-#elif defined(__WIN64)
+#elif defined(_WIN64)
 /* OPENTOOLS14 has changed the name.  wrap _environ for all of windowws */
 char **__io_environ();
 #else
@@ -67,19 +67,16 @@ static struct {
 /* common blocks containing values for inlined number_of_processors()
    and my_processor() functions */
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 WIN_IMP __INT_T ENTCOMN(NP, np)[];
 WIN_IMP __INT_T ENTCOMN(ME, me)[];
-#elif defined(C90) || defined(WINNT)
+#define write _write
+#elif defined(C90)
 __INT_T ENTCOMN(NP, np)[1];
 __INT_T ENTCOMN(ME, me)[1];
 #else
 extern __INT_T ENTCOMN(NP, np)[];
 extern __INT_T ENTCOMN(ME, me)[];
-#endif
-
-#if defined(WIN32) || defined(WIN64)
-#define write _write
 #endif
 
 /* Return logical cpu number */
@@ -98,8 +95,8 @@ __fort_ncpus()
   return __fort_tcpus;
 }
 
-#if defined(WINNT)
-#if !defined(WIN64) && !defined(WIN32)
+#if defined(_WIN32)
+#if !defined(_WIN64)
 __INT_T *CORMEM;
 
 /* special argument pointer access routines */
@@ -161,7 +158,7 @@ __get_fort_np_addr(void)
 {
   return (char *)ENTCOMN(NP, np);
 }
-#endif /* !WIN64 || !WIN32 */
+#endif /* !_WIN64 */
 
 /* access routines for data shared between windows dlls */
 
@@ -309,7 +306,7 @@ __set_fort_tids_elem(int idx, int val)
   __fort_tids[idx] = val;
 }
 
-#endif /* WINNT */
+#endif /* _WIN32 */
 
 int
 __fort_getioproc()

--- a/runtime/flang/inquire.c
+++ b/runtime/flang/inquire.c
@@ -16,7 +16,7 @@
 #include "global.h"
 #include "async.h"
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 #define access _access
 #endif
 

--- a/runtime/flang/io3f.h
+++ b/runtime/flang/io3f.h
@@ -16,11 +16,11 @@
 #define __fio_close(f, s) __fortio_close(f, s)
 #define __fio_find_unit(u) __fortio_find_unit(u)
 #define fio_fileno(f) __fort_getfd(f)
-#ifndef WINNT
+#if !defined(_WIN32)
 #define pgi_fio fioFcbTbl
 #endif
 
-#if defined(WINNT)
+#if defined(_WIN32)
 #define __PC_DOS 1
 #else
 #define __PC_DOS 0

--- a/runtime/flang/irandm3f.c
+++ b/runtime/flang/irandm3f.c
@@ -11,7 +11,7 @@
 
 #include "ent3f.h"
 
-#ifdef WINNT
+#if defined(_WIN32)
 
 int ENT3F(IRANDM, irandm)(int *flag)
 {

--- a/runtime/flang/kill3f.c
+++ b/runtime/flang/kill3f.c
@@ -9,7 +9,7 @@
 
 /*	kill3f.c - Implements LIB3F kill subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 #define POSIX 1
 #include <sys/types.h>
@@ -29,4 +29,4 @@ int *sig;
   return i;
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/ldread.c
+++ b/runtime/flang/ldread.c
@@ -1707,7 +1707,7 @@ skip_record(void)
         }
         return __io_errno();
       }
-#if defined(WINNT)
+#if defined(_WIN32)
       if (ch == '\r') {
         ch = __io_fgetc(fcb->fp);
         if (ch == '\n')

--- a/runtime/flang/ldwrite.c
+++ b/runtime/flang/ldwrite.c
@@ -869,7 +869,7 @@ write_record(void)
           return __io_errno();
     }
   } else { /* sequential write: append carriage return */
-#if defined(WINNT)
+#if defined(_WIN32)
     if (__fortio_binary_mode(fcb->fp))
       if (FWRITE("\r", 1, 1, fcb->fp) != 1)
         return __io_errno();

--- a/runtime/flang/link3f.c
+++ b/runtime/flang/link3f.c
@@ -9,7 +9,7 @@
 
 /*	link3f.c - Implements LIB3F link subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
@@ -35,4 +35,4 @@ int ENT3F(LINK, link)(DCHAR(n1), DCHAR(n2) DCLEN(n1) DCLEN(n2))
   return i;
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/lstat3f.c
+++ b/runtime/flang/lstat3f.c
@@ -9,7 +9,7 @@
 
 /*	lstat3f.c - Implements LIB3F lstat subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 /* must include ent3f.h AFTER io3f.h */
 #include <sys/stat.h>
@@ -45,4 +45,4 @@ int ENT3F(LSTAT, lstat)(DCHAR(nm), int *statb DCLEN(nm))
   return i;
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/lstat643f.c
+++ b/runtime/flang/lstat643f.c
@@ -9,7 +9,7 @@
 
 /*	lstat3f.c - Implements 64-bit LIB3F lstat subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 /* must include ent3f.h AFTER io3f.h */
 #include <sys/stat.h>
@@ -45,4 +45,4 @@ int ENT3F(LSTAT64, lstat64)(DCHAR(nm), long long *statb DCLEN(nm))
   return i;
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/mclock3f.c
+++ b/runtime/flang/mclock3f.c
@@ -12,7 +12,7 @@
 
 /* assumes the Unix times system call */
 
-#if   defined(WINNT)
+#if defined(_WIN32)
 
 #include <time.h>
 

--- a/runtime/flang/misc.c
+++ b/runtime/flang/misc.c
@@ -5,7 +5,7 @@
  *
  */
 
-#if !defined(PARAMID) && !defined(WINNT)
+#if !defined(PARAMID) && !defined(_WIN32)
 #include <sys/types.h>
 #include <fcntl.h>
 #include <time.h>

--- a/runtime/flang/nmlwrite.c
+++ b/runtime/flang/nmlwrite.c
@@ -313,7 +313,7 @@ emit_eol(void)
   int ret_err;
 
   if (!internal_file) {
-#if defined(WINNT)
+#if defined(_WIN32)
     if (__fortio_binary_mode(f->fp)) {
       ret_err = write_char('\r');
       if (ret_err)

--- a/runtime/flang/open.c
+++ b/runtime/flang/open.c
@@ -20,7 +20,7 @@
 #include "async.h"
 #include <fcntl.h>
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 #define access _access
 #define unlink _unlink
 #endif
@@ -94,7 +94,7 @@ __fortio_open(int unit, int action_flag, int status_flag, int dispose_flag,
     for (i = 0; i < namelen; i++)
       filename[i] = name[i];
     filename[namelen] = '\0';
-#if defined(WINNT)
+#if defined(_WIN32)
     if (filename[0] == '/' && filename[1] == '/' && filename[3] == '/') {
       /* convert posix format to win32 format */
       filename[0] = filename[2]; /* drive letter */

--- a/runtime/flang/packtimeqq3f.c
+++ b/runtime/flang/packtimeqq3f.c
@@ -8,7 +8,7 @@
 /* clang-format off */
 
 /*	packtimeqq3f.c - Implements DFLIB packtimeqq subprogram.  */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 #include <string.h>
@@ -17,7 +17,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 extern char *__fstr2cstr();
 extern void __GetTimeToSecondsSince1970(ULARGE_INTEGER *fileTime,
                                         unsigned int *out);

--- a/runtime/flang/perror3f.c
+++ b/runtime/flang/perror3f.c
@@ -13,7 +13,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#if !defined(WIN64) && !defined(WIN32)
+#if !defined(_WIN32)
 extern char *strerror(); /* SVR4 only ? */
 #endif
 extern FILE *__getfile3f();

--- a/runtime/flang/rand3f.c
+++ b/runtime/flang/rand3f.c
@@ -12,7 +12,7 @@
 #include "ent3f.h"
 
 /* drand48 is not currently available on win64 */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 #include <stdlib.h>
 

--- a/runtime/flang/random3f.c
+++ b/runtime/flang/random3f.c
@@ -12,7 +12,7 @@
 #include "ent3f.h"
 
 /* drand48, srand48 are not currently available on win64 */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 #include <stdlib.h>
 

--- a/runtime/flang/rewind.c
+++ b/runtime/flang/rewind.c
@@ -44,7 +44,7 @@ _f90io_rewind(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
 
     if (f->nonadvance) {
       f->nonadvance = FALSE;
-#if defined(WINNT)
+#if defined(_WIN32)
       if (__fortio_binary_mode(f->fp))
         __io_fputc('\r', f->fp);
 #endif

--- a/runtime/flang/setfileaccessqq3f.c
+++ b/runtime/flang/setfileaccessqq3f.c
@@ -8,7 +8,7 @@
 /* clang-format off */
 
 /*	setfileaccessqq3f.c - Implements DFLIB setfileaccessqq subprogram.  */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 #include <string.h>
@@ -22,7 +22,7 @@
 #define FILE$ERROR -3
 #define FILE$CURTIME -1
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 extern char *__fstr2cstr();
 
 int ENT3F(SETFILEACCESSQQ, setfileaccessqq)(DCHAR(ffile),

--- a/runtime/flang/setfiletimeqq3f.c
+++ b/runtime/flang/setfiletimeqq3f.c
@@ -8,7 +8,7 @@
 /* clang-format off */
 
 /*	setfiletimeqq3f.c - Implements DFLIB setfiletimeqq subprogram.  */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 #include <string.h>
@@ -22,7 +22,7 @@
 #define FILE$ERROR -3
 #define FILE$CURTIME -1
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 extern char *__fstr2cstr();
 extern void __UnpackTime(unsigned int secsSince1970, ULARGE_INTEGER *fileTime);
 extern int __GETFILEINFOQQ(DCHAR(ffiles), char *buffer,

--- a/runtime/flang/signalqq3f.c
+++ b/runtime/flang/signalqq3f.c
@@ -14,7 +14,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#if defined(WIN64) || !defined(WINNT)
+#if defined(_WIN64) || !defined(_WIN32)
 
 #define LONGINTSIZE unsigned long long
 
@@ -30,4 +30,4 @@ ENT3F(SIGNALQQ, signalqq)(short *signum, void (*proc)(int))
     return (LONGINTSIZE)p;
 }
 
-#endif /* WIN64 or !WINNT */
+#endif /* _WIN64 or !_WIN32 */

--- a/runtime/flang/sleep3f.c
+++ b/runtime/flang/sleep3f.c
@@ -14,7 +14,7 @@
 #endif
 #include "ent3f.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 #include <windows.h>
 

--- a/runtime/flang/sleepqq3f.c
+++ b/runtime/flang/sleepqq3f.c
@@ -14,7 +14,7 @@
 #endif
 #include "ent3f.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 #include <windows.h>
 

--- a/runtime/flang/splitpathqq3f.c
+++ b/runtime/flang/splitpathqq3f.c
@@ -15,7 +15,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 extern char *__fstr2cstr();
 int ENT3F(SPLITPATHQQ, splitpathqq)(DCHAR(fpath), DCHAR(fdrive), DCHAR(fdir),

--- a/runtime/flang/srand3f.c
+++ b/runtime/flang/srand3f.c
@@ -13,7 +13,7 @@
 #include "ent3f.h"
 
 /* srand48 is not currently available on win64 */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 void ENT3F(SRAND1, srand1)(int *iseed) { srand(*iseed); }
 

--- a/runtime/flang/stat.c
+++ b/runtime/flang/stat.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <memory.h>
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 #define write _write
 #endif
 

--- a/runtime/flang/stat3f.c
+++ b/runtime/flang/stat3f.c
@@ -19,7 +19,7 @@ extern void __cstr_free();
 
 int ENT3F(STAT, stat)(DCHAR(nm), int *statb DCLEN(nm))
 {
-#ifdef WIN32
+#if defined(_WIN32)
   struct _stat32 b;
   char *p;
   int i;
@@ -62,7 +62,7 @@ int ENT3F(STAT, stat)(DCHAR(nm), int *statb DCLEN(nm))
   statb[8] = b.st_atime;
   statb[9] = b.st_mtime;
   statb[10] = b.st_ctime;
-#if !defined(WINNT)
+#if !defined(_WIN32)
   statb[11] = b.st_blksize;
   statb[12] = b.st_blocks;
 #else

--- a/runtime/flang/stat643f.c
+++ b/runtime/flang/stat643f.c
@@ -19,7 +19,7 @@ extern void __cstr_free();
 
 int ENT3F(STAT64, stat64)(DCHAR(nm), long long *statb DCLEN(nm))
 {
-#if defined(TARGET_WIN) || defined(WIN32) || defined(WIN64)
+#if defined(TARGET_WIN) || defined(_WIN32)
   /*
    * The __int64_t members in the _stat64 are 8-byte aligned, thus the
    * st_size member is at offset 24. On WIN32, 64-bit ints are 4-byte

--- a/runtime/flang/stime3f.c
+++ b/runtime/flang/stime3f.c
@@ -9,7 +9,7 @@
 
 /*	stime3f.c - Implements LIB3F stime subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 #include <time.h>
 #include "io3f.h"
@@ -27,4 +27,4 @@ int ENT3F(STIME, stime)(int *tp)
   return i;
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/symlnk3f.c
+++ b/runtime/flang/symlnk3f.c
@@ -9,7 +9,7 @@
 
 /*	symlnk3f.c - Implements LIB3F symlnk subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 #include "io3f.h"
 #include "ent3f.h"
@@ -34,4 +34,4 @@ int ENT3F(SYMLNK, symlnk)(DCHAR(n1), DCHAR(n2) DCLEN(n1) DCLEN(n2))
   return i;
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/timef3f.c
+++ b/runtime/flang/timef3f.c
@@ -10,7 +10,7 @@
 /*	timef3f.c - Implements timef subprogram.  */
 
 /* assumes the Unix times system call */
-/* how do we do this for WINNT */
+/* how do we do this for WIN32 */
 #include "ent3f.h"
 
 #ifndef _WIN64

--- a/runtime/flang/times3f.c
+++ b/runtime/flang/times3f.c
@@ -9,7 +9,7 @@
 
 /*	times3f.c - Implements LIB3F times subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 #include <sys/times.h>
 #include "io3f.h"
@@ -27,4 +27,4 @@ int ENT3F(TIMES, times)(int *buff)
   return i;
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/ttynam3f.c
+++ b/runtime/flang/ttynam3f.c
@@ -9,7 +9,7 @@
 
 /*	ttynam3f.c - Implements LIB3F ttynam subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
@@ -48,4 +48,4 @@ sk:
   return;
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flang/type.c
+++ b/runtime/flang/type.c
@@ -1082,7 +1082,7 @@ get_source_and_dest_sizes(F90_Desc *ad, F90_Desc *bd,
     }
   } else if (bd && !flag && ISSCALAR(bd) && bd->tag != __POLY &&
              bd->tag != __STR && bd->tag < __NTYPES) {
-#if defined(WINNT)
+#if defined(_WIN32)
     *src_sz = __get_fort_size_of(bd->tag);
 #else
     *src_sz = __fort_size_of[bd->tag];

--- a/runtime/flang/unpacktimeqq3f.c
+++ b/runtime/flang/unpacktimeqq3f.c
@@ -8,7 +8,7 @@
 /* clang-format off */
 
 /*	unpacktimeqq3f.c - Implements DFLIB packtimeqq subprogram.  */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 #include <string.h>
@@ -18,7 +18,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 extern char *__fstr2cstr();
 extern void __UnpackTime(unsigned int secsSince1970, ULARGE_INTEGER *fileTime);
 

--- a/runtime/flang/utils3f.c
+++ b/runtime/flang/utils3f.c
@@ -6,7 +6,7 @@
  */
 
 /*	  */
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 #include "io3f.h"
@@ -109,7 +109,7 @@ extern FILE *__getfile3f(unit) int unit;
   }
 }
 
-#if defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 void
 __GetTimeToSecondsSince1970(ULARGE_INTEGER *fileTime, unsigned int *out)
 {

--- a/runtime/flang/utilsi64.c
+++ b/runtime/flang/utilsi64.c
@@ -26,7 +26,7 @@ extern int __fort_atoxi64();
 extern void __fort_i64toax();
 
 /* has native support for 8-byte integers*/
-#if !defined(WIN64)
+#if !defined(_WIN64)
 typedef long I8_T;
 typedef unsigned long UI8_T;
 #else

--- a/runtime/flang/wait.c
+++ b/runtime/flang/wait.c
@@ -14,7 +14,7 @@
 #include "global.h"
 #include "async.h"
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define access _access
 #endif
 

--- a/runtime/flang/wait3f.c
+++ b/runtime/flang/wait3f.c
@@ -9,7 +9,7 @@
 
 /*	wait3f.c - Implements LIB3F wait subprogram.  */
 
-#ifndef WINNT
+#if !defined(_WIN32)
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -26,4 +26,4 @@ int ENT3F(WAIT, wait)(int *st)
   return wait(wst);
 }
 
-#endif /* !WINNT */
+#endif /* !_WIN32 */

--- a/runtime/flangmain/flangmain.c
+++ b/runtime/flangmain/flangmain.c
@@ -17,7 +17,7 @@ extern char **__io_environ();
 extern void __io_set_argc(int);
 extern void __io_set_argv(char **);
 
-#if defined(PGDLL) && defined(WINNT) && !defined(WIN64)
+#if defined(PGDLL) && defined(_WIN32) && !defined(_WIN64)
 struct {
   char *pghpf_01p;
   char *pghpf_02p;
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
   __io_set_argc(argc);
   __io_set_argv(argv);
 
-#if defined(PGDLL) && defined(WINNT) && !defined(WIN64)
+#if defined(PGDLL) && defined(_WIN32) && !defined(_WIN64)
   pghpf_0.pghpf_01p = __get_fort_01_addr();
   pghpf_0.pghpf_02p = __get_fort_02_addr();
   pghpf_0.pghpf_03p = __get_fort_03_addr();

--- a/runtime/flangrti/iostdinit.c
+++ b/runtime/flangrti/iostdinit.c
@@ -6,7 +6,7 @@
  */
 
 #include <stdio.h>
-#if !defined(WINNT) && !defined(ST100)
+#if !defined(_WIN32) && !defined(ST100)
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
@@ -15,7 +15,7 @@
 
 /* get environ */
 
-#if defined(WIN64)
+#if defined(_WIN64)
 char * * * __cdecl __p__environ(void);
 /*
  * enclose _fileno within parens to ensure calling the function rather than
@@ -24,7 +24,7 @@ char * * * __cdecl __p__environ(void);
 #define fileno(x) (_fileno)(x)
 #endif
 
-#if   defined(WINNT)
+#if   defined(_WIN32)
 #include <stdlib.h>
 extern char **environ;
 #elif defined(TARGET_OSX)
@@ -169,12 +169,10 @@ __io_isatty(int fd)
 int
 __io_binary_mode(void *fp)
 {
-#if defined(WINNT)
+#if defined(_WIN32)
 #include <fcntl.h>
 
-#if defined(WIN64) || defined(WIN32)
 #define O_BINARY _O_BINARY
-#endif
 
   int mode;
 
@@ -196,12 +194,10 @@ __io_binary_mode(void *fp)
 int
 __io_setmode_binary(void *fp)
 {
-#if defined(WINNT)
+#if defined(_WIN32)
 #include <fcntl.h>
 
-#if defined(WIN64) || defined(WIN32)
 #define O_BINARY _O_BINARY
-#endif
 
   int mode;
 
@@ -214,7 +210,7 @@ __io_setmode_binary(void *fp)
 int
 __io_ispipe(void *f)
 {
-#if !defined(WINNT) && !defined(ST100)
+#if !defined(_WIN32) && !defined(ST100)
   struct stat st;
 
   fstat(fileno((FILE *)f), &st);
@@ -254,7 +250,7 @@ __io_fwrite(char *ptr, size_t size, size_t nitems, FILE *stream)
 #endif
 }
 
-#if defined(WINNT) || defined(WIN64) || defined(WIN32)
+#if defined(_WIN32)
 
 #if   defined(PGI_CRTDLL)
 extern long *_imp___timezone_dll; /* for crtdll.dll */
@@ -263,7 +259,7 @@ extern long *_imp___timezone_dll; /* for crtdll.dll */
 #define timezone _timezone /* cygnus, timezone is usually a function */
 #endif
 
-#elif !defined(DEC) && !defined(IBM) && !defined(ST100_V1_2) &&                !defined(OSX86) /* !defined(WINNT) */
+#elif !defined(DEC) && !defined(IBM) && !defined(ST100_V1_2) && !defined(OSX86)
 extern time_t timezone; /* for the rest */
 #endif
 
@@ -272,14 +268,14 @@ __io_timezone(void *tm)
 {
 #if defined(SUN4) || defined(PPC) || defined(OSX86)
   return ((struct tm *)tm)->tm_gmtoff;
-#elif defined(WINNT) || defined(WIN64) || defined(WIN32)
+#elif defined(_WIN32)
   return (0);
 #else
   return -(timezone - (((struct tm *)tm)->tm_isdst ? 3600 : 0));
 #endif
 }
 
-#if  (defined(WIN32) || defined(WIN64))
+#if defined(_WIN32)
 /* wrappers for stderr, stdin, stdout : include
   pgc/port/pgi_iobuf.h after stdio.h 
  */

--- a/runtime/flangrti/memalign.c
+++ b/runtime/flangrti/memalign.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#if (defined(WIN32) || defined(WIN64))
+#if defined(_WIN32)
 extern void *_aligned_malloc();
 extern void _aligned_free();
 #else
@@ -40,7 +40,7 @@ __aligned_malloc(size_t sz, size_t aln)
     aln = 1 << s;
   }
   need = sz + MINALN;
-#if (defined(WIN32) || defined(WIN64))
+#if defined(_WIN32)
   q = _aligned_malloc(need, aln);
   if (!q)
     return NULL;
@@ -53,7 +53,7 @@ __aligned_malloc(size_t sz, size_t aln)
 void
 __aligned_free(void *p)
 {
-#if (defined(WIN32) || defined(WIN64))
+#if defined(_WIN32)
   _aligned_free(p);
 #else
   free(p);

--- a/runtime/flangrti/tempnam.c
+++ b/runtime/flangrti/tempnam.c
@@ -5,7 +5,7 @@
  *
  */
 
-#if !defined(WINNT) && !defined(USETEMPNAM) /* { */
+#if !defined(_WIN32) && !defined(USETEMPNAM) /* { */
 #include <errno.h>
 #include <stdio.h>
 
@@ -146,7 +146,7 @@ extern char *tempnam(char *, char *);
 char *
 __io_tempnam(char *dir, char *pfx)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
   return (_tempnam(dir, pfx));
 #else
   return (tempnam(dir, pfx));

--- a/runtime/flangrti/trace.c
+++ b/runtime/flangrti/trace.c
@@ -56,7 +56,7 @@ dbg_stop_before_exit(void)
  * 3 - traceback (signal)
  */
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 #define getpid _getpid
 #define _Exit _exit
 #endif
@@ -133,7 +133,7 @@ __abort_init(char *path)
   int n;
   int neg;
 
-#if defined(WINNT)
+#if defined(_WIN32)
   fn = path;
 #endif
   p = getenv("TRACE_TERM");

--- a/runtime/include/FuncArgMacros.h
+++ b/runtime/include/FuncArgMacros.h
@@ -18,7 +18,7 @@
 #define _PGHPFENT_H_
 
 /* Alternate Fortran entry symbol formats */
-#if defined(WIN64)
+#if defined(_WIN64)
 #if defined(DESC_I8)
 #define ENTF90IO(UC, LC) pgf90io_##LC##_i8
 #define ENTF90(UC, LC) pgf90_##LC##_i8
@@ -45,7 +45,7 @@
 #define ENTCRFTN(UC, LC) pgcrhpf_##LC
 #define ENTCOMN(UC, LC) pghpf_##LC##_
 
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #define ENTF90(UC, LC) pgf90_##LC
 #define ENTF90IO(UC, LC) pgf90io_##LC
 #define ENTFTN(UC, LC) pghpf_##LC
@@ -58,19 +58,7 @@
 #define ENTCOMN(UC, LC) pghpf_##LC
 #define F90_MATMUL(s) pg_mm_##s##_
 #define F90_NORM2(s) pg_norm2_##s##_
-
-#elif defined(WINNT)
-#define ENTF90(UC, LC) pgf90_##LC
-#define ENTF90IO(UC, LC) pgf90io_##LC
-#define ENTFTN(UC, LC) pghpf_##LC
-#define ENTFTNIO(UC, LC) pghpfio_##LC
-#define ENTRY(UC, LC) LC
-#define ENTCRF90IO(UC, LC) pgcrf90io_##LC
-#define ENTCRFTNIO(UC, LC) pgcrhpfio_##LC
-#define ENTCRF90(UC, LC) pgcrf90_##LC
-#define ENTCRFTN(UC, LC) pgcrhpf_##LC
 #define ENTCOMN(UC, LC) pghpf_win_##LC
-#define F90_MATMUL(s) pg_mm_##s##_
 
 #else
 #if defined(DESC_I8)
@@ -127,8 +115,7 @@
 #define CADR(ARG) (ARG##_adr)
 #define CLEN(ARG) (ARG##_len)
 
-/* #if defined(WIN64) || defined(WIN32) */
-#if defined(PGDLL) && defined(_DLL) &&                                         (defined(TARGET_WIN) || defined(WIN64) || defined(WIN32))
+#if defined(PGDLL) && defined(_DLL) && defined(_WIN32)
 #define WIN_EXP __declspec(dllexport)
 #define WIN_IMP extern __declspec(dllimport)
 #else

--- a/runtime/libpgmath/lib/common/amod.c
+++ b/runtime/libpgmath/lib/common/amod.c
@@ -7,7 +7,7 @@
 
 #include "mthdecls.h"
 
-#ifndef TARGET_WIN_X8664
+#if !defined(_WIN64)
 float
 __mth_i_amod(float f, float g)
 {

--- a/runtime/libpgmath/lib/common/dmod.c
+++ b/runtime/libpgmath/lib/common/dmod.c
@@ -7,10 +7,15 @@
 
 #include "mthdecls.h"
 
-#ifndef TARGET_WIN_X8664
+#if !defined(_WIN64)
 double
 __mth_i_dmod(double f, double g)
 {
+/* Need to do this way until a bug in the Win64 fmod routine is fixed */
+#if defined(_WIN64)
+  return __fmth_i_dmod(f, g);
+#else
   return fmod(f, g);
+#endif
 }
 #endif

--- a/runtime/libpgmath/lib/common/fltfenv.c
+++ b/runtime/libpgmath/lib/common/fltfenv.c
@@ -164,7 +164,7 @@ __fenv_fetestexcept(int exc)
 /* Windows doesn't seem to preserve x87 exception bits across context
  * switches, so this info is unreliable.
  */
-#ifdef WINNT
+#if defined(_WIN32)
   x87 = 0;
 #else
   asm("\tfnstsw %0" : "=m"(x87) :);

--- a/runtime/libpgmath/lib/common/mthdecls.h
+++ b/runtime/libpgmath/lib/common/mthdecls.h
@@ -339,7 +339,7 @@ static inline __attribute__((always_inline)) double_complex_t  pgmath_cmplx(doub
  * to the different entry points for the various architectures.
  */
 
-#if defined(WIN64)
+#if defined(_WIN64)
 /*
  * Windows.
  */

--- a/runtime/libpgmath/lib/generic/datan.c
+++ b/runtime/libpgmath/lib/generic/datan.c
@@ -5,7 +5,7 @@
  *
  */
 
-#if !defined(WIN64)
+#if !defined(_WIN64)
 #include "mthdecls.h"
 #else
 double atan(double d);

--- a/runtime/libpgmath/lib/generic/datan2.c
+++ b/runtime/libpgmath/lib/generic/datan2.c
@@ -5,7 +5,7 @@
  *
  */
 
-#if !defined(WIN64)
+#if !defined(_WIN64)
 #include "mthdecls.h"
 #else
 double atan2(double x, double y);

--- a/runtime/libpgmath/lib/generic/dlog10.c
+++ b/runtime/libpgmath/lib/generic/dlog10.c
@@ -5,7 +5,7 @@
  *
  */
 
-#if !defined(WIN64)
+#if !defined(_WIN64)
 #include "mthdecls.h"
 #else
 double log10(double d);

--- a/runtime/libpgmath/lib/x86_64/dint.S
+++ b/runtime/libpgmath/lib/x86_64/dint.S
@@ -7,7 +7,7 @@
 
 
 #if 0
-#if defined(WIN64)
+#if defined(_WIN64)
 typedef long long I64;
 typedef unsigned long long UI64; 
 #else

--- a/runtime/libpgmath/lib/x86_64/fast/fastmath.h
+++ b/runtime/libpgmath/lib/x86_64/fast/fastmath.h
@@ -1817,7 +1817,7 @@ LBL(.L__lnan):
         jmp     LBL(.L__finish)
 
 LBL(.L__finish):
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  RZ_OFF(24)(%rsp), %xmm6
 #endif
 
@@ -1841,7 +1841,7 @@ LBL(.L__finish):
 ENT(__fvs_exp_dbl):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(56)(%rsp)
 	movq	%rsi, RZ_OFF(64)(%rsp)
 	movq	%rdi, RZ_OFF(72)(%rsp)
@@ -1910,7 +1910,7 @@ LBL(.L__Scalar_fvsexp_dbl):
         popq    %rbp
 
 	/* Done */
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 	movq	RZ_OFF(64)(%rsp), %rsi
 	movq	RZ_OFF(72)(%rsp), %rdi
@@ -1987,7 +1987,7 @@ ENT(__fvd_exp_long):
 	sar	$5,%edx
 	addpd	%xmm5,%xmm2    /* xmm2 = r = r1 + r2 */
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(56)(%rsp)
 #endif
 	/* Step 2. Compute the polynomial. */
@@ -2061,7 +2061,7 @@ ENT(__fvd_exp_long):
 	movq	%rdx,RZ_OFF(16)(%rsp) 	/* get 2^n to memory */
 	mulpd	RZ_OFF(24)(%rsp),%xmm0  /* result*= 2^n */
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 #endif
 
@@ -2667,7 +2667,7 @@ ENT(ASM_CONCAT(__mth_i_cdexp_gh,__MTH_C99_CMPLX_SUFFIX)):
 ENT(ASM_CONCAT(__mth_i_cdexp,__MTH_C99_CMPLX_SUFFIX)):
 #endif
 
-#ifdef	WIN64
+#if defined(_WIN64)
 	/*
 	 * Return structure in (%rcx).
 	 * Will be managed by macro I1.
@@ -2760,7 +2760,7 @@ ENT_GH(__mth_i_cdexp_1v):
 IF_GH(ENT(__fsz_exp):)
 ENT_GH(__mth_i_cdexp):
 
-#if defined(WIN64) 
+#if defined(_WIN64)
 	/*
 	 *	WIN64 ONLY:
 	 *	Jump entry point into routine from __fsz_exp_c99.
@@ -2794,7 +2794,7 @@ LBL(.L__fsz_exp_win64):
         mulpd   %xmm1,%xmm4                             /* Mpy to scale both */
 
         RZ_PUSH
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, RZ_OFF(40)(%rsp)
         movdqa  %xmm7, RZ_OFF(56)(%rsp)
         movdqa  %xmm8, RZ_OFF(72)(%rsp)
@@ -3031,7 +3031,7 @@ LBL(.L__fsz_exp_win64):
         mulsd   %xmm0,%xmm1
         mulsd   %xmm9,%xmm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movq	RZ_OFF(104)(%rsp),I1
         movdqa  RZ_OFF(40)(%rsp),%xmm6
         movdqa  RZ_OFF(56)(%rsp),%xmm7
@@ -3194,7 +3194,7 @@ IF_GH(ENT(__fvs_exp):)
 ENT_GH(__fvsexp):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(56)(%rsp)
 	movq	%rsi, RZ_OFF(64)(%rsp)
 	movq	%rdi, RZ_OFF(72)(%rsp)
@@ -3327,7 +3327,7 @@ ENT_GH(__fvsexp):
 
 LBL(.L_vsp_final_check):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 	movq	RZ_OFF(64)(%rsp), %rsi
 	movq	RZ_OFF(72)(%rsp), %rdi
@@ -3338,7 +3338,7 @@ LBL(.L_vsp_final_check):
 	ret
 
 LBL(.L__Scalar_fvsexp):
-#if defined(WIN64)
+#if defined(_WIN64)
 	/* Need to restore callee-saved regs can do here for this path
 	 * because entry was only thru fvs_exp/fvsexp_gh
 	 */
@@ -3621,7 +3621,7 @@ IF_GH(ENT(__fss_log):)
 ENT_GH(__fmth_i_alog):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(24)(%rsp)
 #endif
 	/* First check for valid input:
@@ -3717,7 +3717,7 @@ LBL(.LB1_100):
 
 LBL(.LB1_900):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(24)(%rsp), %xmm6
 #endif
 	RZ_POP
@@ -3809,7 +3809,7 @@ IF_GH(ENT(__fsd_log):)
 ENT_GH(__fmth_i_dlog):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(24)(%rsp)
 #endif
 	/* Get input x into the range [0.5,1) */
@@ -3889,7 +3889,7 @@ LBL(.L__100):
 	addsd	%xmm1,%xmm0
 
 LBL(.L__finish):
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(24)(%rsp), %xmm6
 #endif
 
@@ -4012,7 +4012,7 @@ IF_GH(ENT(__fvs_log):)
 ENT_GH(__fvslog):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(56)(%rsp)
 	movdqa	%xmm7, RZ_OFF(72)(%rsp)
 #endif
@@ -4148,7 +4148,7 @@ LBL(.LB_100):
 
 LBL(.LB_900):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 	movdqa	RZ_OFF(72)(%rsp), %xmm7
 #endif
@@ -4227,7 +4227,7 @@ IF_GH(ENT(__fvd_log):)
 ENT_GH(__fvdlog):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(56)(%rsp)
 #endif
 
@@ -4324,7 +4324,7 @@ LBL(.Lfinish):
 	jnz		LBL(.Lnear_one)
 LBL(.Lfinishn1):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 #endif
 	RZ_POP
@@ -4651,7 +4651,7 @@ ENT_GH(__fmth_i_dsin):
         mulsd   %xmm0,%xmm4 
 
         RZ_PUSH
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, RZ_OFF(24)(%rsp)
         movdqa  %xmm7, RZ_OFF(40)(%rsp)
 #endif
@@ -4783,7 +4783,7 @@ ENT_GH(__fmth_i_dsin):
         addsd   %xmm4,%xmm1                   /* ((ds2...) + dc2*dp) + ds1*dq */
         addsd   %xmm5,%xmm1
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  RZ_OFF(24)(%rsp),%xmm6
         movdqa  RZ_OFF(40)(%rsp),%xmm7
 #endif
@@ -5379,7 +5379,7 @@ ENT_GH(__fvdsin):
 	test	$3, %ecx
         jnz	LBL(.L__Scalar_fvdsin2)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, (%rsp)
         movdqa  %xmm7, 16(%rsp)
 #endif
@@ -5543,7 +5543,7 @@ ENT_GH(__fvdsin):
         mulpd   %xmm6,%xmm0                   /* dc1 * dp */
         addpd   %xmm4,%xmm1                   /* ((ds2...) + dc2*dp) + ds1*dq */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  (%rsp),%xmm6
         movdqa  16(%rsp),%xmm7
 #endif
@@ -5923,7 +5923,7 @@ ENT_GH(__fmth_i_dcos):
         mulsd   %xmm0,%xmm4 
 
         RZ_PUSH
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, RZ_OFF(24)(%rsp)
         movdqa  %xmm7, RZ_OFF(40)(%rsp)
 #endif
@@ -6057,7 +6057,7 @@ ENT_GH(__fmth_i_dcos):
         addsd   %xmm4,%xmm1
         addsd   %xmm1,%xmm0                   /* cos(x) = (C + Cq(r)) + Sq(r) */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  RZ_OFF(24)(%rsp),%xmm6
         movdqa  RZ_OFF(40)(%rsp),%xmm7
 #endif
@@ -6662,7 +6662,7 @@ ENT_GH(__fvdcos):
 	test	$3, %ecx
         jnz	LBL(.L__Scalar_fvdcos2)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, (%rsp)
         movdqa  %xmm7, 16(%rsp)
 #endif
@@ -6827,7 +6827,7 @@ ENT_GH(__fvdcos):
         mulpd   %xmm0,%xmm4                   /* dc1 * dq */
         subpd   %xmm6,%xmm1                   /* ((dc2...) - ds2*dp) - ds1*dp */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  (%rsp),%xmm6
         movdqa  16(%rsp),%xmm7
 #endif
@@ -7189,7 +7189,7 @@ LBL(.L__fss_sinh_shortcuts):
 IF_GH(ENT(__fsd_sinh):)
 ENT_GH(__fmth_i_dsinh):
 	RZ_PUSH
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(40)(%rsp)
 #endif
 
@@ -7329,7 +7329,7 @@ ENT_GH(__fmth_i_dsinh):
 
 LBL(.L__fsd_sinh_done):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(40)(%rsp), %xmm6
 #endif
 	RZ_POP
@@ -7393,7 +7393,7 @@ IF_GH(ENT(__fvs_sinh):)
 ENT_GH(__fvssinh):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(56)(%rsp)
 	movq	%rsi, RZ_OFF(64)(%rsp)
 	movq	%rdi, RZ_OFF(72)(%rsp)
@@ -7595,7 +7595,7 @@ ENT_GH(__fvssinh):
 
 LBL(.L_fvsinh_final_check):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 	movq	RZ_OFF(64)(%rsp), %rsi
 	movq	RZ_OFF(72)(%rsp), %rdi
@@ -7610,7 +7610,7 @@ LBL(.L__Scalar_fvssinh):
         /* Need to restore callee-saved regs can do here for this path
          * because entry was only thru fvs_sinh/fvs_sinh
          */
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 	movq	RZ_OFF(64)(%rsp), %rsi
 	movq	RZ_OFF(72)(%rsp), %rdi
@@ -7711,7 +7711,7 @@ ENT_GH(__fvdsinh):
 	testl	$3, %r8d
 	jnz	LBL(.L__Scalar_fvdsinh)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, RZ_OFF(72)(%rsp)
 #endif
 
@@ -7885,7 +7885,7 @@ ENT_GH(__fvdsinh):
 
 	subpd	%xmm6,%xmm0		/* done with sinh */
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa  RZ_OFF(72)(%rsp),%xmm6
  
 #endif
@@ -8078,7 +8078,7 @@ IF_GH(ENT(__fsd_cosh):)
 ENT_GH(__fmth_i_dcosh):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(40)(%rsp)
 #endif
 
@@ -8209,7 +8209,7 @@ ENT_GH(__fmth_i_dcosh):
 	mulsd	RZ_OFF(24)(%rsp),%xmm6	/* result *= 2^n */
 	addsd	%xmm6, %xmm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(40)(%rsp), %xmm6
 #endif
 
@@ -8244,7 +8244,7 @@ IF_GH(ENT(__fvs_cosh):)
 ENT_GH(__fvscosh):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(56)(%rsp)
 	movq	%rsi, RZ_OFF(64)(%rsp)
 	movq	%rdi, RZ_OFF(72)(%rsp)
@@ -8440,7 +8440,7 @@ ENT_GH(__fvscosh):
 
 LBL(.L_fvcosh_final_check):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 	movq	RZ_OFF(64)(%rsp), %rsi
 	movq	RZ_OFF(72)(%rsp), %rdi
@@ -8455,7 +8455,7 @@ LBL(.L__Scalar_fvscosh):
         /* Need to restore callee-saved regs can do here for this path
          * because entry was only thru fvs_cosh_fma4/fvs_cosh_vex
          */
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 	movq	RZ_OFF(64)(%rsp), %rsi
 	movq	RZ_OFF(72)(%rsp), %rdi
@@ -8551,7 +8551,7 @@ ENT_GH(__fvdcosh):
 	testl	$3, %r8d
 	jnz	LBL(.L__Scalar_fvdcosh)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, RZ_OFF(72)(%rsp)
 #endif
 
@@ -8718,7 +8718,7 @@ ENT_GH(__fvdcosh):
 
 	addpd	%xmm6,%xmm0		/* done with cosh */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  RZ_OFF(72)(%rsp),%xmm6
 #endif
 
@@ -9008,7 +9008,7 @@ ENT_GH(__fmth_i_dsincos):
         mulsd   %xmm0,%xmm4 
 
         RZ_PUSH
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, RZ_OFF(24)(%rsp)
         movdqa  %xmm7, RZ_OFF(40)(%rsp)
         movdqa  %xmm8, RZ_OFF(56)(%rsp)
@@ -9163,7 +9163,7 @@ ENT_GH(__fmth_i_dsincos):
         addsd   %xmm8,%xmm0                   /* sin(x) = Cp(r) + (S+Sq(r)) */
         addsd   %xmm7,%xmm1                   /* cos(x) = (C + Cq(r)) + Sq(r) */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  RZ_OFF(24)(%rsp),%xmm6
         movdqa  RZ_OFF(40)(%rsp),%xmm7
         movdqa  RZ_OFF(56)(%rsp),%xmm8
@@ -9298,7 +9298,7 @@ ENT_GH(__fvssincos):
         /* Set n = nearest integer to r */
 	movhps	%xmm1,(%rsp)                     /* Store x4, x3 */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, 16(%rsp)
         movdqa  %xmm7, 32(%rsp)
 #endif
@@ -9458,7 +9458,7 @@ LBL(.L__fvsincos_done_twice):
 	movaps  %xmm5, %xmm0
 	movaps  %xmm7, %xmm1
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  16(%rsp), %xmm6
         movdqa  32(%rsp), %xmm7
 #endif
@@ -9597,7 +9597,7 @@ LBL(.L__Scalar_fvsincos1):
         cvtpd2ps %xmm4,%xmm4            /* cos(x4), cos(x3) */
         shufps  $68, %xmm4, %xmm1       /* cos(x4),cos(x3),cos(x2),cos(x1) */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  (%rsp), %xmm6
 #endif
 
@@ -9888,7 +9888,7 @@ ENT_GH(__fvdsincos):
 	test	$3, %ecx
         jnz	LBL(.L__Scalar_fvdsincos2)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, (%rsp)
         movdqa  %xmm7, 16(%rsp)
         movdqa  %xmm8, 32(%rsp)
@@ -10076,7 +10076,7 @@ ENT_GH(__fvdsincos):
         addpd   %xmm8,%xmm0                   /* sin(x) = Cp(r) + (S+Sq(r)) */
         addpd   %xmm7,%xmm1                   /* cos(x) = (C + Cq(r)) + Sq(r) */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  (%rsp),%xmm6
         movdqa  16(%rsp),%xmm7
         movdqa  32(%rsp),%xmm8
@@ -10100,7 +10100,7 @@ LBL(.L__Scalar_fvdsincos1):
 	test    $2, %eax
 	jz	LBL(.L__Scalar_fvdsincos1a)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  %xmm6, (%rsp)
         movdqa  %xmm7, 16(%rsp)
 #endif
@@ -10199,7 +10199,7 @@ LBL(.L__Scalar_fvdsincos1):
         mulpd   %xmm3,%xmm1                     /* x2 * (0.5 + ...) */
         addpd   .L__real_one(%rip),%xmm1        /* 1.0 - 0.5x2 + (...) done */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movdqa  (%rsp),%xmm6
         movdqa  16(%rsp),%xmm7
 #endif
@@ -10684,7 +10684,7 @@ ENT_GH(__fmth_i_dpowd):
 	movsd	%xmm1, 0(%rsp)
 	movsd	%xmm0, 8(%rsp)
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, 16(%rsp)
 #endif
 	/* r8 holds flags for x, in rax */
@@ -10782,7 +10782,7 @@ LBL(.L__D_algo_start):
 	CALL(ENT(__fsd_exp_long))
 
 LBL(.L__Dpop_and_return):
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	16(%rsp), %xmm6
 #endif
 	movq	%rbp, %rsp
@@ -11212,7 +11212,7 @@ ENT_GH(__fvdpow):
 	test	$3, %r8d
 	jnz	LBL(.L__Scalar_fvdpow)
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, 48(%rsp)
 #endif
 	/* Call log long version */
@@ -11251,7 +11251,7 @@ ENT_GH(__fvdpow):
 
 	CALL(ENT(__fvd_exp_long))
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	48(%rsp), %xmm6
 #endif
 
@@ -11328,7 +11328,7 @@ IF_GH(ENT(__fss_log10):)
 ENT_GH(__fmth_i_alog10):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(24)(%rsp)
 #endif
 	/* First check for valid input:
@@ -11427,7 +11427,7 @@ LBL(.LB1_100_log10):
 
 LBL(.LB1_900_log10):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(24)(%rsp), %xmm6
 #endif
 	RZ_POP
@@ -11503,7 +11503,7 @@ IF_GH(ENT(__fsd_log10):)
 ENT_GH(__fmth_i_dlog10):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(24)(%rsp)
 #endif
 	/* Get input x into the range [0.5,1) */
@@ -11590,7 +11590,7 @@ LBL(.L__cvt_to_dlog10):
 	addsd	%xmm1,%xmm0
 
 LBL(.L__finish_dlog10):
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(24)(%rsp), %xmm6
 #endif
 
@@ -11715,7 +11715,7 @@ IF_GH(ENT(__fvs_log10):)
 ENT_GH(__fvslog10):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(56)(%rsp)
 	movdqa	%xmm7, RZ_OFF(72)(%rsp)
 #endif
@@ -11853,7 +11853,7 @@ LBL(.LB_100_log10):
 
 LBL(.LB_900_log10):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 	movdqa	RZ_OFF(72)(%rsp), %xmm7
 #endif
@@ -11935,7 +11935,7 @@ IF_GH(ENT(__fvd_log10):)
 ENT_GH(__fvdlog10):
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	%xmm6, RZ_OFF(56)(%rsp)
 #endif
 
@@ -12039,7 +12039,7 @@ ENT_GH(__fvdlog10):
 
 LBL(.Lfinishn1_log10):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	movdqa	RZ_OFF(56)(%rsp), %xmm6
 #endif
 	RZ_POP

--- a/runtime/libpgmath/lib/x86_64/fast/fastmath_vex.h
+++ b/runtime/libpgmath/lib/x86_64/fast/fastmath_vex.h
@@ -106,7 +106,7 @@ ENT(ASM_CONCAT(__fvd_sin_,TARGET_VEX_OR_FMA)):
 	test	$3, %ecx
         jnz	LBL(.L__Scalar_fvdsin2)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, 64(%rsp)
         vmovdqu  %ymm7, 96(%rsp)
 #endif
@@ -300,7 +300,7 @@ ENT(ASM_CONCAT(__fvd_sin_,TARGET_VEX_OR_FMA)):
 #endif
         vmulpd   %xmm6,%xmm0,%xmm0                   /* dc1 * dp */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  64(%rsp),%ymm6
         vmovdqu  96(%rsp),%ymm7
 #endif
@@ -554,7 +554,7 @@ ENT(ASM_CONCAT(__fvd_cos_,TARGET_VEX_OR_FMA)):
 	test	$3, %ecx
         jnz	LBL(.L__Scalar_fvdcos2)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, 64(%rsp)
         vmovdqu  %ymm7, 96(%rsp)
 #endif
@@ -752,7 +752,7 @@ ENT(ASM_CONCAT(__fvd_cos_,TARGET_VEX_OR_FMA)):
         vsubpd   %xmm6,%xmm1,%xmm1                   /* ((dc2...) - ds2*dp) - ds1*dp */
 #endif
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  64(%rsp),%ymm6
         vmovdqu  96(%rsp),%ymm7
 #endif
@@ -1012,7 +1012,7 @@ ENT(ASM_CONCAT(__fvd_sincos_,TARGET_VEX_OR_FMA)):
 	test	$3, %ecx
         jnz	LBL(.L__Scalar_fvdsincos2)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, 32(%rsp)
         vmovdqu  %ymm7, 64(%rsp)
         vmovdqu  %ymm8, 96(%rsp)
@@ -1244,7 +1244,7 @@ ENT(ASM_CONCAT(__fvd_sincos_,TARGET_VEX_OR_FMA)):
 #endif
         vaddpd   %xmm7,%xmm1,%xmm1                   /* cos(x) = (C + Cq(r)) + Sq(r) */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  32(%rsp),%ymm6
         vmovdqu  64(%rsp),%ymm7
         vmovdqu  96(%rsp),%ymm8
@@ -1268,7 +1268,7 @@ LBL(.L__Scalar_fvdsincos1):
 	test    $2, %eax
 	jz	LBL(.L__Scalar_fvdsincos1a)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, 64(%rsp)
         vmovdqu  %ymm7, 96(%rsp)
 #endif
@@ -1348,7 +1348,7 @@ LBL(.L__Scalar_fvdsincos1):
         vaddpd   .L__real_one(%rip),%xmm1,%xmm1        /* 1.0 - 0.5x2 + (...) done */
 /* #endif */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  64(%rsp),%ymm6
         vmovdqu  96(%rsp),%ymm7
 #endif
@@ -2568,7 +2568,7 @@ ENT(ASM_CONCAT(__fvs_sincos_,TARGET_VEX_OR_FMA)):
         /* Set n = nearest integer to r */
 	vmovhps	%xmm1,(%rsp)                     /* Store x4, x3 */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, 64(%rsp)
         vmovdqu  %ymm7, 96(%rsp)
 #endif
@@ -2754,7 +2754,7 @@ LBL(.L__fvsincos_done_twice):
 	vmovaps  %xmm5, %xmm0
 	vmovaps  %xmm7, %xmm1
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  64(%rsp), %ymm6
         vmovdqu  96(%rsp), %ymm7
 #endif
@@ -2782,7 +2782,7 @@ LBL(.L__Scalar_fvsincos1):
 	vcvtps2pd 16(%rsp),%xmm0               /* x(2), x(1) */
 	vcvtps2pd 24(%rsp),%xmm1               /* x(4), x(3) */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, 96(%rsp)
 #endif
         vmovapd  %xmm0,16(%rsp)
@@ -2926,7 +2926,7 @@ LBL(.L__Scalar_fvsincos1):
         vcvtpd2ps %xmm4,%xmm4            /* cos(x4), cos(x3) */
         vshufps  $68, %xmm4, %xmm1,%xmm1       /* cos(x4),cos(x3),cos(x2),cos(x1) */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  96(%rsp), %ymm6
 #endif
 
@@ -3801,7 +3801,7 @@ ENT(ASM_CONCAT(__fsd_sin_,TARGET_VEX_OR_FMA)):
         vmulsd   %xmm0,%xmm4,%xmm4
 
         RZ_PUSH
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, RZ_OFF(64)(%rsp)
         vmovdqu  %ymm7, RZ_OFF(96)(%rsp)
 #endif
@@ -3996,7 +3996,7 @@ ENT(ASM_CONCAT(__fsd_sin_,TARGET_VEX_OR_FMA)):
 	vaddsd	%xmm1,%xmm0,%xmm0			/* sin(x) = Cp(r) + (S+Sq(r)) */
 /* #endif */
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(64)(%rsp),%ymm6
 	vmovdqu	RZ_OFF(96)(%rsp),%ymm7
 #endif
@@ -4093,7 +4093,7 @@ ENT(ASM_CONCAT(__fsd_cos_,TARGET_VEX_OR_FMA)):
         vmulsd   %xmm0,%xmm4,%xmm4
 
         RZ_PUSH
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, RZ_OFF(64)(%rsp)
         vmovdqu  %ymm7, RZ_OFF(96)(%rsp)
 #endif
@@ -4284,7 +4284,7 @@ ENT(ASM_CONCAT(__fsd_cos_,TARGET_VEX_OR_FMA)):
 
         vaddsd   %xmm1,%xmm0,%xmm0			/* cos(x) = (C + Cq(r)) + Sq(r) */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  RZ_OFF(64)(%rsp),%ymm6
         vmovdqu  RZ_OFF(96)(%rsp),%ymm7
 #endif
@@ -4377,7 +4377,7 @@ ENT(ASM_CONCAT(__fsd_sincos_,TARGET_VEX_OR_FMA)):
         vmulsd   %xmm0,%xmm4,%xmm4
 
         RZ_PUSH
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, RZ_OFF(32)(%rsp)
         vmovdqu  %ymm7, RZ_OFF(64)(%rsp)
         vmovdqu  %ymm8, RZ_OFF(96)(%rsp)
@@ -4578,7 +4578,7 @@ ENT(ASM_CONCAT(__fsd_sincos_,TARGET_VEX_OR_FMA)):
 #endif
         vaddsd   %xmm7,%xmm1,%xmm1                   /* cos(x) = (C + Cq(r)) + Sq(r) */
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  RZ_OFF(32)(%rsp),%ymm6
         vmovdqu  RZ_OFF(64)(%rsp),%ymm7
         vmovdqu  RZ_OFF(96)(%rsp),%ymm8
@@ -4873,7 +4873,7 @@ ENT(ASM_CONCAT(__fvz_exp_,TARGET_VEX_OR_FMA)):
 ENT(ASM_CONCAT(__fsz_exp_1v_,TARGET_VEX_OR_FMA)):
 
 
-#ifdef	WIN64
+#if	defined(_WIN64)
 	/*
 	 * Return structure in (%rcx).
 	 * Will be managed by macro I1.
@@ -4946,7 +4946,7 @@ ENT(ASM_CONCAT3(__fsz_exp_,TARGET_VEX_OR_FMA,_c99)):
 ENT(ASM_CONCAT(__fsz_exp_,TARGET_VEX_OR_FMA)):
 
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	/*
 	 *	WIN64 ONLY:
 	 *	Jump entry point into routine from __fsz_exp_vex_v1.
@@ -4954,7 +4954,7 @@ ENT(ASM_CONCAT(__fsz_exp_,TARGET_VEX_OR_FMA)):
 LBL(.L__fsz_exp_vex_win64):
 #endif
 
-#if	defined(WIN64)
+#if	defined(_WIN64)
 	vmovapd	%xmm1,%xmm0
 	vmovapd	%xmm2,%xmm1
 #endif
@@ -4985,7 +4985,7 @@ LBL(.L__fsz_exp_vex_win64):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, 128(%rsp)
         vmovdqu  %ymm7, 160(%rsp)
         vmovdqu  %ymm8, 192(%rsp)
@@ -5291,7 +5291,7 @@ LBL(.L__fsz_exp_vex_win64):
         vmulsd   %xmm0,%xmm1,%xmm1
         vmulsd   %xmm9,%xmm0,%xmm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movq    24(%rsp),I1
         vmovdqu  128(%rsp),%ymm6
         vmovdqu  160(%rsp),%ymm7
@@ -5894,7 +5894,7 @@ ENT(ASM_CONCAT(__fvd_pow_,TARGET_VEX_OR_FMA)):
 	test	$3, %r8d
 	jnz	LBL(.L__Scalar_fvdpow)
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, 96(%rsp)
 #endif
 	/* Call log long version */
@@ -5945,7 +5945,7 @@ ENT(ASM_CONCAT(__fvd_pow_,TARGET_VEX_OR_FMA)):
 	CALL(ENT(ASM_CONCAT(__fvd_exp_long_,TARGET_VEX_OR_FMA)))
 
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	96(%rsp), %ymm6
 #endif
 
@@ -5989,7 +5989,7 @@ ENT(ASM_CONCAT(__fsd_pow_,TARGET_VEX_OR_FMA)):
 	vmovsd	%xmm1, 0(%rsp)
 	vmovsd	%xmm0, 8(%rsp)
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, 32(%rsp)
 #endif
 	/* r8 holds flags for x, in rax */
@@ -6100,7 +6100,7 @@ LBL(.L__D_algo_start):
 
 
 LBL(.L__Dpop_and_return):
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	32(%rsp), %ymm6
 #endif
 	movq	%rbp, %rsp
@@ -7067,7 +7067,7 @@ ENT(ASM_CONCAT(__fvs_exp_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(104)(%rsp)
 	movq	%rsi, RZ_OFF(64)(%rsp)
 	movq	%rdi, RZ_OFF(72)(%rsp)
@@ -7223,7 +7223,7 @@ ASM_CONCAT(.L__fvs_exp_dbl_entry_,TARGET_VEX_OR_FMA):
 
 LBL(.L_vsp_final_check):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(104)(%rsp), %ymm6
 	movq	RZ_OFF(64)(%rsp), %rsi
 	movq	RZ_OFF(72)(%rsp), %rdi
@@ -7234,7 +7234,7 @@ LBL(.L_vsp_final_check):
 	ret
 
 LBL(.L__Scalar_fvsexp):
-#if defined(WIN64)
+#if defined(_WIN64)
 	/* Need to restore callee-saved regs can do here for this path
 	 * because entry was only thru fvs_exp_fma4/fvs_exp_vex
 	 */
@@ -7292,7 +7292,7 @@ ENT(__fvs_exp_dbl_vex):
 #endif
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(104)(%rsp)
 	movq	%rsi, RZ_OFF(64)(%rsp)
 	movq	%rdi, RZ_OFF(72)(%rsp)
@@ -7357,7 +7357,7 @@ LBL(.L__Scalar_fvs_exp_dbl):
         popq    %rbp
 
 	/* Done */
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(104)(%rsp), %ymm6
 	movq	RZ_OFF(64)(%rsp), %rsi
 	movq	RZ_OFF(72)(%rsp), %rdi
@@ -7641,7 +7641,7 @@ ENT(__fvd_exp_long_vex):
 	sar	$5,%edx
 	vaddpd	%xmm5,%xmm2,%xmm2    /* xmm2 = r = r1 + r2 */
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(72)(%rsp)
 #endif
 	/* Step 2. Compute the polynomial. */
@@ -7738,7 +7738,7 @@ ENT(__fvd_exp_long_vex):
 	movq	%rdx,RZ_OFF(16)(%rsp) 	/* get 2^n to memory */
 	vmulpd	RZ_OFF(24)(%rsp),%xmm0,%xmm0  /* result*= 2^n */
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(72)(%rsp), %ymm6
 #endif
 
@@ -7842,7 +7842,7 @@ ENT(ASM_CONCAT(__fsd_log_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(96)(%rsp)
 #endif
 	/* Get input x into the range [0.5,1) */
@@ -7946,7 +7946,7 @@ LBL(.L__100):
 	vaddsd	%xmm1,%xmm0,%xmm0
 
 LBL(.L__finish):
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(96)(%rsp), %ymm6
 #endif
 
@@ -8061,7 +8061,7 @@ ENT(ASM_CONCAT(__fvd_log_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(72)(%rsp)
 #endif
 
@@ -8178,7 +8178,7 @@ LBL(.Lfinish):
 	jnz		LBL(.Lnear_one)
 LBL(.Lfinishn1):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(72)(%rsp), %ymm6
 #endif
 	RZ_POP
@@ -8801,7 +8801,7 @@ ENT(ASM_CONCAT(__fvs_log_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(72)(%rsp)
 	vmovdqu	%ymm7, RZ_OFF(104)(%rsp)
 #endif
@@ -8961,7 +8961,7 @@ LBL(.LB_100):
 
 LBL(.LB_900):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(72)(%rsp), %ymm6
 	vmovdqu	RZ_OFF(104)(%rsp), %ymm7
 #endif
@@ -9069,7 +9069,7 @@ ENT(ASM_CONCAT(__fss_log_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(96)(%rsp)
 #endif
 	/* First check for valid input:
@@ -9182,7 +9182,7 @@ LBL(.LB1_100):
 
 LBL(.LB1_900):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(96)(%rsp), %ymm6
 #endif
 	RZ_POP
@@ -9258,7 +9258,7 @@ ENT(ASM_CONCAT(__fvd_log10_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(72)(%rsp)
 #endif
 
@@ -9391,7 +9391,7 @@ ENT(ASM_CONCAT(__fvd_log10_,TARGET_VEX_OR_FMA)):
 
 LBL(.Lfinishn1_log10):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(72)(%rsp), %ymm6
 #endif
 	RZ_POP
@@ -9570,7 +9570,7 @@ ENT(ASM_CONCAT(__fsd_log10_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(96)(%rsp)
 #endif
 	/* Get input x into the range [0.5,1) */
@@ -9689,7 +9689,7 @@ LBL(.L__cvt_to_dlog10):
 	vaddsd	%xmm1,%xmm0,%xmm0
 
 LBL(.L__finish_dlog10):
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(96)(%rsp), %ymm6
 #endif
 
@@ -9824,7 +9824,7 @@ ENT(ASM_CONCAT(__fvs_log10_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(72)(%rsp)
 	vmovdqu	%ymm7, RZ_OFF(104)(%rsp)
 #endif
@@ -9991,7 +9991,7 @@ LBL(.LB_100_log10):
 
 LBL(.LB_900_log10):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(72)(%rsp), %ymm6
 	vmovdqu	RZ_OFF(104)(%rsp), %ymm7
 #endif
@@ -10099,7 +10099,7 @@ ENT(ASM_CONCAT(__fss_log10_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(96)(%rsp)
 #endif
 	/* First check for valid input:
@@ -10210,7 +10210,7 @@ LBL(.LB1_100_log10):
 
 LBL(.LB1_900_log10):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(96)(%rsp), %ymm6
 #endif
 	RZ_POP
@@ -10615,7 +10615,7 @@ ENT(ASM_CONCAT(__fsd_cosh_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(96)(%rsp)
 #endif
 
@@ -10801,7 +10801,7 @@ ENT(ASM_CONCAT(__fsd_cosh_,TARGET_VEX_OR_FMA)):
 	vaddsd	%xmm6, %xmm0,%xmm0
 #endif
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(96)(%rsp), %ymm6
 #endif
 
@@ -10832,7 +10832,7 @@ ENT(ASM_CONCAT(__fsd_cosh_,TARGET_VEX_OR_FMA)):
 ENT(ASM_CONCAT(__fsd_sinh_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	%ymm6, RZ_OFF(96)(%rsp)
 #endif
 
@@ -11024,7 +11024,7 @@ ENT(ASM_CONCAT(__fsd_sinh_,TARGET_VEX_OR_FMA)):
 
 LBL(.L__fsd_sinh_done):
 
-#if defined(WIN64)
+#if defined(_WIN64)
 	vmovdqu	RZ_OFF(96)(%rsp), %ymm6
 #endif
 	RZ_POP
@@ -11104,7 +11104,7 @@ ENT(ASM_CONCAT(__fvs_cosh_,TARGET_VEX_OR_FMA)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movq    %rsi, 64(%rsp)
         movq    %rdi, 56(%rsp)
         vmovdqu %ymm6, 192(%rsp)
@@ -11342,7 +11342,7 @@ ENT(ASM_CONCAT(__fvs_cosh_,TARGET_VEX_OR_FMA)):
 
 LBL(.L_fvcosh_final_check):
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movq    64(%rsp), %rsi
         movq    56(%rsp), %rdi
         vmovdqu 192(%rsp), %ymm6
@@ -11358,7 +11358,7 @@ LBL(.L__Scalar_fvscosh):
         /* Need to restore callee-saved regs can do here for this path
          * because entry was only thru fvs_cosh_fma4/fvs_cosh_vex
          */
-#if defined(WIN64)
+#if defined(_WIN64)
         movq    64(%rsp), %rsi
         movq    56(%rsp), %rdi
         vmovdqu 192(%rsp), %ymm6
@@ -11418,7 +11418,7 @@ ENT(ASM_CONCAT(__fvs_sinh_,TARGET_VEX_OR_FMA)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movq    %rsi, 64(%rsp)
         movq    %rdi, 56(%rsp)
         vmovdqu %ymm6, 192(%rsp)
@@ -11656,7 +11656,7 @@ ENT(ASM_CONCAT(__fvs_sinh_,TARGET_VEX_OR_FMA)):
 
 LBL(.L_fvsinh_final_check):
 
-#if defined(WIN64)
+#if defined(_WIN64)
         movq    64(%rsp), %rsi
         movq    56(%rsp), %rdi
         vmovdqu 192(%rsp), %ymm6
@@ -11672,7 +11672,7 @@ LBL(.L__Scalar_fvssinh):
         /* Need to restore callee-saved regs can do here for this path
          * because entry was only thru fvs_sinh_fma4/fvs_sinh_vex
          */
-#if defined(WIN64)
+#if defined(_WIN64)
         movq    64(%rsp), %rsi
         movq    56(%rsp), %rdi
         vmovdqu 192(%rsp), %ymm6
@@ -11751,7 +11751,7 @@ ENT(ASM_CONCAT(__fvd_cosh_,TARGET_VEX_OR_FMA)):
 	testl	$3, %r8d
 	jnz	LBL(.L__Scalar_fvdcosh)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, 72(%rsp)
 #endif
 
@@ -11963,7 +11963,7 @@ ENT(ASM_CONCAT(__fvd_cosh_,TARGET_VEX_OR_FMA)):
 	vaddpd	%xmm6,%xmm0,%xmm0		/* done with cosh */
 #endif
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  72(%rsp),%ymm6
 #endif
 
@@ -12044,7 +12044,7 @@ ENT(ASM_CONCAT(__fvd_sinh_,TARGET_VEX_OR_FMA)):
 	testl	$3, %r8d
 	jnz	LBL(.L__Scalar_fvdsinh)
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  %ymm6, 72(%rsp)
 #endif
 
@@ -12264,7 +12264,7 @@ ENT(ASM_CONCAT(__fvd_sinh_,TARGET_VEX_OR_FMA)):
 	vsubpd	%xmm6,%xmm0,%xmm0		/* done with sinh */
 #endif
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu  72(%rsp),%ymm6
 #endif
 
@@ -12325,7 +12325,7 @@ ENT(ASM_CONCAT3(__fvs_exp_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
         movq    %rsi, 192(%rsp)
         movq    %rdi, 224(%rsp)
@@ -12346,7 +12346,7 @@ ENT(ASM_CONCAT3(__fvs_exp_,TARGET_VEX_OR_FMA,_256)):
         vmovups 80(%rsp), %ymm1
         vinsertf128     $1, %xmm0, %ymm1, %ymm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
         movq    %rsi, 192(%rsp)
         movq    %rdi, 224(%rsp)
@@ -12471,7 +12471,7 @@ ENT(ASM_CONCAT3(__fvd_sin_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
         vmovdqu %ymm7, 160(%rsp)
 #endif
@@ -12492,7 +12492,7 @@ ENT(ASM_CONCAT3(__fvd_sin_,TARGET_VEX_OR_FMA,_256)):
         vmovups 80(%rsp), %ymm1
         vinsertf128     $1, %xmm0, %ymm1, %ymm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
         vmovdqu 160(%rsp), %ymm7
 #endif
@@ -12571,7 +12571,7 @@ ENT(ASM_CONCAT3(__fvd_cos_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
         vmovdqu %ymm7, 160(%rsp)
 #endif
@@ -12592,7 +12592,7 @@ ENT(ASM_CONCAT3(__fvd_cos_,TARGET_VEX_OR_FMA,_256)):
         vmovups 80(%rsp), %ymm1
         vinsertf128     $1, %xmm0, %ymm1, %ymm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
         vmovdqu 160(%rsp), %ymm7
 #endif
@@ -12627,7 +12627,7 @@ ENT(ASM_CONCAT3(__fvs_log_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $512, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
         vmovdqu %ymm7, 160(%rsp)
         vmovdqu %ymm8, 192(%rsp)
@@ -12816,7 +12816,7 @@ LBL(.LB_900_256):
 
 /*******************************************/
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
         vmovdqu 160(%rsp), %ymm7
         vmovdqu 192(%rsp), %ymm8
@@ -12925,7 +12925,7 @@ ENT(ASM_CONCAT3(__fvd_log_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
 #endif
 
@@ -12945,7 +12945,7 @@ ENT(ASM_CONCAT3(__fvd_log_,TARGET_VEX_OR_FMA,_256)):
         vmovups 80(%rsp), %ymm1
         vinsertf128     $1, %xmm0, %ymm1, %ymm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
 #endif
 
@@ -12978,7 +12978,7 @@ ENT(ASM_CONCAT3(__fvs_log10_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
         vmovdqu %ymm7, 160(%rsp)
 #endif
@@ -12999,7 +12999,7 @@ ENT(ASM_CONCAT3(__fvs_log10_,TARGET_VEX_OR_FMA,_256)):
         vmovups 80(%rsp), %ymm1
         vinsertf128     $1, %xmm0, %ymm1, %ymm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
         vmovdqu 160(%rsp), %ymm7
 #endif
@@ -13033,7 +13033,7 @@ ENT(ASM_CONCAT3(__fvd_log10_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
 #endif
 
@@ -13053,7 +13053,7 @@ ENT(ASM_CONCAT3(__fvd_log10_,TARGET_VEX_OR_FMA,_256)):
         vmovups 80(%rsp), %ymm1
         vinsertf128     $1, %xmm0, %ymm1, %ymm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
 #endif
 
@@ -13086,7 +13086,7 @@ ENT(ASM_CONCAT3(__fvs_sinh_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
         vmovdqu %ymm7, 160(%rsp)
 	movq	%rsi, 192(%rsp)
@@ -13109,7 +13109,7 @@ ENT(ASM_CONCAT3(__fvs_sinh_,TARGET_VEX_OR_FMA,_256)):
         vmovups 80(%rsp), %ymm1
         vinsertf128     $1, %xmm0, %ymm1, %ymm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
         vmovdqu 160(%rsp), %ymm7
 	movq	192(%rsp), %rsi
@@ -13190,7 +13190,7 @@ ENT(ASM_CONCAT3(__fvs_cosh_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
         vmovdqu %ymm7, 160(%rsp)
         movq    %rsi, 192(%rsp)
@@ -13213,7 +13213,7 @@ ENT(ASM_CONCAT3(__fvs_cosh_,TARGET_VEX_OR_FMA,_256)):
         vmovups 80(%rsp), %ymm1
         vinsertf128     $1, %xmm0, %ymm1, %ymm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
         vmovdqu 160(%rsp), %ymm7
         movq    192(%rsp), %rsi
@@ -13294,7 +13294,7 @@ ENT(ASM_CONCAT3(__fvs_sincos_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
         vmovdqu %ymm7, 160(%rsp)
 #endif
@@ -13319,7 +13319,7 @@ ENT(ASM_CONCAT3(__fvs_sincos_,TARGET_VEX_OR_FMA,_256)):
         vmovups 96(%rsp), %ymm4
         vinsertf128     $1, %xmm1, %ymm4, %ymm1
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
         vmovdqu 160(%rsp), %ymm7
 #endif
@@ -13353,7 +13353,7 @@ ENT(ASM_CONCAT3(__fvd_sincos_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
         vmovdqu %ymm7, 160(%rsp)
         vmovdqu	%ymm8, 192(%rsp)
@@ -13379,7 +13379,7 @@ ENT(ASM_CONCAT3(__fvd_sincos_,TARGET_VEX_OR_FMA,_256)):
         vmovups 96(%rsp), %ymm4
         vinsertf128     $1, %xmm1, %ymm4, %ymm1
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
         vmovdqu 160(%rsp), %ymm7
         vmovdqu	192(%rsp), %ymm8
@@ -13463,7 +13463,7 @@ ENT(ASM_CONCAT3(__fvd_pow_,TARGET_VEX_OR_FMA,_256)):
         movq    %rsp, %rbp
         subq    $256, %rsp
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu %ymm6, 128(%rsp)
 #endif
 
@@ -13486,7 +13486,7 @@ ENT(ASM_CONCAT3(__fvd_pow_,TARGET_VEX_OR_FMA,_256)):
         vmovups 64(%rsp), %ymm1
         vinsertf128     $1, %xmm0, %ymm1, %ymm0
 
-#if defined(WIN64)
+#if defined(_WIN64)
         vmovdqu 128(%rsp), %ymm6
 #endif
 

--- a/runtime/libpgmath/lib/x86_64/mthdecls.h
+++ b/runtime/libpgmath/lib/x86_64/mthdecls.h
@@ -339,7 +339,7 @@ static inline __attribute__((always_inline)) double_complex_t  pgmath_cmplx(doub
  * to the different entry points for the various architectures.
  */
 
-#if defined(WIN64)
+#if defined(_WIN64)
 /*
  * Windows.
  */
@@ -391,7 +391,7 @@ static inline __attribute__((always_inline)) double_complex_t  pgmath_cmplx(doub
 #define BESSEL_Y0 y0
 #define BESSEL_Y1 y1
 #define BESSEL_YN yn
-#endif		/* #if defined (WIN64) */
+#endif		/* #if defined (_WIN64) */
 
 /*  declarations for math functions */
 

--- a/runtime/libpgmath/lib/x86_64/relaxed/relaxedmath_vex.h
+++ b/runtime/libpgmath/lib/x86_64/relaxed/relaxedmath_vex.h
@@ -678,7 +678,7 @@ ENT(ASM_CONCAT(__rvs_exp_,TARGET_VEX_OR_FMA)):
 
 	RZ_PUSH
 
-#if defined(WIN64) || defined(TARGET_INTERIX_X8664)
+#if defined(_WIN64) || defined(TARGET_INTERIX_X8664)
 	vmovdqu	%ymm6, RZ_OFF(104)(%rsp)
 	movq	%rsi, RZ_OFF(64)(%rsp)
 	movq	%rdi, RZ_OFF(72)(%rsp)
@@ -912,7 +912,7 @@ ENT(ASM_CONCAT(__rvs_exp_,TARGET_VEX_OR_FMA)):
 
 LBL(.L_vsp_final_check):
 
-#if defined(WIN64) || defined(TARGET_INTERIX_X8664)
+#if defined(_WIN64) || defined(TARGET_INTERIX_X8664)
 	vmovdqu	RZ_OFF(104)(%rsp), %ymm6
 	movq	RZ_OFF(64)(%rsp), %rsi
 	movq	RZ_OFF(72)(%rsp), %rdi
@@ -986,7 +986,7 @@ ENT(ASM_CONCAT3(__rvs_exp_,TARGET_VEX_OR_FMA,_256)):
 	movq	%r14, 232(%rsp)
 	movq	%r15, 240(%rsp)
 
-#if defined(WIN64) || defined(TARGET_INTERIX_X8664)
+#if defined(_WIN64) || defined(TARGET_INTERIX_X8664)
         vmovdqu %ymm6, 128(%rsp)
         movq    %rsi, 200(%rsp)
         movq    %rdi, 208(%rsp)
@@ -1207,7 +1207,7 @@ ENT(ASM_CONCAT3(__rvs_exp_,TARGET_VEX_OR_FMA,_256)):
 
 LBL(.L_vsp_final_check_256):
 
-#if defined(WIN64) || defined(TARGET_INTERIX_X8664)
+#if defined(_WIN64) || defined(TARGET_INTERIX_X8664)
         vmovdqu 128(%rsp), %ymm6
         movq    200(%rsp), %rsi
         movq    208(%rsp), %rdi

--- a/runtime/ompstub/init_nomp.c
+++ b/runtime/ompstub/init_nomp.c
@@ -15,7 +15,7 @@
  * is available in pgc lib.
  */
 
-#if !defined(WIN64)
+#if !defined(_WIN64)
 /* get max avail cpus */
 
 int

--- a/test/f90_correct/src/check.c
+++ b/test/f90_correct/src/check.c
@@ -252,7 +252,7 @@ fcpyi(int *r, int f)
     fcpyi_(r, f);
 }
 
-#if defined(WINNT) || defined(WIN32)
+#if defined(_WIN32)
 void
 __stdcall CHECK(int* res, int* exp, int* np)
 {

--- a/test/f90_correct/src/in09_expct.c
+++ b/test/f90_correct/src/in09_expct.c
@@ -15,7 +15,7 @@ get_expected_f(float src[], float expct[], int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#ifdef  WIN64
+#if defined(_WIN64)
         expct[i] = erf(src[i]);
 #else
         expct[i] = erff(src[i]);

--- a/test/f90_correct/src/in10_expct.c
+++ b/test/f90_correct/src/in10_expct.c
@@ -15,7 +15,7 @@ get_expected_f(float src[], float expct[], int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#ifdef  WIN64
+#if defined(_WIN64)
         expct[i] = erfc(src[i]);
 #else
         expct[i] = erfcf(src[i]);

--- a/test/f90_correct/src/in11_expct.c
+++ b/test/f90_correct/src/in11_expct.c
@@ -16,7 +16,7 @@ get_expected_f(float src[], float expct[], int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#ifdef  WIN64
+#if defined(_WIN64)
         expct[i] = tgamma(src[i]);
 #else
         expct[i] = tgammaf(src[i]);

--- a/test/f90_correct/src/in12_expct.c
+++ b/test/f90_correct/src/in12_expct.c
@@ -15,7 +15,7 @@ get_expected_f(float src[], float expct[], int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#ifdef  WIN64
+#if defined(_WIN64)
         expct[i] = lgamma(src[i]);
 #else
         expct[i] = lgammaf(src[i]);

--- a/test/f90_correct/src/in13_expct.c
+++ b/test/f90_correct/src/in13_expct.c
@@ -16,7 +16,7 @@ get_expected_f(float src1[], float src2[], float expct[], int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#ifdef  WIN64
+#if defined(_WIN64)
         expct[i] = hypot(src1[i],src2[i]);
 #else
         expct[i] = hypotf(src1[i], src2[i]);

--- a/test/f90_correct/src/in15_expct.c
+++ b/test/f90_correct/src/in15_expct.c
@@ -15,7 +15,7 @@ get_expected_f(float src1[], float expct[], int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#ifdef  _WIN64
+#if defined(_WIN64)
         expct[i] = asinh(src1[i]);
 #else
         expct[i] = asinhf(src1[i]);

--- a/test/f90_correct/src/in17_expct.c
+++ b/test/f90_correct/src/in17_expct.c
@@ -15,7 +15,7 @@ get_expected_f(float src1[], float expct[], int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#if  defined( _WIN64) || defined(_WIN32) || defined(osx86)
+#if defined(_WIN32) || defined(osx86)
         expct[i] = j0(src1[i]);
 #else
         expct[i] = j0f(src1[i]);

--- a/test/f90_correct/src/in18_expct.c
+++ b/test/f90_correct/src/in18_expct.c
@@ -15,7 +15,7 @@ get_expected_f(float src1[], float expct[], int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#if  defined( _WIN64) || defined(_WIN32) || defined(osx86)
+#if defined(_WIN32) || defined(osx86)
         expct[i] = j1(src1[i]);
 #else
         expct[i] = j1f(src1[i]);

--- a/test/f90_correct/src/in19_expct.c
+++ b/test/f90_correct/src/in19_expct.c
@@ -15,7 +15,7 @@ get_expected_f(float src1[], float expct[], int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#if  defined( _WIN64) || defined(_WIN32) || defined(osx86)
+#if defined(_WIN32) || defined(osx86)
         expct[i] = y0(src1[i]);
 #else
         expct[i] = y0f(src1[i]);

--- a/test/f90_correct/src/in20_expct.c
+++ b/test/f90_correct/src/in20_expct.c
@@ -15,7 +15,7 @@ get_expected_f(float src1[], float expct[], int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#if  defined( _WIN64) || defined(_WIN32) || defined(osx86)
+#if defined(_WIN32) || defined(osx86)
         expct[i] = y1(src1[i]);
 #else
         expct[i] = y1f(src1[i]);

--- a/test/f90_correct/src/in21_expct.c
+++ b/test/f90_correct/src/in21_expct.c
@@ -15,7 +15,7 @@ get_expected_f(float src1[], float expct[], int order, int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#if  defined( _WIN64) ||  defined(_WIN32) || defined(osx86)
+#if defined(_WIN32) || defined(osx86)
         expct[i] = jn(order, src1[i]);
 #else
         expct[i] = jnf(order, src1[i]);

--- a/test/f90_correct/src/in22_expct.c
+++ b/test/f90_correct/src/in22_expct.c
@@ -15,7 +15,7 @@ get_expected_f(float src1[], float expct[], int order, int n)
     int i;
 
     for(i= 0; i <n; i++ ) {
-#if  defined( _WIN64) || defined(_WIN32) || defined(osx86)
+#if defined(_WIN32) || defined(osx86)
         expct[i] = (float)yn(order, src1[i]);
 #else
         expct[i] = ynf(order, src1[i]);

--- a/test/f90_correct/src/in25_expct.c
+++ b/test/f90_correct/src/in25_expct.c
@@ -16,7 +16,7 @@ get_expected_f(float src1, float expct[], int n1, int n2, int n)
     int order;
 
         for(order = n1; order <= n2; order++ ) {
-#if  defined( _WIN64) || defined(_WIN32) || defined(osx86)
+#if defined(_WIN32) || defined(osx86)
             switch(order) {
             case 0:
                 expct[order-n1] = (float)y0(src1);

--- a/test/f90_correct/src/in26_expct.c
+++ b/test/f90_correct/src/in26_expct.c
@@ -13,7 +13,7 @@ extern float complex cacosf(float complex);
 extern double complex cacos(double complex);
 
 #undef USELIBMF
-#if !defined(__WIN32) && !defined(__WIN64) && defined(__PGIC__) && defined(__PGIC_MINOR__)
+#if !defined(_WIN32) && !defined(_WIN64) && defined(__PGIC__) && defined(__PGIC_MINOR__)
 #if (__PGIC__ > 15)
 #define USELIBMF
 #elif (__PGIC__ == 15) && (__PGIC_MINOR_ > 4)

--- a/test/f90_correct/src/in27_expct.c
+++ b/test/f90_correct/src/in27_expct.c
@@ -13,7 +13,7 @@ extern float complex casinf(float complex);
 extern double complex casin(double complex);
 
 #undef USELIBMF
-#if !defined(__WIN32) && !defined(__WIN64) && defined(__PGIC__) && defined(__PGIC_MINOR__)
+#if !defined(_WIN32) && !defined(_WIN64) && defined(__PGIC__) && defined(__PGIC_MINOR__)
 #if (__PGIC__ > 15)
 #define USELIBMF
 #elif (__PGIC__ == 15) && (__PGIC_MINOR_ > 4)

--- a/test/mp_correct/src/check.c
+++ b/test/mp_correct/src/check.c
@@ -63,7 +63,7 @@ chkalt(int * ir, int * ie, int * np)
     return chkalt_(ir, ie, np);
 }
 
-#if defined(WINNT) || defined(WIN32)
+#if defined(_WIN32)
 void
 __stdcall CHECK(res, exp, np)
     int *res, *exp, *np;

--- a/tools/flang1/utils/prstab/prstab.h
+++ b/tools/flang1/utils/prstab/prstab.h
@@ -28,7 +28,7 @@
 #define min(a, b) ((a) <= (b) ? (a) : (b))
 #define max(a, b) ((a) >= (b) ? (a) : (b))
 
-#if defined(__WIN64__) || defined(__WIN32__)
+#if defined(_WIN32)
 #define SNPRINTF _snprintf
 #else
 #define SNPRINTF snprintf


### PR DESCRIPTION
Start using compiler defined macros such as _WIN32, _WIN64.
WINNT macro could be also renamed to _WIN32.