### PR TITLE
Add ccache support to GitHub Actions

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ matrix.cc }}-${{ matrix.version }}
 
       - if: matrix.cc == 'gcc' && matrix.version == '10'
         run: |

--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -183,7 +183,9 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr/local \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=/usr/bin/${{ matrix.cc }} \
-            -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.cpp }}"
+            -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.cpp }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
           cd runtime/libpgmath
           mkdir -p build && cd build
           cmake $CMAKE_OPTIONS ..
@@ -202,6 +204,8 @@ jobs:
             -DCMAKE_Fortran_COMPILER_ID=Flang \
             -DFLANG_INCLUDE_DOCS=ON \
             -DFLANG_LLVM_EXTENSIONS=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ..
           make -j$(nproc)
           sudo make install

--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -38,6 +38,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
       - uses: actions/checkout@v2
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+
       - if: matrix.cc == 'gcc' && matrix.version == '10'
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
@@ -164,7 +167,9 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr/local \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=/usr/bin/${{ matrix.cc }} \
-            -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.cpp }}"
+            -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.cpp }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
           git clone --depth 1 --single-branch --branch release_90 https://github.com/llvm-mirror/openmp.git
           cd openmp
           mkdir -p build && cd build


### PR DESCRIPTION
By default action is set up to:
1. Use 500MB size for cache
2. Compress the cache
3. Show the cache stats post-build to ensure it's used efficiently