### PR TITLE
Nested implied do loop fix for real numbers

### DIFF
--- a/test/f90_correct/inc/array_constructor_nested_implied_do.mk
+++ b/test/f90_correct/inc/array_constructor_nested_implied_do.mk
@@ -6,15 +6,16 @@
 
 ########## Make rule for test array_constructor_nested_implied_do  ########
 
-build:
+build: $(SRC)/$(TEST).f90
 	@echo ------------------------------------ building test $(TEST)
 	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
-	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX) > $(TEST).rslt 2>&1
 	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
 
 run:
 	@echo ------------------------------------ executing test $(TEST)
 	./$(TEST).$(EXESUFFIX)
 
-verify: ;
-
+verify: $(TEST).rslt
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f90 $(TEST).rslt $(FC)

--- a/test/f90_correct/src/array_constructor_nested_implied_do.f90
+++ b/test/f90_correct/src/array_constructor_nested_implied_do.f90
@@ -34,14 +34,90 @@ PROGRAM stress_test_nested_implied_do
   ! 3 levels of nesting and multiple items
   INTEGER :: array5(3*m*o) = (/ (((i, i+10, i+100, j=1, i), i=1,n ), k=1, o) /)
   INTEGER :: expect5(3*m*o)
-  data expect5/1, 10, 100,&
-               2, 20, 200, 2, 20, 200,&
-               3, 30, 300, 3, 30, 300, 3, 30, 300,&
-               4, 40, 400, 4, 40, 400, 4, 40, 400, 4, 40, 400,&
-               1, 10, 100,&
-               2, 20, 200, 2, 20, 200,&
-               3, 30, 300, 3, 30, 300, 3, 30, 300,&
-               4, 40, 400, 4, 40, 400, 4, 40, 400, 4, 40, 400/
+  data expect5/1, 11, 101,&
+               2, 12, 102, 2, 12, 102,&
+               3, 13, 103, 3, 13, 103, 3, 13, 103,&
+               4, 14, 104, 4, 14, 104, 4, 14, 104, 4, 14, 104,&
+               1, 11, 101,&
+               2, 12, 102, 2, 12, 102,&
+               3, 13, 103, 3, 13, 103, 3, 13, 103,&
+               4, 14, 104, 4, 14, 104, 4, 14, 104, 4, 14, 104/
+
+  INTEGER(KIND=1) :: i8, j8   ! TY_BINT
+  INTEGER(KIND=2) :: i16, j16 ! TY_SINT
+  INTEGER(KIND=4) :: i32, j32 ! TY_INT
+  INTEGER(KIND=8) :: i64, j64 ! TY_INT8
+
+  ! Different integers fitting into each other
+  ! Array contents are intentionally oversized to show that a warning rather than an error is thrown
+
+  INTEGER(KIND=1) :: array_i1_i1(6) = (/ ((256_1, j8=1_1, i8), i8=1_1, 3_1 ) /)
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 61}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 61}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 61}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 61}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 61}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 61}
+  INTEGER(KIND=1) :: array_i1_i2(6) = (/ ((257_2, j16=1_2, i16), i16=1_2, 3_2 ) /)
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 68}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 68}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 68}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 68}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 68}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 68}
+  INTEGER(KIND=1) :: array_i1_i4(6) = (/ ((257_4, j32=1_4, i32), i32=1_4, 3_4 ) /)
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 75}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 75}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 75}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 75}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 75}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 75}
+  INTEGER(KIND=1) :: array_i1_i8(6) = (/ ((257_8, j64=1_8, i64), i64=1_8, 3_8 ) /)
+
+  INTEGER(KIND=2) :: array_i2_i1(6) = (/ ((256_1, j8=1_1, i8), i8=1_1, 3_1 ) /)
+  INTEGER(KIND=2) :: array_i2_i2(6) = (/ ((65536_2, j16=1_2, i16), i16=1_2, 3_2 ) /)
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 85}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 85}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 85}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 85}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 85}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 85}
+  INTEGER(KIND=2) :: array_i2_i4(6) = (/ ((65537_4, j32=1_4, i32), i32=1_4, 3_4 ) /)
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 92}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 92}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 92}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 92}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 92}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 92}
+  INTEGER(KIND=2) :: array_i2_i8(6) = (/ ((65537_8, j64=1_8, i64), i64=1_8, 3_8 ) /)
+
+  INTEGER(KIND=4) :: array_i4_i1(6) = (/ ((256_1, j8=1_1, i8), i8=1_1, 3_1 ) /)
+  INTEGER(KIND=4) :: array_i4_i2(6) = (/ ((65536_2, j16=1_2, i16), i16=1_2, 3_2 ) /)
+  INTEGER(KIND=4) :: array_i4_i4(6) = (/ ((4294967296_4, j32=1_4, i32), i32=1_4, 3_4 ) /)
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 103}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 103}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 103}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 103}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 103}
+  !{warning "PGF90-W-0128-Integer constant truncated to fit data type: 1" 103}
+  INTEGER(KIND=4) :: array_i4_i8(6) = (/ ((4294967297_8, j64=1_8, i64), i64=1_8, 3_8 ) /)
+
+  INTEGER(KIND=8) :: array_i8_i1(6) = (/ ((256_1, j8=1_1, i8), i8=1_1, 3_1 ) /)
+  INTEGER(KIND=8) :: array_i8_i2(6) = (/ ((65536_2, j16=1_2, i16), i16=1_2, 3_2 ) /)
+  INTEGER(KIND=8) :: array_i8_i4(6) = (/ ((4294967296_4, j32=1_4, i32), i32=1_4, 3_4 ) /)
+  INTEGER(KIND=8) :: array_i8_i8(6) = (/ ((4294967297_8, j64=1_8, i64), i64=1_8, 3_8 ) /)
+
+  ! Integers initializing real arrays
+
+  REAL(KIND=4) :: array_r4_i1(6) = (/ ((256_1, j8=1_1, i8), i8=1_1, 3_1 ) /)
+  REAL(KIND=4) :: array_r4_i2(6) = (/ ((65536_2, j16=1_2, i16), i16=1_2, 3_2 ) /)
+  REAL(KIND=4) :: array_r4_i4(6) = (/ ((4294967296_4, j32=1_4, i32), i32=1_4, 3_4 ) /)
+  REAL(KIND=4) :: array_r4_i8(6) = (/ ((4294967297_8, j64=1_8, i64), i64=1_8, 3_8 ) /)
+
+  REAL(KIND=8) :: array_r8_i1(6) = (/ ((256_1, j8=1_1, i8), i8=1_1, 3_1 ) /)
+  REAL(KIND=8) :: array_r8_i2(6) = (/ ((65536_2, j16=1_2, i16), i16=1_2, 3_2 ) /)
+  REAL(KIND=8) :: array_r8_i4(6) = (/ ((4294967296_4, j32=1_4, i32), i32=1_4, 3_4 ) /)
+  REAL(KIND=8) :: array_r8_i8(6) = (/ ((4294967297_8, j64=1_8, i64), i64=1_8, 3_8 ) /)
 
   call check(array1, expect1, n)
   call check(array2, expect2, m)

--- a/tools/flang1/flang1exe/dinit.c
+++ b/tools/flang1/flang1exe/dinit.c
@@ -801,10 +801,7 @@ dinit_acl_val2(int sptr, int dtype, ACL *ict, int op)
     if ((ict->subc != 0) && (ict->subc->id == AC_IDO)
         && (ict->subc->subc != 0) && (ict->subc->subc->id == AC_IDO)) {
       /* Perform a more relaxed check for a nested implied-do loop. */
-      if (!cmpat_dtype(dtype, ict->dtype)) {
-        errsev(91);
-      }
-      if (!cmpat_dtype(DDTG(dtype), DDTG(ict->dtype))) {
+      if (!cmpat_dtype_array_cast(dtype, ict->dtype)) {
         errsev(91);
       }
     } else {


### PR DESCRIPTION
Fixes https://github.com/flang-compiler/flang/issues/992.

A new `cmpat_dtype_*` function is added that does a few preliminary checks to allow casting of arrays wherever this is possible.
Also a few test cases are added presenting the possibility of initializing arrays with different types.