### PR TITLE
LLVM 12 upgrade

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -15,7 +15,7 @@ jobs:
         cc: [clang]
         cpp: [clang++]
         version: [9, 10, 11]
-        llvm_branch: [release_100, release_11x]
+        llvm_branch: [release_100, release_11x, release_12x]
         include:
           - target: X86
             cc: gcc
@@ -32,6 +32,11 @@ jobs:
             cpp: g++
             version: 10
             llvm_branch: release_11x
+          - target: X86
+            cc: gcc
+            cpp: g++
+            version: 10
+            llvm_branch: release_12x
 
       
     steps:
@@ -113,7 +118,7 @@ jobs:
           url=`jq -r '.artifacts[] | select(.name == "flang-driver_build_${{ matrix.target }}") | .archive_download_url' artifacts_flang-driver`
           wget --output-document flang-driver_build.zip --header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $url
 
-      #Download artifacts for the classic-flang-llvm-project-related builds (all toolchains)
+      # Download artifacts for the classic-flang-llvm-project-related builds (all toolchains)
       - if: matrix.cc != 'gcc' || matrix.version != '9'
         run: |
           cd ../..
@@ -206,6 +211,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER_ID=Flang \
             -DFLANG_INCLUDE_DOCS=ON \
             -DFLANG_LLVM_EXTENSIONS=ON \
+            -DWITH_WERROR=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.3)
 
 # In order to bootstrap the runtime library we need to skip
 # CMake's Fortran tests

--- a/runtime/libpgmath/CMakeLists.txt
+++ b/runtime/libpgmath/CMakeLists.txt
@@ -33,9 +33,9 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 endif()
 
 if (LIBPGMATH_STANDALONE_BUILD)
-  include(FindPythonInterp)
-  if( NOT PYTHONINTERP_FOUND )
-    message(WARNING "Failed to find python interpreter. "
+  include(FindPython3)
+  if( NOT Python3_Interpreter_FOUND )
+    message(WARNING "Failed to find Python 3 interpreter. "
                     "Libpgmath test suite will be disabled.")
     set(LLVM_INCLUDE_TESTS OFF)
   endif()

--- a/runtime/libpgmath/test/CMakeLists.txt
+++ b/runtime/libpgmath/test/CMakeLists.txt
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
-include(FindPythonInterp)
+include(FindPython3)
 include(CheckTypeSize)
 include(CheckLibraryExists)
 
-if(NOT PYTHONINTERP_FOUND)
-  libpgmath_warning_say("Could not find Python.")
+if(NOT Python3_Interpreter_FOUND)
+  libpgmath_warning_say("Could not find Python 3.")
   libpgmath_warning_say("The check-pgm target will not be available!")
   return()
 endif()
@@ -63,7 +63,7 @@ if(${LIBPGMATH_STANDALONE_BUILD})
     "Default options for lit")
   separate_arguments(LIBPGMATH_LIT_ARGS)
   add_custom_target(check-lib${LIBPGMATH_LIBRARY_NAME}
-    COMMAND ${PYTHON_EXECUTABLE} ${LIBPGMATH_LLVM_LIT_EXECUTABLE} ${LIBPGMATH_LIT_ARGS} ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${Python3_EXECUTABLE} ${LIBPGMATH_LLVM_LIT_EXECUTABLE} ${LIBPGMATH_LIT_ARGS} ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Running libpgmath tests"
     ${cmake_3_2_USES_TERMINAL}
     DEPENDS ${LIBPGMATH_LIBRARY_NAME})

--- a/tools/flang1/flang1exe/CMakeLists.txt
+++ b/tools/flang1/flang1exe/CMakeLists.txt
@@ -153,6 +153,7 @@ target_compile_options(flang1
   )
 
 target_link_libraries(flang1
+  PRIVATE
   flangArgParser
   ${FLANG_LIB_DIR}/scutil.a
   -lm

--- a/tools/flang2/flang2exe/CMakeLists.txt
+++ b/tools/flang2/flang2exe/CMakeLists.txt
@@ -133,6 +133,7 @@ target_compile_options(flang2
   )
 
 target_link_libraries(flang2
+  PRIVATE
   flangArgParser
   ${FLANG_LIB_DIR}/scutil.a
   -lm


### PR DESCRIPTION
This PR adds changes to allow Flang to be built on top of LLVM 12 (the candidate branch currently residing in https://github.com/Huawei-PTLab/classic-flang-llvm-project/tree/release_12x). NFCI.

LLVM 12's CMake modules have enabled more warnings and, as a result, building Flang with `-Werror` now fails. This PR turns off the `WITH_WERROR` option to work around the failures; a subsequent MR will fix the compiler warnings.