### PR TITLE
Fix for the issue #1005 : Do not call streamlined/dgemm-like matmul runtime routines for data layouts that could not be proven to be contiguous

### DIFF
--- a/test/f90_correct/inc/mmul_misc3.mk
+++ b/test/f90_correct/inc/mmul_misc3.mk
@@ -1,0 +1,27 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test mmul_misc3  ########
+
+
+mmul_misc3: run
+
+
+build:  $(SRC)/mmul_misc3.f90
+	-$(RM) mmul_misc3.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/mmul_misc3.f90 -o mmul_misc3.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) mmul_misc3.$(OBJX) check.$(OBJX) $(LIBS) -o mmul_misc3.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test mmul_misc3
+	mmul_misc3.$(EXESUFFIX)
+
+verify: ;
+
+mmul_misc3.run: run

--- a/test/f90_correct/lit/mmul_misc3.sh
+++ b/test/f90_correct/lit/mmul_misc3.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/mmul_misc3.f90
+++ b/test/f90_correct/src/mmul_misc3.f90
@@ -1,0 +1,30 @@
+!** Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+!** See https://llvm.org/LICENSE.txt for license information.
+!** SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+program mmul
+  integer, parameter :: n = 4
+  real(kind = 8), dimension(1:n, 1:n) :: a, b, c
+  real(kind = 8), dimension(n * n) :: expected
+  data expected / -256.0, -256.0, -256.0, -256.0, &
+                  -256.0, -256.0, -256.0, -256.0, &
+                  -256.0, -256.0, -256.0, -256.0, &
+                  -256.0, -256.0, -256.0, -256.0 /
+
+  a = 1.0
+  b = -1.0
+  c = 2.0
+  call do_matmul(a, b, c, n)
+  call checkd(reshape(c, (/ n * n /)), expected, n * n)
+
+contains
+
+  subroutine do_matmul(a, b, c, n)
+    integer, intent(in) :: n
+    real(kind = 8), dimension(:, :), intent(in) :: a, b
+    real(kind = 8), dimension(:, :), intent(inout) :: c
+
+    c(1:n, 1:n) = matmul(matmul(matmul(a(1:n, 1:n), b(1:n, 1:n)), matmul(a(1:n, 1:n), b(1:n, 1:n))), b(1:n, 1:n))
+  end subroutine
+
+end program mmul

--- a/tools/flang1/flang1exe/func.c
+++ b/tools/flang1/flang1exe/func.c
@@ -7113,8 +7113,7 @@ mmul_arg(int arr, int transpose, MMUL *mm)
   }
   /* ldim must be before any tranpose */
   if (STYPEG(sptr) == ST_MEMBER) {
-    ldim = ADD_EXTNTAST(DTYPEG(sptr), 0);
-    ldim = check_member(mm->addr, ldim);
+    return FALSE;
   }
 #ifdef NOEXTENTG
   else if (HCCSYMG(sptr) && SCG(sptr) == SC_LOCAL && ALLOCG(sptr) &&
@@ -7135,9 +7134,8 @@ mmul_arg(int arr, int transpose, MMUL *mm)
     ldim = mk_extent_expr(AD_LWBD(tad, 0), AD_UPBD(tad, 0));
   }
 #endif
-  else {
-    ldim = ADD_EXTNTAST(DTYPEG(sptr), 0);
-  }
+  else
+    return FALSE;
   if (transpose) {
     /*  extents are post-tranposed */
     m = mm->extent[0];


### PR DESCRIPTION
Returning FALSE from mmul_arg() function prevents further preparations for making a call to the dgemm-alike f90_mmul_* flang runtime functions. Instead, it should fall back to making a call to one of the f90_matmul_* runtime functions.
