### PR TITLE
Remove release_90 from Github Actions

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -20,11 +20,6 @@ jobs:
           - target: X86
             cc: gcc
             cpp: g++
-            version: 9
-            llvm_branch: release_90
-          - target: X86
-            cc: gcc
-            cpp: g++
             version: 10
             llvm_branch: release_100
           - target: X86
@@ -38,7 +33,6 @@ jobs:
             version: 10
             llvm_branch: release_12x
 
-      
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
       - uses: actions/checkout@v2
@@ -76,50 +70,8 @@ jobs:
           make --version
           ${{ matrix.cc }} --version
 
-      # Download artifacts
-      # For gcc-9 use the flang-driver/llvm fork (as per official instructions)
-      - if: matrix.cc == 'gcc' && matrix.version == '9'
-        run: |
-          cd ../..
-          curl -sL https://api.github.com/repos/flang-compiler/llvm/actions/workflows/build_llvm.yml/runs --output runs_llvm.json
-          curl -sL https://api.github.com/repos/flang-compiler/flang-driver/actions/workflows/build_flang-driver.yml/runs --output runs_flang-driver.json
-
-          wget --output-document artifacts_llvm `jq -r '.workflow_runs[0].artifacts_url?' runs_llvm.json`
-          wget --output-document artifacts_flang-driver `jq -r '.workflow_runs[0].artifacts_url?' runs_flang-driver.json`
-          
-          # Retry with previous build in case no artifacts are available 
-          echo "cat artifacts_llvm"
-          cat artifacts_llvm
-          i="0"
-          while [ `jq -r '.total_count?' artifacts_llvm` == "0" ] && [ $i -lt 3 ]
-          do
-            echo "No artifacts in build $i, counting from latest"
-            i=$[$i+1]
-            wget --output-document artifacts_llvm `jq -r --argjson i "$i" '.workflow_runs[$i].artifacts_url?' runs_llvm.json`
-            echo "cat artifacts_llvm"
-            cat artifacts_llvm
-          done
-
-          echo "cat artifacts_flang-driver"
-          cat artifacts_flang-driver
-          i="0"
-          while [ `jq -r '.total_count?' artifacts_flang-driver` == "0" ] && [ $i -lt 3 ]
-          do
-            echo "No artifacts in build $i, counting from latest"
-            i=$[$i+1]
-            wget --output-document artifacts_flang-driver `jq -r --argjson i "$i" '.workflow_runs[$i].artifacts_url?' runs_flang-driver.json`
-            echo "cat artifacts_flang-driver"
-            cat artifacts_flang-driver
-          done
-
-          url=`jq -r '.artifacts[] | select(.name == "llvm_build_${{ matrix.target }}") | .archive_download_url' artifacts_llvm`
-          wget --output-document llvm_build.zip --header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $url
-
-          url=`jq -r '.artifacts[] | select(.name == "flang-driver_build_${{ matrix.target }}") | .archive_download_url' artifacts_flang-driver`
-          wget --output-document flang-driver_build.zip --header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $url
-
       # Download artifacts for the classic-flang-llvm-project-related builds (all toolchains)
-      - if: matrix.cc != 'gcc' || matrix.version != '9'
+      - name: Download artifacts
         run: |
           cd ../..
           curl -sL https://api.github.com/repos/flang-compiler/classic-flang-llvm-project/actions/workflows/pre-compile_llvm.yml/runs --output runs_llvm.json
@@ -138,26 +90,7 @@ jobs:
           url=`jq -r '.artifacts[] | select(.name == "llvm_build_${{ matrix.target }}_${{ matrix.cc }}_${{ matrix.version }}_${{ matrix.llvm_branch }}") | .archive_download_url' artifacts_llvm`
           wget --output-document llvm_build.zip --header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $url
 
-      # Install llvm and flang-driver from the release_90 branch (according to official instructions)
-      - if: matrix.cc == 'gcc' && matrix.version == '9'
-        run: |
-          cd ../..
-          # Don't clone nor build - use the prepackaged sources and prebuilt build directory
-          unzip llvm_build.zip
-          tar xzf llvm_build.tar.gz
-          cd llvm/build
-          sudo make install/fast
-          
-          # Same with flang-driver
-          cd ../..
-          unzip flang-driver_build.zip
-          tar xzf flang-driver_build.tar.gz
-          cd flang-driver/build
-          sudo make install/fast
-          flang --version
-      
-      # Install llvm from the classic-flang-llvm-project
-      - if: matrix.cc != 'gcc' || matrix.version != '9'
+      - name: Install llvm
         run: |
           cd ../..
           # Don't clone nor build - use the prepackaged sources and prebuilt build directory
@@ -165,24 +98,6 @@ jobs:
           tar xzf llvm_build.tar.gz
           cd classic-flang-llvm-project/build
           sudo make install/fast
-      
-      # The release_90 build requires a manual build of OpenMP
-      - if: matrix.cc == 'gcc' && matrix.version == '9'
-        run: |
-          cd ../..
-          CMAKE_OPTIONS="-DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_INSTALL_PREFIX=/usr/local \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=/usr/bin/${{ matrix.cc }} \
-            -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.cpp }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-          git clone --depth 1 --single-branch --branch release_90 https://github.com/llvm-mirror/openmp.git
-          cd openmp
-          mkdir -p build && cd build
-          cmake $CMAKE_OPTIONS ..
-          make -j$(nproc)
-          sudo make install
       
       - name: Build libpgmath
         run: |
@@ -219,14 +134,10 @@ jobs:
           sudo make install
 
       # Copy llvm-lit
-      - if: matrix.cc != 'gcc' || matrix.version != '9'
+      - name: Copy llvm-lit
         run: |
           cp ../../classic-flang-llvm-project/build/bin/llvm-lit build/bin/.
           
-      - if: matrix.cc == 'gcc' && matrix.version == '9'
-        run: |
-          cp ../../llvm/build/bin/llvm-lit build/bin/.
-      
       - name: Test flang
         run: |
           cd build


### PR DESCRIPTION
As discussed in the Classic Flang weekly call - we want to move to supporting `release_12x` (already there thanks to @bryanpkc ) and drop support for `release_90`.

@bryanpkc , would you be able to remove the [build instructions](https://github.com/flang-compiler/flang/wiki/Building-Flang) for `release_90` or perhaps mark them as obsolete, please? I don't have access to modify the wiki page and it doesn't accept PRs :(