### PR TITLE
[Flang2] Support for vector always loop directive

### DIFF
--- a/test/directives/vector_directive1.f90
+++ b/test/directives/vector_directive1.f90
@@ -1,4 +1,4 @@
-! RUN: %flang -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO-CLAUSE
+! RUN: %flang -S -emit-llvm %s 2>&1 -o - | FileCheck %s --check-prefix=CHECK-NO-CLAUSE
 
 subroutine add(arr1,arr2,arr3,N)
   integer :: i,N
@@ -11,4 +11,5 @@ subroutine add(arr1,arr2,arr3,N)
     arr3(i) = arr1(i) - arr2(i)
   end do
 end subroutine
-! CHECK-NO-CLAUSE: F90-W-0602-No clause specified for the vector directive. Note: Only the always clause is supported.
+! CHECK-NO-CLAUSE-NOT: F90-S-0602
+! CHECK-NO-CLAUSE-NOT: F90-S-0603.

--- a/test/directives/vector_directive3.f90
+++ b/test/directives/vector_directive3.f90
@@ -1,15 +1,22 @@
-! RUN: %flang -c %s 2>&1 | FileCheck %s -allow-empty --check-prefix=CHECK
+!! check for pragma support for !dir$ vector always
+!RUN: %flang -S -O2 -emit-llvm %s -o - | FileCheck %s
+!CHECK: define void @sumsimd_{{.*$}}
+!CHECK: {{.*}}!llvm.access.group{{.*}}
+!CHECK: vector.ph:{{.*}}
+!CHECK: vector.body:{{.*}}
+!CHECK: {{.*}}shufflevector{{.*}}
+!CHECK: {{.*}}add <2 x i64>{{.*}}
+!CHECK: {{.*}}"llvm.loop.parallel_accesses"{{.*}}
+!CHECK: {{.*}}"llvm.loop.isvectorized", i32 1{{.*}}
+!CHECK: {{.*}}"llvm.loop.unroll.runtime.disable"{{.*}}
 
-subroutine add(arr1,arr2,arr3,N)
-  integer :: i,N
-  integer :: arr1(N)
-  integer :: arr2(N)
-  integer :: arr3(N)
+SUBROUTINE sumsimd(myarr1,myarr2,ub)
+  INTEGER, POINTER :: myarr1(:)
+  INTEGER, POINTER :: myarr2(:)
+  INTEGER :: ub
 
-  !dir$ vector always
-  do i = 1, N
-    arr3(i) = arr1(i) - arr2(i)
-  end do
-end subroutine
-! CHECK-NOT: F90-S-0602
-! CHECK-NOT: F90-S-0603
+  !DIR$ VECTOR ALWAYS
+  DO i=1,ub
+      myarr1(i) = myarr1(i)+myarr2(i)
+  END DO
+END SUBROUTINE

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -5108,6 +5108,8 @@ Temporary flags
 .XB 0x01:
 Turn on C++ prototype implementation of the gnu visibility attribute 
 "hidden"
+.XB 0x02:
+Enable vectorize always loop directive
 
 .XF "192:"
 More Accelerator flags
@@ -5306,7 +5308,7 @@ This makes it easier to compare two outputs from slightly different versions.
 .XB 0x80000000:
 Enable unified memory support for OpenACC
 
-.XF "199:" 
+.XF "199:"
 Non-zero value enable -Mvect=fastfuse.  This flag is/must be passed only when
 -fast is enabled.  Value other than 0 represents the miximum number of blocks 
 to enable -Mvect=fastfuse.  default value is 10.

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -284,6 +284,7 @@ typedef enum LL_InstrListFlags {
   NOUNSIGNEDWRAP          = (1 << 12),
   FUNC_RETURN_IS_FUNC_PTR = (1 << 13),
   LDST_HAS_METADATA       = (1 << 13), /**< I_LOAD, I_STORE only */
+  LDST_HAS_ACCESSGRP_METADATA = (1 << 14), /**< I_LOAD, I_STORE only, for llvm.loop.parallel_accesses */
 
   /* Information for atomic operations.
      This information overlaps 12 of the calling convention bits.  In earlier

--- a/tools/shared/pragma.c
+++ b/tools/shared/pragma.c
@@ -655,16 +655,14 @@ do_sw(void)
       if(craydir) {
         typ = gtok();
         if (typ != T_IDENT) {
-          backup_nowarn = gbl.nowarn;
-          gbl.nowarn = false;
-          errwarn((error_code_t)602);
-          gbl.nowarn = backup_nowarn;
+          bclr(DIR_OFFSET(currdir, x[19]), 0x18);
+          bset(DIR_OFFSET(currdir, x[19]), 0x400);
           break;
         }
         LCASE(ctok);
         if (strcmp(ctok, "always") == 0) {
           bclr(DIR_OFFSET(currdir, x[19]), 0x18);
-          bset(DIR_OFFSET(currdir, x[19]), 0x400);
+          bset(DIR_OFFSET(currdir, x[191]), 0x2);
         } else {
           backup_nowarn = gbl.nowarn;
           gbl.nowarn = false;


### PR DESCRIPTION
This PR adds loop directive support for `!dir$ vector always` (XBIT/XFLAG: 191/0x2).
It uses the `llvm.loop.parallel_accesses` metadata with the companion - `llvm.access.group` metadata.