### PR TITLE
[Flang2] Support for vector always loop directive

### DIFF
--- a/test/directives/vector_directive1.f90
+++ b/test/directives/vector_directive1.f90
@@ -1,4 +1,6 @@
-! RUN: %flang -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO-CLAUSE
+! RUN: %flang -c %s 2>&1 -o - | FileCheck %s --check-prefix=CHECK-NO-CLAUSE
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s --check-prefix=METADATA
+! RUN: %flang -S -emit-llvm -O2 %s 2>&1 -o - | FileCheck %s
 
 subroutine add(arr1,arr2,arr3,N)
   integer :: i,N
@@ -11,4 +13,10 @@ subroutine add(arr1,arr2,arr3,N)
     arr3(i) = arr1(i) - arr2(i)
   end do
 end subroutine
-! CHECK-NO-CLAUSE: F90-W-0602-No clause specified for the vector directive. Note: Only the always clause is supported.
+! CHECK-NO-CLAUSE-NOT: F90-S-0602
+! CHECK-NO-CLAUSE-NOT: F90-S-0603
+
+! METADATA: !"llvm.loop.vectorize.enable", i1 true
+! CHECK: load <[[VF:[0-9]+]] x i32>
+! CHECK: store <[[VF]] x i32>
+

--- a/test/directives/vector_directive3.f90
+++ b/test/directives/vector_directive3.f90
@@ -1,15 +1,22 @@
-! RUN: %flang -c %s 2>&1 | FileCheck %s -allow-empty --check-prefix=CHECK
+!! check for pragma support for !dir$ vector always
+!RUN: %flang -S -O2 -emit-llvm %s -o - | FileCheck %s
+!CHECK: define void @sumsimd_{{.*$}}
+!CHECK: {{.*}}!llvm.access.group ![[ACCGRP:[0-9]+]]
+!CHECK: vector.ph:{{.*}}
+!CHECK: vector.body:{{.*}}
+!CHECK: {{.*}}shufflevector{{.*}}
+!CHECK: {{.*}}add <2 x i64>{{.*}}
+!CHECK: {{.*}}"llvm.loop.parallel_accesses", ![[ACCGRP]]}
+!CHECK: {{.*}}"llvm.loop.isvectorized", i32 1{{.*}}
+!CHECK: {{.*}}"llvm.loop.unroll.runtime.disable"{{.*}}
 
-subroutine add(arr1,arr2,arr3,N)
-  integer :: i,N
-  integer :: arr1(N)
-  integer :: arr2(N)
-  integer :: arr3(N)
+SUBROUTINE sumsimd(myarr1,myarr2,ub)
+  INTEGER, POINTER :: myarr1(:)
+  INTEGER, POINTER :: myarr2(:)
+  INTEGER :: ub
 
-  !dir$ vector always
-  do i = 1, N
-    arr3(i) = arr1(i) - arr2(i)
-  end do
-end subroutine
-! CHECK-NOT: F90-S-0602
-! CHECK-NOT: F90-S-0603
+  !DIR$ VECTOR ALWAYS
+  DO i=1,ub
+      myarr1(i) = myarr1(i)+myarr2(i)
+  END DO
+END SUBROUTINE

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -5110,6 +5110,8 @@ Turn on C++ prototype implementation of the gnu visibility attribute
 "hidden"
 .XB 0x02:
 Enable "alwaysinline" attribute for a function, using "forceinline" pragma
+.XB 0x04:
+Enable vectorize always loop directive
 
 .XF "192:"
 More Accelerator flags
@@ -5308,7 +5310,7 @@ This makes it easier to compare two outputs from slightly different versions.
 .XB 0x80000000:
 Enable unified memory support for OpenACC
 
-.XF "199:" 
+.XF "199:"
 Non-zero value enable -Mvect=fastfuse.  This flag is/must be passed only when
 -fast is enabled.  Value other than 0 represents the miximum number of blocks 
 to enable -Mvect=fastfuse.  default value is 10.

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -41,6 +41,7 @@
 #include "main.h"
 #include "symfun.h"
 #include "ilidir.h"
+#include "fdirect.h"
 
 #ifdef OMP_OFFLOAD_LLVM
 #include "ompaccel.h"
@@ -209,6 +210,7 @@ static struct {
   unsigned _fcmp_negate : 1;
   unsigned _last_stmt_is_branch : 1;
   unsigned _rw_no_dep_check : 1;
+  unsigned _rw_acc_grp_check : 1;
 } CGMain;
 
 #define new_ebb (CGMain._new_ebb)
@@ -220,6 +222,7 @@ static struct {
 #define fcmp_negate (CGMain._fcmp_negate)
 #define last_stmt_is_branch (CGMain._last_stmt_is_branch)
 #define rw_nodepcheck (CGMain._rw_no_dep_check)
+#define rw_access_group (CGMain._rw_acc_grp_check)
 
 static int funcId;
 static int fnegcc[17] = LLCCF_NEG;
@@ -234,6 +237,7 @@ static hashmap_t sincos_imap;
 static LL_MDRef cached_loop_metadata;
 static LL_MDRef cached_unroll_enable_metadata;
 static LL_MDRef cached_unroll_disable_metadata;
+static LL_MDRef cached_access_group_metadata;
 
 static bool CG_cpu_compile = false;
 
@@ -799,6 +803,21 @@ clear_rw_nodepchk(void)
   cached_loop_metadata = ll_get_md_null();
 }
 
+INLINE static void
+mark_rw_access_grp(int bih)
+{
+  rw_access_group = 1;
+  if (!BIH_NODEPCHK2(bih))
+    cached_loop_metadata = ll_get_md_null();
+}
+
+INLINE static void
+clear_rw_access_grp(void)
+{
+  rw_access_group = 0;
+  cached_loop_metadata = ll_get_md_null();
+}
+
 void
 print_personality(void)
 {
@@ -948,6 +967,20 @@ assign_fortran_storage_classes(void)
     }
   }
 } /* end assign_fortran_storage_classes() */
+
+/*
+ * when vector always pragma is specified, "llvm.loop.parallel_accesses" metadata has
+ * to be generated along with "llvm.access.group" for each load/store instructions.
+ */
+INLINE static LL_MDRef
+cons_loop_parallel_accesses_metadata(void)
+{
+  LL_MDRef lvcomp[2];
+
+  lvcomp[0] = ll_get_md_string(cpu_llvm_module, "llvm.loop.parallel_accesses");
+  lvcomp[1] = cached_access_group_metadata;
+  return ll_get_md_node(cpu_llvm_module, LL_PlainMDNode, lvcomp, 2);
+} // cons_loop_parallel_accesses_metadata
 
 INLINE static LL_MDRef
 cons_novectorize_metadata(void)
@@ -1290,6 +1323,21 @@ cons_no_depchk_metadata(void)
 }
 
 static LL_MDRef
+cons_vec_always_metadata(void)
+{
+  if (LL_MDREF_IS_NULL(cached_loop_metadata)) {
+    LL_MDRef vectorize = cons_vectorize_metadata();
+    LL_MDRef paraccess = cons_loop_parallel_accesses_metadata();
+    LL_MDRef md = ll_create_flexible_md_node(cpu_llvm_module);
+    ll_extend_md_node(cpu_llvm_module, md, md);
+    ll_extend_md_node(cpu_llvm_module, md, vectorize);
+    ll_extend_md_node(cpu_llvm_module, md, paraccess);
+    cached_loop_metadata = md;
+  }
+  return cached_loop_metadata;
+}
+
+static LL_MDRef
 cons_unroll_metadata(void) //Calls the metadata for unroll
 {
   LL_MDRef lvcomp[1];
@@ -1343,6 +1391,36 @@ remove_dead_instrs(void)
       instr = instr->prev;
   }
 }
+
+/*
+ * Check if the branch instruction is having a loop pragma
+ * xbit/xflag pair.
+ */
+static bool check_for_loop_directive(int branch_line_number, int xbit, int xflag) {
+  int iter;
+  LPPRG *lpprg;
+
+  // Check if any loop pragmas are specified
+  if (direct.lpg.avail > 1) {
+    // Loop thru all the loop pragmas
+    for (iter = 1; iter < direct.lpg.avail; iter++) {
+      lpprg = direct.lpg.stgb + iter;
+      // check if xbit/xflag pair is available
+      if ((lpprg->dirset.x[xbit] & xflag)
+          &&
+          (branch_line_number == lpprg->end_line)) {
+        return  true;
+      } // if
+
+      if (branch_line_number < lpprg->beg_line) {
+        // branch instruction is not having any pragma specified.
+        break;
+      } // if
+    } // for
+  } // if
+
+  return false;
+} // check_for_loop_directive
 
 /**
    \brief process debug info of constants with parameter attribute.
@@ -1538,6 +1616,9 @@ restartConcur:
   bih = BIH_NEXT(0);
   if ((XBIT(34, 0x200) || gbl.usekmpc) && !processHostConcur)
     bih = gbl.entbih;
+
+  cached_access_group_metadata = ll_create_distinct_md_node(cpu_llvm_module, LL_PlainMDNode, NULL, 0);
+
   /* construct the body of the function */
   for (; bih; bih = BIH_NEXT(bih))
     for (ilt = BIH_ILTFIRST(bih); ilt; ilt = ILT_NEXT(ilt))
@@ -1620,6 +1701,12 @@ restartConcur:
     } else {
       clear_rw_nodepchk();
     }
+    if (XBIT(191, 0x4)) {
+      fix_nodepchk_flag(bih);
+      mark_rw_access_grp(bih);
+    } else {
+      clear_rw_access_grp();
+    }
     if (flg.x[9] > 0)
       unroll_factor = flg.x[9];
     if (XBIT(11, 0x2) && unroll_factor)
@@ -1677,6 +1764,14 @@ restartConcur:
             (BIH_NODEPCHK(bih) && (!BIH_NODEPCHK2(bih)) &&
             (!ignore_simd_block(bih))) || BIH_SIMD(bih)) {
           LL_MDRef loop_md = cons_no_depchk_metadata();
+          INSTR_LIST *i = find_last_executable(llvm_info.last_instr);
+          if (i) {
+            i->flags |= LOOP_BACKEDGE_FLAG;
+            i->misc_metadata = loop_md;
+          }
+        }
+        if ((check_for_loop_directive(ILT_LINENO(ilt), 191, 0x4))) {
+          LL_MDRef loop_md = cons_vec_always_metadata();
           INSTR_LIST *i = find_last_executable(llvm_info.last_instr);
           if (i) {
             i->flags |= LOOP_BACKEDGE_FLAG;
@@ -2786,6 +2881,20 @@ write_no_depcheck_metadata(LL_Module *module, INSTR_LIST *insn)
   }
 }
 
+INLINE static void
+write_llaccgroup_metadata(LL_Module *module, INSTR_LIST *insn)
+{
+  if (insn->flags & LDST_HAS_ACCESSGRP_METADATA) {
+    char buf[64];
+    int n;
+    DEBUG_ASSERT(insn->misc_metadata, "missing metadata");
+    n = snprintf(buf, 64, ", !llvm.access.group !%u",
+                 LL_MDREF_value(cached_access_group_metadata));
+    DEBUG_ASSERT(n < 64, "buffer overrun");
+    print_token(buf);
+  }
+}
+
 /* write out the struct member types */
 static void
 write_verbose_type(LL_Type *ll_type)
@@ -3190,6 +3299,7 @@ write_instructions(LL_Module *module)
         assert(p->next == NULL, "write_instructions(), bad next ptr", 0,
                ERR_Fatal);
         write_no_depcheck_metadata(module, instrs);
+        write_llaccgroup_metadata(module, instrs);
         write_tbaa_metadata(module, instrs->ilix, instrs->operands,
                             instrs->flags);
         break;
@@ -3210,6 +3320,7 @@ write_instructions(LL_Module *module)
 
         write_memory_order_and_alignment(instrs);
         write_no_depcheck_metadata(module, instrs);
+        write_llaccgroup_metadata(module, instrs);
         write_tbaa_metadata(module, instrs->ilix, instrs->operands->next,
                             instrs->flags & VOLATILE_FLAG);
         break;
@@ -3424,6 +3535,10 @@ mk_store_instr(OPERAND *val, OPERAND *addr)
   if (rw_nodepcheck) {
     insn->flags |= LDST_HAS_METADATA;
     insn->misc_metadata = cons_no_depchk_metadata();
+  }
+  if (rw_access_group) {
+    insn->flags |= LDST_HAS_ACCESSGRP_METADATA;
+    insn->misc_metadata = cons_vec_always_metadata();
   }
   ad_instr(0, insn);
   return insn;
@@ -3685,6 +3800,10 @@ ad_csed_instr(LL_InstrName instr_name, int ilix, LL_Type *ll_type,
   if ((instr_name == I_LOAD) && rw_nodepcheck) {
     flags |= LDST_HAS_METADATA;
     instr->misc_metadata = cons_no_depchk_metadata();
+  }
+  if ((instr_name == I_LOAD) && rw_access_group) {
+    flags |= LDST_HAS_ACCESSGRP_METADATA;
+    instr->misc_metadata = cons_vec_always_metadata();
   }
   instr->flags = flags;
   ad_instr(ilix, instr);
@@ -6732,6 +6851,10 @@ make_load(int ilix, OPERAND *load_op, LL_Type *rslt_type, MSZ msz,
   if (rw_nodepcheck) {
     flags |= LDST_HAS_METADATA;
     Curr_Instr->misc_metadata = cons_no_depchk_metadata();
+  }
+  if (rw_access_group) {
+    flags |= LDST_HAS_ACCESSGRP_METADATA;
+    Curr_Instr->misc_metadata = cons_vec_always_metadata();
   }
   Curr_Instr->flags = (LL_InstrListFlags)flags;
   load_op->next = NULL;

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -284,6 +284,7 @@ typedef enum LL_InstrListFlags {
   NOUNSIGNEDWRAP          = (1 << 12),
   FUNC_RETURN_IS_FUNC_PTR = (1 << 13),
   LDST_HAS_METADATA       = (1 << 13), /**< I_LOAD, I_STORE only */
+  LDST_HAS_ACCESSGRP_METADATA = (1 << 14), /**< I_LOAD, I_STORE only, for llvm.loop.parallel_accesses */
 
   /* Information for atomic operations.
      This information overlaps 12 of the calling convention bits.  In earlier

--- a/tools/shared/pragma.c
+++ b/tools/shared/pragma.c
@@ -657,16 +657,14 @@ do_sw(void)
       if(craydir) {
         typ = gtok();
         if (typ != T_IDENT) {
-          backup_nowarn = gbl.nowarn;
-          gbl.nowarn = false;
-          errwarn((error_code_t)602);
-          gbl.nowarn = backup_nowarn;
+          bclr(DIR_OFFSET(currdir, x[19]), 0x18);
+          bset(DIR_OFFSET(currdir, x[19]), 0x400);
           break;
         }
         LCASE(ctok);
         if (strcmp(ctok, "always") == 0) {
           bclr(DIR_OFFSET(currdir, x[19]), 0x18);
-          bset(DIR_OFFSET(currdir, x[19]), 0x400);
+          bset(DIR_OFFSET(currdir, x[191]), 0x4);
         } else {
           backup_nowarn = gbl.nowarn;
           gbl.nowarn = false;


### PR DESCRIPTION
This PR adds loop directive support for !dir$ vector always (XBIT/XFLAG: 191/0x2).
It uses the llvm.loop.parallel_accesses metadata with the companion - llvm.access.group metadata.

(Created new PR as I had deleted the fork of the older one due to my misunderstanding).

@kiranchandramohan please add the reviewers here.