### PR TITLE
[NFC][License] Switch to new LLVM License

### DIFF
--- a/runtime/flang/itrailz.c
+++ b/runtime/flang/itrailz.c
@@ -1,17 +1,7 @@
 /*
- * Copyright (c) 2019, Arm Ltd.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
  */
 int

--- a/runtime/flang/itrailzi.c
+++ b/runtime/flang/itrailzi.c
@@ -1,17 +1,7 @@
 /*
- * Copyright (c) 2019, Arm Ltd.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
  */
 int

--- a/runtime/flang/ktrailz.c
+++ b/runtime/flang/ktrailz.c
@@ -1,17 +1,7 @@
 /*
- * Copyright (c) 2019, Arm Ltd.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
  */
 #include <stdint.h>

--- a/test/debug_info/debug_module_import.f90
+++ b/test/debug_info/debug_module_import.f90
@@ -1,17 +1,7 @@
 !
-! Copyright (c) 2018, Arm Ltd.  All rights reserved.
-!
-! Licensed under the Apache License, Version 2.0 (the "License");
-! you may not use this file except in compliance with the License.
-! You may obtain a copy of the License at
-!
-!     http://www.apache.org/licenses/LICENSE-2.0
-!
-! Unless required by applicable law or agreed to in writing, software
-! distributed under the License is distributed on an "AS IS" BASIS,
-! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-! See the License for the specific language governing permissions and
-! limitations under the License.
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
 
 ! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s

--- a/test/f90_correct/inc/minmaxloc_back.mk
+++ b/test/f90_correct/inc/minmaxloc_back.mk
@@ -1,19 +1,8 @@
 #
-# Copyright (c) 2019, Arm Ltd..  All rights reserved.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 build:  $(SRC)/minmaxloc_back.f90
 	-$(RM) minmaxloc_back.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
 	-$(RM) $(OBJ)

--- a/test/f90_correct/inc/norm2.mk
+++ b/test/f90_correct/inc/norm2.mk
@@ -1,19 +1,8 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 EXE=norm2.$(EXESUFFIX)
 
 build:  $(SRC)/norm2.F90

--- a/test/f90_correct/inc/norm2_double_precision.mk
+++ b/test/f90_correct/inc/norm2_double_precision.mk
@@ -1,17 +1,7 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 EXE=norm2_double_precision.$(EXESUFFIX)

--- a/test/f90_correct/inc/norm2_error.mk
+++ b/test/f90_correct/inc/norm2_error.mk
@@ -1,16 +1,8 @@
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 build: clean
 	@echo ------------------------------------ building test $(TEST)

--- a/test/f90_correct/inc/norm2_function.mk
+++ b/test/f90_correct/inc/norm2_function.mk
@@ -1,17 +1,7 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 EXE=norm2_function.$(EXESUFFIX)

--- a/test/f90_correct/inc/norm2_single_precision.mk
+++ b/test/f90_correct/inc/norm2_single_precision.mk
@@ -1,17 +1,7 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 EXE=norm2_single_precision.$(EXESUFFIX)

--- a/test/f90_correct/inc/trailz.mk
+++ b/test/f90_correct/inc/trailz.mk
@@ -1,17 +1,7 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 EXE=trailz.$(EXESUFFIX)

--- a/test/f90_correct/inc/trailz_elemental.mk
+++ b/test/f90_correct/inc/trailz_elemental.mk
@@ -1,17 +1,7 @@
 #
-# Copyright (c) 2019, Arm Ltd..  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 EXE=trailz_elemental.$(EXESUFFIX)

--- a/test/f90_correct/inc/trailz_kind.mk
+++ b/test/f90_correct/inc/trailz_kind.mk
@@ -1,17 +1,7 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 EXE=trailz_kind.$(EXESUFFIX)

--- a/test/f90_correct/lit/minmaxloc_back.sh
+++ b/test/f90_correct/lit/minmaxloc_back.sh
@@ -2,6 +2,7 @@
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
 
 # Shared lit script for each tests. Run bash commands that run tests with make.
 

--- a/test/f90_correct/lit/norm2.sh
+++ b/test/f90_correct/lit/norm2.sh
@@ -1,17 +1,8 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 # Shared lit script for each tests. Run bash commands that run tests with make.
 

--- a/test/f90_correct/lit/norm2_double_precision.sh
+++ b/test/f90_correct/lit/norm2_double_precision.sh
@@ -1,17 +1,8 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 # Shared lit script for each tests. Run bash commands that run tests with make.
 # Due to: https://github.com/flang-compiler/flang/issues/837

--- a/test/f90_correct/lit/norm2_error.sh
+++ b/test/f90_correct/lit/norm2_error.sh
@@ -1,17 +1,8 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 # Shared lit script for each tests. Run bash commands that run tests with make.
 

--- a/test/f90_correct/lit/norm2_function.sh
+++ b/test/f90_correct/lit/norm2_function.sh
@@ -1,17 +1,8 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 # Shared lit script for each tests. Run bash commands that run tests with make.
 

--- a/test/f90_correct/lit/norm2_single_precision.sh
+++ b/test/f90_correct/lit/norm2_single_precision.sh
@@ -1,17 +1,8 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 # Shared lit script for each tests. Run bash commands that run tests with make.
 

--- a/test/f90_correct/lit/trailz.sh
+++ b/test/f90_correct/lit/trailz.sh
@@ -1,17 +1,8 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 # Shared lit script for each tests. Run bash commands that run tests with make.
 

--- a/test/f90_correct/lit/trailz_elemental.sh
+++ b/test/f90_correct/lit/trailz_elemental.sh
@@ -1,17 +1,8 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 # Shared lit script for each tests. Run bash commands that run tests with make.
 

--- a/test/f90_correct/lit/trailz_kind.sh
+++ b/test/f90_correct/lit/trailz_kind.sh
@@ -1,17 +1,8 @@
 #
-# Copyright (c) 2019, Arm Ltd.  All rights reserved.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 # Shared lit script for each tests. Run bash commands that run tests with make.
 

--- a/test/f90_correct/src/minmaxloc_back.f90
+++ b/test/f90_correct/src/minmaxloc_back.f90
@@ -1,17 +1,8 @@
-!** Copyright (c) 2019, Arm Ltd.  All rights reserved.
-
-!** Licensed under the Apache License, Version 2.0 (the "License");
-!** you may not use this file except in compliance with the License.
-!** You may obtain a copy of the License at
-!**
-!**     http://www.apache.org/licenses/LICENSE-2.0
-!**
-!** Unless required by applicable law or agreed to in writing, software
-!** distributed under the License is distributed on an "AS IS" BASIS,
-!** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-!implied.
-!** See the License for the specific language governing permissions and
-!** limitations under the License.
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
 
 program p
 implicit none

--- a/test/f90_correct/src/norm2.F90
+++ b/test/f90_correct/src/norm2.F90
@@ -1,16 +1,8 @@
-! Copyright (c) 2019, Arm Ltd.  All rights reserved.
 !
-! Licensed under the Apache License, Version 2.0 (the "License");
-! you may not use this file except in compliance with the License.
-! You may obtain a copy of the License at
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!     http://www.apache.org/licenses/LICENSE-2.0
-!
-! Unless required by applicable law or agreed to in writing, software
-! distributed under the License is distributed on an "AS IS" BASIS,
-! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-! See the License for the specific language governing permissions and
-! limitations under the License.
 
 program test
 

--- a/test/f90_correct/src/norm2_double_precision.F90
+++ b/test/f90_correct/src/norm2_double_precision.F90
@@ -1,16 +1,8 @@
-! Copyright (c) 2019, Arm Ltd.  All rights reserved.
 !
-! Licensed under the Apache License, Version 2.0 (the "License");
-! you may not use this file except in compliance with the License.
-! You may obtain a copy of the License at
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!     http://www.apache.org/licenses/LICENSE-2.0
-!
-! Unless required by applicable law or agreed to in writing, software
-! distributed under the License is distributed on an "AS IS" BASIS,
-! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-! See the License for the specific language governing permissions and
-! limitations under the License.
 
 
 program test

--- a/test/f90_correct/src/norm2_error.f90
+++ b/test/f90_correct/src/norm2_error.f90
@@ -1,16 +1,8 @@
-! Copyright (c) 2019, Arm Ltd.  All rights reserved.
 !
-! Licensed under the Apache License, Version 2.0 (the "License");
-! you may not use this file except in compliance with the License.
-! You may obtain a copy of the License at
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!     http://www.apache.org/licenses/LICENSE-2.0
-!
-! Unless required by applicable law or agreed to in writing, software
-! distributed under the License is distributed on an "AS IS" BASIS,
-! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-! See the License for the specific language governing permissions and
-! limitations under the License.
 
 
 subroutine s1 ! error

--- a/test/f90_correct/src/norm2_function.F90
+++ b/test/f90_correct/src/norm2_function.F90
@@ -1,16 +1,8 @@
-! Copyright (c) 2019, Arm Ltd.  All rights reserved.
 !
-! Licensed under the Apache License, Version 2.0 (the "License");
-! you may not use this file except in compliance with the License.
-! You may obtain a copy of the License at
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!     http://www.apache.org/licenses/LICENSE-2.0
-!
-! Unless required by applicable law or agreed to in writing, software
-! distributed under the License is distributed on an "AS IS" BASIS,
-! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-! See the License for the specific language governing permissions and
-! limitations under the License.
 
 
 program test

--- a/test/f90_correct/src/norm2_single_precision.F90
+++ b/test/f90_correct/src/norm2_single_precision.F90
@@ -1,16 +1,8 @@
-! Copyright (c) 2019, Arm Ltd.  All rights reserved.
 !
-! Licensed under the Apache License, Version 2.0 (the "License");
-! you may not use this file except in compliance with the License.
-! You may obtain a copy of the License at
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!     http://www.apache.org/licenses/LICENSE-2.0
-!
-! Unless required by applicable law or agreed to in writing, software
-! distributed under the License is distributed on an "AS IS" BASIS,
-! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-! See the License for the specific language governing permissions and
-! limitations under the License.
 
 
 program test

--- a/test/f90_correct/src/trailz.f90
+++ b/test/f90_correct/src/trailz.f90
@@ -1,16 +1,8 @@
-! Copyright (c) 2019, ARM Ltd.  All rights reserved.
 !
-! Licensed under the Apache License, Version 2.0 (the "License");
-! you may not use this file except in compliance with the License.
-! You may obtain a copy of the License at
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!     http://www.apache.org/licenses/LICENSE-2.0
-!
-! Unless required by applicable law or agreed to in writing, software
-! distributed under the License is distributed on an "AS IS" BASIS,
-! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-! See the License for the specific language governing permissions and
-! limitations under the License.
       program test
       integer, parameter :: num = 25
       integer results(num)

--- a/test/f90_correct/src/trailz_elemental.f90
+++ b/test/f90_correct/src/trailz_elemental.f90
@@ -1,17 +1,8 @@
-! Copyright (c) 2019, ARM Ltd.  All rights reserved.
 !
-! Licensed under the Apache License, Version 2.0 (the "License");
-! you may not use this file except in compliance with the License.
-! You may obtain a copy of the License at
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!     http://www.apache.org/licenses/LICENSE-2.0
-!
-! Unless required by applicable law or agreed to in writing, software
-! distributed under the License is distributed on an "AS IS" BASIS,
-! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-! See the License for the specific language governing permissions and
-! limitations under the License.
-
       module trailz_elemental
          implicit none
          contains

--- a/test/f90_correct/src/trailz_kind.f90
+++ b/test/f90_correct/src/trailz_kind.f90
@@ -1,4 +1,3 @@
-! Copyright (c) 2019, ARM Ltd.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.


### PR DESCRIPTION
A few old PRs which carried the old license were merged recently. This patch switches to the new license.