### PR TITLE
runtime: register atfork handler to re-initialize internal flangrti locks at fork

### DIFF
--- a/runtime/flangrti/CMakeLists.txt
+++ b/runtime/flangrti/CMakeLists.txt
@@ -78,6 +78,12 @@ add_flang_library(flangrti_shared
 # Resolve symbols against libm
 target_link_libraries(flangrti_shared m)
 
+# Resolve symbols against libpthread
+find_package(Threads REQUIRED)
+if (CMAKE_THREAD_LIBS_INIT)
+  target_link_libraries(flangrti_shared "${CMAKE_THREAD_LIBS_INIT}")
+endif()
+
 # Import OpenMP
 if (NOT DEFINED LIBOMP_EXPORT_DIR)
   find_library( 

--- a/test/mp_correct/inc/fork_omp.mk
+++ b/test/mp_correct/inc/fork_omp.mk
@@ -1,0 +1,18 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+fork_omp: fork_omp.$(OBJX)
+	@echo ------------ executing test $@
+	-$(RUN2) ./a.$(EXESUFFIX) $(LOG)
+fork.$(OBJX): $(SRC)/fork.c
+	-$(CC) $(CFLAGS) $(SRC)/fork.c
+fork_omp.$(OBJX): $(SRC)/fork_omp.F90 fork.$(OBJX) check.$(OBJX)
+	@echo ------------ building test $@
+	-$(FC) $(FFLAGS) $(SRC)/fork_omp.F90
+	@$(RM) ./a.$(EXESUFFIX)
+	-$(FC) $(LDFLAGS) fork_omp.$(OBJX) fork.$(OBJX) check.$(OBJX) $(LIBS) \
+		-o a.$(EXESUFFIX)
+build: fork_omp
+run: ;

--- a/test/mp_correct/lit/fork_omp.sh
+++ b/test/mp_correct/lit/fork_omp.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/mp_correct/src/fork.c
+++ b/test/mp_correct/src/fork.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+void fork_(int *pid)
+{
+  *pid = fork();
+}
+
+void waitpid_(int *pid)
+{
+  int status;
+
+  waitpid(*pid, &status, 0);
+  if (WCOREDUMP(status)) {
+    fprintf(stderr, "FAIL\n");
+    exit(-1);
+  }
+}

--- a/test/mp_correct/src/fork_omp.F90
+++ b/test/mp_correct/src/fork_omp.F90
@@ -1,0 +1,31 @@
+program forking
+  implicit none
+  integer :: pid
+
+  pid = -1
+  call sub
+  call fork(pid)
+  if (pid /= 0) then
+    call waitpid(pid)
+  endif
+  call sub
+  if (pid /= 0) then
+#ifdef _OPENMP
+    call check(1, 1, 1)
+#else
+    call check(0, 1, 1)
+#endif
+  endif
+
+contains
+
+  subroutine sub
+    use omp_lib
+    implicit none
+!$omp parallel
+!$omp critical
+    print *, omp_get_thread_num()
+!$omp end critical
+!$omp end parallel
+  end subroutine
+end program


### PR DESCRIPTION
The llcrit.c code of flangrti runtime library creates internal locks
which are initialized on the first encounter of any Fortran procedure
that contains at least one OpenMP directive. The flang compiler emits
a call to one of the two functions modified by this patch at the
beginning of every Fortran procedure containing at least one OpenMP
directive. When executed for the first time, these functions
initialize internal locks and modify corresponding static global
variable confirming the initialization has actually occured. On any
subsequent execution, these functions make use of those locks.

Unfortunately, the values of those global indicator variables are not
being reset at fork, hence the locks are not being initialized in the
child processes. Any attempt of using those internal locks results in
a runtime crash of the child process.

This patch registers atfork handler executed as the first thing by any
of the children process.

A test case depicting the problem is also provided with this patch.
