### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,55 @@
 Flang
 =====
 
-Flang is a Fortran compiler targeting LLVM.
+Flang (also known as "Classic Flang") is an out-of-tree Fortran compiler
+targeting LLVM. It is an open-sourced version of pgfortran, a commercial
+Fortran compiler from PGI/NVIDIA. It is different from the new Flang
+(formerly known as "F18"; see https://flang.llvm.org/), which has been part
+of the LLVM project since 2020, although both are developed by the same
+community. It is also unrelated to other projects of the same name, such as
+https://github.com/llvm-flang/flang and https://github.com/isanbard/flang.
 
-Visit the flang wiki for more information:
+Classic Flang is used in several downstream commercial projects, and
+continues to be maintained, but the plan is to replace Classic Flang with
+the new Flang in the future.
+
+Visit the Flang wiki for more information:
 
 https://github.com/flang-compiler/flang/wiki
 
-We have mailing lists for announcements and developers.
-Here's the link with the sign-up information:
+To sign up for the developer mailing lists for announcements and discussions,
+visit:
 
 https://lists.llvm.org/cgi-bin/mailman/listinfo/flang-dev
 
-We have a flang-compiler channel on Slack.  Slack is invitation only but anyone can join.  Here's the link:
+We have a flang-compiler channel on Slack. Slack is invitation-only but
+anyone can join with the invitation link below:
 
 https://join.slack.com/t/flang-compiler/shared_invite/MjExOTEyMzQ3MjIxLTE0OTk4NzQyNzUtODQzZWEyMjkwYw
-
-> **Note:** This project is not related to the project of the same name found at https://github.com/llvm-flang/flang.
-> See [this page](https://github.com/flang-compiler/flang/issues/38) for details.
 
 ## Building Flang
 
 Instructions for building Flang can be found on the Flang wiki:
+
 https://github.com/flang-compiler/flang/wiki/Building-Flang
 
 ## Compiler Options
 
-For a list of compiler options, enter
+For a list of compiler options, enter:
 
 ```
 % flang -help
 ```
 
-The Flang compiler supports accepts all clang 4.0 compiler options and supports many, as well as the following flang-specific compiler options:
+Flang accepts all Clang compiler options and supports many, as well as
+the following Fortran-specific compiler options:
 
 ```lang-none
 -noFlangLibs          Do not link against Flang libraries
 -mp                   Enable OpenMP and link with with OpenMP library libomp
 -nomp                 Do not link with OpenMP library libomp
--Mbackslash           Treat backslash character like a C-style escape character
--Mno-backslash        Treat backslash like any other character
+-Mbackslash           Treat backslash in quoted strings like any other character
+-Mnobackslash         Treat backslash in quoted strings like a C-style escape character (Default)
 -Mbyteswapio          Swap byte-order for unformatted input/output
 -Mfixed               Assume fixed-format source
 -Mextend              Allow source lines up to 132 characters
@@ -49,8 +59,8 @@ The Flang compiler supports accepts all clang 4.0 compiler options and supports 
 -Mstandard            Check standard conformance
 -Msave                Assume all variables have SAVE attribute
 -module               path to module file (-I also works)
--Mallocatable=95      Select Fortran 95 semantics for assignments to allocatable objects (Default)
--Mallocatable=03      Select Fortran 03 semantics for assignments to allocatable objects
+-Mallocatable=95      Select Fortran 95 semantics for assignments to allocatable objects
+-Mallocatable=03      Select Fortran 03 semantics for assignments to allocatable objects (Default)
 -static-flang-libs    Link using static Flang libraries
 -M[no]daz             Treat denormalized numbers as zero
 -M[no]flushz          Set SSE to flush-to-zero mode


### PR DESCRIPTION
Update README.md to distinguish Classic Flang from other projects of the same name, and fix some typos.

Closes #1027, and partially supersedes #69.