### PR TITLE
[DebugInfo] Support for `-gpubnames` option in `flang`

### DIFF
--- a/test/debug_info/debug_module_import.f90
+++ b/test/debug_info/debug_module_import.f90
@@ -24,12 +24,12 @@ print *, var1
 print *, var2
 end program hello
 
-! //CHECK: ![[DBG_MOD1:[0-9]+]] = !DIModule({{.*}}, name: "first"
-! //CHECK: ![[DBG_DIC:[0-9]+]] = distinct !DICompileUnit({{.*}}, imports: ![[DBG_IMPORTS:[0-9]+]])
-! //CHECK: ![[DBG_MOD2:[0-9]+]] = !DIModule({{.*}}, name: "second"
-! //CHECK: ![[DBG_IMPORTS]] = !{![[DBG_IE1:[0-9]+]], ![[DBG_IE2:[0-9]+]], ![[DBG_IE3:[0-9]+]]}
-! //CHECK: ![[DBG_IE1]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP1:[0-9]+]], entity: ![[DBG_MOD1]],
-! //CHECK: ![[DBG_SP1]] = distinct !DISubprogram(name: "init", scope: ![[DBG_MOD2]]
-! //CHECK: ![[DBG_IE2]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP2:[0-9]+]], entity: ![[DBG_MOD1]],
-! //CHECK: ![[DBG_SP2]] = distinct !DISubprogram(name: "hello", scope: ![[DBG_DIC]]
-! //CHECK: ![[DBG_IE3]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP2]], entity: ![[DBG_MOD2]],
+! CHECK: ![[DBG_MOD1:[0-9]+]] = !DIModule({{.*}}, name: "first"
+! CHECK: ![[DBG_DIC:[0-9]+]] = distinct !DICompileUnit({{.*}}, imports: ![[DBG_IMPORTS:[0-9]+]], nameTableKind: None
+! CHECK: ![[DBG_MOD2:[0-9]+]] = !DIModule({{.*}}, name: "second"
+! CHECK: ![[DBG_IMPORTS]] = !{![[DBG_IE1:[0-9]+]], ![[DBG_IE2:[0-9]+]], ![[DBG_IE3:[0-9]+]]}
+! CHECK: ![[DBG_IE1]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP1:[0-9]+]], entity: ![[DBG_MOD1]],
+! CHECK: ![[DBG_SP1]] = distinct !DISubprogram(name: "init", scope: ![[DBG_MOD2]]
+! CHECK: ![[DBG_IE2]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP2:[0-9]+]], entity: ![[DBG_MOD1]],
+! CHECK: ![[DBG_SP2]] = distinct !DISubprogram(name: "hello", scope: ![[DBG_DIC]]
+! CHECK: ![[DBG_IE3]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP2]], entity: ![[DBG_MOD2]],

--- a/test/debug_info/nametable.f90
+++ b/test/debug_info/nametable.f90
@@ -1,0 +1,16 @@
+!RUN: %flang %s -gdwarf-5 -c -o - | llvm-readelf -S - | FileCheck %s --check-prefix=NONAMESECTION
+!RUN: %flang %s -g -c -o - | llvm-readelf -S - | FileCheck %s --check-prefix=NOPUBNAMESECTION
+
+!RUN: %flang %s -gdwarf-5 -gpubnames -c -o - | llvm-readelf -S - | FileCheck %s --check-prefix=NAMESECTION
+!RUN: %flang %s -g -gpubnames -c -o - | llvm-readelf -S - | FileCheck %s --check-prefix=PUBNAMESECTION
+
+!Ensure that `.debug_names` or `.debug_pubnames` are NOT present by default.
+!NONAMESECTION-NOT: .debug_names
+!NOPUBNAMESECTION-NOT: .debug_pubnames
+!Ensure that `.debug_names` or `.debug_pubnames` are present when `-gpubnames` is specified.
+!NAMESECTION: .debug_names
+!PUBNAMESECTION: .debug_pubnames
+
+PROGRAM main
+END PROGRAM main
+

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -3303,7 +3303,7 @@ Generating eh_frame.
 .XB 0x20000000:
 Generating eh_frame with .cfi directives: requires 120,0x10000000 to be on
 .XB 0x40000000
-AVAILABLE
+Generate .debug_names/.debug_pubnames section.
 .XB 0x80000000:
 no license check in executable.
 

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -865,7 +865,8 @@ enum FieldType {
   DWVirtualityField,
   DWEncodingField,
   DWEmissionField,
-  SignedOrMDField
+  SignedOrMDField,
+  DebugNameTableKindField
 };
 
 enum FieldFlags {
@@ -957,7 +958,7 @@ static const MDTemplate Tmpl_DICompileUnit[] = {
 
 /* "subprograms" removed from DICompileUnit in LLVM 3.9 */
 static const MDTemplate Tmpl_DICompileUnit_ver39[] = {
-  { "DICompileUnit", TF, 13 },
+  { "DICompileUnit", TF, 14 },
   { "tag",                      DWTagField, FlgHidden },
   { "file",                     NodeField },
   { "language",                 DWLangField },
@@ -970,7 +971,8 @@ static const MDTemplate Tmpl_DICompileUnit_ver39[] = {
   { "globals",                  NodeField },
   { "emissionKind",             DWEmissionField },
   { "imports",                  NodeField },
-  { "splitDebugFilename",       StringField }
+  { "splitDebugFilename",       StringField },
+  { "nameTableKind",            DebugNameTableKindField }
 };
 
 static const MDTemplate Tmpl_DICompileUnit_pre34[] = {
@@ -1557,6 +1559,24 @@ dwarf_emission_name(int value)
 }
 
 /**
+   \brief generate DWARF table kind
+ */
+static const char *
+dwarf_table_name(int value)
+{
+  switch (value) {
+  case 0:
+    return "Default";
+  case 1:
+    return "GNU";
+  case 2:
+    return "None";
+  default:
+    return "None";
+  }
+}
+
+/**
    \brief Write out an an LL_MDRef as a field in a specialised MDNode class
    \param out        file to write to
    \param module       module containing the metadata
@@ -1692,6 +1712,10 @@ write_mdfield(FILE *out, LL_Module *module, int needs_comma, LL_MDRef mdref,
 
     case DWEmissionField:
       fprintf(out, "%s%s: %s", prefix, tmpl->name, dwarf_emission_name(value));
+      break;
+
+    case DebugNameTableKindField:
+      fprintf(out, "%s%s: %s", prefix, tmpl->name, dwarf_table_name(value));
       break;
 
     default:

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -349,6 +349,8 @@ lldbg_create_compile_unit_mdnode(LL_DebugInfo *db, int lang_tag, char *filename,
       llmd_add_i32(mdb, 1); /* emissionMode: FullDebug */
     llmd_add_md(mdb, *imported_entity_list);
     llmd_add_string(mdb, "");
+    if (!XBIT(120, 0x40000000))
+      llmd_add_i32(mdb, 2); /* nameTableKind: None */
   }
 
   llmd_set_distinct(mdb);


### PR DESCRIPTION
This option is used to generate extra debug information.
i.e
DWARFv4
`flang -gdwarf-4 -gpubnames test.c` will generate `.debug_pubnames` and
`.debug_pubtypes` in the executable.
DWARFv5
`flang -gdwarf-5 -gpubnames test.c` will generate `.debug_names` in
the executable.

Prior to this change these sections were getting generated by default.

These sections were extra and may or maynot be used by the debugger. Hence
generation of these sections are bind to this `-gpubnames` option.
This behavior is analogous to `clang`, `gcc`, gfortran.