### PR TITLE
Github Action use the prebuilt clang to build flang

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -9,9 +9,11 @@ on:
 jobs:       
   build_flang:
     runs-on: ubuntu-20.04
+    env:
+      install_prefix: /usr/local
     strategy:
       matrix:
-        target: [X86] # , AArch64, PowerPC]
+        target: [X86]
         cc: [clang]
         cpp: [clang++]
         version: [9, 10, 11]
@@ -42,25 +44,6 @@ jobs:
         with:
           key: ${{ matrix.cc }}-${{ matrix.version }}
 
-      - if: matrix.cc == 'gcc' && matrix.version == '10'
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
-          sudo apt install gcc-10 g++-10
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 10
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 20
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 10
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 20
-      
-      - if: matrix.cc == 'clang'
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
-          sudo touch /etc/apt/sources.list.d/llvm.list
-          echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | sudo tee -a /etc/apt/sources.list.d/llvm.list
-          echo 'deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'  | sudo tee -a /etc/apt/sources.list.d/llvm.list
-          wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-          sudo apt update
-          sudo apt install -f -y llvm-${{ matrix.version }} clang-${{ matrix.version}}
-
       - name: Check tools
         run: |
           sudo apt update
@@ -68,7 +51,6 @@ jobs:
           git --version
           cmake --version
           make --version
-          ${{ matrix.cc }} --version
 
       # Download artifacts for the classic-flang-llvm-project-related builds (all toolchains)
       - name: Download artifacts
@@ -102,10 +84,10 @@ jobs:
       - name: Build libpgmath
         run: |
           CMAKE_OPTIONS="-DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=/usr/bin/${{ matrix.cc }} \
-            -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.cpp }} \
+            -DCMAKE_C_COMPILER=${{ env.install_prefix }}/bin/clang \
+            -DCMAKE_CXX_COMPILER=${{ env.install_prefix }}/bin/clang++ \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
           cd runtime/libpgmath
@@ -118,11 +100,11 @@ jobs:
         run: |
           mkdir -p build && cd build
           cmake -DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=/usr/bin/${{ matrix.cc }} \
-            -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.cpp }} \
-            -DCMAKE_Fortran_COMPILER=/usr/local/bin/flang \
+            -DCMAKE_C_COMPILER=${{ env.install_prefix }}/bin/clang \
+            -DCMAKE_CXX_COMPILER=${{ env.install_prefix }}/bin/clang++ \
+            -DCMAKE_Fortran_COMPILER=${{ env.install_prefix }}/bin/flang \
             -DCMAKE_Fortran_COMPILER_ID=Flang \
             -DFLANG_INCLUDE_DOCS=ON \
             -DFLANG_LLVM_EXTENSIONS=ON \


### PR DESCRIPTION
Previously the native compiler was used, but this resulted in some tests failing for X86 and AArch64.