### PR TITLE
Fix issue of processing character variables via the DATA statement.

### DIFF
--- a/test/f90_correct/inc/data_char.mk
+++ b/test/f90_correct/inc/data_char.mk
@@ -1,0 +1,23 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/data_char.sh
+++ b/test/f90_correct/lit/data_char.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/data_char.f90
+++ b/test/f90_correct/src/data_char.f90
@@ -1,0 +1,22 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for character variable initialized by DATA statement.
+
+program p
+  character*6 a
+  character*10 b
+  character*10 c
+  data a(2:5) /'AAA'/
+  data b(3:6) /'BBB'/
+  data b(8:9) /'CC'/
+  data c(3:5) /'345'/
+  data c(6:9) /'6789'/
+
+  if (a .ne. ' AAA  ') stop 1
+  if (b .ne. '  BBB  CC ') stop 2
+  if (c .ne. '  3456789 ') stop 3
+
+  print *, 'PASS'
+end

--- a/tools/flang2/flang2exe/llassem.cpp
+++ b/tools/flang2/flang2exe/llassem.cpp
@@ -1273,6 +1273,7 @@ process_dsrt(DSRT *dsrtp, ISZ_T size, char *cptr, bool stop_at_sect, ISZ_T addr)
   INT loc_base, skip_cnt;
   ISZ_T repeat_cnt;
   DREC *p;
+  bool is_char = false;
   ISZ_T i8cnt = 0;
   int ptrcnt = 0;
   char *cptrCopy = strdup(cptr);
@@ -1284,6 +1285,11 @@ process_dsrt(DSRT *dsrtp, ISZ_T size, char *cptr, bool stop_at_sect, ISZ_T addr)
   for (; dsrtp; dsrtp = dsrtp->next) {
     loc_base = dsrtp->offset; /* assumes this is a DINIT_LOC */
 
+    if (dsrtp->sptr && (DTY(DTYPEG(dsrtp->sptr)) == TY_CHAR)) {
+      is_char = true;
+    } else {
+      is_char = false;
+    }
     if (dsrtp->sectionindex != DATA_SEC) {
       gbl.func_count = dsrtp->func_count;
     } else {
@@ -1306,7 +1312,7 @@ process_dsrt(DSRT *dsrtp, ISZ_T size, char *cptr, bool stop_at_sect, ISZ_T addr)
           if (!first_data && skip_cnt)
             fputs(", ", ASMFIL);
         }
-        i8cnt = i8cnt + put_skip(addr, dsrtp->offset);
+        i8cnt = i8cnt + put_skip(addr, dsrtp->offset, is_char);
         first_data = 0;
         addr = dsrtp->offset;
       } else if (addr > dsrtp->offset) {
@@ -1341,7 +1347,7 @@ process_dsrt(DSRT *dsrtp, ISZ_T size, char *cptr, bool stop_at_sect, ISZ_T addr)
                 ptrcnt);
 
       emit_init(p->dtype, p->conval, &addr, &repeat_cnt, loc_base, &i8cnt,
-                &ptrcnt, &ptr);
+                &ptrcnt, &ptr, is_char);
     }
   }
 
@@ -1370,7 +1376,7 @@ process_dsrt(DSRT *dsrtp, ISZ_T size, char *cptr, bool stop_at_sect, ISZ_T addr)
     } else if (i8cnt) {
       fprintf(ASMFIL, "] ");
     }
-    put_skip(addr, size);
+    put_skip(addr, size, is_char);
     i8cnt = skip_size;
   }
   free(cptrCopy);

--- a/tools/flang2/flang2exe/llassem.h
+++ b/tools/flang2/flang2exe/llassem.h
@@ -63,7 +63,7 @@ typedef struct DSRT {
 
 char *get_local_overlap_var(void);
 char *put_next_member(char *ptr);
-ISZ_T put_skip(ISZ_T old, ISZ_T New);
+ISZ_T put_skip(ISZ_T old, ISZ_T New, bool is_char);
 
 /*
  * macros to get and put DSRT pointers in symbol table entry - this

--- a/tools/flang2/flang2exe/llassem_common.cpp
+++ b/tools/flang2/flang2exe/llassem_common.cpp
@@ -114,24 +114,32 @@ put_next_member(char *ptr)
 }
 
 ISZ_T
-put_skip(ISZ_T old, ISZ_T New)
+put_skip(ISZ_T old, ISZ_T New, bool is_char)
 {
   ISZ_T amt;
+  char *s = "i8 0";
+  char *str = "i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,"
+              "i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,"
+              "i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0";
 
+  if (is_char) {
+    s = "i8 32";
+    str = "i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,"
+          "i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,"
+          "i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32,i8 32";
+  }
   if ((amt = New - old) > 0) {
     INT i;
     i = amt;
     while (i > 32) {
-      fprintf(ASMFIL, "i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 "
-                      "0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 "
-                      "0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0,i8 0");
+      fprintf(ASMFIL, str);
       i -= 32;
       if (i)
         fprintf(ASMFIL, ",");
     }
     if (i) {
       while (1) {
-        fprintf(ASMFIL, "i8 0");
+        fprintf(ASMFIL, s);
         i--;
         if (i == 0)
           break;
@@ -162,7 +170,7 @@ write_proc_pointer(SPTR sptr)
 
 void
 emit_init(DTYPE tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
-          ISZ_T loc_base, ISZ_T *i8cnt, int *ptrcnt, char **cptr)
+          ISZ_T loc_base, ISZ_T *i8cnt, int *ptrcnt, char **cptr, bool is_char)
 {
   ISZ_T al;
   int area, d;
@@ -206,7 +214,7 @@ emit_init(DTYPE tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
       if (!first_data)
         fprintf(ASMFIL, ", ");
     }
-    *i8cnt = *i8cnt + put_skip(*addr, ALIGN(*addr, tconval));
+    *i8cnt = *i8cnt + put_skip(*addr, ALIGN(*addr, tconval), is_char);
     *addr = ALIGN(*addr, tconval);
     first_data = 0;
     break;
@@ -270,7 +278,7 @@ emit_init(DTYPE tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
       if (!first_data)
         fprintf(ASMFIL, ", ");
       if (*i8cnt) {
-        *i8cnt = put_skip(*addr, ALIGN(*addr, al));
+        *i8cnt = put_skip(*addr, ALIGN(*addr, al), is_char);
         *i8cnt = 0;
         fprintf(ASMFIL, /*[*/ "], ");
       } else if (*ptrcnt || !(*i8cnt)) {
@@ -282,7 +290,7 @@ emit_init(DTYPE tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
 #endif
           *cptr = put_next_member(*cptr);
         fprintf(ASMFIL, "[" /*]*/);
-        *i8cnt = put_skip(*addr, ALIGN(*addr, al));
+        *i8cnt = put_skip(*addr, ALIGN(*addr, al), is_char);
         fprintf(ASMFIL, /*[*/ "], ");
       }
     } else if (*i8cnt) {
@@ -340,7 +348,7 @@ emit_init(DTYPE tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
       if (!first_data)
         fprintf(ASMFIL, ", ");
     }
-    *i8cnt = *i8cnt + put_skip(*addr, tconval + loc_base);
+    *i8cnt = *i8cnt + put_skip(*addr, tconval + loc_base, is_char);
     *addr = tconval + loc_base;
     first_data = 0;
     break;

--- a/tools/flang2/flang2exe/llassem_common.h
+++ b/tools/flang2/flang2exe/llassem_common.h
@@ -16,7 +16,7 @@
 /**
    \brief ...
  */
-ISZ_T put_skip(ISZ_T old, ISZ_T New);
+ISZ_T put_skip(ISZ_T old, ISZ_T New, bool is_char);
 
 /**
    \brief ...
@@ -47,7 +47,7 @@ void add_init_routine(char *initroutine);
    \brief ...
  */
 void emit_init(DTYPE tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
-               ISZ_T loc_base, ISZ_T *i8cnt, int *ptrcnt, char **cptr);
+               ISZ_T loc_base, ISZ_T *i8cnt, int *ptrcnt, char **cptr, bool is_char);
 
 /**
    \brief ...


### PR DESCRIPTION
Fix the bug while using DATA, the test case is as following:
```Fortran
program p
  character*6 a
  character*10 b
  character*10 c
  data a(2:5) /'AAA'/
  data b(3:6) /'BBB'/
  data b(8:9) /'CC'/
  data c(3:5) /'345'/
  data c(6:9) /'6789'/

  print *, "a = ", a
  print *, "b = ", b
  print *, "c = ", c

end
```
After using data to append string, Fortran expected results should be:
```
a = ' AAA  '
b = '  BBB  CC '
c = '  3456789 '
```
But the flang print incorrect result for using 0x00 in ASCII code as space.
The outputs as following:
```
a = ' AAA '
b = ' BBB CC'
c = ' 3456789'
```