### PR TITLE
Fix error of outputting derived type.

### DIFF
--- a/test/f90_correct/inc/io28.mk
+++ b/test/f90_correct/inc/io28.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/io28.sh
+++ b/test/f90_correct/lit/io28.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/io28.f90
+++ b/test/f90_correct/src/io28.f90
@@ -1,0 +1,33 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for I/O take derived type array reference.
+! The function should be called only one time if a function
+! reference appears in the derived type array reference.
+
+program test
+  type my_type
+     integer :: i
+     integer :: j
+  end type my_type
+  character(80) :: str1(2), str2(2)
+  type(my_type) :: t(2)
+
+  t(1) = my_type(11, 12)
+  t(2) = my_type(21, 22)
+
+  write(str1(1), *), t(1)
+  write(str1(2), *), t(2)
+  write(str2(1), *), t(func())
+  write(str2(2), *), t(func())
+  if (any(str1 .ne. str2)) STOP 1
+  write(*, *) 'PASS'
+
+contains
+  integer function func()
+    integer, save :: i = 1
+    func = i
+    i = i + 1
+  end function
+end

--- a/tools/flang1/flang1exe/semantio.c
+++ b/tools/flang1/flang1exe/semantio.c
@@ -2895,7 +2895,12 @@ semantio(int rednum, SST *top)
             CNULL);
     }
     if (DTYG(SST_DTYPEG(RHS(1))) == TY_DERIVED &&
-        A_TYPEG(SST_ASTG(RHS(1))) == A_FUNC) {
+        (A_TYPEG(SST_ASTG(RHS(1))) == A_FUNC ||
+        /* Allocate a temporary ast to store the value of the derived type array
+         * reference whose subscript is a function reference, otherwise the
+         * function would be incorrectly called in each component I/O. */
+        (A_TYPEG(SST_ASTG(RHS(1))) == A_SUBSCR &&
+         A_CALLFGG(SST_ASTG(RHS(1)))))) {
       ast = sem_tempify(RHS(1));
       (void)add_stmt(ast);
       SST_IDP(RHS(1), S_IDENT);


### PR DESCRIPTION
The test case is as following :
```fortran
program test
  type my_type
     integer :: i
     integer :: j
     integer :: k
  end type my_type
  character(80) :: str1, str2
  type(my_type), dimension(3) :: t

  t(1) = my_type(11, 12, 13)
  t(2) = my_type(21, 22, 33)
  t(3) = my_type(31, 32, 33)

  print *, t(func())

contains
  integer function func()
    integer, save :: i = 1
    func = i
    i = i + 1
  end function
end
```
The correct result should be:
 `         11          12          13`
But flang print incorrect result:
 `         11          22          33`
Flang calls incorrectly `func()` three times and prints the values of `t(1)%i`, `t(2)%j` and `t(3)%k`.