### PR TITLE
Fix power operation optimization when the left operand is -1 and the right is a negative integer.

### DIFF
--- a/test/f90_correct/inc/apower.mk
+++ b/test/f90_correct/inc/apower.mk
@@ -1,0 +1,28 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test power opereator  ########
+
+
+apower: run
+
+
+build:  $(SRC)/apower.f90
+	-$(RM) apower.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/apower.f90 -o apower.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) apower.$(OBJX) check.$(OBJX) $(LIBS) -o apower.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test apower
+	apower.$(EXESUFFIX)
+
+verify: ;
+
+apower.run: run
+

--- a/test/f90_correct/lit/apower.sh
+++ b/test/f90_correct/lit/apower.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/apower.f90
+++ b/test/f90_correct/src/apower.f90
@@ -1,0 +1,30 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! This test case is test for power operator (int precision).
+! The result of power using base -1 depends on the parity of the exponent.
+
+program test
+  integer :: i1, i2, res(6)
+  integer(kind = 8) :: i2_8
+  integer :: eres(6) = [1, 1, -1, -1, 0, 0]
+
+  i2 = -8
+  i1 = -1
+  res(1) = i1 ** i2
+  res(2) = i1 ** (-8)
+
+  i2 = -7
+  i1 = -1
+  res(3) = i1 ** i2
+  res(4) = i1 ** -7
+
+  i2 = -7
+  i1 = -2
+  res(5) = i1 ** i2
+  res(6) = i1 ** -7
+
+  call check(res, eres, 6)
+end

--- a/tools/flang1/flang1exe/ast.c
+++ b/tools/flang1/flang1exe/ast.c
@@ -918,8 +918,12 @@ mk_binop(int optype, int lop, int rop, DTYPE dtype)
           INT v;
           v1 = CONVAL2G(A_SPTRG(lop));
           v2 = CONVAL2G(A_SPTRG(rop));
-          if (v2 < 0)
+          if (v2 < 0) {
+            if (v1 == -1)
+              /* if v2 is odd number, the result will be -1 */
+              return (v2 & 1) ? mk_cval((INT)-1, DT_INT) : astb.i1;
             return astb.i0;
+          }
           v = v1;
           while (--v2 > 0)
             v *= v1;


### PR DESCRIPTION
The test case is following:
```fortran
program test
  integer :: i1, i2, res(2)
  i1 = -1
  i2 = -8
  res(1) = i1 ** i2
  res(2) = i1 ** (-7)
  print *, res
end
```
the result with `-O0` and `-O1` is correct:
 `           1            -1`
the result with `-O2`, `-O3`, and `-Os` is incorrect:
 `           0            0`