### PR TITLE
Do not optimize common block variable that is potentially aliased

### DIFF
--- a/test/f90_correct/inc/common_01.mk
+++ b/test/f90_correct/inc/common_01.mk
@@ -1,0 +1,34 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+
+########## Make rule for test common_01  ########
+
+fcheck.o check_mod.mod: $(SRC)/check_mod.f90
+	-$(FC) -c $(FFLAGS) $(SRC)/check_mod.f90 -o fcheck.o
+
+common_01.o:  $(SRC)/common_01.f90 check_mod.mod
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) -O1 $(LDFLAGS) $(SRC)/common_01.f90 -o common_01.o
+
+common_01: common_01.o fcheck.o
+	-$(FC) $(FFLAGS) $(LDFLAGS) common_01.o fcheck.o $(LIBS) -o common_01
+
+common_01.run: common_01
+	@echo ------------------------------------ executing test common_01
+	common_01
+	-$(RM) shape_mod.mod test_shape_mod.mod
+
+### TA Expected Targets ###
+
+build: $(TEST)
+
+.PHONY: run
+run: $(TEST).run
+
+verify: ;
+
+### End of Expected Targets ###

--- a/test/f90_correct/lit/common_01.sh
+++ b/test/f90_correct/lit/common_01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/common_01.f90
+++ b/test/f90_correct/src/common_01.f90
@@ -1,0 +1,34 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Check if two common block variables are equal when turn on optimization
+
+module mod1
+  integer :: mi1
+  common /com1/ mi1
+contains
+  subroutine newmi1()
+    mi1 = 30
+  end subroutine newmi1
+end module mod1
+
+program test
+  use mod1
+  use check_mod
+  integer, parameter :: n = 6
+  logical :: reslt(n), expct(n)
+  integer :: pi1
+  common /com1/ pi1
+
+  reslt = .false.
+  expct = .true.
+  pi1 = 10
+  mi1 = 20
+  reslt(1:3) = (/pi1 == mi1, pi1 == 20, mi1 == 20/)
+  call newmi1()
+  reslt(4:6) = (/pi1 == mi1, pi1 == 30, mi1 == 30/)
+
+  call check(reslt, expct, n)
+end

--- a/tools/flang1/flang1exe/optutil.c
+++ b/tools/flang1/flang1exe/optutil.c
@@ -802,6 +802,16 @@ def_ok(int def, int fgx, int stmt)
     return FALSE;
   }
 
+  /* If sym is a common block variable (and potentially aliased), do not propagate
+   * its definition, like how variables in an equivalent statement are handled.
+   */
+  if (SCG(sym) == SC_CMBLK && MODCMNG(CMBLKG(sym)) == 0) {
+    if (OPTDBG(9, 16384))
+      fprintf(gbl.dbgfil, "def %d not ok, sym %d is common block "
+              "variable\n", def, sym);
+    return FALSE;
+  }
+
   if (FG_IN(fgx) == NULL) {
     if (OPTDBG(9, 16384))
       fprintf(gbl.dbgfil, "can't copy def %d, no in of fg %d\n", def, fgx);

--- a/tools/flang2/flang2exe/dtypeutl.cpp
+++ b/tools/flang2/flang2exe/dtypeutl.cpp
@@ -1256,3 +1256,29 @@ kanji_prefix(unsigned char *p, int newlen, int len)
   return (p - begin);
 }
 
+#define IS_COMMON_VAR(sptr) (SCG(sptr) == SC_CMBLK &&\
+                            MODCMNG(MIDNUMG(sptr)) == 0)
+
+/* Return true if two common block variables are overlapping */
+bool
+is_overlap_cmblk_var(int sptr1, int sptr2)
+{
+  /* Check if name of two common blocks are same */
+  if (sptr1 != sptr2 && IS_COMMON_VAR(sptr1) && IS_COMMON_VAR(sptr2) &&
+      getsymbol(SYMNAME(MIDNUMG(sptr1))) ==
+      getsymbol(SYMNAME(MIDNUMG(sptr2)))) {
+    int ub1, ub2;
+    int lb1, lb2;
+    /* lower bound of variable in common block */
+    lb1 = ADDRESSG(sptr1);
+    lb2 = ADDRESSG(sptr2);
+    /* uppper bound of variable in common block */
+    ub1 = size_of_sym((SPTR)sptr1) + lb1;
+    ub2 = size_of_sym((SPTR)sptr2) + lb2;
+
+    /* check for overlapping symbols */
+    if (ub2 > lb1 && ub1 > lb2)
+      return true;
+  }
+  return false;
+}

--- a/tools/flang2/flang2exe/dtypeutl.h
+++ b/tools/flang2/flang2exe/dtypeutl.h
@@ -68,6 +68,8 @@ bool is_empty_typedef(DTYPE dtype);
  */
 bool no_data_components(DTYPE dtype);
 
+bool is_overlap_cmblk_var(int sptr1, int sptr2);
+
 /**
    \brief if array datatype, returns the element dtype, else returns dtype
  */

--- a/tools/shared/nmeutil.c
+++ b/tools/shared/nmeutil.c
@@ -1245,6 +1245,13 @@ conflict(int nm1, int nm2)
             if (sptr2 == SOC_SPTR(t1))
               return CONFLICT;
       }
+
+      /* If sptr1 and sptr2 are overlapping common block variables, do not
+       * optimize their loads/stores, like how variables in an equivalence
+       * statement are handled.
+       */
+      if (is_overlap_cmblk_var(sptr1, sptr2))
+        return CONFLICT;
       if (!hlcf || XBIT(104, 0x8)) {
         if (SCG(sptr1) == SC_BASED && INLNG(sptr1) && UNSAFEG(sptr1) &&
             SCG(sptr2) == SC_BASED && INLNG(sptr2) && UNSAFEG(sptr2))


### PR DESCRIPTION
Fix the bug while using common in module and subroutine, the testcase is following:
```fortran
module mod1
  integer :: mi1
  common /com1/ mi1
contains
  subroutine newmi1()
    mi1 = 30
  end subroutine newmi1
end module mod1

subroutine sub(x)
  use mod1
  integer :: si1, x
  common /com1/ si1
  si1 = 40
  mi1 = 50
  if(si1 == mi1)  x = 1
end subroutine sub  

program p
  use mod1
  integer :: res(5)
  integer :: pi1
  common /com1/ pi1
  res = 0
  pi1 = 10
  mi1 = 20

  if(pi1 == mi1)    res(1) = 1
  if(pi1 == 20)     res(2) = 1
  call newmi1()
  mi1 = 20
  pi1 = 10
  if(pi1 == mi1)    res(3) = 1
  if(mi1 == 10)     res(4) = 1
  call sub(res(5))

  do i = 1,5
    if (res(i) == 1) print *, "case ", i, "passed."
    if (res(i) == 0) print *, "case ", i, "failed."
  end do
end program p                               
```
the result while -O0 is correct:
```
 case             1 passed.
 case             2 passed.
 case             3 passed.
 case             4 passed.
 case             5 passed.
```
While using `-O1` option, the unexpected result appears as:
```
 case             1 failed.
 case             2 passed.
 case             3 failed.
 case             4 passed.
 case             5 failed.
```
Then, using `-O2`, `-O3` and `-Os`, there is 2 more error:
```
 case             1 failed.
 case             2 failed.
 case             3 failed.
 case             4 failed.
 case             5 failed.
 ```