### PR TITLE
[DebugInfo] line table entry missing for statements

### DIFF
--- a/test/debug_info/redundant_inst.f90
+++ b/test/debug_info/redundant_inst.f90
@@ -1,0 +1,21 @@
+!RUN: %flang %s -g -S -emit-llvm -o - | FileCheck %s --check-prefix=STORE
+!RUN: %flang %s -g -S -emit-llvm -o - | llc -O0 -fast-isel=true -filetype=obj -o %t
+!RUN: llvm-dwarfdump --debug-line %t | FileCheck %s --check-prefix=LINETABLE
+
+!Check that `store` instruction is getting emitted for the second assignment.
+!STORE: store i32 4, i32* %[[VAR_A:.*]], align 4
+!STORE: %[[TEMP:.*]] = load i32, i32* %[[VAR_A]], align 4, !dbg ![[LOCATION:.*]]
+!STORE: store i32 %[[TEMP]], i32* %[[VAR_A]], align 4, !dbg ![[LOCATION]]
+!STORE: ![[LOCATION]] = !DILocation(line: 19, column: 1, scope: !{{.*}})
+
+!Check the line table entry of the second assignment.
+!LINETABLE: Address    Line Column File ISA Discriminator Flags
+!LINETABLE: 0x{{.*}}    19    1      1   0         0       is_stmt
+
+
+program main
+       integer :: a
+       a = 4
+       a = a !line no. 19
+       print*, a
+end

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -3729,6 +3729,8 @@ ad_instr(int ilix, INSTR_LIST *instr)
 static bool
 cancel_store(int ilix, int op_ili, int addr_ili)
 {
+  if(!ENABLE_CSE_OPT)
+    return false;
   ILI_OP op_opc = ILI_OPC(op_ili);
   bool csed = false;
 


### PR DESCRIPTION
flang was performing some opts even at "-g -O0" level.

Speifically, CSE is getting performed uncoditionally just before
the translation of the `store` instructions from ILI to LLVMIR.
Resulting in loss of debug-info and failures in GDB/gdb.fortran
testsuite. This patch inserts a check to disable the CSE opt if
it is not enabled.
Note: In flang CSE is enabled at `>=O1` optimization level.