### PR TITLE
win: fix the build on Windows

### DIFF
--- a/runtime/flangrti/llcrit.c
+++ b/runtime/flangrti/llcrit.c
@@ -9,7 +9,13 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#if !defined(_WIN32)
 #include <pthread.h>
+#else
+// FIXME: fork() is not available on Windows. So atfork routine can be a simple stub.
+// until it is fixed properly on Windows.
+#define pthread_atfork(F1,F2,F3) 0
+#endif
 #include <stdioInterf.h>
 #include "komp.h"
 


### PR DESCRIPTION
Pthread is not available on Windows so that is necessary to be guarded.
Therefore we need to add a workaround for those functions which rely on it.
Currently this PR aims to define atfork routine as stub function until
we figure out how it can be fixed.