### PR TITLE
Fix the bug that NEAREST returns wrong value for +/- infinity.

### DIFF
--- a/runtime/flang/miscsup_com.c
+++ b/runtime/flang/miscsup_com.c
@@ -4544,6 +4544,10 @@ ENTF90(NEARESTX, nearestx)(__REAL4_T f, __LOG_T sign)
       ++x.i;
     else
       --x.i;
+  } else if (!(sign & GET_DIST_MASK_LOG) && (x.i == 0x7F800000)) {
+    x.i = 0x7F7FFFFF;
+  } else if ((sign & GET_DIST_MASK_LOG) && (x.i == 0xFF800000)) {
+    x.i = 0xFF7FFFFF;
   }
   return x.f;
 }
@@ -4563,13 +4567,15 @@ ENTF90(NEARESTDX, nearestdx)(__REAL8_T d, __LOG_T sign)
   if (x.d == 0.0) {
     x.i.h = (sign & 1) ? 0x00100000 : 0x80100000;
     x.i.l = 0;
-  } else {
-    if ((x.ll >> 52 & 0x7FF) != 0x7FF) { /* not nan or inf */
+  } else if ((x.ll >> 52 & 0x7FF) != 0x7FF) { /* not nan or inf */
       if ((x.d < 0) ^ (sign & GET_DIST_MASK_LOG))
         ++x.ll;
       else
         --x.ll;
-    }
+  } else if (!(sign & GET_DIST_MASK_LOG) && (x.ll == 0x7FF0000000000000)) {
+    x.ll = 0x7FEFFFFFFFFFFFFF;
+  } else if ((sign & GET_DIST_MASK_LOG) && (x.ll == 0xFFF0000000000000)) {
+    x.ll = 0xFFEFFFFFFFFFFFFF;
   }
   return x.d;
 }

--- a/test/f90_correct/inc/intrinsic_nearest.mk
+++ b/test/f90_correct/inc/intrinsic_nearest.mk
@@ -1,0 +1,15 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# This test checks whether the largest possible floating-point number works.
+build:
+	@echo ------------------------------------- building test $@
+	$(FC) $(FFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(EXE)
+
+run:
+	@echo ------------------------------------ executing test $@
+	./$(TEST).$(EXE)
+
+verify:
+	@echo ------------------------------------ verifying
+	@echo test should have printed verification above

--- a/test/f90_correct/lit/intrinsic_nearest.sh
+++ b/test/f90_correct/lit/intrinsic_nearest.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/intrinsic_nearest.f90
+++ b/test/f90_correct/src/intrinsic_nearest.f90
@@ -1,0 +1,33 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! This test case is test for NEAREST intrinsic function(float and double precision).
+
+program test_nearest
+  real(kind=4) :: res4, infr4, maxr4
+  real(kind=8) :: res8, infr8, maxr8
+  integer(kind=4) :: infi4, maxi4
+  integer(kind=8) :: infi8, maxi8
+  equivalence (infr4, infi4)
+  equivalence (maxr4, maxi4)
+  equivalence (infr8, infi8)
+  equivalence (maxr8, maxi8)
+
+  infi4 = int(z'7f800000')
+  maxi4 = int(z'7f7fffff')
+  infi8 = int(z'7ff0000000000000', kind = 8)
+  maxi8 = int(z'7fefffffffffffff', kind = 8)
+
+  res4 = nearest(-infr4, 1.0)
+  if (res4 .ne. -maxr4) STOP 1
+  res4 = nearest(infr4, -1.0)
+  if (res4 .ne. maxr4) STOP 2
+  res8 = nearest(-infr8, 1.0_8)
+  if (res8 .ne. -maxr8) STOP 3
+  res8 = nearest(infr8, -1.0_8)
+  if (res8 .ne. maxr8) STOP 4
+
+  write(*,*) 'PASS'
+end program


### PR DESCRIPTION
When the 1st parameter is positive or negative infinity, the intrinsic function `NEAREST` wrongly returns the same value while it should return the positive or negative number of the largest magnitude accordingly when the 2nd parameter has the different sign.

This patch fixes this bug by adding logic to handle the aforementioned situations for all single-, double-precision fp numbers.
