### PR TITLE
Fix improper handling of errors caused by invalid declaration of result variable

### DIFF
--- a/test/f90_correct/inc/func_result.mk
+++ b/test/f90_correct/inc/func_result.mk
@@ -1,0 +1,15 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build: $(SRC)/$(TEST).f90
+	@echo ------------------------------------ building test $(TEST)
+	-$(FC) -c $(SRC)/$(TEST).f90 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ nothing to run for test $(TEST)
+
+verify: $(TEST).rslt
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f90 $(TEST).rslt $(FC)
+

--- a/test/f90_correct/lit/func_result.sh
+++ b/test/f90_correct/lit/func_result.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/func_result.f90
+++ b/test/f90_correct/src/func_result.f90
@@ -1,0 +1,22 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! An initialization shall not appear if object-name is a function result
+
+function f() result(r)
+  !{error "PGF90-S-0155-Function result cannot have the PARAMETER attribute - r"}
+  real, parameter :: r = 5.0
+end function
+
+function g() result(s)
+  !{error "PGF90-S-0155-Function result cannot have an initializer - s"}
+  real :: s = 5.0
+end function
+
+function h() result(i)
+  !{error "PGF90-S-0155-A derived type type-name conflicts with function result - i"}
+  type :: i
+  end type
+end function

--- a/tools/flang1/flang1exe/semant.c
+++ b/tools/flang1/flang1exe/semant.c
@@ -3552,6 +3552,11 @@ semant1(int rednum, SST *top)
             np);
       if (IS_INTRINSIC(STYPEG(sptr)))
         sptr = insert_sym(sptr);
+    } else if (RESULTG(sptr)) {
+      error(155, 3, gbl.lineno, "A derived type type-name conflicts with"
+                                " function result -",
+            np);
+      sptr = insert_sym(sptr);
     } else
       sptr = getocsym(sptr, OC_OTHER, TRUE);
     if (STYPEG(sptr) == ST_TYPEDEF && DTY(DTYPEG(sptr) + 2) == 0) {
@@ -9026,6 +9031,13 @@ semant1(int rednum, SST *top)
             SYMNAME(sptr));
     }
 
+    if (RESULTG(sptr) && STYPEG(sptr) != ST_ENTRY &&
+        (entity_attr.exist & ET_B(ET_PARAMETER))) {
+      error(155, ERR_Severe, gbl.lineno, "Function result cannot have the"
+                                         " PARAMETER attribute -",
+            SYMNAME(sptr));
+      goto entity_decl_end;
+    }
     if ((entity_attr.exist & ET_B(ET_PARAMETER)) || 
         do_fixup_param_vars_for_derived_arrays(inited, sptr, 
                                                SST_IDG(RHS(3)))) {
@@ -9042,6 +9054,12 @@ semant1(int rednum, SST *top)
     }
 
     if (RESULTG(sptr) && STYPEG(sptr) != ST_ENTRY) {
+      if (inited) {
+        error(155, ERR_Severe, gbl.lineno, "Function result cannot have"
+                                           " an initializer -",
+              SYMNAME(sptr));
+        goto entity_decl_end;
+      }
       /* set the type for the entry point as well */
       copy_type_to_entry(sptr);
     }


### PR DESCRIPTION

This patch fixes the following bugs:
- When declaring the result variable with the `PARAMETER` attribute, flang doesn't raise an error, causing segmentation fault downstream.
- When initializing the result variable at the time of declaration, flang reports a wrong error.
- When the result variable collides with the name of a derived type, flang doesn't raise an error, causing ICE downstream.
