### PR TITLE
Add reporting for two grammar errors pertaining to PROTECTED attribute.

### DIFF
--- a/test/f90_correct/inc/protected.mk
+++ b/test/f90_correct/inc/protected.mk
@@ -1,0 +1,15 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build: $(SRC)/$(TEST).f90
+	@echo ------------------------------------ building test $(TEST)
+	-$(FC) -c $(SRC)/$(TEST).f90 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ nothing to run for test $(TEST)
+
+verify: $(TEST).rslt
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f90 $(TEST).rslt $(FC)
+

--- a/test/f90_correct/lit/protected.sh
+++ b/test/f90_correct/lit/protected.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/protected.f90
+++ b/test/f90_correct/src/protected.f90
@@ -1,0 +1,31 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for protected attribute
+
+module m
+  implicit none
+  integer, protected, pointer :: v
+  integer, protected :: v1
+end module m
+
+program p
+  use m
+  implicit none
+  integer, target :: a
+  !{error "PGF90-S-0155-A use-associated object with the PROTECTED attribute cannot be an actual argument when the dummy argument is INTENT(OUT) or INTENT(INOUT) - v1"}
+  call reset1(v1)
+  !{error "PGF90-S-0155-A use-associated object with the PROTECTED attribute cannot be an actual argument when the dummy argument is INTENT(OUT) or INTENT(INOUT) - v1"}
+  call reset2(v1)
+  !{error "PGF90-S-0155-A use-associated object with the PROTECTED attribute cannot be assigned - v"}
+  v => a
+contains
+  subroutine reset1(z)
+    integer, intent(inout) :: z
+  end subroutine
+  subroutine reset2(z)
+    integer, intent(out) :: z
+  end subroutine
+end program p

--- a/tools/flang1/flang1exe/semfunc2.c
+++ b/tools/flang1/flang1exe/semfunc2.c
@@ -2572,6 +2572,11 @@ chk_arguments(int ext, int count, ITEM *list, char *kwd_str, int paramct,
                    INTENTG(A_SPTRG(actual)) == INTENT_IN &&
                    !POINTERG(A_SPTRG(actual)))
           error(193, 2, gbl.lineno, buf, SYMNAME(ext));
+        sptr = sym_of_ast(actual);
+        if (!POINTERG(sptr) && is_protected(sptr)) {
+          err_protected(sptr, "be an actual argument when the dummy argument "
+                              "is INTENT(OUT) or INTENT(INOUT)");
+        }
       }
       if (!ALLOCATTRG(arg) && ASSUMSHPG(arg) && actual) {
         /* full descriptor required for 'arg' */

--- a/tools/flang1/flang1exe/semutil.c
+++ b/tools/flang1/flang1exe/semutil.c
@@ -43,6 +43,8 @@
 #define TY_OF(s) (DTYG(TYPE_OF(s)))
 #define PT_OF(s) (DDTG(TYPE_OF(s))) /* pointer to data type */
 
+#define ERRMSG_BUFFSIZE 200
+
 static int ref_array(SST *, ITEM *);
 static INT clog_to_log(INT);
 static int mkunion(int, int, int);
@@ -3887,6 +3889,10 @@ assign_pointer(SST *newtop, SST *stktop)
     error(72, 3, gbl.lineno, SYMNAME(pvar), "- must be a POINTER variable");
     return 0;
   }
+  if (is_protected(pvar)) {
+    err_protected(pvar, "be assigned");
+    return 0;
+  }
  
   if (is_procedure_ptr(pvar)) {
     int iface=0;
@@ -4606,7 +4612,7 @@ is_protected(int sptr)
 void
 err_protected(int sptr, const char *context)
 {
-  char bf[128];
+  char bf[ERRMSG_BUFFSIZE];
   sprintf(bf, "%s %s -",
           "A use-associated object with the PROTECTED attribute cannot",
           context);


### PR DESCRIPTION
A syntactical error should be reported when a dummy argument is specified with `INTENT(out)` or `INTENT(inout)` while the actual argument has the attribute `PROTECTED`.

A syntactical error should be reported when modifying a `PROTECTED` pointer variable.

This patch catches and reports 2 new grammar errors related to the `PROTECTED` parameter (and extends the buffer for the error message):
1.A use-associated object with the `PROTECTED` attribute cannot be an actual argument when the dummy argument
2.A use-associated object with the `PROTECTED` attribute cannot be assigned