### PR TITLE
Fix the bug where the name of ENTRY is used as an argument

### DIFF
--- a/test/f90_correct/inc/en02.mk
+++ b/test/f90_correct/inc/en02.mk
@@ -1,0 +1,15 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build: $(SRC)/$(TEST).f90
+	@echo ------------------------------------ building test $(TEST)
+	-$(FC) -c $(SRC)/$(TEST).f90 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ nothing to run for test $(TEST)
+
+verify: $(TEST).rslt
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f90 $(TEST).rslt $(FC)
+

--- a/test/f90_correct/lit/en02.sh
+++ b/test/f90_correct/lit/en02.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/en02.f90
+++ b/test/f90_correct/src/en02.f90
@@ -1,0 +1,23 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for RESULT in entry and function
+
+module m
+  implicit none
+contains
+  function func(a) result(res)
+    implicit none
+    integer :: a, res
+    real :: func2
+    !{error "PGF90-S-0072-Assignment operation illegal to func - should use res"}
+    func = a*2
+    return
+  entry ent(a) result(func2)
+    !{error "PGF90-S-0072-Assignment operation illegal to ent - should use func2"}
+    ent = -a*0.5
+    return
+  end function func
+end module m

--- a/tools/flang1/flang1exe/semant3.c
+++ b/tools/flang1/flang1exe/semant3.c
@@ -542,6 +542,13 @@ semant3(int rednum, SST *top)
       if (CLASSG(sptr) && !MONOMORPHICG(sptr) && !ALLOCATTRG(sptr)) {
         error(1217, ERR_Severe, gbl.lineno, SYMNAME(sptr), CNULL);
       }
+      if (STYPEG(sptr) == ST_ENTRY && FVALG(sptr)) {
+        char buffer[256];
+        (void)snprintf(buffer, sizeof(buffer), "- should use %s",
+                       SYMNAME(FVALG(sptr)));
+        error(72, 3, gbl.lineno, SYMNAME(sptr), buffer);
+        sptr = FVALG(sptr);
+      }
       chk_and_rewrite_cmplxpart_assn(RHS(2), RHS(5));
 
       /* really an assignment statement */


### PR DESCRIPTION
Flang doesn’t catch and handle the syntax error that the name of an entry point is used as an argument when a result clause is present, ultimately causing a segmentation fault in flang2. This patch fixes the issue by catching and reporting the syntax error described above. It then restores the right state.
