### PR TITLE
Fix 2 bugs of PACK when the mask arg is a scalar of false

### DIFF
--- a/runtime/flang/pack.c
+++ b/runtime/flang/pack.c
@@ -70,8 +70,6 @@ void ENTFTN(PACK, pack)(void *rb,         /* result base */
   if (ISSCALAR(mask)) {
     mlen = GET_DIST_SIZE_OF(TYPEKIND(mask));
     mval = I8(__fort_varying_log)(mb, &mlen);
-    if (!mval)
-      return;
     mask_is_array = 0;
   } else if (F90_TAG_G(mask) == __DESC) {
     for (i = F90_RANK_G(mask); --i >= 0;)

--- a/test/f90_correct/inc/intrinsic_pack.mk
+++ b/test/f90_correct/inc/intrinsic_pack.mk
@@ -1,0 +1,16 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# This test checks pack intrinsic.
+build:
+	@echo ------------------------------------- building test $@
+	$(FC) $(FFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(EXE)
+	 
+run:
+	@echo ------------------------------------ executing test $@
+	./$(TEST).$(EXE)
+	 
+verify: 
+	@echo ------------------------------------ verifying
+	@echo test should have printed verification above
+

--- a/test/f90_correct/lit/intrinsic_pack.sh
+++ b/test/f90_correct/lit/intrinsic_pack.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/intrinsic_pack.f90
+++ b/test/f90_correct/src/intrinsic_pack.f90
@@ -1,0 +1,35 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! This test case is test for PACK intrinsic function with a scalar mask whose value is .false..
+
+program intrinsic_pack
+  integer, dimension(3, 3) :: arr1
+  integer, dimension(9) :: arr2
+  logical :: l1
+
+  l1 = .false.
+  arr2 = (/1, 2, 3, 4, 5, 6, 7, 8, 9/)
+  arr1 = reshape(arr2, (/3, 3/))
+
+  if (size(pack(arr1, .false.)) .ne. 0) STOP 1
+  if (size(pack(arr1, l1)) .ne. 0) STOP 2
+  if (size(pack(arr1(1:2, 2:3), .false.)) .ne. 0) STOP 3
+  if (size(pack(arr1(1:2, 2:3), l1)) .ne. 0) STOP 4
+
+  if (size(pack(arr1, .false., (/10, 11, 12/))) .ne. 3) STOP 5
+  if (any(pack(arr1, .false., (/10, 11, 12/)) .ne. (/10, 11, 12/))) STOP 6
+
+  if (size(pack(arr1, l1, (/10, 11, 12/))) .ne. 3) STOP 7
+  if (any(pack(arr1, l1, (/10, 11, 12/)) .ne. (/10, 11, 12/))) STOP 8
+
+  if (size(pack(arr1(1:2, 2:3), .false., (/10, 11, 12/))) .ne. 3) STOP 9
+  if (any(pack(arr1(1:2, 2:3), .false., (/10, 11, 12/)) .ne. (/10, 11, 12/))) STOP 10
+
+  if (size(pack(arr1(1:2, 2:3), l1, (/10, 11, 12/))) .ne. 3) STOP 11
+  if (any(pack(arr1(1:2, 2:3), l1, (/10, 11, 12/)) .ne. (/10, 11, 12/))) STOP 12
+
+  write(*,*) "PASS"
+end program

--- a/tools/flang1/flang1exe/semfunc.c
+++ b/tools/flang1/flang1exe/semfunc.c
@@ -7165,10 +7165,13 @@ ref_pd(SST *stktop, ITEM *list)
     if (stkp != NULL)
       /* use size of vector */
       ast = size_of_ast(ARG_AST(2));
-    else if (DTY(dtype2) != TY_ARRAY)
-      /* mask is a scalar; use size of array */
-      ast = size_of_ast(ARG_AST(0));
-    else {
+    else if (DTY(dtype2) != TY_ARRAY) {
+      /* mask is a scalar; use (size of array * (- (int)mask) ) */
+      int temp;
+      ast = mk_convert(ARG_AST(1), DT_INT);
+      temp = mk_binop(OP_SUB, astb.bnd.zero, ast, astb.bnd.dtype);
+      ast = mk_binop(OP_MUL, size_of_ast(ARG_AST(0)), temp, astb.bnd.dtype);
+    } else {
       /* else compute size by the expression  'count(mask)' */
       int t1;
       t1 = mk_argt(2);              /* space for arguments */


### PR DESCRIPTION
1. When the mask is a scalar false and the vector arg is absent, `PACK` wrongly returns an array of the same size as the array arg with all elements being the zero value, while it should return an empty array. This happens because the size of the result is calculated wrongly in the particular situation and the patch fixes it by giving the correct size for the result.
2. When the mask is a scalar false but the vector arg is given, `PACK` returns an array of the same size as the vector but all elements being zero, while the elements should have the same value and in the same order as the vector. This bug is caused in the runtime lib code for the intrinsic function `PACK` where it doesn't collect vector elements and returns too early when the the mask is a false scalar value. This patch therefore fixes the bug by simply remove the check-then-return block of code.