### PR TITLE
[DebugInfo] Fix debug info for derived type having scalar pointer member

### DIFF
--- a/test/debug_info/dertyp_member_ptr.f90
+++ b/test/debug_info/dertyp_member_ptr.f90
@@ -1,0 +1,57 @@
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: distinct !DIGlobalVariable(name: "dvar",
+!CHECK-SAME: type: [[TYPE:![0-9]+]]
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "dtype"
+!CHECK-SAME: elements: [[MEMBERS:![0-9]+]]
+!CHECK: [[MEMBERS]] = !{[[MEM1:![0-9]+]], [[MEM2:![0-9]+]], [[MEM3:![0-9]+]], [[MEM4:![0-9]+]], [[MEM5:![0-9]+]]
+!CHECK: [[MEM1]] = !DIDerivedType(tag: DW_TAG_member, name: "i",
+!CHECK-SAME: baseType: [[INTTYP:![0-9]+]]
+!CHECK: [[MEM2]] = !DIDerivedType(tag: DW_TAG_member, name: "sclrptr",
+!CHECK-SAME: baseType: [[SCLRPTRTYP:![0-9]+]]
+!CHECK: [[SCLRPTRTYP]] = !DIDerivedType(tag: DW_TAG_pointer_type,
+!CHECK-SAME: baseType: [[REALTYP:![0-9]+]]
+!CHECK: [[REALTYP]] = !DIBasicType(name: "real"
+!CHECK: [[MEM3]] = !DIDerivedType(tag: DW_TAG_member, name: "arrptr",
+!CHECK-SAME: baseType: [[ARRTYP:![0-9]+]]
+!CHECK: [[ARRTYP]] = !DICompositeType(tag: DW_TAG_array_type,
+!CHECK: [[MEM4]] = !DIDerivedType(tag: DW_TAG_member, name: "dtptr",
+!CHECK-SAME: baseType: [[DTTYP:![0-9]+]]
+!CHECK: [[DTTYP]] = !DIDerivedType(tag: DW_TAG_pointer_type,
+!CHECK: [[MEM5]] = !DIDerivedType(tag: DW_TAG_member, name: "dtarrptr",
+!CHECK-SAME: baseType: [[DTARRTYP:![0-9]+]]
+!CHECK: [[DTARRTYP]] = !DICompositeType(tag: DW_TAG_array_type,
+
+program main
+  implicit none
+
+  type dtyp1
+    integer :: scalar
+    integer :: arr(10)
+  end type dtyp1
+
+  type dtype
+    integer :: i
+    real, pointer :: sclrptr
+    integer, pointer :: arrptr(:)
+    type(dtyp1), pointer :: dtptr
+    type(dtyp1), pointer :: dtarrptr(:)
+  end type dtype
+
+  real, target :: rval
+  integer, target :: arr(10) = (/0,2,4,6,8,1,3,5,7,9/)
+  type(dtyp1), target :: dtvar
+  type(dtyp1), target :: dtarr(10)
+  type(dtype) :: dvar
+
+  dtvar%scalar = 5
+  dtvar%arr = 99
+  dtarr = dtvar
+  dtarr(5)%scalar = 55
+  dvar%i = 4
+  dvar%sclrptr => rval
+  dvar%arrptr => arr
+  dvar%dtptr => dtvar
+  dvar%dtarrptr => dtarr
+
+end program main

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -952,14 +952,15 @@ lldbg_create_aggregate_members_type(LL_DebugInfo *db, SPTR first, int findex,
           db->need_dup_composite_type |= true;
         }
       } else {
-        if (!ll_feature_debug_info_ver90(&db->module->ir)) {
+        if (!SDSCG(element))
           element = SYMLKG(element);
-          assert(element > NOSYM,
-                 "lldbg_create_aggregate_members_type: element not exists",
-                 element, ERR_Fatal);
+        assert(element > NOSYM,
+               "lldbg_create_aggregate_members_type: element not exists",
+               element, ERR_Fatal);
+        is_desc_member = true;
+        if (!ll_feature_debug_info_ver90(&db->module->ir)) {
           db->need_dup_composite_type = false;
         }
-        is_desc_member = true;
       }
     }
     elem_dtype = DTYPEG(element);


### PR DESCRIPTION
Compiler generated artificial variables were being leaked, which
is fixed now.
Please consider below testcase and its debug session.
````````````
    program main
      implicit none
      type dtype
        real, pointer :: sclrptr
      end type dtype
      real, target :: rval = 0.5
      type(dtype) :: dvar
      dvar%sclrptr => rval
    end program main
````````````
    Inside debugger
````````````
    (gdb) pt dvar
    type = Type dtype
        real :: sclrptr
        PTR TO -> ( real :: sclrptr$p )
    End Type dtype
    (gdb) p dvar
    $1 = ( sclrptr = 2.96079792e-39, sclrptr$p = 0x203d80 <.STATICS1> )
`````````````
    After fix
`````````````
    (gdb) pt dvar
    type = Type dtype
        PTR TO -> ( real :: sclrptr )
    End Type dtype
    (gdb) p dvar
    $1 = ( sclrptr = 0x203d60 <.STATICS1> )
    (gdb) x/f 0x203d60
    0x203d60 <.STATICS1>:   0.5
