### PR TITLE
Fix the build on Windows

### DIFF
--- a/runtime/flang/alias.c
+++ b/runtime/flang/alias.c
@@ -40,7 +40,7 @@ extern int omp_in_parallel_()
 
 extern void omp_set_dynamic_(int dynamic_threads)
 {
-  return omp_set_dynamic(dynamic_threads);
+  omp_set_dynamic(dynamic_threads);
 }
 
 extern int omp_get_dynamic_()
@@ -50,7 +50,7 @@ extern int omp_get_dynamic_()
 
 extern void omp_set_nested_(int nested)
 {
-  return omp_set_nested(nested);
+  omp_set_nested(nested);
 }
 
 extern int omp_get_nested_()
@@ -75,7 +75,7 @@ extern int omp_get_thread_limit_()
 
 extern void omp_set_max_active_levels_(int max_levels)
 {
-  return omp_set_max_active_levels(max_levels);
+  omp_set_max_active_levels(max_levels);
 }
 
 extern int omp_get_max_active_levels_()
@@ -130,7 +130,7 @@ extern int omp_get_partition_num_places_()
 
 extern void omp_set_default_device_(int device_num)
 {
-  return omp_set_default_device(device_num);
+  omp_set_default_device(device_num);
 }
 
 extern int omp_get_default_device_()


### PR DESCRIPTION
These aliased OpenMP function defined as void,
and these void functions should not return a value.
The error is reported by clang-cl 12.0.0.