### PR TITLE
Add missing OpenMP function to ompstub

### DIFF
--- a/runtime/ompstub/ompstubs.c
+++ b/runtime/ompstub/ompstubs.c
@@ -590,6 +590,12 @@ omp_get_wtick_(void)
   return 365. * 86400.;
 }
 
+int
+omp_in_final(void)
+{
+  return 1;
+}
+
 kmp_int32
 __kmpc_global_thread_num(void *id)
 {


### PR DESCRIPTION
OpenMP library is not available for Windows on ARM64 yet.
'omp_in_final' is missing and causes a link error.