### PR TITLE
Fix x86_64 linker issues caused by PR #695

### DIFF
--- a/runtime/libpgmath/lib/common/CMakeLists.txt
+++ b/runtime/libpgmath/lib/common/CMakeLists.txt
@@ -72,7 +72,8 @@ if(${LIBPGMATH_SYSTEM_PROCESSOR} MATCHES "x86_64" AND NOT ${LIBPGMATH_WITH_GENER
 
     set(SRCS
       mth_yintrinsics.c
-      mth_zintrinsics.c)
+      mth_zintrinsics.c
+      kidnnt.c)
   elseif(${LIBPGMATH_SYSTEM_NAME} MATCHES "Darwin|Windows")
     add_subdirectory("sincosf")
     add_subdirectory("tanf")
@@ -112,7 +113,8 @@ if(${LIBPGMATH_SYSTEM_PROCESSOR} MATCHES "x86_64" AND NOT ${LIBPGMATH_WITH_GENER
 
     set(SRCS
       mth_yintrinsics.c
-      mth_zintrinsics.c)
+      mth_zintrinsics.c
+      kidnnt.c)
   endif()
 elseif(${LIBPGMATH_SYSTEM_PROCESSOR} MATCHES "ppc64le")
   set_property(SOURCE dispatch.c APPEND_STRING PROPERTY COMPILE_FLAGS "-fno-builtin")


### PR DESCRIPTION
This patch fixes link-time issues described in bug report #1056 on
x86_64 machines. The commit in PR #695 has removed duplicated files,
kidnnt.c among them. Unfortunately, due to a sudden omission, the
original kidnnt.c file was not listed for being built for x86_64
targets.
