### PR TITLE
Fix an ICE occurring when a named constant array is declared deferred shape.

### DIFF
--- a/test/f90_correct/inc/arr01.mk
+++ b/test/f90_correct/inc/arr01.mk
@@ -1,0 +1,15 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build: $(SRC)/$(TEST).f90
+	@echo ------------------------------------ building test $(TEST)
+	-$(FC) -c $(SRC)/$(TEST).f90 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ nothing to run for test $(TEST)
+
+verify: $(TEST).rslt
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f90 $(TEST).rslt $(FC)
+

--- a/test/f90_correct/lit/arr01.sh
+++ b/test/f90_correct/lit/arr01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/arr01.f90
+++ b/test/f90_correct/src/arr01.f90
@@ -1,0 +1,11 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! test for use deferrd shape array which declared wrongly
+
+program test
+  !{error "PGF90-S-0084-Illegal use of symbol a - a named constant array must have constant extents"}
+  integer, parameter :: a(:) = 1
+  integer, parameter :: b(4) = reshape([a, a+1, a+2, a+3], shape(b))
+end program test


### PR DESCRIPTION

When a named constant array is declared as a deferred shape array, flang1 only reports the error without setting the array in a proper state, leading to the ICE afterwards.

This patch fixes the ICE by recovering the array as a zero-sized array.