### PR TITLE
Correct the type of unlimited polymorphic pointers.

### DIFF
--- a/test/f90_correct/inc/class_pointer.mk
+++ b/test/f90_correct/inc/class_pointer.mk
@@ -1,0 +1,28 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test class_pointer  ########
+
+
+class_pointer: run
+	
+
+build:  $(SRC)/class_pointer.f90
+	-$(RM) class_pointer.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/class_pointer.f90 -o class_pointer.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) class_pointer.$(OBJX) check.$(OBJX) $(LIBS) -o class_pointer.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test class_pointer
+	class_pointer.$(EXESUFFIX)
+
+verify: ;
+
+class_pointer.run: run
+

--- a/test/f90_correct/lit/class_pointer.sh
+++ b/test/f90_correct/lit/class_pointer.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/class_pointer.f90
+++ b/test/f90_correct/src/class_pointer.f90
@@ -1,0 +1,57 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! The dummy argument is class pointer and the real argument is type.
+
+module mod1
+  type, public :: mytype1
+    integer, private :: key = 0
+  end type mytype1
+
+  type, public :: mytype2
+    class(*), pointer :: p_key
+  end type mytype2
+contains
+
+  function test(curr, key) result(rst)
+    class(mytype2) :: curr
+    class(*), target, intent(in) :: key
+    integer :: rst
+    integer :: ier = 0, debug = 1
+    ! The key%sd will be generated bacause of the statement of
+    ! allocate(curr%p_key, source = key) in parser stage, in which case, flang
+    ! will make RTE_init_unl_poly_desc and get the wrong argument of type
+    ! descriptor in check_pointer_type. If the statement is removed, flang will
+    ! not generate RTE_init_unl_poly_desc and process the statement of
+    ! ptr2_assign(curr%p_key,key) later.
+    if (debug > ier) then
+      curr%p_key => key
+    else
+      allocate(curr%p_key, source = key)
+    endif
+    rst = cmp(curr%p_key)
+  end function
+
+  function cmp(ty) result(res)
+    class(*) :: ty
+    select type(ty)
+      class is(mytype1)
+        res = 1
+      class default
+        res = 0
+    end select
+  end function
+end module
+
+program example
+  use mod1
+  integer :: rst(1)
+  integer :: expect(1)
+  integer, parameter :: n = 1
+  type(mytype1), target :: lnk
+  type(mytype2) :: currp
+  expect = 1
+  rst = test(currp, lnk)
+  call check(rst, expect, n)
+end

--- a/tools/flang1/flang1exe/func.c
+++ b/tools/flang1/flang1exe/func.c
@@ -1527,6 +1527,8 @@ check_pointer_type(int past, int tast, int stmt, LOGICAL is_sourced_allocation)
     assert(psdsc > NOSYM, "no descriptor for psptr", psptr, 3);
     if (STYPEG(tsptr) == ST_MEMBER) {
       tsdsc = get_member_descriptor(tsptr);
+    } else if (SCG(tsptr) == SC_DUMMY) {
+      tsdsc = get_type_descr_arg(gbl.currsub, tsptr);
     } else {
       tsdsc = SDSCG(tsptr);
     }


### PR DESCRIPTION
The type of an unlimited polymorphic pointer,
assigned from an unlimited polymorphic argument,
is wrongly set to `_f03_unl_poly$0$$$$td`
when invoking `f90_init_unl_poly_desc_i8`.

This patch corrects it to the type descriptor of the argument.