### PR TITLE
Fix the bug where the `v_list` argument is not provided as a zero-sized array in some cases as required by the standard.

### DIFF
--- a/test/f90_correct/inc/dtio01.mk
+++ b/test/f90_correct/inc/dtio01.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+	
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/dtio01.sh
+++ b/test/f90_correct/lit/dtio01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/dtio01.f90
+++ b/test/f90_correct/src/dtio01.f90
@@ -1,0 +1,46 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! If there is no v-list in the edit descriptor or if the data transfer statement
+! specifies list-directed or namelist formatting, the processor shall provide v_list
+! as a zero-sized array.
+
+MODULE m
+  IMPLICIT NONE
+  TYPE dt
+    INTEGER, ALLOCATABLE :: i
+    CONTAINS
+      PROCEDURE :: write_dt
+      GENERIC :: WRITE(formatted) => write_dt
+  END TYPE
+
+  CONTAINS
+    SUBROUTINE write_dt(dtv, unit, iotype, v_list, iostat, iomsg)
+      CLASS(dt), INTENT(IN) :: dtv
+      INTEGER, INTENT(IN) :: unit
+      CHARACTER(*), INTENT(IN) :: iotype
+      INTEGER, INTENT(IN) :: v_list(:)
+      INTEGER, INTENT(OUT) :: iostat
+      CHARACTER(*), INTENT(INOUT) :: iomsg
+      real, dimension(0) :: a
+      if (any(lbound(v_list) .ne. lbound(a))) STOP 1
+      if (any(ubound(v_list) .ne. ubound(a))) STOP 2
+      if (any(shape(v_list) .ne. shape(a))) STOP 3
+      if (size(v_list) .ne. size(a)) STOP 4
+      if (any(v_list .ne. a)) STOP 5
+    END SUBROUTINE
+END MODULE m
+
+program p
+  use m
+
+  TYPE(dt) d
+  CHARACTER(10) :: internal_file
+  INTEGER :: iostat
+
+  WRITE(internal_file, *) d
+  print *, 'PASS'
+end program

--- a/tools/flang1/flang1exe/semantio.c
+++ b/tools/flang1/flang1exe/semantio.c
@@ -5958,10 +5958,7 @@ gen_dtio_args(SST *stkptr, int arg1, int iotype_ast, int vlist_ast)
       AD_UPBD(ad, 0) = astb.i0;
       AD_MLPYR(ad, 0) = astb.i1;
 
-      sptr = getcctmp_sc('d', sem.dtemps++, ST_VAR, dtype, io_sc);
-      ALLOCP(sptr, 1);
-      get_static_descriptor(sptr);
-      get_all_descriptors(sptr);
+      sptr = getcctmp_sc('d', sem.dtemps++, ST_ARRAY, dtype, io_sc);
       vlist_ast = mk_id(sptr);
       DESCUSEDP(sptr, 1);
       ARGP(sptr, 1);


### PR DESCRIPTION
The standard specifies: “If there is no v-list in the edit descriptor or if the data transfer statement speciﬁes list-directed or namelist formatting, the processor shall provide v_list as a zero-sized array.” flang fails to do this.

This patch meets the requirement by making a zero-sized array and providing it to `v_list`