### PR TITLE
Fix `switch`- and `case`-related warnings; NFCI

### DIFF
--- a/include/universal.h
+++ b/include/universal.h
@@ -12,6 +12,29 @@
 #ifndef UNIVERSAL_DEFS_H_
 #define UNIVERSAL_DEFS_H_
 
+// Only use __has_cpp_attribute in C++ mode. GCC defines __has_cpp_attribute in
+// C mode, but the :: in __has_cpp_attribute(scoped::attribute) is invalid.
+#ifndef FLANG_HAS_CPP_ATTRIBUTE
+#if defined(__cplusplus) && defined(__has_cpp_attribute)
+# define FLANG_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#else
+# define FLANG_HAS_CPP_ATTRIBUTE(x) 0
+#endif
+#endif
+
+/// FLANG_FALLTHROUGH - Mark fallthrough cases in switch statements.
+#if defined(__cplusplus) && __cplusplus > 201402L && FLANG_HAS_CPP_ATTRIBUTE(fallthrough)
+#define FLANG_FALLTHROUGH [[fallthrough]]
+#elif FLANG_HAS_CPP_ATTRIBUTE(gnu::fallthrough)
+#define FLANG_FALLTHROUGH [[gnu::fallthrough]]
+#elif __has_attribute(fallthrough)
+#define FLANG_FALLTHROUGH __attribute__((fallthrough))
+#elif FLANG_HAS_CPP_ATTRIBUTE(clang::fallthrough)
+#define FLANG_FALLTHROUGH [[clang::fallthrough]]
+#else
+#define FLANG_FALLTHROUGH
+#endif
+
 #ifdef __cplusplus
 
 #ifdef SHADOW_BUILD
@@ -32,6 +55,9 @@
 #define BEGIN_DECL_WITH_C_LINKAGE
 #define END_DECL_WITH_C_LINKAGE
 
+/* Do not define the bool type if included by Flang runtime files.
+   The runtime defines its own bool type. */
+#ifndef FLANG_RUNTIME_GLOBAL_DEFS_H_
 /* Linux and MacOS environments provide <stdbool.h> even for C89.
    Microsoft OpenTools 10 does not, even for C99. */
 #if __linux__ || __APPLE__ || __STDC_VERSION__ >= 199901L && !__PGI_TOOLS10
@@ -40,6 +66,7 @@
 typedef char bool;
 #define true 1
 #define false 0
+#endif
 #endif
 
 #ifndef INLINE

--- a/lib/ArgParser/arg_parser.c
+++ b/lib/ArgParser/arg_parser.c
@@ -460,10 +460,6 @@ parse_arguments(const arg_parser_t *parser, int argc, char **argv)
         *(((bool_string_t *)value->location)->string_ptr) = next_string;
       }
       break;
-
-    default:
-      interr("Uknown command line argument value type", value->type, ERR_Fatal);
-      break;
     }
 
     /* Remember that the value as set */

--- a/lib/scutil/legacy-folding-api.c
+++ b/lib/scutil/legacy-folding-api.c
@@ -497,8 +497,6 @@ check(enum fold_status status)
   case FOLD_UNDERFLOW:
     fperror(FPE_FPUNF);
     break;
-  default:
-    assert(!"scutil-api.c:check:unknown status");
   }
 }
 

--- a/runtime/flang/assign.c
+++ b/runtime/flang/assign.c
@@ -52,6 +52,7 @@ __fortio_assign(char *item,           /* where to store */
   case __INT8:
     if (__ftn_32in64_)
       I64_MSH(valp->val.i8) = 0;
+    FLANG_FALLTHROUGH;
   case __BIGINT:
   case __BIGREAL:
     lp = valp;

--- a/runtime/flang/atol.c
+++ b/runtime/flang/atol.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdlib.h>
+#include "global.h"
 
 int
 __fort_atol(char *p)
@@ -47,9 +48,11 @@ __fort_strtol(char *str, char **ptr, int base)
       case 'g':
       case 'G':
         val <<= 10;
+        FLANG_FALLTHROUGH;
       case 'm':
       case 'M':
         val <<= 10;
+        FLANG_FALLTHROUGH;
       case 'k':
       case 'K':
         val <<= 10;

--- a/runtime/flang/fmtwrite.c
+++ b/runtime/flang/fmtwrite.c
@@ -1896,6 +1896,7 @@ fw_writenum(int code, char *item, int type)
       w = d + 10;
     }
     e_flag = TRUE;
+    FLANG_FALLTHROUGH;
   case FED_G0: /* G0 */
     if (code == FED_G0 && dval == 0) {
       d = 0; /* d = 0 for zeros */

--- a/runtime/flang/global.h
+++ b/runtime/flang/global.h
@@ -9,6 +9,10 @@
  * \brief Global definitions and declarations for Fortran I/O library
  */
 
+#ifndef FLANG_RUNTIME_GLOBAL_DEFS_H_
+#define FLANG_RUNTIME_GLOBAL_DEFS_H_
+
+#include "universal.h"
 #include "fioMacros.h"
 #include "stdioInterf.h" /* stubbed version of stdio.h */
 #include "cnfg.h" /* declarations for configuration items */
@@ -400,3 +404,5 @@ extern void *__fortio_fiofcb_next(FIO_FCB *);
 
 extern bool __fio_eq_str(char *str, int len, char *pattern);
 extern VOID __fortio_swap_bytes(char *, int, long);
+
+#endif /* FLANG_RUNTIME_GLOBAL_DEFS_H_ */

--- a/runtime/flang/nmlread.c
+++ b/runtime/flang/nmlread.c
@@ -742,8 +742,7 @@ again:
   case 'Y':
   case 'Z':
     c = c + ('a' - 'A');
-  /*  fall thru ... */
-
+    FLANG_FALLTHROUGH;
   case 'a':
   case 'b':
   case 'c':
@@ -1019,8 +1018,7 @@ again:
     /*  else, treat this '.' as beginning of numeric constant:  */
     currc--;
     c = '.';
-  /*  fall thru .... */
-
+    FLANG_FALLTHROUGH;
   case '+':
   case '-':
     i = 0;

--- a/runtime/flang/rdst.c
+++ b/runtime/flang/rdst.c
@@ -1112,7 +1112,6 @@ ENTFTN(TEMPLATE, template)
       break;
 
     case __TRANSCRIPTIVE:
-    default:
       __fort_abort("TEMPLATE: bad dist-target flags");
     }
 
@@ -1154,7 +1153,6 @@ ENTFTN(TEMPLATE, template)
       break;
 
     case __TRANSCRIPTIVE:
-    default:
       __fort_abort("TEMPLATE: bad dist-format flags");
     }
 

--- a/tools/flang1/flang1exe/accpp.c
+++ b/tools/flang1/flang1exe/accpp.c
@@ -2648,7 +2648,7 @@ subst(PPSYM *sp)
               continue;
             case CONCAT:
               *qq = ARGST;
-            /***** fall thru *****/
+              FLANG_FALLTHROUGH;
             case ARGST:
               qq++;
               break;
@@ -4085,6 +4085,7 @@ again:
   case '$':
     if (XBIT(123, 0x100000))
       goto defret;
+    FLANG_FALLTHROUGH;
 
   /* Identifier or Fortran 'C' comment.
    * If this is Fortran and a 'C', it might be an identifier or comment.
@@ -4113,6 +4114,7 @@ again:
       }
       /* Fall thru if we do not have a C or c in the first column */
     }
+    FLANG_FALLTHROUGH;
 
   case 'A':
   case 'B': /* case 'C': */

--- a/tools/flang1/flang1exe/ast.c
+++ b/tools/flang1/flang1exe/ast.c
@@ -705,6 +705,7 @@ mk_binop(int optype, int lop, int rop, DTYPE dtype)
     if (DTY(dtype) == TY_INT8 || DTY(dtype) == TY_LOG8) {
       lop = convert_int(lop, dtype);
     }
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -718,7 +719,7 @@ mk_binop(int optype, int lop, int rop, DTYPE dtype)
   case OP_LOR:
   case OP_LAND:
     commutable = TRUE;
-  /***** fall through *****/
+    FLANG_FALLTHROUGH;
   default:
     if (A_TYPEG(lop) == A_CNST) {
       ncons = 1;
@@ -1411,6 +1412,7 @@ convert_cnst(int cnst, int newtyp)
     case TY_DWORD:
       if (to == TY_BLOG)
         return cnst; /* don't convert typeless for now */
+      FLANG_FALLTHROUGH;
     case TY_BLOG:
     case TY_SLOG:
     case TY_LOG:
@@ -1433,6 +1435,7 @@ convert_cnst(int cnst, int newtyp)
     case TY_DWORD:
       if (to == TY_SLOG)
         return cnst; /* don't convert typeless for now */
+      FLANG_FALLTHROUGH;
     case TY_BINT:
     case TY_SINT:
     case TY_INT:
@@ -1455,6 +1458,7 @@ convert_cnst(int cnst, int newtyp)
     case TY_DWORD:
       if (to == TY_LOG)
         return cnst; /* don't convert typeless for now */
+      FLANG_FALLTHROUGH;
     case TY_BINT:
     case TY_SINT:
     case TY_INT:
@@ -1483,6 +1487,7 @@ convert_cnst(int cnst, int newtyp)
       break;
     case TY_DCMPLX:
       sptr = CONVAL1G(sptr);
+      FLANG_FALLTHROUGH;
     case TY_DBLE:
       num[0] = CONVAL1G(sptr);
       num[1] = CONVAL2G(sptr);
@@ -1527,6 +1532,7 @@ convert_cnst(int cnst, int newtyp)
         break;
       case TY_DCMPLX:
         sptr = CONVAL1G(sptr);
+        FLANG_FALLTHROUGH;
       case TY_DBLE:
         num1[0] = CONVAL1G(sptr);
         num1[1] = CONVAL2G(sptr);
@@ -1557,6 +1563,7 @@ convert_cnst(int cnst, int newtyp)
         break;
       case TY_DCMPLX:
         sptr = CONVAL1G(sptr);
+        FLANG_FALLTHROUGH;
       case TY_DBLE:
         num[0] = CONVAL1G(sptr);
         num[1] = CONVAL2G(sptr);
@@ -2848,7 +2855,7 @@ replace_memsym_of_ast(int ast, SPTR sptr)
     if (A_TYPEG(A_MEMG(ast)) == A_ID) {
       return mk_member(A_PARENTG(ast), mk_id(sptr), A_DTYPEG(ast)); 
     }
-    /* else fall through to error */
+    FLANG_FALLTHROUGH;
   default:
     interr("replace_memsym_of_ast: unexpected ast", ast, 3);
   }
@@ -2950,7 +2957,7 @@ left_array_symbol(int ast)
       sptr = A_SPTRG(ast);
       if (DTY(DTYPEG(sptr)) == TY_ARRAY)
         return sptr;
-    /* FALLTHROUGH */
+      FLANG_FALLTHROUGH;
     case A_LABEL:
     case A_ENTRY:
       if (asym)
@@ -3002,6 +3009,7 @@ left_subscript_ast(int ast)
       if (DTY(DTYPEG(sptr)) == TY_ARRAY) {
         interr("left_subscript_ast: found unsubscripted array ID", ast, 3);
       }
+      FLANG_FALLTHROUGH;
     case A_LABEL:
     case A_ENTRY:
       if (aleft)
@@ -3057,6 +3065,7 @@ left_nonscalar_subscript_ast(int ast)
                " found unsubscripted array ID",
                ast, 3);
       }
+      FLANG_FALLTHROUGH;
     case A_LABEL:
     case A_ENTRY:
       if (aleft)
@@ -3150,7 +3159,9 @@ dist_ast(int ast)
       case ST_MEMBER:
         if (DISTG(sptr) || ALIGNG(sptr))
           return ast;
-      default:;
+        break;
+      default:
+        break;
       }
     }
   }
@@ -3207,7 +3218,7 @@ contiguous_array_section(int subscr_ast)
     case A_FUNC:
       if (A_SHAPEG(ast))
         return FALSE;
-    /* FALL THRU */
+      FLANG_FALLTHROUGH;
     case A_CNST:
     case A_BINOP:
     case A_UNOP:
@@ -3498,6 +3509,7 @@ replace_ast_subtree(int original, int subtree, int replacement)
     /* should not get here, the replacement should have
      * replaced the original by now */
     interr("replace_ast_subtree: unexpected ID ast", original, 3);
+    FLANG_FALLTHROUGH;
   default:
     interr("replace_ast_subtree: unexpected ast type", original, 3);
   }
@@ -7051,6 +7063,7 @@ ast_intr(int i_intr, DTYPE dtype, int cnt, ...)
       case TY_SINT:
         if ((sptr = GSINTG(sptr)))
           break;
+        FLANG_FALLTHROUGH;
       case TY_WORD:
       case TY_DWORD:
       case TY_BLOG:
@@ -7636,6 +7649,7 @@ find_pointer_variable(int ast)
     ast = A_MEMG(ast);
     if (A_TYPEG(ast) == A_ID)
       return (A_SPTRG(ast));
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -8421,11 +8435,13 @@ cngcon(INT oldval, int oldtyp, int newtyp)
     switch (from) {
     case TY_CMPLX:
       oldval = CONVAL1G(oldval);
+      FLANG_FALLTHROUGH;
     case TY_REAL:
       xfix(oldval, &result);
       return result;
     case TY_DCMPLX:
       oldval = CONVAL1G(oldval);
+      FLANG_FALLTHROUGH;
     case TY_DBLE:
       num[0] = CONVAL1G(oldval);
       num[1] = CONVAL2G(oldval);
@@ -8476,11 +8492,13 @@ cngcon(INT oldval, int oldtyp, int newtyp)
       switch (from) {
       case TY_CMPLX:
         oldval = CONVAL1G(oldval);
+        FLANG_FALLTHROUGH;
       case TY_REAL:
         xfix64(oldval, num);
         return getcon(num, newtyp);
       case TY_DCMPLX:
         oldval = CONVAL1G(oldval);
+        FLANG_FALLTHROUGH;
       case TY_DBLE:
         num1[0] = CONVAL1G(oldval);
         num1[1] = CONVAL2G(oldval);
@@ -8533,6 +8551,7 @@ cngcon(INT oldval, int oldtyp, int newtyp)
         return CONVAL1G(oldval);
       case TY_DCMPLX:
         oldval = CONVAL1G(oldval);
+        FLANG_FALLTHROUGH;
       case TY_DBLE:
         num[0] = CONVAL1G(oldval);
         num[1] = CONVAL2G(oldval);
@@ -8573,6 +8592,7 @@ cngcon(INT oldval, int oldtyp, int newtyp)
         return CONVAL1G(oldval);
       case TY_CMPLX:
         oldval = CONVAL1G(oldval);
+        FLANG_FALLTHROUGH;
       case TY_REAL:
         xdble(oldval, num);
         break;

--- a/tools/flang1/flang1exe/astout.c
+++ b/tools/flang1/flang1exe/astout.c
@@ -3259,6 +3259,7 @@ print_sname(int sym)
       put_string("::");
       break;
     }
+    FLANG_FALLTHROUGH;
   default:
     if (ENCLFUNCG(sym) && STYPEG(ENCLFUNCG(sym)) == ST_MODULE) {
       put_string(SYMNAME(ENCLFUNCG(sym)));
@@ -3935,7 +3936,7 @@ put_const(int sptr)
     sptr = CONVAL1G(sptr); /* sptr to char string constant */
     dtype = DTYPEG(sptr);
     put_l_to_u("nc");
-/*** fall thru ***/
+    FLANG_FALLTHROUGH;
   case TY_CHAR:
     from = stb.n_base + CONVAL1G(sptr);
     put_char('\'');

--- a/tools/flang1/flang1exe/bblock.c
+++ b/tools/flang1/flang1exe/bblock.c
@@ -1768,6 +1768,7 @@ eliminate_unused_variables(int which)
       case SC_BASED:
         if (MIDNUMG(sptr) && VISITG(MIDNUMG(sptr)))
           break;
+        FLANG_FALLTHROUGH;
       case SC_LOCAL:
       case SC_NONE:
       case SC_PRIVATE:

--- a/tools/flang1/flang1exe/datadep.c
+++ b/tools/flang1/flang1exe/datadep.c
@@ -2173,7 +2173,7 @@ mkSub(int astliTriples, int sub, int astmpyr, int ast)
      */
     if (!is_linear(A_LOPG(ast)))
       return FALSE;
-  /***** fall thru -- treat as ID *****/
+    FLANG_FALLTHROUGH;
   case A_ID:
     i = 0;
     for (astli = astliTriples; astli; astli = ASTLI_NEXT(astli), i++)
@@ -2826,7 +2826,7 @@ distrib(int ili, int mpyr)
       l->next = NULL;
       return l;
     }
-  /* continue into the default case */
+    FLANG_FALLTHROUGH;
   default:
     opc1 = ILI_OPC(mpyr);
     if (opc1 == IL_IADD) {
@@ -3102,20 +3102,24 @@ ILI_OPC(int astx)
       if (DT_ISBASIC(A_DTYPEG(astx)))
         return IL_IADD;
       interr("ILI_OPC: unknown dtype for ADD", astx, 4);
+      return 0;
     case OP_SUB:
       if (A_DTYPEG(astx) == DT_ADDR)
         return IL_ASUB;
       if (DT_ISBASIC(A_DTYPEG(astx)))
         return IL_ISUB;
       interr("ILI_OPC: unknown dtype for SUB", astx, 4);
+      return 0;
     case OP_MUL:
       if (DT_ISBASIC(A_DTYPEG(astx)))
         return IL_IMUL;
       interr("ILI_OPC: unknown dtype for MUL", astx, 4);
+      return 0;
     case OP_DIV:
       if (DT_ISBASIC(A_DTYPEG(astx)))
         return IL_IDIV;
       interr("ILI_OPC: unknown dtype for DIV", astx, 4);
+      return 0;
     default:
       return 0; /* opcode unknown */
     }

--- a/tools/flang1/flang1exe/dinit.c
+++ b/tools/flang1/flang1exe/dinit.c
@@ -1512,6 +1512,7 @@ dinit_eval(int ast)
     if (A_OPTYPEG(ast) == I_NULL) {
       return 0;
     }
+    FLANG_FALLTHROUGH;
   default:
     break;
   }

--- a/tools/flang1/flang1exe/dpm_out.c
+++ b/tools/flang1/flang1exe/dpm_out.c
@@ -1447,6 +1447,8 @@ transform_wrapup(void)
         if (IGNOREG(sptr) || CONSTRUCTSYMG(sptr) != i || EARLYSPECG(sptr) != j)
           continue;
         switch (STYPEG(sptr)) {
+        default:
+          break;
         case ST_VAR:
         case ST_ARRAY:
           wraplist[wrapcount++] = sptr;

--- a/tools/flang1/flang1exe/dtypeutl.c
+++ b/tools/flang1/flang1exe/dtypeutl.c
@@ -39,7 +39,7 @@ target_name(DTYPE dtype)
     if (XBIT(57, 0x200)) {
       return "complex*16";
     }
-  /* else fall through */
+    FLANG_FALLTHROUGH;
   case TY_LOG:
   case TY_INT:
   case TY_FLOAT:
@@ -559,6 +559,7 @@ size_ast(int sptr, DTYPE dtype)
 
   case TY_NCHAR:
     mlpyr = 2;
+    FLANG_FALLTHROUGH;
   case TY_CHAR:
     if (dtype == DT_ASSCHAR || dtype == DT_DEFERCHAR
         || dtype == DT_ASSNCHAR || dtype == DT_DEFERNCHAR
@@ -686,6 +687,7 @@ size_ast_of(int ast, DTYPE dtype)
 
   case TY_NCHAR:
     mlpyr = 2;
+    FLANG_FALLTHROUGH;
   case TY_CHAR:
     concat = 0;
     if (ast) {
@@ -1199,6 +1201,7 @@ alignment(DTYPE dtype)
   case TY_QCMPLX:
     if (!flg.dalign)
       return dtypeinfo[TY_INT].align;
+    FLANG_FALLTHROUGH;
   case TY_QUAD:
   case TY_WORD:
   case TY_HOLL:
@@ -2913,6 +2916,7 @@ pr_dent(DTYPE dt, FILE *f)
       fprintf(f, " +++++ MEMBER %d(%s)\n", ss, SYMNAME(ss));
       pr_dent(DTYPEG(ss), f);
     }
+    FLANG_FALLTHROUGH;
   default:
     break;
   }

--- a/tools/flang1/flang1exe/dump.c
+++ b/tools/flang1/flang1exe/dump.c
@@ -1640,6 +1640,7 @@ dastreex(int astx, int l, int notlast)
     break;
   case A_MP_ATOMICREAD:
     dastreex(A_SRCG(astx), l + 4, 0);
+    FLANG_FALLTHROUGH;
   case A_MP_ATOMICWRITE:
   case A_MP_ATOMICUPDATE:
   case A_MP_ATOMICCAPTURE:
@@ -1656,6 +1657,7 @@ dastreex(int astx, int l, int notlast)
     break;
   case A_MP_CANCEL:
     dastreex(A_IFPARG(astx), l + 4, 0);
+    FLANG_FALLTHROUGH;
   case A_MP_SECTIONS:
   case A_MP_CANCELLATIONPOINT:
     dastreex(A_ENDLABG(astx), l + 4, 0);

--- a/tools/flang1/flang1exe/exterf.c
+++ b/tools/flang1/flang1exe/exterf.c
@@ -911,6 +911,7 @@ export_module_subprogram(FILE *subprog_file, int subprog_sym, int limitsptr,
           Trace(("Ignore %d(%s) in %d(%s)", sptr, SYMNAME(sptr), subprog_sym,
                  SYMNAME(subprog_sym)));
         }
+        FLANG_FALLTHROUGH;
       case ST_TYPEDEF:
         if (SCOPEG(sptr) && (SCOPEG(sptr) != sym_module)) {
           /*
@@ -1364,9 +1365,11 @@ rqueue_ast(int ast, int *unused)
   case A_ID:
     if (A_ALIASG(ast) && A_ALIASG(ast) != ast)
       queue_ast(A_ALIASG(ast));
+    FLANG_FALLTHROUGH;
   case A_CNST:
     if (ast < ast_flag_lowest_const)
       ast_flag_lowest_const = ast;
+    FLANG_FALLTHROUGH;
   case A_LABEL:
   case A_INIT:
     if (A_SPTRG(ast) && A_SPTRG(ast) < symbol_flag_size)
@@ -1441,6 +1444,7 @@ rqueue_ast(int ast, int *unused)
     break;
   case A_MP_CANCEL:
     queue_ast(A_IFPARG(ast));
+    FLANG_FALLTHROUGH;
   case A_MP_SECTIONS:
   case A_MP_CANCELLATIONPOINT:
     queue_ast(A_ENDLABG(ast));
@@ -1984,6 +1988,7 @@ queue_symbol(int sptr)
       /* FS#17726 - export overloaded type */
       queue_symbol((int)GTYPEG(sptr));
     }
+    FLANG_FALLTHROUGH;
   case ST_OPERATOR:
     if (GSAMEG(sptr))
       queue_symbol((int)GSAMEG(sptr));
@@ -2795,7 +2800,7 @@ export_one_ast(int ast)
         lzprintf(outlz, "\n");
       }
     }
-  /* fall through to dump argt */
+    FLANG_FALLTHROUGH;
   case A_CALL:
   case A_ICALL:
   case A_ENDMASTER:

--- a/tools/flang1/flang1exe/fgraph.c
+++ b/tools/flang1/flang1exe/fgraph.c
@@ -281,8 +281,7 @@ flowgraph(void)
        * from happening.
        */
       CNTL_TOPFG(cntl.top) = 0;
-    /* fall thru */
-
+      FLANG_FALLTHROUGH;
     default:
     check_last_std:
       is_ujmp = FALSE;
@@ -675,7 +674,7 @@ partition_blocks(void)
         STD_KERNEL(s) = STD_KERNEL(std);
         cr_block(s);
       }
-    /*  fall thru  */
+      FLANG_FALLTHROUGH;
     case A_DOWHILE:
       wr_block();
       cr_block(std);
@@ -929,6 +928,7 @@ partition_blocks(void)
       break;
     case A_RETURN:
       STD_BR(std) = 1;
+      FLANG_FALLTHROUGH;
     default:
       chk_block(std);
       break;

--- a/tools/flang1/flang1exe/flow.c
+++ b/tools/flang1/flang1exe/flow.c
@@ -1211,6 +1211,7 @@ again:
   case A_CNST:
     if (!XBIT(7, 0x100000))
       break;
+    FLANG_FALLTHROUGH;
   default:
     interr("bld_use, ast nyd", ast, 3);
   }
@@ -1394,6 +1395,7 @@ again:
   case A_CNST:
     if (!XBIT(7, 0x100000))
       break;
+    FLANG_FALLTHROUGH;
   default:
     interr("bld_lhs, ast nyd", ast, 3);
     df = NULL;
@@ -1662,6 +1664,8 @@ add_store(int nme)
      */
     for (; 1; nme = NME_NM(nme)) {
       switch (NME_TYPE(nme)) {
+      default:
+        break;
 
       case NT_ARR:
       case NT_MEM:
@@ -1726,6 +1730,8 @@ add_store(int nme)
 #endif
 
     switch (NME_TYPE(nme)) {
+    default:
+      break;
 
     case NT_ARR:
       if (NME_SYM(nme))

--- a/tools/flang1/flang1exe/fpp.c
+++ b/tools/flang1/flang1exe/fpp.c
@@ -1993,6 +1993,7 @@ tobinary(char *st, int b)
       t = c - 'a' + 10;
       if (b > 10)
         break;
+      FLANG_FALLTHROUGH;
     case 'A':
     case 'B':
     case 'C':
@@ -2002,6 +2003,7 @@ tobinary(char *st, int b)
       t = c - 'A' + 10;
       if (b > 10)
         break;
+      FLANG_FALLTHROUGH;
     default:
       t = -1;
       if (c == 'l' || c == 'L' || c == 'u' || c == 'U')
@@ -2129,7 +2131,7 @@ again:
         goto nextok_ret;
       }
     }
-  /* FALL THROUGH */
+    FLANG_FALLTHROUGH;
   case 'A':
   case 'B':
   case 'D':
@@ -2424,8 +2426,7 @@ again:
         goto nextok_ret;
       }
     }
-  /* FALL THROUGH */
-
+    FLANG_FALLTHROUGH;
   default:
     switch (MASK(c)) {
     case NOFUNC:

--- a/tools/flang1/flang1exe/func.c
+++ b/tools/flang1/flang1exe/func.c
@@ -1358,6 +1358,7 @@ check_pointer_type(int past, int tast, int stmt, LOGICAL is_sourced_allocation)
       isNullAssn = true;
       break;
     }
+    FLANG_FALLTHROUGH;
   default:
     return;
   }
@@ -3451,7 +3452,7 @@ rewrite_sub_args(int arg_ast, int lc)
             sym = VTABLEG(sym);
             break;
           }
-        /* Fall Thru */
+          FLANG_FALLTHROUGH;
         default:
           sym = A_SPTRG(A_LOPG(arg));
         }
@@ -4159,6 +4160,7 @@ rewrite_calls(void)
     case A_MP_CANCEL:
       a = rewrite_sub_ast(A_IFPARG(ast), 0);
       A_IFPARP(ast, a);
+      FLANG_FALLTHROUGH;
     case A_MP_SECTIONS:
     case A_MP_CANCELLATIONPOINT:
       a = rewrite_sub_ast(A_ENDLABG(ast), 0);
@@ -4530,6 +4532,7 @@ search_conform_array(int ast, int flag)
       if (A_SHAPEG(ARGT_ARG(argt, i)))
         if ((j = search_conform_array(ARGT_ARG(argt, i), flag)) != 0)
           return j;
+    FLANG_FALLTHROUGH;
   case A_FUNC:
     if (elemental_func_call(ast)) {
       /* search up to all arguments of elemental function for
@@ -5784,7 +5787,7 @@ inline_reduction_f90(int ast, int dest, int lc, LOGICAL *doremove)
   case I_MAXLOC:
   case I_MINLOC:
     dtypeval = DDTG(A_DTYPEG(ARGT_ARG(args, 0)));
-  /* fall through */
+    FLANG_FALLTHROUGH;
   case I_MAXVAL:
   case I_MINVAL:
     astdim = ARGT_ARG(args, 1);

--- a/tools/flang1/flang1exe/inliner.c
+++ b/tools/flang1/flang1exe/inliner.c
@@ -1518,6 +1518,7 @@ move_labels(int stdstart, int stdlast)
     case A_ENDFORALL:
     case A_ELSEFORALL:
       interr("move_labels: statement not handled", std, 4);
+      FLANG_FALLTHROUGH;
     default:
       STD_LABEL(std) = sptrLbl;
       break;

--- a/tools/flang1/flang1exe/interf.c
+++ b/tools/flang1/flang1exe/interf.c
@@ -2778,6 +2778,7 @@ exit_loop:
             DLLG(ps->new_sptr) == DLL_EXPORT) {
           DLLP(ps->new_sptr, DLL_IMPORT);
         }
+        FLANG_FALLTHROUGH;
       case ST_CMBLK:
         if (stb.curr_scope != curr_scope()->sptr &&
             DLLG(ps->new_sptr) == DLL_EXPORT) {
@@ -5983,7 +5984,7 @@ fill_links_symbol(SYMITEM *ps, WantPrivates wantPrivates)
     if (CLASSG(sptr) && TBPLNKG(sptr) && can_find_dtype(TBPLNKG(sptr))) {
       TBPLNKP(sptr, new_dtype(TBPLNKG(sptr)));
     }
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case ST_STFUNC:
   case ST_PD:
   case ST_ISOC:

--- a/tools/flang1/flang1exe/lower.c
+++ b/tools/flang1/flang1exe/lower.c
@@ -760,7 +760,8 @@ trav_struct(int dtype, int off)
     if (sizeof(DT_QUAD) == 16)
       interr("trav_struct: update handling of long doubles", dtype, 3);
 #endif
-  /* we're treating this like DBLE for now. */
+    /* We're treating this like DBLE for now. */
+    FLANG_FALLTHROUGH;
   case TY_DBLE:
     regclass[regi] = CLASS_SSEDP;
     return;

--- a/tools/flang1/flang1exe/lowerexp.c
+++ b/tools/flang1/flang1exe/lowerexp.c
@@ -594,6 +594,7 @@ conv_blog_ilm(int ast, int ilm, int dtype)
   case TY_INT8:
     ilm = plower("oi", "I8TOI", ilm);
     ilm = plower("oi", "ITOSC", ilm);
+    FLANG_FALLTHROUGH;
   case TY_WORD:
     if (ast && A_TYPEG(ast) == A_CNST) {
       s = lower_getintcon(cngcon(CONVAL2G(A_SPTRG(ast)), DTYG(dtype), DT_SLOG));
@@ -942,6 +943,7 @@ conv_dble_ilm(int ast, int ilm, int dtype)
   case TY_SINT:
   case TY_SLOG:
     ilm = conv_int_ilm(ast, ilm, dtype);
+    FLANG_FALLTHROUGH;
   case TY_LOG:
   case TY_INT:
     ilm = plower("oi", "DFLOAT", ilm);
@@ -1014,6 +1016,7 @@ conv_cmplx_ilm(int ast, int ilm, int dtype)
   case TY_SINT:
   case TY_SLOG:
     ilm = conv_int_ilm(ast, ilm, dtype);
+    FLANG_FALLTHROUGH;
   case TY_LOG:
   case TY_INT:
     ilm = plower("oi", "FLOAT", ilm);
@@ -1091,6 +1094,7 @@ conv_dcmplx_ilm(int ast, int ilm, int dtype)
   case TY_SINT:
   case TY_SLOG:
     ilm = conv_int_ilm(ast, ilm, dtype);
+    FLANG_FALLTHROUGH;
   case TY_LOG:
   case TY_INT:
     ilm = plower("oi", "DFLOAT", ilm);
@@ -2049,6 +2053,7 @@ lower_function(int ast)
         sptr = A_SPTRG(A_MEMG(a));
         if (param && POINTERG(param) && POINTERG(sptr))
           goto by_reference;
+        FLANG_FALLTHROUGH;
       case A_INTR:
         if (is_iso_cloc(a)) {
           /* byval C_LOC(x) == regular pass by reference (X),
@@ -2057,7 +2062,7 @@ lower_function(int ast)
           a = ARGT_ARG(A_ARGSG(a), 0);
           goto by_reference;
         }
-      /* default fall through */
+        FLANG_FALLTHROUGH;
       default:
       /* expressions & scalar variables -- always emit BYVAL.
        * expand will take do the right thing for nonscalar
@@ -4480,6 +4485,7 @@ lower_intrinsic(int ast)
   case I_INDEX:
   case I_KINDEX:
     ilm = lower_conv_ilm(ast, ilm, fromdtype, A_NDTYPEG(ast));
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -4656,6 +4662,7 @@ lower_ast(int ast, int *unused)
       lilm = lower_conv(A_LOPG(ast), DT_REAL4);
       rilm = lower_conv(A_ROPG(ast), DT_REAL4);
       ilm = plower("oii", "CMPLX", lilm, rilm);
+      FLANG_FALLTHROUGH;
     case TY_DCMPLX:
       lilm = lower_conv(A_LOPG(ast), DT_REAL8);
       rilm = lower_conv(A_ROPG(ast), DT_REAL8);

--- a/tools/flang1/flang1exe/lowerilm.c
+++ b/tools/flang1/flang1exe/lowerilm.c
@@ -433,6 +433,7 @@ lower_start_stmt(int lineno, int label, int exec, int std)
       case A_CONTINUE:
         if (STD_LABEL(prev))
           goto exitloop;
+        FLANG_FALLTHROUGH;
       case A_COMMENT:
         break;
       default:
@@ -990,7 +991,7 @@ handle_arguments(int ast, int symfunc, int via_ptr)
       }
       break;
     }
-  /* else fall thru */
+    FLANG_FALLTHROUGH;
   default:
     tbp_mem = tbp_pass_arg = tbp_bind = 0;
   }
@@ -1122,6 +1123,7 @@ handle_arguments(int ast, int symfunc, int via_ptr)
         sptr = A_SPTRG(A_MEMG(a));
         if (param && POINTERG(param) && POINTERG(sptr))
           goto by_reference;
+        FLANG_FALLTHROUGH;
       case A_INTR:
         if (is_iso_cloc(a)) {
           /* byval C_LOC(x) == regular pass by reference (X),
@@ -1130,7 +1132,7 @@ handle_arguments(int ast, int symfunc, int via_ptr)
           a = ARGT_ARG(A_ARGSG(a), 0);
           goto by_reference;
         }
-      /* default fall through */
+        FLANG_FALLTHROUGH;
       default:
       /* expressions & scalar variables -- always emit BYVAL.
        * expand will take do the right thing for nonscalar
@@ -1274,7 +1276,7 @@ handle_arguments(int ast, int symfunc, int via_ptr)
               sym = VTABLEG(sym);
               break;
             }
-          /* Fall Thru */
+            FLANG_FALLTHROUGH;
           default:
             sym = 0;
           }
@@ -4341,6 +4343,7 @@ lower_stmt(int std, int ast, int lineno, int label)
        * fall through */
       break;
     }
+    FLANG_FALLTHROUGH;
   case A_CALL:
     lower_start_stmt(lineno, label, TRUE, std);
     lop = A_LOPG(ast);
@@ -4527,7 +4530,7 @@ lower_stmt(int std, int ast, int lineno, int label)
       lower_push(0);
     }
     lower_push(STKCANCEL);
-
+    FLANG_FALLTHROUGH;
   case A_DO:
     lower_do_stmt(std, ast, lineno, label);
     break;
@@ -5743,6 +5746,7 @@ lower_base_address(int ast, int pointerval)
     switch (pointerval) {
     case SourceBase:
       base = plower("oi", "LOC", base);
+      FLANG_FALLTHROUGH;
     case VarBase:
     case TargetBase:
     case ArgumentBase:
@@ -6006,6 +6010,7 @@ lower_ilm(int ast)
       /* should only reach here if no conversion was needed anyway */
       lop = A_LOPG(ast);
       ilm = lower_ilm(lop);
+      FLANG_FALLTHROUGH;
     default:
       break;
     }

--- a/tools/flang1/flang1exe/lowersym.c
+++ b/tools/flang1/flang1exe/lowersym.c
@@ -134,7 +134,7 @@ lower_set_symbols(void)
           }
         }
       }
-    /* fall through */
+      FLANG_FALLTHROUGH;
     case ST_MEMBER:
     case ST_DESCRIPTOR:
       if (!IGNOREG(sptr) && DTY(DTYPEG(sptr)) == TY_ARRAY) {
@@ -144,7 +144,7 @@ lower_set_symbols(void)
           VISIT2P(sptr, 1);
         }
       }
-    /* fall through */
+      FLANG_FALLTHROUGH;
     case ST_VAR:
       if (SCG(sptr) == SC_BASED) {
         /* look at section descriptor, pointer */
@@ -900,8 +900,7 @@ lower_prepare_symbols()
           fill_fixed_array_dtype(dtype);
         }
       }
-      /* fall through */
-
+      FLANG_FALLTHROUGH;
     case ST_VAR:
     case ST_IDENT:
     case ST_STRUCT:
@@ -1083,6 +1082,7 @@ lower_prepare_symbols()
       if (fval) {
         CCSYMP(fval, 1);
       }
+      FLANG_FALLTHROUGH;
     default:
       break;
     }
@@ -1949,6 +1949,7 @@ lower_visit_symbol(int sptr)
     if (SCG(sptr) == SC_NONE) {
       SCP(sptr, SC_LOCAL);
     }
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -5453,6 +5454,7 @@ llvm_check_retval_inargs(int sptr)
           SCP(fval, SC_DUMMY);
         }
       }
+      FLANG_FALLTHROUGH;
     case TY_DCMPLX:
       if (DTY(ent_dtype) != TY_DCMPLX) {
         return;

--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -1560,6 +1560,7 @@ check_sc(int sptr)
       mdalloc_list = px;
       break;
     }
+    FLANG_FALLTHROUGH;
   case SC_CMBLK:
     MDALLOCP(sptr, 0);
     break;
@@ -1598,7 +1599,7 @@ check_sc(int sptr)
         break;
       }
     }
-  /* else fall thru */
+    FLANG_FALLTHROUGH;
   default:
 #ifdef DEVICEG
     propagate_device_flags(sptr);

--- a/tools/flang1/flang1exe/optutil.c
+++ b/tools/flang1/flang1exe/optutil.c
@@ -951,6 +951,7 @@ _avail(int expr, LOGICAL *av_p)
           *av_p = FALSE;
           return TRUE;
         }
+        FLANG_FALLTHROUGH;
       case NT_ARR:
       case NT_MEM:
       case NT_UNK:
@@ -2179,9 +2180,11 @@ is_ptrast_arg(int ptrast, int ast)
             astx = A_LOPG(ptrast);
           if (memsym_of_ast(astx) == sptr)
             return FALSE; /* not safe */
+          FLANG_FALLTHROUGH;
         case A_MEM:
           if (is_parentof_ast(ele, ptrast))
             return FALSE;
+          FLANG_FALLTHROUGH;
         case A_SUBSCR:
         default:
           break;

--- a/tools/flang1/flang1exe/outconv.c
+++ b/tools/flang1/flang1exe/outconv.c
@@ -405,7 +405,7 @@ convert_omp_workshare(void)
         } else if (HCCSYMG(lsptr) && SCG(lsptr) == SC_PRIVATE) {
           break;
         }
-      /* FALL THRU */
+        FLANG_FALLTHROUGH;
       default:
         single = mk_stmt(A_MP_SINGLE, 0);
         add_stmt_before(single, std);
@@ -2699,7 +2699,7 @@ convert_template_instance(void)
           }
         }
       }
-    /* FALL THROUGH */
+      FLANG_FALLTHROUGH;
     default:
       ast_visit(1, 1);
       ast_traverse(ast, NULL, _mark_descr, &dummy);
@@ -5108,6 +5108,7 @@ eliminate_barrier(void)
        * top of a pghpf_local_mode region */
       at = at_local_mode(ast);
       bLocal += at;
+      FLANG_FALLTHROUGH;
     default:
       bFound = FALSE;
       break;

--- a/tools/flang1/flang1exe/rest.c
+++ b/tools/flang1/flang1exe/rest.c
@@ -722,6 +722,7 @@ copy_to_scalar(int ast, int std, int sym)
       if (DESCARRAYG(sptr))
         break;
     }
+    FLANG_FALLTHROUGH;
   default:
     if (!pure_gbl.local_mode) {
       LOGICAL rhs_is_dist = FALSE;
@@ -1408,7 +1409,7 @@ transform_call(int std, int ast)
         }
         break;
       }
-    /* FALL THROUGH */
+      FLANG_FALLTHROUGH;
     case A_CNST:
       if (DTY(A_DTYPEG(ele)) == TY_HOLL) {
         /* treat as sequence-associated */
@@ -1421,7 +1422,7 @@ transform_call(int std, int ast)
         }
         break;
       }
-    /* FALL THROUGH */
+      FLANG_FALLTHROUGH;
     case A_BINOP:
     case A_PAREN:
     case A_CMPLXC:

--- a/tools/flang1/flang1exe/scan.c
+++ b/tools/flang1/flang1exe/scan.c
@@ -618,6 +618,7 @@ again:
 
   case ';': /* statement separator; set flag and ... */
     scn.multiple_stmts = TRUE;
+    FLANG_FALLTHROUGH;
   case '!':  /* inline comment character .. treat like end
               * of line character .......   */
   case '\n': /* return end of statement token: */
@@ -1115,7 +1116,7 @@ get_stmt(void)
     case CT_SMP:
       is_smp = TRUE;
       is_sgi = sentinel == SL_SGI;
-    /* fall thru */
+      FLANG_FALLTHROUGH;
     case CT_INITIAL:
     initial_card:
       gbl.in_include = in_include;
@@ -1284,7 +1285,7 @@ get_stmt(void)
         sem.submod_sym = 0;
       }
       finish();
-
+      FLANG_FALLTHROUGH;
     case CT_DIRECTIVE:
       put_astfil(curr_line, &printbuff[8], TRUE);
       put_lineno(curr_line);
@@ -2408,6 +2409,7 @@ crunch(void)
 #if DEBUG
           case '=':
             interr("crunch ==", 3, 2);
+            FLANG_FALLTHROUGH;
 #endif
           case '<':
           case '>':
@@ -2971,7 +2973,7 @@ classify_smp(void)
         }
       }
     }
-  /* fall thru to end_shared_nowait: */
+    FLANG_FALLTHROUGH;
   case TK_MP_ENDSECTIONS:
   case TK_MP_ENDSIMD:
   case TK_MP_ENDSINGLE:
@@ -3116,6 +3118,7 @@ classify_smp(void)
           cp -= 8;
           break;
         }
+        FLANG_FALLTHROUGH;
       case 's':
         if (strncmp(cp, "simd", 4) == 0) {
           scn.stmtyp = tkntyp = TK_MP_ENDDISTSIMD;
@@ -3149,7 +3152,7 @@ classify_smp(void)
         break;
       }
     }
-  /* fall thru to end_shared: */
+    FLANG_FALLTHROUGH;
   case TK_MP_ENDCRITICAL:
   case TK_MP_ENDMASTER:
   case TK_MP_ENDORDERED:
@@ -3238,6 +3241,7 @@ classify_smp(void)
           cp -= 8;
           break;
         }
+        FLANG_FALLTHROUGH;
       case 's':
         if (strncmp(cp, "simd", 4) == 0) {
           scn.stmtyp = tkntyp = TK_MP_ENDTARGTEAMSDISTSIMD;
@@ -3389,6 +3393,7 @@ classify_smp(void)
       cp += 4 + 1;
       scn.stmtyp = tkntyp = TK_MP_PARDOSIMD;
     }
+    FLANG_FALLTHROUGH;
   case TK_MP_PARSECTIONS:
   case TK_MP_PARWORKSHR:
   case TK_MP_PARDOSIMD:
@@ -4066,6 +4071,7 @@ classify_dec(void)
       }
       goto ill_dec;
     }
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -4800,6 +4806,7 @@ alpha(void)
             integer_only = TRUE;
           goto alpha_exit;
         }
+        FLANG_FALLTHROUGH;
       case TKF_DOUBLE:
         tkntyp = double_type(&currc[idlen], &idlen);
         if (tkntyp) {
@@ -4842,7 +4849,7 @@ alpha(void)
       scmode = SCM_DEFINED_IO;
       goto return_identifier;
     }
-  /* fall thru  */
+    FLANG_FALLTHROUGH;
   case SCM_OPERATOR:
     scmode = SCM_FIRST;
     if (scn.stmtyp == TK_USE) {
@@ -5240,7 +5247,7 @@ get_keyword:
       scmode = SCM_FIRST;
       break;
     }
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case TK_RECORD:
   case TK_STRUCTURE:
     scmode = SCM_IDENT;
@@ -5309,7 +5316,7 @@ get_keyword:
     scn.stmtyp = tkntyp = double_type(&currc[idlen], &idlen);
     if (tkntyp == 0)
       goto return_identifier;
-    // fall through
+    FLANG_FALLTHROUGH;
   case TK_DBLEPREC:
   case TK_DBLECMPLX:
   case TK_BYTE:
@@ -5400,6 +5407,7 @@ get_keyword:
   case TK_INQUIRE:
     past_equal = TRUE;
     reset_past_equal = FALSE;
+    FLANG_FALLTHROUGH;
   case TK_BACKSPACE:
   case TK_CLOSE:
   case TK_DECODE:
@@ -5749,7 +5757,7 @@ get_keyword:
       idlen -= 4;
       break;
     }
-    // fall through
+    FLANG_FALLTHROUGH;
   case TK_ENDFUNCTION:
   case TK_ENDPROCEDURE:
   case TK_ENDPROGRAM:
@@ -5789,6 +5797,7 @@ get_keyword:
     if (!sem.in_enum) {
       goto return_identifier;
     }
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -7819,7 +7828,7 @@ ff_get_stmt(void)
         sem.submod_sym = 0;
       }
       finish();
-
+      FLANG_FALLTHROUGH;
     case CT_DIRECTIVE:
       put_astfil(curr_line, &printbuff[8], TRUE);
       put_lineno(curr_line);
@@ -7894,7 +7903,7 @@ ff_get_stmt(void)
     case CT_SMP:
       is_smp = TRUE;
       is_sgi = sentinel == SL_SGI;
-    /* fall thru */
+      FLANG_FALLTHROUGH;
     case CT_INITIAL:
     initial_card:
       gbl.in_include = in_include;
@@ -8524,7 +8533,7 @@ ff_get_noncomment(char *inptr)
      *
      */
     card_type = CT_CONTINUATION;
-  /* fall thru  */
+    FLANG_FALLTHROUGH;
   case CT_INITIAL:
   case CT_CONTINUATION:
   cont_shared:
@@ -8779,7 +8788,7 @@ _write_token(int tk, INT ctkv)
     break;
   case TK_EOL:
     currCol = 0;
-  /* fall through to default case */
+    FLANG_FALLTHROUGH;
   default:
     fprintf(astb.astfil, " %d", currCol);
     break;
@@ -9291,7 +9300,7 @@ _rd_token(INT *tknv)
     break;
   case TK_HOLLERITH:
     kind = get_num(10);
-    /* fall thru */
+    FLANG_FALLTHROUGH;
   case TK_FMTSTR:
   case TK_STRING:
   case TK_KSTRING:

--- a/tools/flang1/flang1exe/scopestack.c
+++ b/tools/flang1/flang1exe/scopestack.c
@@ -514,7 +514,6 @@ kind_to_string(SCOPEKIND kind)
   case SCOPE_INTERFACE:  return "Interface";
   case SCOPE_USE:        return "Use";
   case SCOPE_PAR:        return "Par";
-  default:               return "<unknown>";
   }
 }
 

--- a/tools/flang1/flang1exe/semant.c
+++ b/tools/flang1/flang1exe/semant.c
@@ -3015,7 +3015,7 @@ semant1(int rednum, SST *top)
    */
   case BLOCK_STMT1:
     set_construct_name(0);
-    // fall through
+    FLANG_FALLTHROUGH;
   case BLOCK_STMT2:
     if (DI_NEST(sem.doif_depth) >= DI_B(DI_FIRST_DIRECTIVE) && !XBIT(59,8))
       error(1219, ERR_Severe, gbl.lineno,
@@ -4689,7 +4689,7 @@ semant1(int rednum, SST *top)
     } else {
       defer_put_kind_type_param(sem.param_offset, -1, np, 0, ast, 1);
     }
-
+    FLANG_FALLTHROUGH;
   /* ------------------------------------------------------------------ */
   /*
    *	<opt comma> ::= |
@@ -10714,8 +10714,7 @@ procedure_stmt:
             } else if ((da_type == DA_VALUE) || (da_type == DA_REFERENCE)) {
               break;
             }
-
-          /*  fall thru  */
+            FLANG_FALLTHROUGH;
           default:
             error(84, 3, gbl.lineno, SYMNAME(sptr),
                   "- must be defined for ATTRIBUTES");
@@ -11610,7 +11609,7 @@ proc_dcl_init:
 
     if (SST_FIRSTG(RHS(3)) & 0x1 && SST_LSYMG(RHS(3)))
       SST_LSYMP(RHS(1), SST_LSYMG(RHS(3)));
-
+    FLANG_FALLTHROUGH;
   /*
    *	<binding attr list> ::= <binding attr>
    */
@@ -12472,6 +12471,7 @@ gen_dinit(int sptr, SST *stkptr)
   case ST_UNKNOWN:
   case ST_IDENT:
     STYPEP(sptr, ST_VAR);
+    FLANG_FALLTHROUGH;
   case ST_VAR:
   case ST_ARRAY:
     if (SCG(sptr) == SC_NONE)
@@ -14415,13 +14415,14 @@ _do_iface(int iface_state, int i)
     goto iface_err;
   case ST_GENERIC:
     iface = GSAMEG(iface);
+    FLANG_FALLTHROUGH;
   case ST_INTRIN:
   case ST_PD:
     iface = iface_intrinsic(iface);
     if (!iface) {
       goto iface_err;
     }
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case ST_ENTRY:
   case ST_PROC:
     paramct = PARAMCTG(iface);
@@ -16727,8 +16728,6 @@ sem_pgphase_name()
     return "INTERNAL";
   case PHASE_END:
     return "END";
-  default:
-    return "unknown";
   }
 }
 

--- a/tools/flang1/flang1exe/semant2.c
+++ b/tools/flang1/flang1exe/semant2.c
@@ -1170,6 +1170,7 @@ semant2(int rednum, SST *top)
         case ST_PD:
           if (!EXPSTG(sptr))
             break;
+          FLANG_FALLTHROUGH;
         default:
           error(84, 3, gbl.lineno, SYMNAME(sptr),
                 "as a dummy argument to a statement function");

--- a/tools/flang1/flang1exe/semant3.c
+++ b/tools/flang1/flang1exe/semant3.c
@@ -247,7 +247,7 @@ semant3(int rednum, SST *top)
         error(155, 3, gbl.lineno, SYMNAME(gbl.currsub),
               "- ELEMENTAL subprograms may not contain OpenMP directives");
     }
-  /*  fall thru  */
+    FLANG_FALLTHROUGH;
   /*
    *	<simple stmt> ::= <pragma stmt> |
    */
@@ -2516,7 +2516,7 @@ errorstop_shared:
    */
   case ASSOCIATE_STMT1:
     construct_name = 0;
-  /* FALLTHROUGH */
+    FLANG_FALLTHROUGH;
   case ASSOCIATE_STMT2:
     rhstop = rednum == ASSOCIATE_STMT1 ? 3 : 5;
     itemp = SST_BEGG(RHS(rhstop));
@@ -2588,7 +2588,7 @@ errorstop_shared:
    */
   case SELECT_TYPE_STMT1:
     construct_name = 0;
-  /* FALLTHROUGH */
+    FLANG_FALLTHROUGH;
   case SELECT_TYPE_STMT2:
     rhstop = rednum == SELECT_TYPE_STMT1 ? 3 : 5;
     NEED_DOIF(doif, DI_SELECT_TYPE);
@@ -3038,6 +3038,8 @@ errorstop_shared:
     }
     /* treat logical like integer */
     switch (dtype) {
+    default:
+      break;
     case DT_BLOG:
       dtype = DT_BINT;
       break;
@@ -3491,7 +3493,7 @@ errorstop_shared:
         msg = 1044; // 2018-C1124 -- sptr is not a variable
         break;
       }
-      // fall through
+      FLANG_FALLTHROUGH;
     case ST_UNKNOWN: // potential keyword as an identifier
     case ST_IDENT:
     case ST_VAR:
@@ -3523,7 +3525,7 @@ errorstop_shared:
         DI_CONC_ERROR_SYMS(doif) = add_symitem(sptr, DI_CONC_ERROR_SYMS(doif));
         break;
       }
-      // fall through
+      FLANG_FALLTHROUGH;
     case TK_LOCAL:
       if (sptr < DI_CONC_SYMAVL(doif)) {
         // sptr is external to the loop; get a construct instance.
@@ -4555,7 +4557,7 @@ errorstop_shared:
         case ST_UNKNOWN:
         case ST_IDENT:
           STYPEP(sptr, ST_VAR);
-        /*  fall thru  */
+          FLANG_FALLTHROUGH;
         case ST_VAR:
           if (SDSCG(sptr) == 0 && !F90POINTERG(sptr)) {
             if (SCG(sptr) == SC_NONE)
@@ -4979,6 +4981,7 @@ errorstop_shared:
     case S_LVALUE:
       SST_DBEGP(LHS, itemp);
       SST_DENDP(LHS, itemp);
+      FLANG_FALLTHROUGH;
     default:
       break;
     }
@@ -5859,7 +5862,7 @@ check_doconcurrent_ast(int ast, int *doif)
             "Intrinsic subroutine call in DO CONCURRENT", name);
       break;
     }
-    // fall through
+    FLANG_FALLTHROUGH;
   case A_FUNC:
   case A_INTR:
     if (DI_CONC_KIND(*doif) == DC_HEADER)
@@ -5921,7 +5924,7 @@ check_doconcurrent_ast(int ast, int *doif)
       error(1050, ERR_Severe, gbl.lineno, "Branch out of", CNULL); // 2018-C1138
       break;
     }
-    // fall through
+    FLANG_FALLTHROUGH;
   case A_CGOTO:
     for (astli = A_LISTG(ast); astli; astli = ASTLI_NEXT(astli)) {
       sptr = A_SPTRG(ASTLI_AST(astli));

--- a/tools/flang1/flang1exe/semantio.c
+++ b/tools/flang1/flang1exe/semantio.c
@@ -4793,6 +4793,7 @@ put_edit(int code)
     case 2: /* a comma was just seen */
       if (code == FED_RPAREN)
         ERR170("right parenthesis occurred after comma in FORMAT");
+      FLANG_FALLTHROUGH;
     /*
      * fall through for state transition
      */

--- a/tools/flang1/flang1exe/semfin.c
+++ b/tools/flang1/flang1exe/semfin.c
@@ -2186,7 +2186,8 @@ nml_check_item(int sptr)
   switch (STYPEG(sptr)) {
   case ST_UNKNOWN:
   case ST_IDENT:
-    STYPEP(sptr, ST_VAR); /* fall thru */
+    STYPEP(sptr, ST_VAR);
+    FLANG_FALLTHROUGH;
   case ST_VAR:
     if (SCG(sptr) == SC_DUMMY) {
       if (DTY(DDTG(dtype)) != TY_CHAR)
@@ -2885,7 +2886,7 @@ _available_size(int ast)
       return TRUE;
     if (ast == astb.ptr0c)
       return TRUE;
-  /* fall through */
+    FLANG_FALLTHROUGH;
   case A_PAREN:
   case A_CONV:
     if (_available_size(A_LOPG(ast))) {
@@ -2897,7 +2898,7 @@ _available_size(int ast)
     if (!HCCSYMG(A_SPTRG(lop))) {
       return FALSE;
     }
-  /* fall through */
+    FLANG_FALLTHROUGH;
   case A_INTR:
     firstarg = 0;
     narg = A_ARGCNTG(ast);
@@ -2996,7 +2997,7 @@ _available(int ast)
       return TRUE;
     if (ast == astb.ptr0c)
       return TRUE;
-  /* fall through */
+    FLANG_FALLTHROUGH;
   case A_PAREN:
   case A_CONV:
     if (_available(A_LOPG(ast))) {
@@ -3008,7 +3009,7 @@ _available(int ast)
     if (!HCCSYMG(A_SPTRG(lop))) {
       return FALSE;
     }
-  /* fall through */
+    FLANG_FALLTHROUGH;
   case A_INTR:
     firstarg = 0;
     narg = A_ARGCNTG(ast);
@@ -3197,7 +3198,7 @@ misc_checks(void)
         /* unreferenced symbol in host subprogram; set storage class */
         STYPEP(sptr, ST_VAR);
       }
-    /* fall through */
+      FLANG_FALLTHROUGH;
     case ST_ARRAY:
     case ST_VAR:
       if (gbl.internal == 1 && SCG(sptr) == SC_NONE) {
@@ -3424,7 +3425,7 @@ misc_checks(void)
         case ST_IDENT:
           if (SCG(sptr) != SC_NONE)
             break;
-          // fall through
+          FLANG_FALLTHROUGH;
         case ST_VAR:
         case ST_ARRAY:
         case ST_PARAM:

--- a/tools/flang1/flang1exe/semfunc.c
+++ b/tools/flang1/flang1exe/semfunc.c
@@ -132,6 +132,7 @@ get_static_type_descriptor(int sptr)
       sptr = DTY(dtype + 3);
       break;
     }
+    FLANG_FALLTHROUGH;
   default:
     return 0; /* TBD - probably need other cases for unlimited
                * polymorphic entities.
@@ -594,6 +595,8 @@ in_kernel_region()
   int df;
   for (df = 1; df <= sem.doif_depth; df++) {
     switch (DI_ID(df)) {
+    default:
+      break;
     case DI_CUFKERNEL:
     case DI_ACCDO:
     case DI_ACCLOOP:
@@ -4268,6 +4271,7 @@ ref_intrin(SST *stktop, ITEM *list)
     case TY_SINT:
       if ((sptr = GSINTG(sptre)))
         break;
+      FLANG_FALLTHROUGH;
     case TY_WORD:
     case TY_LOG:
     case TY_INT:
@@ -4308,6 +4312,7 @@ ref_intrin(SST *stktop, ITEM *list)
         A_OPTYPEP(SST_ASTG(stktop), intrin);
         return 1;
       }
+      FLANG_FALLTHROUGH;
     default:
       sptr = 0;
       break;
@@ -5117,6 +5122,7 @@ no_const_fold:
         switch (opc) {
         case IM_ICHAR:
           dtyper = stb.user.dt_int;
+          FLANG_FALLTHROUGH;
         case IM_NCHAR:
         case IM_NINDEX:
         case IM_NLEN:
@@ -5303,7 +5309,7 @@ no_const_fold:
       ARG_AST(2) = mk_cval((INT)bits_in((int)DDTG(f_dt)), DT_INT);
       count++;
     }
-  /*  fall thru  */
+    FLANG_FALLTHROUGH;
   default: /* name is just the name of the specific or generic */
   use_intr_sym:
     func_ast = mk_id(sptre);
@@ -5812,6 +5818,7 @@ ref_pd(SST *stktop, ITEM *list)
   case PD_dotproduct:
     if (!XBIT(49, 0x40)) /* if xbit set, CM fortran intrinsics allowed */
       goto bad_args;
+    FLANG_FALLTHROUGH;
   case PD_dot_product:
     if (count != 2) {
       E74_CNT(pdsym, count, 2, 2);
@@ -6202,7 +6209,7 @@ ref_pd(SST *stktop, ITEM *list)
     if (!XBIT(49, 0x40)) /* if xbit set, CM fortran intrinsics allowed */
       goto bad_args;
     pdtype = PD_ubound;
-  /*  fall thru  */
+    FLANG_FALLTHROUGH;
   case PD_lbound:
   case PD_ubound:
   lbound_ubound:
@@ -7224,6 +7231,7 @@ ref_pd(SST *stktop, ITEM *list)
   case PD_dshape:
     if (!XBIT(49, 0x40)) /* if xbit set, CM fortran intrinsics allowed */
       goto bad_args;
+    FLANG_FALLTHROUGH;
   case PD_shape:
     if (count < 1 || count > 2) {
       E74_CNT(pdsym, count, 1, 2);
@@ -7680,6 +7688,7 @@ ref_pd(SST *stktop, ITEM *list)
   case PD_dsize:
     if (!XBIT(49, 0x40)) /* if xbit set, CM fortran intrinsics allowed */
       goto bad_args;
+    FLANG_FALLTHROUGH;
   case PD_size:
     if (count == 0 || count > 3) {
       E74_CNT(pdsym, count, 1, 3);
@@ -9235,6 +9244,7 @@ ref_pd(SST *stktop, ITEM *list)
         conval = pdtype == PD_maxexponent ? 8189 : -8188;
       else
         conval = pdtype == PD_maxexponent ? 16384 : -16381;
+      FLANG_FALLTHROUGH;
     default:
       E74_ARG(pdsym, 0, NULL);
       goto call_e74_arg;

--- a/tools/flang1/flang1exe/semfunc2.c
+++ b/tools/flang1/flang1exe/semfunc2.c
@@ -637,7 +637,7 @@ again:
     case ST_UNKNOWN:
     case ST_IDENT:
       STYPEP(sptr, ST_VAR);
-    /* fall through to ... */
+      FLANG_FALLTHROUGH;
     case ST_VAR:
     case ST_ARRAY:
       if (DTY(DTYPEG(sptr)) != TY_ARRAY || DDTG(DTYPEG(sptr)) == DT_DEFERCHAR ||
@@ -863,6 +863,7 @@ intrinsic_as_arg(int intr)
     sp2 = select_gsame(intr);
     if (sp2 == 0)
       return 0;
+    FLANG_FALLTHROUGH;
   case ST_PD:
   case ST_INTRIN:
     cp = PNMPTRG(sp2);
@@ -1166,7 +1167,7 @@ chkarg(SST *stkptr, int *dtype)
       case ST_UNKNOWN:
       case ST_IDENT:
         STYPEP(sptr, ST_VAR);
-      /* fall through to ... */
+        FLANG_FALLTHROUGH;
       case ST_VAR:
       store_var:
         argtyp = DTYPEG(sptr);
@@ -2601,6 +2602,7 @@ chk_arguments(int ext, int count, ITEM *list, char *kwd_str, int paramct,
           if (ALLOCATTRG(sptr)) {
             ALLOCDESCP(sptr, TRUE);
           }
+          FLANG_FALLTHROUGH;
         default:
           break;
         }

--- a/tools/flang1/flang1exe/semsmp.c
+++ b/tools/flang1/flang1exe/semsmp.c
@@ -7773,6 +7773,8 @@ begin_parallel_clause(int doif)
   {
     switch (DI_ID(doif)) {
       int sptr, ast;
+    default:
+      break;
     case DI_PARDO:
       break;
     case DI_PDO:
@@ -7804,6 +7806,7 @@ begin_parallel_clause(int doif)
   case DI_TARGTEAMSDISTPARDO:
   case DI_TARGPARDO:
     do_private();
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -7814,7 +7817,7 @@ begin_parallel_clause(int doif)
   case DI_PDO:
   case DI_SIMD:
     private_check();
-
+    FLANG_FALLTHROUGH;
   case DI_PAR:
   case DI_PARDO:
   case DI_PARSECTS:
@@ -7831,6 +7834,7 @@ begin_parallel_clause(int doif)
   case DI_TEAMSDISTPARDO:
   case DI_TARGPARDO:
     do_firstprivate((DI_ID(doif) == DI_TASK || DI_ID(doif) == DI_TASKLOOP));
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -7851,6 +7855,7 @@ begin_parallel_clause(int doif)
   case DI_TARGPARDO:
   case DI_TASKLOOP:
     do_lastprivate();
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -7867,6 +7872,7 @@ begin_parallel_clause(int doif)
   case DI_SIMD:
   case DI_TEAMS:
     do_reduction();
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -7886,10 +7892,12 @@ begin_parallel_clause(int doif)
   case DI_PARSECTS:
   case DI_PARWORKS:
     do_copyin();
+    FLANG_FALLTHROUGH;
   case DI_TASK:
   case DI_TASKLOOP:
   case DI_TEAMS:
     do_default_clause(doif);
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -7911,6 +7919,7 @@ end_parallel_clause(int doif)
   case DI_SIMD:
   case DI_TEAMS:
     end_reduction(DI_REDUC(doif), doif);
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -7960,6 +7969,7 @@ end_parallel_clause(int doif)
   case DI_TARGTEAMSDISTPARDO:
   case DI_SIMD:
     deallocate_privates(doif);
+    FLANG_FALLTHROUGH;
   default:
     break;
   }
@@ -7967,6 +7977,8 @@ end_parallel_clause(int doif)
   {
     switch (DI_ID(doif)) {
       int sptr, ast;
+    default:
+      break;
     case DI_PARDO:
     case DI_TARGPARDO:
       break;
@@ -8079,7 +8091,7 @@ gen_reduction(REDUC *reducp, REDUC_SYM *reduc_symp, LOGICAL rmme,
     goto end_reduction;
   case OP_SUB:
     opc = OP_ADD;
-    /*  fall thru  */
+    FLANG_FALLTHROUGH;
   case OP_ADD:
   case OP_MUL:
     SST_OPTYPEP(&opr, opc);
@@ -8238,6 +8250,8 @@ end_lastprivate(int doif)
     return;
   lab = 0;
   switch (DI_ID(doif)) {
+  default:
+    break;
   case DI_SIMD:
     sptr = DI_DOINFO(doif + 1)->index_var;
     i1 = mk_id(sptr);
@@ -8519,6 +8533,8 @@ restore_clauses(void)
   distchunk = sav_chk.distchunk;
   mp_iftype = sav_chk.mp_iftype;
   switch (DI_ID(sem.doif_depth)) {
+  default:
+    break;
   case DI_TARGET:
     if (CL_PRESENT(CL_IF) &&
         (mp_iftype == IF_DEFAULT || mp_iftype == IF_TARGET)) {
@@ -9713,6 +9729,7 @@ needCharLen(int sptr)
     } else if (DTYG(DTYG(dtype)) == TY_NCHAR) {
       return true;
     }
+    FLANG_FALLTHROUGH;
   default:
     return false;
   }

--- a/tools/flang1/flang1exe/semsym.c
+++ b/tools/flang1/flang1exe/semsym.c
@@ -1776,6 +1776,8 @@ decl_private_sym(int sptr)
     int i;
     for (i = sem.doif_depth; i; i--) {
       switch (DI_ID(i)) {
+      default:
+        break;
       case DI_TASK:
       case DI_TASKLOOP:
         TASKP(new, 1);

--- a/tools/flang1/flang1exe/semutil.c
+++ b/tools/flang1/flang1exe/semutil.c
@@ -478,12 +478,12 @@ cngtyp2(SST *old, DTYPE newtyp, bool allowPolyExpr)
       break;
     case TY_CMPLX:
       mkexpr1(old);
-    /* fall thru ... */
+      FLANG_FALLTHROUGH;
     case TY_REAL:
       break;
     case TY_DCMPLX:
       mkexpr1(old);
-    /* fall thru ... */
+      FLANG_FALLTHROUGH;
     case TY_DBLE:
       break;
     case TY_CHAR:
@@ -494,7 +494,7 @@ cngtyp2(SST *old, DTYPE newtyp, bool allowPolyExpr)
     default:
       goto type_error;
     }
-
+    FLANG_FALLTHROUGH;
   case TY_LOG8:
   case TY_INT8:
     switch (from) {
@@ -512,12 +512,12 @@ cngtyp2(SST *old, DTYPE newtyp, bool allowPolyExpr)
       break;
     case TY_CMPLX:
       mkexpr1(old);
-    /* fall thru ... */
+      FLANG_FALLTHROUGH;
     case TY_REAL:
       break;
     case TY_DCMPLX:
       mkexpr1(old);
-    /* fall thru ... */
+      FLANG_FALLTHROUGH;
     case TY_DBLE:
       break;
     case TY_CHAR:
@@ -537,7 +537,7 @@ cngtyp2(SST *old, DTYPE newtyp, bool allowPolyExpr)
     case TY_SINT:
       cngtyp(old, DT_INT);
       SST_DTYPEP(old, DT_INT);
-    /* fall thru ... */
+      FLANG_FALLTHROUGH;
     case TY_LOG:
     case TY_INT:
     case TY_LOG8:
@@ -547,7 +547,7 @@ cngtyp2(SST *old, DTYPE newtyp, bool allowPolyExpr)
       break;
     case TY_DCMPLX:
       mkexpr1(old);
-    /* fall thru ... */
+      FLANG_FALLTHROUGH;
     case TY_DBLE:
       break;
     case TY_CHAR:
@@ -568,7 +568,7 @@ cngtyp2(SST *old, DTYPE newtyp, bool allowPolyExpr)
     case TY_SINT:
       cngtyp(old, DT_INT);
       SST_DTYPEP(old, DT_INT);
-    /* fall thru ... */
+      FLANG_FALLTHROUGH;
     case TY_LOG:
     case TY_INT:
     case TY_LOG8:
@@ -578,7 +578,7 @@ cngtyp2(SST *old, DTYPE newtyp, bool allowPolyExpr)
       break;
     case TY_CMPLX:
       mkexpr1(old);
-    /* fall thru to */
+      FLANG_FALLTHROUGH;
     case TY_REAL:
       break;
     case TY_CHAR:
@@ -599,14 +599,14 @@ cngtyp2(SST *old, DTYPE newtyp, bool allowPolyExpr)
     case TY_SLOG:
       cngtyp(old, DT_INT);
       SST_DTYPEP(old, DT_INT);
-/* fall thru to ... */
+      FLANG_FALLTHROUGH;
     case TY_DBLE:
     case TY_LOG:
     case TY_INT:
     case TY_LOG8:
     case TY_INT8:
       cngtyp(old, DT_REAL);
-    /* fall thru ... */
+      FLANG_FALLTHROUGH;
     case TY_REAL:
       if (fromisv)
         mkexpr1(old);
@@ -638,14 +638,14 @@ cngtyp2(SST *old, DTYPE newtyp, bool allowPolyExpr)
     case TY_SLOG:
       cngtyp(old, DT_INT);
       SST_DTYPEP(old, DT_INT);
-    /* fall thru ... */
+      FLANG_FALLTHROUGH;
     case TY_REAL:
     case TY_LOG:
     case TY_INT:
     case TY_LOG8:
     case TY_INT8:
       cngtyp(old, DT_REAL8);
-    /* fall thru ... */
+      FLANG_FALLTHROUGH;
     case TY_DBLE:
       if (fromisv)
         mkexpr1(old);
@@ -1103,10 +1103,11 @@ again:
       /* Not a frozen intrinsic, so assume its a variable */
       sptr = newsym(sptr);
       sem_set_storage_class(sptr);
-    /* fall thru to ... */
+      FLANG_FALLTHROUGH;
     case ST_UNKNOWN:
     case ST_IDENT:
       STYPEP(sptr, ST_VAR);
+      FLANG_FALLTHROUGH;
     case ST_VAR:
     case ST_STRUCT:
     case ST_MEMBER:
@@ -1117,6 +1118,7 @@ again:
         get_static_descriptor(sptr);
         get_all_descriptors(sptr);
       }
+      FLANG_FALLTHROUGH;
     case ST_DESCRIPTOR:
     var_primary:
       SST_IDP(stkptr, S_LVALUE);
@@ -1361,6 +1363,7 @@ mklvalue(SST *stkptr, int stmt_type)
     case ST_UNKNOWN:
     case ST_IDENT:
       STYPEP(sptr, ST_VAR);
+      FLANG_FALLTHROUGH;
     case ST_VAR:
       if (POINTERG(sptr) && SDSCG(sptr) == 0 && !F90POINTERG(sptr)) {
         if (SCG(sptr) == SC_NONE)
@@ -1411,7 +1414,7 @@ mklvalue(SST *stkptr, int stmt_type)
           setimplicit(sptr);
       }
       // fall through
-
+      FLANG_FALLTHROUGH;
     case ST_PROC: /* Function/intrinsic reference used as an lvalue */
       if (stmt_type == 3) {
         SST_ASTP(stkptr, mk_id(sptr));
@@ -1945,7 +1948,7 @@ mkvarref(SST *stktop, ITEM *list)
   case S_DERIVED:
     sptr = SST_SYMG(stktop);
     dtype = DTYPEG(sptr);
-  /* fall through */
+    FLANG_FALLTHROUGH;
   case S_IDENT: /* dtype has not been set in semantic stack yet */
     sptr = SST_SYMG(stktop);
   varref_ident:
@@ -3281,6 +3284,7 @@ check_derived_type_array_section(int ast)
         }
       }
       mem = parent;
+      FLANG_FALLTHROUGH;
     default:
       return;
     }
@@ -3792,7 +3796,7 @@ assign_pointer(SST *newtop, SST *stktop)
     case ST_GENERIC:
       if (!select_gsame(sptr))
         break;
-    /*  fall thru  */
+      FLANG_FALLTHROUGH;
     case ST_PD:
     case ST_INTRIN:
       sp2 = intrinsic_as_arg(sptr);
@@ -5440,7 +5444,7 @@ mod_type(int dtype, int ty, int kind, int len, int propagated, int sptr)
             CNULL);
       break;
     }
-/* NB: no break here. */
+    FLANG_FALLTHROUGH;
   case TY_REAL:
     if (kind == 0)
       return dtype;
@@ -5467,7 +5471,7 @@ mod_type(int dtype, int ty, int kind, int len, int propagated, int sptr)
       error(32, 2, gbl.lineno, (sptr) ? SYMNAME(sptr) : "doublecomplex", CNULL);
       break;
     }
-/* NB: no break here. */
+    FLANG_FALLTHROUGH;
   case TY_CMPLX:
     if (kind == 0)
       return dtype;
@@ -6245,6 +6249,8 @@ do_end(DOINFO *doinfo)
     }
     for (++sptr; sptr < stb.stg_avail; ++sptr)
       switch (STYPEG(sptr)) {
+      default:
+        break;
       case ST_UNKNOWN:
       case ST_IDENT:
       case ST_VAR:
@@ -6415,6 +6421,8 @@ do_end(DOINFO *doinfo)
       break;
 
     switch (DI_ID(orig_doif)) {
+    default:
+      break;
     case DI_DO:
       (void)add_stmt(mk_stmt(A_ENDDO, 0));
       break;

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -4380,7 +4380,7 @@ construct_acl_from_ast(int ast, DTYPE dtype, int parent_acltype)
           subscr_aclp->u1.expr->lop = construct_acl_from_ast(sub_ast, 0, 0);
           break;
         }
-      /*  fall thru  */
+        FLANG_FALLTHROUGH;
       default:
         l->u1.ast = sub_ast;
         l->dtype = A_DTYPEG(sub_ast);
@@ -6249,15 +6249,17 @@ const_eval(int ast)
       switch (A_OPTYPEG(ast)) {
       case OP_LEQV:
         val = (lv == rv) ? SCFTN_TRUE : SCFTN_FALSE;
+        FLANG_FALLTHROUGH;
       case OP_LNEQV:
         val = (lv == rv) ? SCFTN_FALSE : SCFTN_TRUE;
+        FLANG_FALLTHROUGH;
       case OP_LOR:
         val = (lv == SCFTN_TRUE || rv == SCFTN_TRUE) ? SCFTN_TRUE : SCFTN_FALSE;
+        FLANG_FALLTHROUGH;
       case OP_LAND:
         val = (lv == SCFTN_TRUE && rv == SCFTN_TRUE) ? SCFTN_TRUE : SCFTN_FALSE;
       }
       return val;
-
     case OP_XTOI:
       lop = A_LOPG(ast);
       rop = A_ROPG(ast);
@@ -11107,7 +11109,7 @@ eval_init_expr_item(ACL *cur_e)
         return 0;
       }
     }
-  /* ELSE FALL THRU */
+    FLANG_FALLTHROUGH;
   case AC_CONST:
     new_e = clone_init_const(cur_e, TRUE);
     if (new_e->id == AC_AST) {

--- a/tools/flang1/flang1exe/symtab.c
+++ b/tools/flang1/flang1exe/symtab.c
@@ -1053,6 +1053,7 @@ getprint(int sptr)
   case TY_HOLL:
     sptr = CONVAL1G(sptr);
     dtype = DTYPEG(sptr);
+    FLANG_FALLTHROUGH;
   case TY_CHAR:
   like_char:
     from = stb.n_base + CONVAL1G(sptr);

--- a/tools/flang1/flang1exe/symutl.c
+++ b/tools/flang1/flang1exe/symutl.c
@@ -1984,7 +1984,7 @@ mk_spread_sptr(int arr_ast, char *purpose, int *subscr, int elem_dty, int dim,
         goto no_arr_sptr;
       }
     }
-  /*  fall-thru  */
+    FLANG_FALLTHROUGH;
   case A_ID:
   case A_MEM:
     arr_sptr = find_array(arr_ast, &ssast);

--- a/tools/flang1/utils/prstab/lrutils.c
+++ b/tools/flang1/utils/prstab/lrutils.c
@@ -11,6 +11,7 @@
  *           - miscellaneous
  */
 
+#include "universal.h"
 #include "lrutils.h"
 
 void
@@ -320,8 +321,10 @@ s1toa4(INT *from, INT *to, INT *count)
     break;
   case 1:
     *a4++ = ' ';
+    FLANG_FALLTHROUGH;
   case 2:
     *a4++ = ' ';
+    FLANG_FALLTHROUGH;
   case 3:
     *a4++ = ' ';
   }

--- a/tools/flang2/flang2exe/aarch64-Linux/ll_abi.cpp
+++ b/tools/flang2/flang2exe/aarch64-Linux/ll_abi.cpp
@@ -68,6 +68,8 @@ update_homogeneous(void *context, DTYPE dtype, unsigned address,
     dtype = (DTYPE)DTY(dtype + 1); // ???
 
   switch (dtype) {
+  default:
+    break;
   case DT_CMPLX:
     dtype = DT_FLOAT;
     break;

--- a/tools/flang2/flang2exe/dinit.cpp
+++ b/tools/flang2/flang2exe/dinit.cpp
@@ -1402,6 +1402,8 @@ init_fold_const(int opr, INT conval1, INT conval2, DTYPE dtype)
     return val;
   }
   switch (DTY(dtype)) {
+  default:
+    break;
   case TY_BINT:
   case TY_SINT:
   case TY_INT:
@@ -2489,6 +2491,8 @@ eval_min(CONST *arg, DTYPE dtype)
         c->dtype = wrkarg1->dtype;
       }
       switch (DTY(dtype)) {
+      default:
+        break;
       case TY_INT:
         if (wrkarg2->u1.conval < wrkarg1->u1.conval) {
           c->u1 = wrkarg2->u1;
@@ -2618,6 +2622,8 @@ eval_max(CONST *arg, DTYPE dtype)
         c->dtype = wrkarg1->dtype;
       }
       switch (DTY(dtype)) {
+      default:
+        break;
       case TY_CHAR:
         if (strcmp(stb.n_base + CONVAL1G(wrkarg2->u1.conval),
                    stb.n_base + CONVAL1G(wrkarg1->u1.conval)) > 0) {
@@ -2859,11 +2865,9 @@ negate_const_be(INT conval, DTYPE dtype)
 int
 mk_unop(int optype, int lop, DTYPE dtype)
 {
-  INT conval;
   switch (optype) {
   case OP_ADD:
     return lop;
-
   case OP_SUB:
     switch (DTY(dtype)) {
     case TY_BINT:
@@ -2872,26 +2876,22 @@ mk_unop(int optype, int lop, DTYPE dtype)
     case TY_BLOG:
     case TY_SLOG:
     case TY_LOG:
-      break;
     case TY_REAL:
-      conval = negate_const_be(lop, dtype);
-      break;
-
     case TY_DBLE:
     case TY_CMPLX:
     case TY_DCMPLX:
     case TY_INT8:
     case TY_LOG8:
-      conval = negate_const_be(lop, dtype);
-      break;
-
+      return negate_const_be(lop, dtype);
     default:
       interr("mk_unop-negate: bad dtype", dtype, ERR_Severe);
       break;
     }
-      return conval;
-    }
-
+    break;
+  default:
+    interr("mk_unop-negate: bad op", optype, ERR_Severe);
+    break;
+  }
   return lop;
 }
 
@@ -3223,6 +3223,8 @@ eval_nint(CONST *arg, DTYPE dtype)
 
     con1 = wrkarg->u1.conval;
     switch (DTY(dtype1)) {
+    default:
+      break;
     case TY_REAL:
       num1[0] = CONVAL2G(stb.flt0);
       if (xfcmp(con1, num1[0]) >= 0)
@@ -3264,6 +3266,8 @@ eval_floor(CONST *arg, DTYPE dtype)
     adjust = 0;
     con1 = wrkarg->u1.conval;
     switch (DTY(wrkarg->dtype)) {
+    default:
+      break;
     case TY_REAL:
       conval = cngcon(con1, DT_REAL, dtype);
       num1[0] = CONVAL2G(stb.flt0);
@@ -3316,6 +3320,8 @@ eval_ceiling(CONST *arg, DTYPE dtype)
     adjust = 0;
     con1 = wrkarg->u1.conval;
     switch (DTY(wrkarg->dtype)) {
+    default:
+      break;
     case TY_REAL:
       conval = cngcon(con1, DT_REAL, dtype);
       num1[0] = CONVAL2G(stb.flt0);
@@ -5277,6 +5283,7 @@ eval_init_expr(CONST *e)
         new_e->id = AC_ACONST;
         break;
       }
+      FLANG_FALLTHROUGH;
     default:
       new_e = eval_init_expr_item(cur_e);
       break;

--- a/tools/flang2/flang2exe/dtypeutl.cpp
+++ b/tools/flang2/flang2exe/dtypeutl.cpp
@@ -85,9 +85,11 @@ is_container_dtype(DTYPE dtype)
     if (is_array_dtype(dtype))
       dtype = array_element_dtype(dtype);
     switch (DTYG(dtype)) {
-      case TY_STRUCT:
-      case TY_UNION:
-        return true;
+    default:
+      break;
+    case TY_STRUCT:
+    case TY_UNION:
+      return true;
     }
   }
   return false;

--- a/tools/flang2/flang2exe/exp_ftn.cpp
+++ b/tools/flang2/flang2exe/exp_ftn.cpp
@@ -3868,7 +3868,7 @@ exp_misc(ILM_OP opc, ILM *ilmp, int curilm)
       ILIBLKP(BIH_LABEL(expb.curbih), 0);
       BIH_LABEL(expb.curbih) = SPTR_NULL;
     }
-
+    FLANG_FALLTHROUGH;
 #endif
   case IM_DOEND:
     /* for address of count variable */
@@ -4059,6 +4059,8 @@ exp_misc(ILM_OP opc, ILM *ilmp, int curilm)
       while (arg > 1) {
         ILM *argilm = (ILM *)(ilmb.ilm_base + arg);
         switch (ILM_OPC(argilm)) {
+        default:
+          break;
         case IM_PLD:
           if (depth == 0) {
             arg = ILM_OPND(argilm, 1);

--- a/tools/flang2/flang2exe/exp_rte.cpp
+++ b/tools/flang2/flang2exe/exp_rte.cpp
@@ -3953,6 +3953,7 @@ exp_call(ILM_OP opc, ILM *ilmp, int curilm)
         break;
       }
       /* else fall thru for handling character */
+      FLANG_FALLTHROUGH;
 
     default:
       gargili = ILM_RESULT(ilm1);
@@ -4910,6 +4911,7 @@ exp_fstring(ILM_OP opc, ILM *ilmp, int curilm)
   switch (opc) {
   case IM_ICHAR: /* char to integer */
     tmp = MSZ_BYTE;
+    FLANG_FALLTHROUGH;
   case IM_INCHAR: /* nchar to integer */
     if (opc == IM_INCHAR)
       tmp = MSZ_UHWORD;
@@ -5138,6 +5140,7 @@ exp_fstring(ILM_OP opc, ILM *ilmp, int curilm)
      * ftn_strcmp.
      */
     ILM_RESTYPE(curilm) = ILM_ISCHAR;
+    FLANG_FALLTHROUGH;
   case IM_INDEX:
   case IM_KINDEX:
   case IM_NINDEX:
@@ -5963,6 +5966,7 @@ AssignAddresses(void)
               default:
                 break;
               }
+              break;
             default:
               break;
             }

--- a/tools/flang2/flang2exe/expand.cpp
+++ b/tools/flang2/flang2exe/expand.cpp
@@ -1075,7 +1075,7 @@ replace_by_one(ILM_OP opc, ILM *ilmp, int curilm)
 
   default:
     interr("replace_by_one opc not cased", opc, ERR_Severe);
-    break;
+    return;
   }
   /* CHANGE the ILM in place */
   SetILM_OPC(ilmp, newopc);
@@ -1726,6 +1726,7 @@ exp_store(ILM_OP opc, ILM *ilmp, int curilm)
         store = ad2ili(IL_FREE, expr, dt);
         break;
       }
+      FLANG_FALLTHROUGH;
 
     default:
       interr("PSEUDOST: bad link", curilm, ERR_Severe);
@@ -2333,6 +2334,8 @@ exp_ref(ILM_OP opc, ILM *ilmp, int curilm)
   int dtype;
 
   switch (opc) {
+  default:
+    return;
 
   case IM_BASE:
     /* get the base symbol entry  */
@@ -2353,7 +2356,6 @@ exp_ref(ILM_OP opc, ILM *ilmp, int curilm)
   case IM_ELEMENT:
     exp_array(opc, ilmp, curilm);
     return;
-  default:;
   }
 
   ILM_RESULT(curilm) = ili1;
@@ -2870,14 +2872,13 @@ exp_pure(SPTR extsym, int nargs, ILM *ilmp, int curilm)
   cili = ILI_OF(curilm);
   switch (ILI_OPC(cili)) {
   case IL_DFRAR:
-    switch (nargs) {
-    case 0:
+    if (nargs == 0) {
       cili = jsr2qjsr(cili);
       ilix = ad_acon(extsym, 0);
       ilix = ad2ili(IL_APURE, ilix, cili);
       ILM_RESULT(curilm) = ilix;
       break;
-    case 1:
+    } else if (nargs == 1) {
       switch (IL_RES(ILI_OPC(args[0]))) {
       case ILIA_AR:
         cili = jsr2qjsr(cili);
@@ -2890,23 +2891,20 @@ exp_pure(SPTR extsym, int nargs, ILM *ilmp, int curilm)
         ilix = ad_acon(extsym, 0);
         ilix = ad3ili(IL_APUREI, ilix, args[0], cili);
         ILM_RESULT(curilm) = ilix;
+        break;
       default:
         break;
       }
-    default:
-      break;
     }
     break;
 
   case IL_DFRIR:
-    switch (nargs) {
-    case 0:
+    if (nargs == 0) {
       cili = jsr2qjsr(cili);
       ilix = ad_acon(extsym, 0);
       ilix = ad2ili(IL_IPURE, ilix, cili);
       ILM_RESULT(curilm) = ilix;
-      break;
-    case 1:
+    } else if (nargs == 1) {
       switch (IL_RES(ILI_OPC(args[0]))) {
       case ILIA_AR:
         cili = jsr2qjsr(cili);
@@ -2919,11 +2917,10 @@ exp_pure(SPTR extsym, int nargs, ILM *ilmp, int curilm)
         ilix = ad_acon(extsym, 0);
         ilix = ad3ili(IL_IPUREI, ilix, args[0], cili);
         ILM_RESULT(curilm) = ilix;
+        break;
       default:
         break;
       }
-    default:
-      break;
     }
     break;
 

--- a/tools/flang2/flang2exe/expatomics.cpp
+++ b/tools/flang2/flang2exe/expatomics.cpp
@@ -1756,10 +1756,12 @@ get_ops(MSZ msz, int is_openmp)
     if (is_openmp) {
       return &dp_ops;
     }
+    FLANG_FALLTHROUGH;
   case MSZ_PTR:
     if (is_openmp) {
       return &ar_ops;
     }
+    FLANG_FALLTHROUGH;
   case MSZ_SLWORD:
   case MSZ_ULWORD:
   case MSZ_I8:
@@ -1767,6 +1769,7 @@ get_ops(MSZ msz, int is_openmp)
   case MSZ_F4:
     if (is_openmp)
       return &sp_ops;
+    FLANG_FALLTHROUGH;
   default:
     return &ir_ops;
   }
@@ -2066,6 +2069,7 @@ auto_retrieve(auto_temp *temp)
   switch (IL_TYPE(ILI_OPC(temp->expr))) {
   default:
     interr("auto_retrieve: unexpected IL_TYPE", IL_TYPE(temp->expr), ERR_Fatal);
+    return 0;
   case ILTY_STORE:
   case ILTY_PSTORE:
     return ad_load(temp->expr);

--- a/tools/flang2/flang2exe/expsmp.cpp
+++ b/tools/flang2/flang2exe/expsmp.cpp
@@ -1552,6 +1552,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
                   "Parallel loop activated with %schedule schedule",
                   "schedule=%s", doschedule, NULL);
       }
+      FLANG_FALLTHROUGH;
 
     case KMP_DISTRIBUTE_STATIC_CHUNKED:
     case KMP_DISTRIBUTE_STATIC:

--- a/tools/flang2/flang2exe/exputil.cpp
+++ b/tools/flang2/flang2exe/exputil.cpp
@@ -1106,7 +1106,7 @@ mk_impsym(SPTR sptr)
       sprintf(bf, "__imp_%s_%s", SYMNAME(INMODULEG(sptr)), SYMNAME(sptr));
       break;
     }
-  /*****  else FALLTHRU  *****/
+    FLANG_FALLTHROUGH;
   default:
     sprintf(bf, "__imp_%s", getsname(sptr));
   }

--- a/tools/flang2/flang2exe/iliutil.cpp
+++ b/tools/flang2/flang2exe/iliutil.cpp
@@ -1375,6 +1375,7 @@ ad_cse(int ilix)
       ilix = ad1ili(IL_CSE, ilix);
       break;
     }
+    FLANG_FALLTHROUGH;
   default:
     interr("ad_cse: bad IL_RES", ilix, ERR_Severe);
     break;
@@ -1445,6 +1446,7 @@ ad_free(int ilix)
   switch (r) {
   default:
     interr("ad_free: not yet implemented for this result type", r, ERR_Fatal);
+    return 0;
   case ILIA_IR:
     opc = IL_FREEIR;
     break;
@@ -4701,6 +4703,8 @@ addarth(ILI *ilip)
       if (con1v2 >= 1 && is_zero_one(op2)) {
         /* low-quality range analysis */
         switch (cond) {
+        default:
+          break;
         case CC_EQ:
         case CC_LE:
           if (con1v2 > 1) {
@@ -4762,6 +4766,8 @@ addarth(ILI *ilip)
       if (con2v2 >= 1 && is_zero_one(op1)) {
         /* low-quality range analysis */
         switch (cond) {
+        default:
+          break;
         case CC_EQ:
         case CC_GE:
           if (con2v2 > 1) {
@@ -7370,6 +7376,8 @@ red_kadd(int ilix, INT con[2])
 
   opc = ILI_OPC(ilix);
   switch (opc) {
+  default:
+    break;
 
   case IL_KCON:
     val[0] = CONVAL1G(ILI_OPND(ilix, 1));
@@ -7934,6 +7942,8 @@ addbran(ILI *ilip)
     cc_op2 = (CC_RELATION) op2;
   }
   switch (ilip->opc) {
+  default:
+    break;
 
   case IL_LCJMPZ:
     /*
@@ -8124,6 +8134,8 @@ addbran(ILI *ilip)
       if (CONVAL2G(ILI_OPND(op1, 1)) >= 1 && is_zero_one(op2)) {
         /* low-quality range analysis */
         switch (cond) {
+        default:
+          break;
         case CC_EQ:
         case CC_LE:
           if (CONVAL2G(ILI_OPND(op1, 1)) > 1) {
@@ -8181,6 +8193,8 @@ addbran(ILI *ilip)
       if (CONVAL2G(ILI_OPND(op2, 1)) >= 1 && is_zero_one(op1)) {
         /* low-quality range analysis */
         switch (cond) {
+        default:
+          break;
         case CC_EQ:
         case CC_GE:
           if (CONVAL2G(ILI_OPND(op2, 1)) > 1) {
@@ -8593,6 +8607,8 @@ addbran(ILI *ilip)
 
 fold_jmp:
   switch (cond) {
+  default:
+    break;
   case CC_EQ:
     if (cmp_val == 0)
       return ad1ili(IL_JMP, lab);
@@ -9679,6 +9695,8 @@ has_nme(int nme)
   if (nme == rewr_old_nme)
     return true;
   switch (NME_TYPE(nme)) {
+  default:
+    break;
   case NT_MEM:
   case NT_IND:
   case NT_ARR:
@@ -10112,8 +10130,6 @@ atomic_origin_name(ATOMIC_ORIGIN origin)
     return "openmp";
   case AORG_OPENACC:
     return "openacc";
-  default:
-    return "<bad origin>";
   }
 }
 
@@ -10174,6 +10190,8 @@ dump_ili(FILE *f, int i)
   for (j = 1; j <= noprs; j++) {
     int opn = ILI_OPND(i, j);
     switch (IL_OPRFLAG(opc, j)) {
+    default:
+      break;
     case ILIO_SYM:
     case ILIO_OFF:
       if (opn <= 0) {
@@ -10489,6 +10507,7 @@ dilitree(int i)
         indent += 3;
         break;
       }
+      FLANG_FALLTHROUGH;
     case ILIO_IRLNK:
     case ILIO_KRLNK:
     case ILIO_ARLNK:
@@ -10572,6 +10591,8 @@ prnme(int opn, int ili)
 {
 
   switch (NME_TYPE(opn)) {
+  default:
+    break;
   case NT_VAR:
     prsym(NME_SYM(opn), gbl.dbgfil);
     break;
@@ -13753,6 +13774,7 @@ ili_throw_label(int ilix)
   switch (opc) {
   default:
     interr("ili_throw_label: not a call", ILI_OPC(ilix), ERR_Fatal);
+    return 0;
   case IL_QJSR:
     /* QJSR never throws */
     return 0;
@@ -13772,6 +13794,7 @@ ili_throw_label(int ilix)
   switch (opc) {
   default:
     interr("ili_throw_label: unexpected alt", opc, ERR_Fatal);
+    return 0;
   case IL_GJSR:
     return ILI_OPND(ilix, 3);
   case IL_GJSRA:
@@ -13944,6 +13967,7 @@ atomic_info_index(ILI_OP opc)
   switch (opc) {
   default:
     assert(false, "atomic_info: not an atomic op", opc, ERR_Severe);
+    return 0;
   case IL_CMPXCHGI:
   case IL_CMPXCHGKR:
   case IL_CMPXCHGA:
@@ -14129,6 +14153,7 @@ memory_order(int ilix)
   switch (opc) {
   default:
     assert(false, "memory_order: unimplemented op", opc, ERR_Severe);
+    return MO_UNDEF;
   case IL_CMPXCHGI:
   case IL_CMPXCHGKR:
   case IL_CMPXCHGA: {

--- a/tools/flang2/flang2exe/ll_ftn.cpp
+++ b/tools/flang2/flang2exe/ll_ftn.cpp
@@ -68,10 +68,10 @@ need_charlen(DTYPE dtype)
       return true;
     else if (DTY(DTySeqTyElement(dtype)) == TY_NCHAR)
       return true;
+    return false;
   default:
     return false;
   }
-  return false;
 }
 
 static int
@@ -101,6 +101,8 @@ is_fastcall(int ilix)
   case IL_JSR:  /* sym lnk */
   case IL_JSRA: /* arlnk lnk stc  , arlnk is the address of function */
     switch (ILI_OPC(ILI_OPND(ilix, 2))) {
+    default:
+      break;
     /* mth_i_ ..  routines? */
     case IL_DADP: /* dplnk dp lnk */
     case IL_DASP: /* splnk sp lnk */

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -52,8 +52,6 @@ ll_get_linkage_string(enum LL_LinkageType linkage)
     return "external";
   case LL_NO_LINKAGE:
     break;
-  default:
-    break;
   }
   return "";
 }
@@ -647,9 +645,6 @@ ll_write_instruction(FILE *out, LL_Instruction *inst, LL_Module *module, int no_
     fprintf(out, "%s]", SPACES);
     break;
   case LL_NONE:
-    break;
-  default:
-    fprintf(stderr, "Error: unrendered instruction %d\n", inst->op);
     break;
   }
   if (!LL_MDREF_IS_NULL(inst->dbg_line_op)) {

--- a/tools/flang2/flang2exe/llassem.cpp
+++ b/tools/flang2/flang2exe/llassem.cpp
@@ -3290,12 +3290,12 @@ Found:
      */
     if (!CFUNCG(sptr))
       break;
-  /* else fall through */
+    FLANG_FALLTHROUGH;
   case ST_VAR:
   case ST_STRUCT:
     if (!CFUNCG(sptr))
       return SPTR_NULL;
-  /* fall through */
+    FLANG_FALLTHROUGH;
   case ST_CMBLK:
     if (AG_STYPE(gblsym) != stype) {
       error(S_0166_OP1_cannot_be_a_common_block_and_a_subprogram, ERR_Severe, 0,
@@ -3718,6 +3718,7 @@ getsname(SPTR sptr)
     if (PTR_INITIALIZERG(sptr) && PTR_TARGETG(sptr)) {
       sptr = (SPTR) PTR_TARGETG(sptr);
     }
+    FLANG_FALLTHROUGH;
   case ST_ENTRY:
     if (ALTNAMEG(sptr)) {
       return get_altname(sptr);
@@ -4835,6 +4836,7 @@ get_llvm_name(SPTR sptr)
         sprintf(name, "%s_%d", SYMNAME(sptr), sptr);
         return name;
       }
+      FLANG_FALLTHROUGH;
     case SC_STATIC:
       if (CLASSG(sptr) && DESCARRAYG(sptr))
         goto xlate_name;
@@ -4910,7 +4912,7 @@ get_llvm_name(SPTR sptr)
     case SC_BASED:
       if (MIDNUMG(sptr) && SCG(MIDNUMG(sptr)) == SC_DUMMY)
         return SYMNAME(MIDNUMG(sptr));
-      // fall-through
+      FLANG_FALLTHROUGH;
     case SC_PRIVATE:
       sprintf(name, "%s_%d", SYMNAME(sptr), sptr);
       break;
@@ -5460,9 +5462,13 @@ write_module_as_subroutine(void)
   switch (dttypes[dtype]) {
   case _TY_INT:
     print_token(" 0");
+    break;
   case _TY_REAL:
     print_token(" 0.0");
+    break;
   case _TY_CMPLX:
+    // TODO
+    FLANG_FALLTHROUGH;
   default:
     print_token(" undef");
   }

--- a/tools/flang2/flang2exe/llassem_common.cpp
+++ b/tools/flang2/flang2exe/llassem_common.cpp
@@ -607,6 +607,8 @@ emit_init(DTYPE tdtype, ISZ_T tconval, ISZ_T *addr, ISZ_T *repeat_cnt,
         if (is_empty_typedef(tdtype)) {
           break;
         }
+        // TODO: Print the struct?
+        break;
 
 #ifdef LONG_DOUBLE_FLOAT128
       case TY_X87:

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -3233,6 +3233,7 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
             db, cu_mdnode,
             DTyAlgTyTag(dtype) ? SYMNAME(DTyAlgTyTag(dtype)) : "", file_mdnode,
             0, sz, align, 0, members_mdnode, 0);
+        FLANG_FALLTHROUGH;
       case TY_STRUCT:
         if (LL_MDREF_IS_NULL(type_mdnode)) {
           members_mdnode = ll_create_flexible_md_node(db->module);

--- a/tools/flang2/flang2exe/llsched.cpp
+++ b/tools/flang2/flang2exe/llsched.cpp
@@ -61,6 +61,8 @@ build_same_base_nme(int nme1, int nme2, int *res_nme)
       return false;
 
     switch (NME_TYPE(nme1)) {
+    default:
+      break;
     case NT_VAR:
       if (NME_SYM(nme1) != NME_SYM(nme2) &&
           STYPEG(NME_SYM(nme1)) == STYPEG(NME_SYM(nme2)) &&

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -662,6 +662,8 @@ convert_dtype(LL_Module *module, DTYPE dtype, int addrspace)
   DTYPE dt;
 
   switch (DTY(dtype)) {
+  default:
+    break;
 
   case TY_NONE:
   case TY_ANY:
@@ -839,8 +841,9 @@ is_struct_kind(DTYPE dtype, bool check_return,
   case TY_DCMPLX:
   case TY_CMPLX128:
     return true;
+  default:
+    return false;
   }
-  return false;
 }
 
 LL_Type *
@@ -4335,6 +4338,7 @@ ll_instr_flags_from_aop(ATOMIC_RMW_OP aop)
   switch (aop) {
   default:
     assert(false, "gen_llvm_atomicrmw_expr: unimplemented op", aop, ERR_Fatal);
+    return InstrListFlagsNull;
   case AOP_XCHG:
     return ATOMIC_XCHG_FLAG;
   case AOP_ADD:

--- a/tools/flang2/flang2exe/mwd.cpp
+++ b/tools/flang2/flang2exe/mwd.cpp
@@ -1085,6 +1085,8 @@ dsym(int sptr)
   SYMLKP(0, SPTR_NULL);
 
   switch (stype) {
+  default:
+    break;
   case ST_ARRAY:
   case ST_IDENT:
   case ST_STRUCT:
@@ -3146,6 +3148,7 @@ dumpdtype(DTYPE dtype)
     fprintf(dfile, "<%lu x ", DTyVecLength(dtype));
     putdtype(DTySeqTyElement(dtype));
     fputc('>', dfile);
+    FLANG_FALLTHROUGH;
   default:
     /* simple datatypes, just the one line of info */
     putline();
@@ -4000,8 +4003,7 @@ _printili(int i)
       appendstring1("NULL");
       break;
     }
-/* fall through */
-
+    FLANG_FALLTHROUGH;
   default:
     appendstring1(ilis[opc].name);
     if (noprs) {

--- a/tools/flang2/flang2exe/ompaccel.cpp
+++ b/tools/flang2/flang2exe/ompaccel.cpp
@@ -1135,8 +1135,9 @@ dumpomptarget(OMPACCEL_TINFO *tinfo)
     return;
 
   switch (tinfo->mode) {
+  default:
+    break;
   case mode_none_target:
-
     fprintf(gbl.dbgfil, " <mode none>");
     break;
   case mode_target:
@@ -1777,6 +1778,7 @@ exp_ompaccel_mploop(ILM *ilmp, int curilm)
                 "Parallel loop activated with %schedule schedule",
                 "schedule=%s", doschedule, NULL);
     }
+    FLANG_FALLTHROUGH;
   case KMP_DISTRIBUTE_STATIC_CHUNKED:
   case KMP_DISTRIBUTE_STATIC:
     ili = ll_make_kmpc_for_static_init_simple_spmd(&loop_args, sched);

--- a/tools/flang2/flang2exe/outliner.cpp
+++ b/tools/flang2/flang2exe/outliner.cpp
@@ -1027,6 +1027,7 @@ llCollectSymbolInfo(ILM *ilmpx)
             break;
           default:;
           }
+          break;
         default:;
         }
       }

--- a/tools/flang2/flang2exe/regutil.cpp
+++ b/tools/flang2/flang2exe/regutil.cpp
@@ -688,6 +688,7 @@ endrcand(void)
         NME_RAT(ILI_OPND(val, 2)) = 0;
         if (RCAND_OLOAD(cand))
           ILI_RAT(RCAND_OLOAD(cand)) = 0;
+        FLANG_FALLTHROUGH;
       case RATA_TEMP:
       case RATA_CONST:
       case RATA_RPL:
@@ -737,6 +738,7 @@ endrcand(void)
         NME_RAT(ILI_OPND(val, 2)) = 0;
         if (RCAND_OLOAD(cand))
           ILI_RAT(RCAND_OLOAD(cand)) = 0;
+        FLANG_FALLTHROUGH;
       case RATA_TEMP:
       case RATA_CONST:
       case RATA_RPL:
@@ -1175,7 +1177,7 @@ _assn_rtemp(int ili, int temp)
       rtype = RCAND_RTYPE(rcand) = RATA_VECT;
       break;
     }
-
+    FLANG_FALLTHROUGH;
   default:
     interr("_assn_rtemp: illegal ili for temp assn", ili, ERR_Severe);
   }
@@ -1278,6 +1280,7 @@ select_rtemp(int ili)
         break;
       }
     }
+    FLANG_FALLTHROUGH;
 #ifdef ILIA_CS
   case ILIA_CS:
     type = 5;

--- a/tools/flang2/flang2exe/semutil0.cpp
+++ b/tools/flang2/flang2exe/semutil0.cpp
@@ -482,11 +482,13 @@ cngcon(INT oldval, DTYPE oldtyp, DTYPE newtyp)
       switch (from) {
       case TY_CMPLX:
         oldval = CONVAL1G(oldval);
+        FLANG_FALLTHROUGH;
       case TY_REAL:
         xfix(oldval, &result);
         return result;
       case TY_DCMPLX:
         oldval = CONVAL1G(oldval);
+        FLANG_FALLTHROUGH;
       case TY_DBLE:
         num[0] = CONVAL1G(oldval);
         num[1] = CONVAL2G(oldval);
@@ -498,6 +500,7 @@ cngcon(INT oldval, DTYPE oldtyp, DTYPE newtyp)
       case TY_CHAR:
         if (flg.standard)
           ERR170("conversion of CHARACTER constant to numeric");
+        FLANG_FALLTHROUGH;
       case TY_HOLL:
         cp = stb.n_base + CONVAL1G(oldval);
         oldcvlen = 4;
@@ -538,11 +541,13 @@ cngcon(INT oldval, DTYPE oldtyp, DTYPE newtyp)
       switch (from) {
       case TY_CMPLX:
         oldval = CONVAL1G(oldval);
+        FLANG_FALLTHROUGH;
       case TY_REAL:
         xfix64(oldval, num);
         return getcon(num, newtyp);
       case TY_DCMPLX:
         oldval = CONVAL1G(oldval);
+        FLANG_FALLTHROUGH;
       case TY_DBLE:
         num1[0] = CONVAL1G(oldval);
         num1[1] = CONVAL2G(oldval);
@@ -554,6 +559,7 @@ cngcon(INT oldval, DTYPE oldtyp, DTYPE newtyp)
       case TY_CHAR:
         if (flg.standard)
           ERR170("conversion of CHARACTER constant to numeric");
+        FLANG_FALLTHROUGH;
       case TY_HOLL:
         cp = stb.n_base + CONVAL1G(oldval);
         holtonum(cp, num, 8);
@@ -594,6 +600,7 @@ cngcon(INT oldval, DTYPE oldtyp, DTYPE newtyp)
         return CONVAL1G(oldval);
       case TY_DCMPLX:
         oldval = CONVAL1G(oldval);
+        FLANG_FALLTHROUGH;
       case TY_DBLE:
         num[0] = CONVAL1G(oldval);
         num[1] = CONVAL2G(oldval);
@@ -605,6 +612,7 @@ cngcon(INT oldval, DTYPE oldtyp, DTYPE newtyp)
       case TY_CHAR:
         if (flg.standard)
           ERR170("conversion of CHARACTER constant to numeric");
+        FLANG_FALLTHROUGH;
       case TY_HOLL:
         cp = stb.n_base + CONVAL1G(oldval);
         holtonum(cp, num, 4);

--- a/tools/flang2/flang2exe/symtab.cpp
+++ b/tools/flang2/flang2exe/symtab.cpp
@@ -962,6 +962,7 @@ getprint(int sptr)
   case TY_NCHAR:
     sptr = CONVAL1G(sptr); /* sptr to char string constant */
     dtype = DTYPEG(sptr);
+    FLANG_FALLTHROUGH;
   case TY_HOLL: /* Should be no holleriths in symbol table */
   case TY_CHAR:
     from = stb.n_base + CONVAL1G(sptr);

--- a/tools/flang2/flang2exe/upper.cpp
+++ b/tools/flang2/flang2exe/upper.cpp
@@ -1641,6 +1641,8 @@ read_datatype(void)
   dtype = getDtypeVal("datatype");
   dval = getTYKind();
   switch (dval) {
+  default:
+    break;
   case TY_CMPLX:
     datatypexref[dtype] = DT_CMPLX;
     break;
@@ -1894,6 +1896,7 @@ fix_datatype(void)
           fval = symbolxref[fval];
         }
         DTySetFuncVal(dtype, fval);
+        break;
       default:
         break;
       }
@@ -3594,7 +3597,7 @@ fix_symbol(void)
           }
         }
       }
-      /* fall through */
+      FLANG_FALLTHROUGH;
     case ST_VAR:
       if (STYPEG(sptr) != ST_ARRAY && VARDSCG(sptr)) {
         desc = SDSCG(sptr);
@@ -3892,6 +3895,7 @@ fix_symbol(void)
         ADDRESSP(sptr, ADDRESSG(ptr));
         break;
       }
+      FLANG_FALLTHROUGH;
     case ST_ENTRY:
       paramcount = PARAMCTG(sptr);
       dpdsc = DPDSCG(sptr);
@@ -5805,7 +5809,7 @@ IPA_nme_conflict(int nme1, int nme2)
           /* probably S1 -> *S2, conflict */
           return 1;
         }
-      /* fall through */
+        FLANG_FALLTHROUGH;
       case INFO_GTARGET:
       case INFO_OGTARGET:
       case INFO_OTARGET:
@@ -5906,7 +5910,7 @@ F90_nme_conflict(int nme1, int nme2)
             /* probably S1 -> *S2, conflict */
             return 1;
           }
-        /* fall through */
+          FLANG_FALLTHROUGH;
         case INFO_FLDYNTARGET:
         case INFO_FGDYNTARGET:
         case INFO_FOTARGET:
@@ -5965,7 +5969,7 @@ F90_nme_conflict(int nme1, int nme2)
           /* probably S1 -> *S2, conflict */
           return 1;
         }
-      /* fall through */
+        FLANG_FALLTHROUGH;
       case INFO_FLDYNTARGET:
       case INFO_FGDYNTARGET:
       case INFO_FOTARGET:

--- a/tools/flang2/flang2exe/x86_64-Linux/ll_abi.cpp
+++ b/tools/flang2/flang2exe/x86_64-Linux/ll_abi.cpp
@@ -146,6 +146,9 @@ amd64_update_class(void *context, DTYPE dtype, unsigned address,
 
   enum amd64_class cls[2] = {AMD64_MEMORY, AMD64_MEMORY};
   switch (DTY(dtype)) {
+  default:
+    break;
+
   case TY_VECT:
   case TY_128:
   case TY_FLOAT128:

--- a/tools/shared/nmeutil.c
+++ b/tools/shared/nmeutil.c
@@ -252,6 +252,10 @@ add_arrnme(NT_KIND type, SPTR insym, int nm, ISZ_T cnst, int sub, bool inlarr)
 
   case NT_ADD:
     switch (NME_TYPE(nm)) {
+    case NT_INDARR:
+    case NT_ADD:
+    case NT_SAFE:
+      break;
 
     case NT_VAR:
     case NT_MEM:
@@ -546,12 +550,12 @@ dt_nme(int nm)
 {
   int i;
   switch (NME_TYPE(nm)) {
-
+  case NT_INDARR:
+  case NT_ADD:
   case NT_UNK:
     break;
   case NT_VAR:
     return DTYPEG(NME_SYM(nm));
-
   case NT_MEM:
     if (NME_SYM(nm) == 0 || NME_SYM(nm) == 1) {
       if (dt_nme((int)NME_NM(nm)) == DT_DCMPLX) {
@@ -564,7 +568,6 @@ dt_nme(int nm)
       return DTYPEG(NME_SYM(nm));
     else
       return DTYPEG(i);
-
   case NT_ARR: {
     DTYPE i = dt_nme((int)NME_NM(nm));
     if (DTY(i) == TY_ARRAY)
@@ -1568,6 +1571,9 @@ DumpnameHelper(FILE *f, int opn)
   level++;
 
   switch (NME_TYPE(opn)) {
+  case NT_INDARR:
+  case NT_ADD:
+    break;
   case NT_VAR:
     prsym(NME_SYM(opn), ff);
     break;
@@ -1652,6 +1658,8 @@ DumpnmeHelper(FILE *f, int opn)
 
   __dmpnme(ff, opn, 0);
   switch (NME_TYPE(opn)) {
+  case NT_INDARR:
+  case NT_ADD:
   case NT_VAR:
     break;
   case NT_MEM:

--- a/tools/shared/pragma.c
+++ b/tools/shared/pragma.c
@@ -585,7 +585,7 @@ do_sw(void)
     break;
   case SW_IVDEP:
     no_specified = true;
-  /*  fall thru  */
+    FLANG_FALLTHROUGH;
   case SW_DEPCHK:
     if (no_specified)
       assn(DIR_OFFSET(currdir, depchk), 0);
@@ -1389,7 +1389,7 @@ assn(int diroff, int v)
     break; /* TBDLOOP */
   case S_GLOBAL:
     ((int *)(&direct.gbl))[diroff] = v;
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case S_ROUTINE:
     ((int *)(&direct.rou))[diroff] = v;
     /*
@@ -1403,7 +1403,7 @@ assn(int diroff, int v)
       direct.loop_flag = false;
       do_now = false;
     }
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case S_LOOP:
     ((int *)(&direct.loop))[diroff] = v;
     break;
@@ -1418,7 +1418,7 @@ bset(int diroff, int v)
     break; /* TBDLOOP */
   case S_GLOBAL:
     ((int *)(&direct.gbl))[diroff] |= v;
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case S_ROUTINE:
     ((int *)(&direct.rou))[diroff] |= v;
     if (do_now || (gbl.currsub == 0 && sem.pgphase == 0)) {
@@ -1426,7 +1426,7 @@ bset(int diroff, int v)
       direct.loop_flag = false;
       do_now = false;
     }
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case S_LOOP:
     ((int *)(&direct.loop))[diroff] |= v;
     break;
@@ -1442,7 +1442,7 @@ bclr(int diroff, int v)
     break; /* TBDLOOP */
   case S_GLOBAL:
     ((int *)(&direct.gbl))[diroff] &= ~v;
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case S_ROUTINE:
     ((int *)(&direct.rou))[diroff] &= ~v;
     if (do_now || (gbl.currsub == 0 && sem.pgphase == 0)) {
@@ -1450,7 +1450,7 @@ bclr(int diroff, int v)
       direct.loop_flag = false;
       do_now = false;
     }
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case S_LOOP:
     ((int *)(&direct.loop))[diroff] &= ~v;
     break;
@@ -1665,7 +1665,7 @@ retry:
   case 'Y':
   case 'Z':
     c += upper_to_lower;
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case 'a':
   case 'b':
   case 'c':
@@ -1726,7 +1726,7 @@ retry:
       typ = T_INT;
       break;
     }
-  /* fall thru */
+    FLANG_FALLTHROUGH;
   case '1':
   case '2':
   case '3':

--- a/tools/shared/x86.c
+++ b/tools/shared/x86.c
@@ -44,7 +44,7 @@ set_mach(X86TYPE *mach, int machtype)
      */
     mach->type[MACH_AMD_ZEN] = 1;
     mach->feature[FEATURE_AVX2] = 1;
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_PILEDRIVER:
     /* AMD piledriver
@@ -55,7 +55,7 @@ set_mach(X86TYPE *mach, int machtype)
     mach->feature[FEATURE_LD_VMOVUPD] = 1;    /* added on 14 Dec 2015 */
     mach->feature[FEATURE_ST_VMOVUPD] = 1;    /*   "    "    "    "   */
     mach->feature[FEATURE_ST_MOVUPD] = 1;     /*   "    "    "    "   */
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_BULLDOZER:
     /* AMD bulldozer
@@ -72,13 +72,13 @@ set_mach(X86TYPE *mach, int machtype)
     }
     mach->feature[FEATURE_ALIGNLOOP8] = 1;
     mach->feature[FEATURE_ALIGNJMP8] = 1;
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_ISTANBUL:
     /* AMD instanbul
      */
     mach->type[MACH_AMD_ISTANBUL] = 1;
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_SHANGHAI:
     /* AMD shanghai, like greyhound but with a larger cache.
@@ -87,7 +87,7 @@ set_mach(X86TYPE *mach, int machtype)
     mach->feature[FEATURE_MULTI_ACCUM] = 1;
     if (mach->cachesize == 0)
       mach->cachesize = (6 * 1024 * 1024);
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_GH:
     /* AMD greyhound
@@ -134,7 +134,7 @@ set_mach(X86TYPE *mach, int machtype)
     /* AMD hammer
      */
     mach->feature[FEATURE_SSE3] = 1;
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_K8:
     /* AMD hammer
@@ -181,7 +181,7 @@ set_mach(X86TYPE *mach, int machtype)
       mach->type[MACH_INTEL_SKYLAKE] = 1;
       mach->feature[FEATURE_AVX512VL] = 1;
     }
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_KNIGHTS_LANDING:
     if (! DONT_GENERATE_AVX512) {
@@ -190,7 +190,7 @@ set_mach(X86TYPE *mach, int machtype)
       }
       mach->feature[FEATURE_AVX512F] = 1;
     }
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_HASWELL:
     mach->type[MACH_INTEL_HASWELL] = 1;
@@ -199,7 +199,7 @@ set_mach(X86TYPE *mach, int machtype)
     has_fma3 = 1;
     mach->feature[FEATURE_LD_VMOVUPD] = 1;
     mach->feature[FEATURE_ST_VMOVUPD] = 1;
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_IVYBRIDGE:
   case TP_SANDYBRIDGE:
@@ -207,7 +207,7 @@ set_mach(X86TYPE *mach, int machtype)
     mach->feature[FEATURE_AVX] = 1;
     mach->feature[FEATURE_ST_MOVUPD] = 1;
     mach->feature[FEATURE_MULTI_ACCUM] = 1;
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_NEHALEM:
     mach->type[MACH_INTEL_NEHALEM] = 1;
@@ -217,14 +217,14 @@ set_mach(X86TYPE *mach, int machtype)
     mach->feature[FEATURE_SSEPMAX] = 1;
     if (mach->cachesize == 0)
       mach->cachesize = (8 * 1024 * 1024);
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_PENRYN:
     mach->type[MACH_INTEL_PENRYN] = 1;
     mach->feature[FEATURE_SSE41] = 1;
     if (mach->cachesize == 0)
       mach->cachesize = (6 * 1024 * 1024);
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_CORE2:
     mach->type[MACH_INTEL_CORE2] = 1;
@@ -232,7 +232,7 @@ set_mach(X86TYPE *mach, int machtype)
     mach->feature[FEATURE_MNI] = 1;
     if (mach->cachesize == 0)
       mach->cachesize = (4 * 1024 * 1024);
-    /* ...and fall through... */
+    FLANG_FALLTHROUGH;
 
   case TP_P7:
     /* Intel P7 Pentium IV


### PR DESCRIPTION
Add `FLANG_FALLTHROUGH` in affected case statements to silence
`-Wimplicit-fallthrough` warnings. The definition of the macro is lifted
from LLVM's `include/llvm/Support/Compiler.h`. Also add or remove default
`case` statements to silence `-Wswitch` or `-Wcovered-switch-default` warnings. NFCI.