### PR TITLE
[flang1][flang2] Guard unused code with macros; NFCI

### DIFF
--- a/runtime/flang/allo.c
+++ b/runtime/flang/allo.c
@@ -102,6 +102,7 @@ static long num_hdrs = NUM_HDRS;
 
 #define ALLHDR()
 
+#ifdef FLANG_ALLO_UNUSED
 /** \brief
  * Allocate ALLO_HDR list */
 static void
@@ -138,6 +139,7 @@ allhdr()
 
   MP_V(sem);
 }
+#endif
 
 /** \brief
  * Return nonzero if addresses p1 and p2 are aligned with respect to a

--- a/runtime/flang/encodefmt.c
+++ b/runtime/flang/encodefmt.c
@@ -705,6 +705,7 @@ int *len;
 
 /* ---------------------------------------------------------------- */
 
+#ifdef FLANG_ENCODEFMT_UNUSED
 static int ef_nextdtchar(p, len)
     /* call after encounter DT */
     char *p;
@@ -723,6 +724,7 @@ int *len;
     c = c + ('A' - 'a');
   return c;
 }
+#endif
 
 /* -------------------------------------------------------------------- */
 

--- a/runtime/flang/fmtconv.c
+++ b/runtime/flang/fmtconv.c
@@ -37,8 +37,10 @@ static void conv_e(int, int, int, bool);
 static void conv_en(int, int, bool);
 static void conv_es(int, int, bool);
 static void conv_f(int, int);
+#ifdef FLANG_FMTCONV_UNUSED
 static void fp_canon(__BIGREAL_T, int, int);
 static void cvtp_round(int);
+#endif
 static void cvtp_cp(int);
 static void cvtp_set(int, int);
 static void alloc_fpbuf(int);
@@ -1063,6 +1065,7 @@ __fortio_fmt_z(unsigned int c)
   return buff_pos;
 }
 
+#ifdef FLANG_FMTCONV_UNUSED
 static void
 fp_canon(__BIGREAL_T val, int type, int round)
 {
@@ -1119,6 +1122,7 @@ cvtp_round(int d)
   }
 
 }
+#endif
 
 static void
 cvtp_cp(int n)

--- a/runtime/flang/fpcvt.c
+++ b/runtime/flang/fpcvt.c
@@ -56,6 +56,7 @@ static void fperror(int x);
 #define FP_UNDERFLOW_ERROR      -3
 #define FP_UNDEFINED_ERROR      -4
 
+#ifdef FLANG_FPCVT_UNUSED
 static void
 ui64toa(INT m[2], char *s, int n, int decpl)
 {
@@ -89,6 +90,7 @@ ui64toa(INT m[2], char *s, int n, int decpl)
     s[j] = buff[i];
   s[j] = '\0';
 }
+#endif
 
 static void
 manshftr(INT *m, /* m[4] */
@@ -299,6 +301,7 @@ ufpxten(UFP *u, int exp)
   u->fexp += ftab1[i][2] + ftab2[j][2];
 }
 
+#ifdef FLANG_FPCVT_UNUSED
 static void
 ufptosci(UFP *u, char *s, int dp, int *decpt, int *sign)
 {
@@ -340,7 +343,9 @@ again:
   }
   *decpt = exp10;
 }
+#endif
 
+#ifdef FLANG_FPCVT_UNUSED
 static void
 ufptodec(UFP *u, char *s, int dp, int *decpt, int *sign)
 {
@@ -363,7 +368,9 @@ ufptodec(UFP *u, char *s, int dp, int *decpt, int *sign)
   manrnd(u->fman, 64);
   ui64toa(u->fman, s, 0, dp);
 }
+#endif
 
+#ifdef FLANG_FPCVT_UNUSED
 static void
 dtoufp(IEEE64 d, UFP *u)
 {
@@ -396,6 +403,7 @@ dtoufp(IEEE64 d, UFP *u)
   } else
     u->fman[0] |= 0x00100000L;
 }
+#endif
 
 static void
 ufptod(UFP *u, IEEE64 *r)

--- a/runtime/flang/query.c
+++ b/runtime/flang/query.c
@@ -32,6 +32,7 @@ static int I8(fetch_int)(void *b, F90_Desc *s)
   }
 }
 
+#ifdef FLANG_QUERY_UNUSED
 static int I8(fetch_log)(void *b, F90_Desc *s)
 {
   dtype kind = TYPEKIND(s);
@@ -49,6 +50,7 @@ static int I8(fetch_log)(void *b, F90_Desc *s)
     return 0;
   }
 }
+#endif
 
 static void I8(fetch_vector)(void *ab, F90_Desc *as, __INT_T *vector,
                              int veclen)

--- a/runtime/flang/rdst.c
+++ b/runtime/flang/rdst.c
@@ -261,6 +261,7 @@ I8(is_nonsequential_section)(F90_Desc *a, __INT_T dim)
 #define EXPAND 0x080
 #define RECOPY 0x100
 
+#ifdef FLANG_RDST_UNUSED
 static void
 invalid_flags(int flags)
 {
@@ -270,6 +271,7 @@ invalid_flags(int flags)
 #endif
   __fort_abort("COPY_IN: internal error, invalid flags");
 }
+#endif
 
 static void
 copy_in_abort(char *msg)
@@ -2829,7 +2831,10 @@ ENTF90(EXECCMDLINE, execcmdline)(DCHAR(command), __LOG_T *wait,
                                  __INT_T *cmdstat_int_kind 
                                  DCLEN64(command) DCLEN64(cmdmsg)) {
   char *cmd, *cmdmes;
-  int cmdmes_len, stat;
+  int cmdmes_len;
+#if (defined(TARGET_LINUX_X8664) || defined(TARGET_OSX_X8664) || defined(TARGET_LINUX_POWER) || defined(TARGET_LINUX_ARM32) || defined(TARGET_LINUX_ARM64)) && !defined(TARGET_WIN)
+  int stat;
+#endif
   int cmdflag = 0;
   enum CMD_ERR{NO_SUPPORT_ERR=-1, FORK_ERR=1, EXECL_ERR=2, SIGNAL_ERR=3};
   

--- a/tools/flang1/flang1exe/accpp.c
+++ b/tools/flang1/flang1exe/accpp.c
@@ -641,7 +641,9 @@ static int findtok(char *, int);
 static int macro_recur_check(PPSYM *);
 static int predarg(char *);
 static void predicate(char *);
+#ifdef ATT_PREDICATE
 static void add_predicate(char *);
+#endif
 static ptrdiff_t realloc_linebuf(ptrdiff_t);
 static int nextok(char *, int);
 static int _nextline(void);
@@ -649,7 +651,9 @@ static int mac_push(PPSYM *, char *);
 static void popstack(void);
 static void stash_paths(char *);
 static void dumpval(char *, FILE *);
+#ifdef DUMPTAB
 static void dumptab(void);
+#endif
 static void dumpmac(PPSYM *sp);
 static void putmac(PPSYM *);
 static void putunmac(char *);
@@ -1969,6 +1973,7 @@ doincl(LOGICAL include_next)
 
 }
 
+#ifdef FLANG1_ACCPP_UNUSED
 /** \brief
  * Check if fullname is a file in a standard include directory.
  */
@@ -2011,6 +2016,7 @@ is_in_stdinc(const char *fullname)
   }
   return FALSE;
 }
+#endif
 
 /** \brief
  * Add fullname to the list of include files in incllist.
@@ -2144,6 +2150,7 @@ found:
   add_to_incllist(fullname);
 }
 
+#ifdef FLANG1_ACCPP_UNUSED
 static void
 preincl(char *prename)
 {
@@ -2220,6 +2227,7 @@ found:
   pr_line(fullname, 1, inclstack[inclev].from_stdinc);
   add_to_incllist(fullname);
 } /* preincl */
+#endif
 
 static void
 domodule(void)
@@ -2936,6 +2944,7 @@ dumpmac(PPSYM *sp)
   dumpval(&deftab[sp->value], stderr);
 }
 
+#ifdef DUMPTAB
 static void
 dumptab(void)
 {
@@ -2946,6 +2955,7 @@ dumptab(void)
     dumpmac(hashrec + i);
   }
 }
+#endif
 
 /*
  * output macro value in human readable form
@@ -4889,6 +4899,7 @@ static char *predtab[NPRED];
 static int prednum = 1;
 static int pred = 0;
 
+#ifdef ATT_PREDICATE
 static void
 add_predicate(char *str)
 {
@@ -4918,6 +4929,7 @@ add_predicate(char *str)
     *q = 0;
   }
 }
+#endif
 
 static void
 predicate(char *tokval)

--- a/tools/flang1/flang1exe/bblock.c
+++ b/tools/flang1/flang1exe/bblock.c
@@ -1019,6 +1019,11 @@ merge_commons()
   }
 } /* merge_commons */
 
+#ifdef FLANG_COMMON_BLOCK_ERROR_UNUSED
+/* FIXME: This function is not being used, but it isn't clear why error 482
+ * ("COMMON /$/ is declared differently in two subprograms - $") does not
+ * need to be emitted.
+ */
 static void
 puttwice(int cmn1, int cmn2)
 {
@@ -1037,6 +1042,7 @@ puttwice(int cmn1, int cmn2)
   sprintf(errmsg, "%s and %s", SYMNAME(func1), SYMNAME(func2));
   error(482, 3, FUNCLINEG(gbl.currsub), SYMNAME(cmn1), errmsg);
 } /* puttwice */
+#endif
 
 static LOGICAL
 same_datatype(int s1, int s2)

--- a/tools/flang1/flang1exe/comm.c
+++ b/tools/flang1/flang1exe/comm.c
@@ -66,8 +66,10 @@ static void shape_comm(int cstd, int fstd, int forall);
 static int sequentialize_mask_call(int forall, int stdnext);
 static int sequentialize_stmt_call(int forall, int stdnext);
 static int sequentialize_call(int cstd, int stdnext, int forall);
+#ifdef FLANG_COMM_UNUSED
 static int gen_shape_comm(int arg, int forall, int std, int nomask);
 static int reference_for_pure_temp(int sptr, int lhs, int arg, int forall);
+#endif
 static void init_pertbl(void);
 static void free_pertbl(void);
 static int get_pertbl(void);
@@ -77,9 +79,11 @@ static void init_opt_tables(void);
 static LOGICAL is_scatter(int std);
 static void opt_overlap(void);
 static int insert_forall_comm(int ast);
+#ifdef FLANG_COMM_UNUSED
 static int construct_list_for_pure(int arg, int mask, int list);
 static LOGICAL is_pure_temp_too_large(int list, int arg);
 static int handle_pure_temp_too_large(int expr, int std);
+#endif
 static int forall_2_sec(int a, int forall);
 static int make_sec_ast(int arr, int std, int allocstd, int sectflag);
 static int temp_copy_section(int std, int forall, int lhs, int rhs, int dty,
@@ -3338,6 +3342,7 @@ shape_comm(int cstd, int fstd, int forall)
   }
 }
 
+#ifdef FLANG_COMM_UNUSED
 /* The function of this routine is to handle communication of arg.
  * This arg is from PURE function and it has shape. It will try to
  * bring to lhs of forall. Distribution of TMP will be based on LHS.
@@ -3355,7 +3360,6 @@ shape_comm(int cstd, int fstd, int forall)
  * is_pure_temp_too_large() decides whether tmp will have more dimension than
  * arg. if it is, tmp will be replication of arg.
  */
-
 static int
 gen_shape_comm(int arg, int forall, int std, int nomask)
 {
@@ -3636,6 +3640,7 @@ handle_pure_temp_too_large(int expr, int std)
     return expr;
   }
 }
+#endif
 
 static void
 insert_call_comm(int std, int forall)

--- a/tools/flang1/flang1exe/commgen.c
+++ b/tools/flang1/flang1exe/commgen.c
@@ -27,7 +27,9 @@
 #include "fdirect.h"
 #include "rtlRtns.h"
 
+#ifdef FLANG_COMMGEN_UNUSED
 static void generate_forall(int);
+#endif
 static void change_forall_triple(int, int, int, LOGICAL);
 static int fill_cyclic_k(int);
 static void fill_cyclic_1(int);
@@ -35,19 +37,25 @@ static void generate_hallobnds(int);
 static void generate_sect(int);
 static void generate_copy(int);
 static void generate_gather(int);
+#ifdef FLANG_COMMGEN_UNUSED
 static void generate_shift(int);
-static void generate_ownerproc(int astAssn);
-static int inline_ownerproc(int astAssn);
+#endif
 static void generate_get_scalar(void);
 static void eliminate_redundant(void);
+#ifdef FLANG_COMMGEN_UNUSED
 static int rewrite_expr(int, int, int);
+#endif
 static void pointer_changer(void);
 static int pointer_squeezer(int);
 static int cyclic_section(int, int, int, int, int);
+#ifdef FLANG_COMMGEN_UNUSED
 static LOGICAL is_same_lower_dim(int, int, int, int);
+#endif
 static int gen_minmax(int, int, int);
+#ifdef FLANG_COMMGEN_UNUSED
 static int rhs_cyclic(int, int, int);
 static int cyclic_localize(int, int, int);
+#endif
 
 void
 comm_generator(void)
@@ -567,6 +575,7 @@ generate_gather(int ast)
   }
 }
 
+#ifdef FLANG_COMMGEN_UNUSED
 static void
 generate_shift(int ast)
 {
@@ -687,6 +696,7 @@ generate_shift(int ast)
   A_ARGSP(ast, argt);
   add_stmt_after(ast, freestd);
 }
+#endif
 
 /*  This routine will give outvalue   */
 
@@ -1392,6 +1402,7 @@ fill_cyclic_k(int ast)
   return mk_triple(lb, ub, 0);
 }
 
+#ifdef FLANG_COMMGEN_UNUSED
 static void
 generate_forall(int ast)
 {
@@ -1495,6 +1506,7 @@ rhs_cyclic(int ast, int std, int ifexpr)
     return 0;
   }
 }
+#endif
 
 int
 gen_localize_index(int sptr, int dim, int subAst, int astmem)
@@ -1554,6 +1566,7 @@ cyclic_section(int sptr, int idxAst, int clofAst, int i, int memberast)
   return ast2;
 }
 
+#ifdef FLANG_COMMGEN_UNUSED
 /* to check two sptr lower bounds are the same at
  * at the given dimension.
  */
@@ -1636,6 +1649,7 @@ rewrite_expr(int expr, int a, int b)
     return expr;
   }
 }
+#endif
 
 /* This routine is to emit bounds calculation for BLOCK distribution
  * stride==1

--- a/tools/flang1/flang1exe/commopt.c
+++ b/tools/flang1/flang1exe/commopt.c
@@ -2809,6 +2809,7 @@ dlist(LITEMF *list)
   fprintf(dfile, "\n");
 }
 
+#ifdef FLANG_COMMOPT_UNUSED
 static int
 common_compute_point(LITEMF *nm_list, int fg, int std)
 {
@@ -2864,6 +2865,7 @@ common_compute_point(LITEMF *nm_list, int fg, int std)
   else
     return STD_PREV(std);
 }
+#endif
 
 /* This routine is to change all allocate statements into
  * allocate ast which is defined for hpf communication ast.
@@ -3271,7 +3273,8 @@ is_same_def(int def, int def1)
   return TRUE;
 }
 
-/* This routine is checks that def has only one definition and
+#ifdef FLANG_COMMOPT_UNUSED
+/* This routine checks that def has only one definition and
  * src of that definition is a constant; if so, it returns
  * the ast of the difference, else it returns 'defaultval'
  */
@@ -3314,6 +3317,7 @@ diff_def_cnst(int cnstAst, int def, int defaultval)
 
   return ast;
 }
+#endif
 
 static void
 rewrite_all_shape(LITEMF *exceptions)

--- a/tools/flang1/flang1exe/detect.c
+++ b/tools/flang1/flang1exe/detect.c
@@ -29,15 +29,19 @@ static void tag_comms(int);
 static void matched_dim(int);
 static void no_comm_class(int);
 static void overlap_class(int);
+#ifdef FLANG_DETECT_UNUSED
 static void copy_section_class(int);
 static void gather_class(int, int);
+#endif
 static void convert_idx_scalar(int);
 static int is_structured(int);
+#ifdef FLANG_DETECT_UNUSED
 static LOGICAL is_scatterx_gatherx_subscript(int, int);
 static LOGICAL result_base_relation(int result, int base, int forall);
 static LOGICAL mask_array_relation(int mask, int array, int forall);
 static int generic_intrinsic_type(int);
 static LOGICAL is_all_idx_appears(int, int);
+#endif
 static LOGICAL is_array_in_expr(int ast);
 static LOGICAL is_nonscalar_array_in_expr(int ast);
 
@@ -698,6 +702,7 @@ no_comm_class(int a)
     ARREF_CLASS(arref) = NO_COMM;
 }
 
+#ifdef FLANG_DETECT_UNUSED
 /* Algorithm:
  * This routine does not cares about neither template nor distribution types.
  * It looks the subscripts of lhs and rhs:
@@ -920,6 +925,7 @@ scatter_type(int std)
   comminfo.scat.function = func;
   comminfo.scat.array_simple = TRUE;
 }
+#endif
 
 LOGICAL
 scatter_class(int std)
@@ -927,6 +933,7 @@ scatter_class(int std)
   return FALSE;
 }
 
+#ifdef FLANG_DETECT_UNUSED
 static int
 generic_intrinsic_type(int otype)
 {
@@ -1025,6 +1032,7 @@ result_base_relation(int result, int base, int forall)
     return TRUE;
   return FALSE;
 }
+#endif
 
 /** \brief Inquire whether array has indirection in its subscripts */
 LOGICAL
@@ -1649,6 +1657,7 @@ convert_idx_scalar(int arref)
   }
 }
 
+#ifdef FLANG_DETECT_UNUSED
 /* This routine is to check
  * whether all ind from list appears at array subscript
  * For example, (i=, j=) a(i,j) true
@@ -1684,4 +1693,5 @@ is_all_idx_appears(int a, int list)
   }
   return TRUE;
 }
+#endif
 

--- a/tools/flang1/flang1exe/dpm_out.c
+++ b/tools/flang1/flang1exe/dpm_out.c
@@ -38,9 +38,11 @@
 #define NO_DERIVEDPTR XBIT(58, 0x40000)
 
 static void handle_nonalloc_template(void);
+#ifdef FLANG_DPM_OUT_UNUSED
 static int exist_test(int, int);
 
 static void add_adjarr_bounds_extr_f77(int, int, int);
+#endif
 static bool allocate_one_auto(int);
 static void component_init_allocd_auto(int, int);
 static int bnd_assn_precedes(int, int, int);
@@ -48,8 +50,10 @@ static void add_auto_bounds(int, int);
 static void mk_allocate_scalar(int memberast, int sptr, int before);
 static void mk_deallocate_scalar(int memberast, int sptr, int after);
 static void dealloc_dt_auto(int, int, int);
+#ifdef FLANG_DPM_OUT_UNUSED
 static int find_actual(int, int, int);
 static void set_actual(int, int, LOGICAL);
+#endif
 
 static void open_entry_guard(int);
 static void close_entry_guard(void);
@@ -68,16 +72,22 @@ static void change_mk_id(int sptr, int sptr1);
 static void do_change_mk_id(void);
 
 static void finish_fl(void);
+#ifdef FLANG_DPM_OUT_UNUSED
 static void add_fl(int);
+#endif
 static bool emit_alnd(int sptr, int memberast, LOGICAL free_flag,
                       LOGICAL for_allocate, int allocbounds);
 static void emit_secd(int sptr, int memberast, LOGICAL free_flag,
                       LOGICAL for_allocate);
+#ifdef FLANG_DPM_OUT_UNUSED
 static void construct_align_sc(int, int, int);
+#endif
 static void fix_sdsc_sc(int, int, int);
 static void emit_redim(int arg);
 static void emit_kopy_in(int, int, int);
+#ifdef FLANG_DPM_OUT_UNUSED
 static LOGICAL is_f77_adjustable(int sptr);
+#endif
 static void emit_scalar_kopy_in(int, int);
 static int gen_ptr_in(int, int);
 static int gen_ptr_out(int, int);
@@ -94,9 +104,11 @@ static void update_dist(int);
 static int get_scalar_in_expr(int expr, int std, LOGICAL astversion);
 static int emit_get_scalar_sub(int, int);
 
+#ifdef FLANG_DPM_OUT_UNUSED
 static void update_with_actual(int);
 static void update_bounds_with_actual(int);
 static void emit_bcst_scalar(int sptr, int std);
+#endif
 
 static int get_arg_table(void);
 static void put_arg_table(int);
@@ -192,6 +204,7 @@ finish_fl(void)
   FREE(fl.base);
 }
 
+#ifdef FLANG_DPM_OUT_UNUSED
 static void
 add_fl(int a)
 {
@@ -224,6 +237,7 @@ add_fl(int a)
     fl.base[nd] = a;
   }
 }
+#endif
 
 /**
    \brief Stub
@@ -507,6 +521,7 @@ make_alnd(int sptr)
   return nd;
 }
 
+#ifdef FLANG_DPM_OUT_UNUSED
 static void
 construct_align_sc(int alnd, int alignee, int target)
 {
@@ -626,6 +641,7 @@ construct_align_sc(int alnd, int alignee, int target)
     return;
   }
 }
+#endif
 
 static LOGICAL
 is_set(int flag, int value)
@@ -2665,6 +2681,7 @@ newargs_for_entry(int this_entry)
   return new_dscptr;
 }
 
+#ifdef FLANG_DPM_OUT_UNUSED
 /* This routine generate IFTHEN to test static descriptor
  * initilaized. "if(a$sd(1) .eq. 0)
  */
@@ -2683,6 +2700,7 @@ exist_test(int sdsc, int memberast)
   A_IFEXPRP(astnew, ifexpr);
   return astnew;
 }
+#endif
 
 static int *orderargs; /* List of arguments in dependence order. */
 
@@ -3284,6 +3302,7 @@ emit_kopy_in(int arg, int this_entry, int actual)
   gbitable.unconditional = 1;
 } /* emit_kopy_in */
 
+#ifdef FLANG_DPM_OUT_UNUSED
 /* Return TRUE if the arry given by sptr is adjustable according to
  * Fortran-77. */
 static LOGICAL
@@ -3320,6 +3339,7 @@ is_f77_adjustable(int sptr)
   }
   return TRUE;
 }
+#endif
 
 /* pghpf_copy_out_(void *db, void *sb, section *ds,
  *			  section *ss, int intent);
@@ -4521,6 +4541,7 @@ redimension(int sptr, int memberast)
   add_stmt_before(astnew, EntryStd);
 }
 
+#ifdef FLANG_DPM_OUT_UNUSED
 static void
 add_adjarr_bounds_extr_f77(int sym, int entry, int call_ast)
 {
@@ -4662,6 +4683,7 @@ set_actual(int entry, int call_ast, LOGICAL arrays)
     }
   }
 }
+#endif
 
 #undef BND_ASSN_PRECEDES
 

--- a/tools/flang1/flang1exe/dump.c
+++ b/tools/flang1/flang1exe/dump.c
@@ -72,6 +72,7 @@ putint(char *s, int d)
   putit();
 } /* putint */
 
+#ifdef FLANG_DUMP_UNUSED
 static void
 putintstar(char *s, int d, int star, char *starstring)
 {
@@ -82,6 +83,7 @@ putintstar(char *s, int d, int star, char *starstring)
   }
   putit();
 } /* putintstar */
+#endif
 
 static void
 put2int(char *s, int d1, int d2)
@@ -204,6 +206,7 @@ putsym1(int sptr)
   putit();
 } /* putsym1 */
 
+#ifdef FLANG_DUMP_UNUSED
 static void
 putintsym1(int d, int sptr)
 {
@@ -216,6 +219,7 @@ putintsym1(int d, int sptr)
   }
   putit();
 } /* putintsym1 */
+#endif
 
 static void
 putsymilist(int symi)
@@ -499,6 +503,7 @@ dumplists()
   }
 } /* dumplists */
 
+#ifdef FLANG_DUMP_UNUSED
 static void
 putsymflags()
 {
@@ -577,6 +582,7 @@ putsymflags()
     putit();
   }
 } /* putsymflags */
+#endif
 
 static void
 putbit(char *s, int b)
@@ -605,6 +611,7 @@ check(char *s, int v)
   }
 } /* check */
 
+#ifdef FLANG_DUMP_UNUSED
 static void
 putmap(char *s, int m)
 {
@@ -624,6 +631,7 @@ putmap(char *s, int m)
     putit();
   }
 } /* putmap */
+#endif
 
 void
 putasttype(char *s, int opc)

--- a/tools/flang1/flang1exe/exterf.c
+++ b/tools/flang1/flang1exe/exterf.c
@@ -110,21 +110,28 @@ static void export_ieee_arith_libraries(void);
 static void export_one_std(int);
 static void queue_one_std(int std);
 static void all_stds(void (*)(int));
+#ifdef FLANG_EXTERF_UNUSED
 static void export_parameter_info(ast_visit_fn);
+#endif
 static void export_data_file(int);
 static void export_component_init(int);
 static void export_data_file_asts(ast_visit_fn, int, int, int);
 static void export_component_init_asts(ast_visit_fn, int, int);
+#ifdef FLANG_EXTERF_UNUSED
 static void export_equiv_asts(int, ast_visit_fn);
 static void export_dist_info(int, ast_visit_fn);
 static void export_align_info(int, ast_visit_fn);
+#endif
 static void export_equivs(void);
 static void export_external_equiv();
 
+#ifdef FLANG_EXTERF_UNUSED
 static void export_dinit_file(void (*)(int), void (*)(int, INT), int);
 static void export_dinit_record(int, INT);
+#endif
 static int dtype_skip(int dtype);
 
+#ifdef FLANG_EXTERF_UNUSED
 /* return 1 if the base type is double/complex/other 8-byte-type */
 static int
 doubletype(int sptr)
@@ -149,6 +156,7 @@ doubletype(int sptr)
   }
   return 0;
 } /* doubletype */
+#endif
 
 void
 export_public_module(int module, int exceptlist)
@@ -2881,13 +2889,16 @@ all_stds(void (*callproc)(int))
     (*callproc)(std);
 }
 
+#ifdef FLANG_EXTERF_UNUSED
 /* export a single record to the interf file */
 static void
 export_dinit_record(int rectype, INT recval)
 {
   lzprintf(outlz, "I %d %x\n", rectype, recval);
 } /* export_dinit_record */
+#endif
 
+#ifdef FLANG_EXTERF_UNUSED
 /*
  * go through data initialization file.
  * call symproc for symbols in that file that will be saved
@@ -2983,7 +2994,9 @@ export_dinit_file(void (*symproc)(int), void (*recproc)(int, INT),
   }
   dinit_fseek_end();
 } /* export_dinit_file */
+#endif
 
+#ifdef FLANG_EXTERF_UNUSED
 /* go through symbols; if we find one that is a parameter, export
  * the ASTs for its value */
 static void
@@ -2998,7 +3011,9 @@ export_parameter_info(ast_visit_fn astproc)
     }
   }
 } /* export_parameter_info */
+#endif
 
+#ifdef FLANG_EXTERF_UNUSED
 static int
 externalequiv(int evp)
 {
@@ -3013,7 +3028,9 @@ externalequiv(int evp)
   } while (evp != 0 && EQV(evp).is_first == 0);
   return FALSE;
 } /* externalequiv */
+#endif
 
+#ifdef FLANG_EXTERF_UNUSED
 static void
 export_equiv_asts(int queuesym, ast_visit_fn astproc)
 {
@@ -3044,6 +3061,7 @@ export_equiv_asts(int queuesym, ast_visit_fn astproc)
     }
   }
 } /* export_equiv_asts */
+#endif
 
 static void
 export_equiv_item(int evp)
@@ -3062,6 +3080,7 @@ export_equiv_item(int evp)
   lzprintf(outlz, " -1\n"); /*  end of subscripts */
 } /* export_equiv_item */
 
+#ifdef FLANG_EXTERF_UNUSED
 static void
 export_external_equiv()
 {
@@ -3079,6 +3098,7 @@ export_external_equiv()
     }
   }
 } /* export_external_equiv */
+#endif
 
 static void
 export_equivs(void)

--- a/tools/flang1/flang1exe/flow.c
+++ b/tools/flang1/flang1exe/flow.c
@@ -119,12 +119,16 @@ static LOGICAL bld_ud(int, int *); /**< pre-order visit routine called during
 static int bld_use(int, LOGICAL);  /**< visit routine for adding uses */
 static DEF *bld_lhs(int, int, LOGICAL, int); /**< visit routine for the lhs of
                                                 assignments */
+#ifdef FLANG_FLOW_UNUSED
 static void def_from_triple(int, int);
+#endif
 
 static void _cr_nme(int ast, int *dummy);
 static int copy_const(int);
+#ifdef FLANG_FLOW_UNUSED
 static int lhs_notsubscr(int);
 static void cp_cse_store(void);
+#endif
 static void new_ud(int astx);
 static void new_du_ud(void);
 
@@ -1401,6 +1405,7 @@ again:
   return df;
 }
 
+#ifdef FLANG_FLOW_UNUSED
 /* stmt ast containing the triple whose fields are
  * being defined */
 static void
@@ -1426,6 +1431,7 @@ def_from_triple(int stmt, int triple)
       df->flags.bits.other = 1;
   }
 }
+#endif
 
 static void
 build_do_init(int tree)
@@ -2382,6 +2388,7 @@ bv_count(int *bv)
   return count;
 } /* bv_count */
 
+#ifdef FLANG_FLOW_UNUSED
 static void
 dump_queue(Q_ITEM *head)
 {
@@ -2397,6 +2404,7 @@ dump_queue(Q_ITEM *head)
     fprintf(gbl.dbgfil, " ...");
   fprintf(gbl.dbgfil, " (%4d entries)\n", count);
 } /* dump_queue */
+#endif
 #endif
 
 /*
@@ -2859,6 +2867,7 @@ const_prop(void)
   return changes;
 }
 
+#ifdef FLANG_FLOW_UNUSED
 static int
 lhs_notsubscr(int use)
 {
@@ -2871,6 +2880,7 @@ lhs_notsubscr(int use)
     return 0;
   return 1;
 }
+#endif
 
 static int
 copy_const(int use)

--- a/tools/flang1/flang1exe/func.c
+++ b/tools/flang1/flang1exe/func.c
@@ -115,6 +115,7 @@ gen_scalar_mask(int ast, int list)
   return 0;
 } /* gen_scalar_mask */
 
+#ifdef FLANG_FUNC_UNUSED
 /*
  * SUM and PRODUCT reductions use a longer datatype for
  * the reduction temporary; for instance, they use
@@ -160,7 +161,9 @@ reduction_type(DTYPE dtype)
     return dtype;
   }
 } /* reduction_type */
+#endif
 
+#ifdef FLANG_FUNC_UNUSED
 static int
 assign_result(int sptr, int ast, DTYPE dtype, DTYPE dtyperes, int stdnext,
               int lineno)
@@ -182,6 +185,7 @@ assign_result(int sptr, int ast, DTYPE dtype, DTYPE dtyperes, int stdnext,
   STD_KERNEL(std) = STD_KERNEL(stdnext);
   return tsclrAst;
 } /* assign_result */
+#endif
 
 /* this will check whether cshift or eoshift needs any communication. */
 static LOGICAL

--- a/tools/flang1/flang1exe/hlvect.c
+++ b/tools/flang1/flang1exe/hlvect.c
@@ -28,8 +28,12 @@
 #if DEBUG
 #include <stdarg.h>
 
+#ifdef FLANG_HLVECT_UNUSED
 #define Trace(a) TraceOutput a
 #define STrace(a) STraceOutput a
+#endif
+
+#ifdef FLANG_HLVECT_UNUSED
 /* print a message, continue */
 static void
 TraceOutput(const char *fmt, ...)
@@ -49,7 +53,9 @@ TraceOutput(const char *fmt, ...)
   }
   va_end(argptr);
 } /* TraceOutput */
+#endif
 
+#ifdef FLANG_HLVECT_UNUSED
 /* print a message, continue */
 static void
 STraceOutput(const char *fmt, ...)
@@ -69,6 +75,7 @@ STraceOutput(const char *fmt, ...)
   }
   va_end(argptr);
 } /* STraceOutput */
+#endif
 
 extern void dumpnme(int n);
 extern void dumploop(int l);
@@ -86,6 +93,7 @@ int hlv_getsym(int phase, int type);
 void vdel_bih(int bihx);
 LOGICAL is_parent_loop(int lpParent, int lpChild);
 
+#ifdef FLANG_HLVECT_UNUSED
 static void analyze_subs(int loop);
 static void compute_subs(int mr, int loop);
 static LOGICAL ilt_preceeds(int ilt1, int ilt2);
@@ -121,10 +129,13 @@ static LOGICAL _contains_shape_string(int ast, LOGICAL *pflag);
 static LOGICAL has_valid_stmts(int lp);
 
 static void hlv_syminitfunc(void);
+#endif
 
 #if DEBUG
 void dump_memrefs(int start, int cnt);
+#ifdef FLANG_HLVECT_UNUSED
 static void dump_subs(void);
+#endif
 void dump_vinduc(int start, int cnt);
 void dump_vloops(int first, int base);
 #endif
@@ -178,6 +189,7 @@ enum {
 
 static int vdel_lst; /* list of blocks to be deleted at end of processing */
 
+#ifdef FLANG_HLVECT_UNUSED
 /* Init for function */
 static void
 hlv_init(void)
@@ -216,7 +228,9 @@ hlv_init(void)
 
   hlv_syminitfunc();
 }
+#endif
 
+#ifdef FLANG_HLVECT_UNUSED
 /* end for function */
 static void
 hlv_end(void)
@@ -234,6 +248,7 @@ hlv_end(void)
   FREE(hlv.scbase);
   FREE(hlv.eabase);
 }
+#endif
 
 /************************************************************************
  ************************************************************************/
@@ -260,6 +275,7 @@ unmark_vinduc(int loop)
     NME_RFPTR(VIND_NM(i)) = 0;
 }
 
+#ifdef FLANG_HLVECT_UNUSED
 static void
 hlv_syminitfunc(void)
 {
@@ -271,6 +287,7 @@ hlv_syminitfunc(void)
           hlv_temps[i][j].iavl_max;
   hlv_vtemps.iavl = hlv_vtemps.iavl_base = hlv_vtemps.iavl_max;
 }
+#endif
 
 int
 hlv_getsym(int phase, int type)
@@ -326,6 +343,7 @@ vdel_bih(int bihx)
   vdel_lst = bihx;
 }
 
+#ifdef FLANG_HLVECT_UNUSED
 /* Delete all bih's within the vdel_lst list, as well as all ilt's within
  * those bih's. */
 static void
@@ -343,15 +361,19 @@ vunlnk_bih(void)
     delbih(bihx);
   }
 }
+#endif
 
+#ifdef FLANG_HLVECT_UNUSED
 static void
 delbih(int fgx)
 {
   FG_LNEXT(FG_LPREV(fgx)) = FG_LNEXT(fgx);
   FG_LPREV(FG_LNEXT(fgx)) = FG_LPREV(fgx);
 }
+#endif
 
 #if DEBUG
+#ifdef FLANG_HLVECT_UNUSED
 /* DEBUG DUMP ROUTINES */
 static void
 dump_subs(void)
@@ -374,6 +396,7 @@ dump_subs(void)
     }
   }
 }
+#endif
 
 void
 dump_memref_hdr(void)

--- a/tools/flang1/flang1exe/induc.c
+++ b/tools/flang1/flang1exe/induc.c
@@ -60,9 +60,11 @@ static void scan_ind_uses(int);
 static void scan_def(int, int);
 
 static int find_fam(int);
+#ifdef FLANG_INDUC_UNUSED
 static DU *get_du(int, int, int, int, int);
 static void add_du(DU *, int);
 static int add_def(int, int, int, DU *, DU *);
+#endif
 static void do_branch(void);
 static int conv_to_int(int);
 
@@ -137,9 +139,11 @@ static int mark_invb; /* remember first available invariant tbl ent*/
 static int lastval_cnt;         /* ili of loop count computed by induction
                                  * to be used to compute last values
                                  */
+#ifdef FLANG_INDUC_UNUSED
 static LOGICAL cr_lastval_uses; /* True if compute_last_values must record
                                  * uses of lastval_cnt
                                  */
+#endif
 static Q_ITEM *cr_lastval_q;    /* queue of lastval_cnt uses in preheader
                                     * or exit for which new uses (add_new_uses())
                                     * must be created.
@@ -1045,6 +1049,7 @@ not_iuse:
   return TRUE; /* stop the traverse */
 }
 
+#ifdef FLANG_INDUC_UNUSED
 static DU *
 get_du(int nme, int fgx, int iltx, int ilix, int cse)
 {
@@ -1061,7 +1066,9 @@ get_du(int nme, int fgx, int iltx, int ilix, int cse)
   du->use = i;
   return du;
 }
+#endif
 
+#ifdef FLANG_INDUC_UNUSED
 static void
 add_du(DU *du, int ind)
 {
@@ -1089,7 +1096,9 @@ add_du(DU *du, int ind)
     DEF_DU(def) = du;
   }
 }
+#endif
 
+#ifdef FLANG_INDUC_UNUSED
 static int
 add_def(int nme, int fgx, int iltx, DU *csel, DU *du)
 {
@@ -1107,6 +1116,7 @@ add_def(int nme, int fgx, int iltx, DU *csel, DU *du)
   NME_DEF(nme) = i;
   return i;
 }
+#endif
 
 static void
 do_branch(void)
@@ -1336,6 +1346,7 @@ check_alias(int store)
   return TRUE;
 }
 
+#ifdef FLANG_INDUC_UNUSED
 /*     Compute last values for induction variables.                */
 
 static void
@@ -1354,6 +1365,7 @@ last_values(void)
   cr_lastval_uses = FALSE;
 
 }
+#endif
 
 static void
 dump_ind(void)

--- a/tools/flang1/flang1exe/interf.c
+++ b/tools/flang1/flang1exe/interf.c
@@ -320,10 +320,12 @@ static void new_symbol_and_link(int, int *, SYMITEM **);
 static void fill_links_symbol(SYMITEM *, WantPrivates);
 static int can_find_symbol(int);
 static int can_find_dtype(int);
+#ifdef FLANG_INTERF_UNUSED
 static SYMITEM *find_symbol(int);
 static int common_conflict(void);
 static int install_common(SYMITEM *, int);
 static LOGICAL common_mem_eq(int, int);
+#endif
 static int new_installed_dtype(int old_dt);
 static DITEM * finddthash(int old_dt);
 
@@ -1657,6 +1659,7 @@ find_nmptr(char *symname)
   return putsname(symname, len);
 } /* find_nmptr */
 
+#ifdef FLANG_INTERF_UNUSED
 /** \brief Find a nmptr index for this name, then link this symbol into
  * the stb.hashtb hash links.
  */
@@ -1679,6 +1682,7 @@ hash_link_name(int sptr, char *symname)
   HASHLKP(sptr, stb.hashtb[hash]);
   stb.hashtb[hash] = sptr;
 } /* hash_link_name */
+#endif
 
 static int
 find_member_name(char *symname, int stype, int scopesym, int offset)
@@ -3341,6 +3345,7 @@ get_nstring(char *dest, int len)
   dest[i] = '\0';
 }
 
+#ifdef FLANG_INTERF_UNUSED
 static char *
 getlstring(int area)
 {
@@ -3364,6 +3369,7 @@ getlstring(int area)
   currp = p;
   return s;
 } /* getlstring */
+#endif
 
 static int ipa_ast(int a);
 static int dindex(int dtype);
@@ -6230,6 +6236,7 @@ new_symbol_and_link(int old_sptr, int *pnew, SYMITEM **pps)
   interr("interf:new_symbol_and_link, symbol not found", old_sptr, 4);
 } /* new_symbol_and_link */
 
+#ifdef FLANG_INTERF_UNUSED
 static SYMITEM *
 find_symbol(int old_sptr)
 {
@@ -6248,6 +6255,7 @@ find_symbol(int old_sptr)
 #endif
   return symbol_list;
 }
+#endif
 
 static int
 can_find_symbol(int old_sptr)
@@ -6270,6 +6278,7 @@ can_find_dtype(int old_dt)
   return 0;
 }
 
+#ifdef FLANG_INTERF_UNUSED
 /** \brief Ensure that the common blocks from the interface file do not already
   * exist in the subprogram or if they do, their elements match.
   *
@@ -6312,7 +6321,9 @@ common_conflict(void)
   }
   return 0;
 } /* common_conflict */
+#endif
 
+#ifdef FLANG_INTERF_UNUSED
 /** \brief Compare the existing common block with the common block from the
   * interface file. Install the members while they match.
   *
@@ -6367,7 +6378,9 @@ common_diff:
   BZERO(stb.stg_base, SYM, 1);
   return cmblk;
 } /* install_common */
+#endif
 
+#ifdef FLANG_INTERF_UNUSED
 /** \brief return TRUE if two data types are equal.
   *
   * This function only needs to handle dtype situations resulting
@@ -6402,6 +6415,7 @@ common_mem_eq(int d1, int d2)
 
   return TRUE;
 }
+#endif
 
 static int
 import_mk_newsym(char *name, int stype)

--- a/tools/flang1/flang1exe/invar.c
+++ b/tools/flang1/flang1exe/invar.c
@@ -56,7 +56,9 @@ static LOGICAL invar_src(int);
 static void invar_init(int);
 static void invar_mark(int);
 static void invar_end(int);
+#ifdef FLANG_INVAR_UNUSED
 static void invar_arrnme(int);
+#endif
 static void invar_motion(int);
 static void store_ili(int);
 static void initnames(STL *);
@@ -536,6 +538,7 @@ mark_variant:
 
 }
 
+#ifdef FLANG_INVAR_UNUSED
 /*
  * for any array nme's in nme, check their subscripts.  Note that this only
  * marks the ili if necessary.  Detecting an invariant subscript is not
@@ -562,6 +565,7 @@ invar_arrnme(int nme)
     anme = NME_NM(anme);
   }
 }
+#endif
 
 static LOGICAL is_std_hoistable(int, int);
 
@@ -924,6 +928,7 @@ store_ili(int ilix)
   /* assign temp; routine marks ILI with candidate entry */
 }
 
+#ifdef FLANG_INVAR_UNUSED
 static LOGICAL
 is_nme_loop_safe(int ldnme, int lpx)
 {
@@ -953,6 +958,7 @@ is_nme_loop_safe(int ldnme, int lpx)
   */
   return TRUE;
 }
+#endif
 
 LOGICAL
 is_sym_invariant_safe(int nme, int lpx)

--- a/tools/flang1/flang1exe/lower.c
+++ b/tools/flang1/flang1exe/lower.c
@@ -40,9 +40,11 @@ static char *contained_char = NULL;
 static int *outerflags = NULL;
 
 #define STB_LOWER() ((gbl.outfil == lowersym.lowerfile) && gbl.stbfil)
+#ifdef FLANG_LOWER_UNUSED
 static void lower_directives_llvm(void);
 
 static int docount, funccount;
+#endif
 
 #if DEBUG
 void
@@ -917,6 +919,7 @@ check_return(int retdtype)
     return CLASS_INT4; /* something not CLASS_MEM */
 }
 
+#ifdef FLANG_LOWER_UNUSED
 static void
 lower_directives_llvm(void)
 {
@@ -938,4 +941,5 @@ lower_directives_llvm(void)
   }
   fprintf(gbl.stbfil, "end\n");
 } /* lower_directives_llvm */
+#endif
 

--- a/tools/flang1/flang1exe/lowerilm.c
+++ b/tools/flang1/flang1exe/lowerilm.c
@@ -1516,6 +1516,7 @@ compute_dotrip(int std, int initincsame, int doinitilm, int doendilm, int doinc,
   return dotripilm;
 } /* compute_dotrip */
 
+#ifdef FLANG_LOWERILM_UNUSED
 /* Hacked compute_dotrip() where the dotripilm is not converted to DT_INT4 */
 static int
 compute_dotrip8(int std, int initincsame, int doinitilm, int doendilm,
@@ -1546,6 +1547,7 @@ compute_dotrip8(int std, int initincsame, int doinitilm, int doendilm,
   }
   return dotripilm;
 } /* compute_dotrip8 */
+#endif
 
 static int
 dotemp(char letter, int dtype, int std)
@@ -1987,8 +1989,10 @@ llvm_omp_sched(int std, int ast, int dtype, int dotop, int dobottom, int dovar,
  * use cyclic (if chunk size is one) or block-cyclic (otherwise)
  * scheduling;  otherwise, use static block scheduling (for now)
  */
+#ifdef FLANG_LOWERILM_UNUSED
 static int lcpu2(int);
 static int ncpus2(int);
+#endif
 
 static void
 lower_do_stmt(int std, int ast, int lineno, int label)
@@ -2475,6 +2479,7 @@ lower_do_stmt(int std, int ast, int lineno, int label)
   }
 } /* lower_do_stmt */
 
+#ifdef FLANG_LOWERILM_UNUSED
 static int
 lcpu2(int dt)
 {
@@ -2484,7 +2489,9 @@ lcpu2(int dt)
     ilm = plower("oi", "ITOI8", ilm);
   return ilm;
 }
+#endif
 
+#ifdef FLANG_LOWERILM_UNUSED
 static int
 ncpus2(int dt)
 {
@@ -2494,6 +2501,7 @@ ncpus2(int dt)
     ilm = plower("oi", "ITOI8", ilm);
   return ilm;
 }
+#endif
 
 static void
 llvm_lower_enddo_stmt(int lineno, int label, int std, int ispdo)
@@ -2771,6 +2779,7 @@ lower_enddo_stmt(int lineno, int label, int std, int ispdo)
 
 } /* lower_enddo_stmt */
 
+#ifdef FLANG_LOWERILM_UNUSED
 static void
 lower_omp_atomic_read(int ast, int lineno)
 {
@@ -2789,6 +2798,7 @@ lower_omp_atomic_read(int ast, int lineno)
   }
   plower("oin", "MP_ATOMICREAD", rilm, mem_order);
 }
+#endif
 
 static void
 lower_omp_atomic_write(int ast, int lineno)

--- a/tools/flang1/flang1exe/lowersym.c
+++ b/tools/flang1/flang1exe/lowersym.c
@@ -220,7 +220,9 @@ lower_unset_symbols(void)
   }
 } /* lower_unset_symbols */
 
+#ifdef FLANG_LOWERSYM_UNUSED
 static void save_vol_descriptors(int);
+#endif
 
 /* call this first so the symbol count and datatype count won't change later */
 static void
@@ -385,6 +387,7 @@ lower_make_all_descriptors(void)
   }
 } /* lower_make_all_descriptors */
 
+#ifdef FLANG_LOWERSYM_UNUSED
 static void
 save_vol_descriptors(int sptr)
 {
@@ -422,6 +425,7 @@ save_vol_descriptors(int sptr)
     VOLP(sptr, 0);
   }
 }
+#endif
 
 static int
 remove_list(int list, int sym)
@@ -2346,6 +2350,7 @@ lower_use_datatype(int dtype, int usage)
   }
 } /* lower_use_datatype */
 
+#ifdef FLANG_LOWERSYM_UNUSED
 /* Return TRUE if this dtype was not already marked used */
 static int
 lower_unused_datatype(int dtype)
@@ -2358,6 +2363,7 @@ lower_unused_datatype(int dtype)
     return 0;
   return 1;
 } /* lower_unused_datatype */
+#endif
 
 static int
 eval_con_expr(int ast, int *val, int *dtyp)
@@ -3237,7 +3243,9 @@ lower_clear_visit_fields(void)
 } /* lower_clear_visit_fields */
 
 static int lower_cmptrvar(char *, int, int, int *);
+#ifdef FLANG_LOWERSYM_UNUSED
 static int get_cmptrvar(char *, int, int, int *);
+#endif
 
 /** \brief Add common blocks to hold various zeros
 
@@ -3365,6 +3373,7 @@ lower_cmptrvar(char *name, int stype, int dtype, int *bsym)
   return sym;
 }
 
+#ifdef FLANG_LOWERSYM_UNUSED
 static int
 get_cmptrvar(char *name, int stype, int dtype, int *bsym)
 {
@@ -3399,6 +3408,7 @@ get_cmptrvar(char *name, int stype, int dtype, int *bsym)
 
   return sym;
 }
+#endif
 
 #if TY_MAX != 36
 #error "Need to edit lowersym.c to add new TY_... data types"

--- a/tools/flang1/flang1exe/optimize.c
+++ b/tools/flang1/flang1exe/optimize.c
@@ -49,7 +49,9 @@ extern void close_pragma(void);
 static void br_to_br(void);
 static void merge_blocks(void);
 static void loop_init(int lp);
+#ifdef FLANG_OPTIMIZE_UNUSED
 static void process_exit(int lp, int s);
+#endif
 static void replace_label(int bihx, int label, int newlab);
 
 /*   SHARED init and end routines for the vectorizer and optimizer */
@@ -527,6 +529,7 @@ optimize(int whichpass)
 
 /*******************************************************************/
 
+#ifdef FLANG_OPTIMIZE_UNUSED
 /*
  * attempt to move the label which labels a bih.  The condition for
  * moving the label is if the block contains an unconditional branch.
@@ -538,6 +541,7 @@ move_label(int lab, int bih)
 {
 
 }
+#endif
 
 static void
 br_to_br(void)
@@ -856,6 +860,7 @@ add_single_loop_exit(int lp)
 
 /*******************************************************************/
 
+#ifdef FLANG_OPTIMIZE_UNUSED
 /*
  * node s is an exit target of the loop. newtarget_fg represents the
  * new exit target which must be executed before executing s.
@@ -876,6 +881,7 @@ static void
 process_exit(int lp, int s)
 {
 }
+#endif
 
 /*******************************************************************/
 

--- a/tools/flang1/flang1exe/optutil.c
+++ b/tools/flang1/flang1exe/optutil.c
@@ -1946,6 +1946,7 @@ get_next_parent(int astptr, int myparent)
   return astptr;
 }
 
+#ifdef FLANG_OPTUTIL_UNUSED
 /*  All of following should consider true
  *  astptr is                          p%p1%p2%p3
  *  astx may be one of the following:  p, p%p1, p%p1, p%p1%p2%p3
@@ -1997,6 +1998,7 @@ is_this_astptr(int astptr, int astx, int std)
 
   return FALSE;
 }
+#endif
 
 /*
  *  it check if astc is a child of astp, ignoring subscript
@@ -2196,6 +2198,7 @@ is_ptrast_arg(int ptrast, int ast)
   return FALSE;
 }
 
+#ifdef FLANG_OPTUTIL_UNUSED
 /* 1) a=>b return 1
  * 2) call(a) return 2
  * 3) all else return 0
@@ -2213,6 +2216,7 @@ isstd_ptrdef(int std)
   }
   return 0;
 }
+#endif
 
 /*
  * is a ptr def in the path <srch_ae.start.fg, srch_ae.start.stmt>,
@@ -2503,6 +2507,7 @@ ptrdefs_has_lhsconflict(int nme, int std, int def)
   return FALSE;
 }
 
+#ifdef FLANG_OPTUTIL_UNUSED
 static LOGICAL
 is_member_ast(int ast)
 {
@@ -2521,6 +2526,7 @@ is_member_ast(int ast)
   }
   return FALSE;
 }
+#endif
 
 static void
 _find_rhs_def_conflict(int ast, int *args)
@@ -2721,6 +2727,7 @@ add_lhs_nme(int nme, int std, int isdummy)
 }
 
 #if DEBUG
+#ifdef FLANG_OPTUTIL_UNUSED
 static void
 dump_lhs_nme(int nme, int std, int isdummy)
 {
@@ -2730,6 +2737,7 @@ dump_lhs_nme(int nme, int std, int isdummy)
     print_nme(nme);
   }
 }
+#endif
 #endif
 
 /* find all origin of lhs defs */

--- a/tools/flang1/flang1exe/outconv.c
+++ b/tools/flang1/flang1exe/outconv.c
@@ -53,7 +53,9 @@ static void find_descrs(void);
 static void collapse_allocates(LOGICAL bDescr);
 static void report_collapse(int lp);
 #if DEBUG
+#ifdef FLANG_OUTCONV_UNUSED
 static void dump_collapse(void);
+#endif
 #endif
 static int position_finder(int forall, int ast);
 static void find_calls_pos(int std, int forall, int must_pos);
@@ -3400,6 +3402,7 @@ is_same_mask_in_fused(int std, int *pos)
   return TRUE;
 }
 
+#ifdef FLANG_OUTCONV_UNUSED
 /* Register the barrier at stdBar for all FORALL statements fused with
  * astForall. If bBefore = TRUE, the barrier occurs before the loop. */
 static void
@@ -3424,6 +3427,7 @@ record_fused_barriers(LOGICAL bBefore, int astForall, int stdBar)
     record_barrier(bBefore, astFused, stdBar);
   }
 }
+#endif
 
 int
 conv_forall(int std)
@@ -4685,6 +4689,7 @@ report_collapse(int lp)
 
 #if DEBUG
 
+#ifdef FLANG_OUTCONV_UNUSED
 /* Dump the COLLAPSE table. */
 static void
 dump_collapse(void)
@@ -4709,6 +4714,7 @@ dump_collapse(void)
     dbg_print_ast(COLLAPSE_ASTSCLR(ci), gbl.dbgfil);
   }
 }
+#endif
 #endif
 
 /* END OF ARRAY COLLAPSING */

--- a/tools/flang1/flang1exe/pointsto.c
+++ b/tools/flang1/flang1exe/pointsto.c
@@ -1565,6 +1565,7 @@ find_pointer_assignments_f90(int stdx)
   ast_unvisit();
 } /* find_pointer_assignments_f90 */
 
+#ifdef FLANG_POINTSTO_UNUSED
 /*
  * return unique identifier for an anonymous variable
  */
@@ -1580,7 +1581,9 @@ anonymous_number(int n)
   ganon.stg_base[a] = n;
   return a;
 } /* anonymous_number */
+#endif
 
+#ifdef FLANG_POINTSTO_UNUSED
 /*
  * return unique identifier for a dynamically-allocated block of space
  */
@@ -1596,7 +1599,9 @@ dynamic_number(int n)
   gdyn.stg_base[d] = n;
   return d;
 } /* dynamic_number */
+#endif
 
+#ifdef FLANG_POINTSTO_UNUSED
 /*
  * Add pseudo assignments for initial pointer information at the program entry
  */
@@ -1661,6 +1666,7 @@ make_init_assignment(int v, int sourcesptr, int stars, int targettype,
     FIRSTAS(v) = asx;
   }
 } /* make_init_assignment */
+#endif
 
 /*
  * add the TPTE at ptex to the TPTE list at LHEAD(s)

--- a/tools/flang1/flang1exe/rest.c
+++ b/tools/flang1/flang1exe/rest.c
@@ -34,8 +34,10 @@ static int _transform_func(int, int);
 static LOGICAL stride_1_dummy(int, int, int);
 static LOGICAL stride_1_section(int, int, int, int);
 static LOGICAL dev_section_ignore_c(int, int, int, int, int);
+#ifdef FLANG_REST_UNUSED
 static LOGICAL is_expr_has_function(int);
 static void transform_extrinsic(int, int);
+#endif
 void remove_alias(int, int);
 static int first_element_from_section(int);
 static void copy_arg_to_seq_tmp(int, int, int, int, int, int, int *, int *,
@@ -44,7 +46,9 @@ static int temp_type_descriptor(int ast, int std);
 static LOGICAL is_seq_dummy(int, int, int);
 static LOGICAL needs_type_in_descr(SPTR, int);
 static LOGICAL is_optional_char_dummy(int, int, int);
+#ifdef FLANG_REST_UNUSED
 static void check_nonseq_element(int, int, int, int);
+#endif
 static void check_pure_interface(int, int, int);
 static void handle_seq_section(int, int, int, int, int *, int *, LOGICAL, int);
 static int mk_descr_from_section(int, DTYPE, int);
@@ -489,6 +493,7 @@ transform_ast(int std, int ast)
   }
 }
 
+#ifdef FLANG_REST_UNUSED
 /* This routine is to search function from expression. */
 
 static LOGICAL
@@ -580,6 +585,7 @@ is_expr_has_function(int expr)
     return FALSE;
   }
 }
+#endif
 
 int pghpf_type_sptr = 0;
 
@@ -2458,6 +2464,7 @@ is_optional_char_dummy(int entry, int arr, int pos)
   return FALSE;
 }
 
+#ifdef FLANG_REST_UNUSED
 /*
  * A scalar element of a non-sequence array can be passed as an actual
  * argument if and only if the dummy is scalar.  pghpf should enforce
@@ -2479,6 +2486,7 @@ check_nonseq_element(int std, int entry, int arr, int pos)
   if (dummy_sptr && is_array_type(dummy_sptr))
     error(472, 3, STD_LINENO(std), SYMNAME(sptr), CNULL);
 }
+#endif
 
 static int
 pure_procedure(int ast)

--- a/tools/flang1/flang1exe/rte.c
+++ b/tools/flang1/flang1exe/rte.c
@@ -30,8 +30,10 @@
 
 static int get_per_dim_member(int, int, int);
 static int get_header_member(int sdsc, int info);
+#ifdef FLANG_RTE_UNUSED
 static int divmod(LOGICAL bIsDiv, int astNum, int astDen, int astRecip,
                   int astShift, int std);
+#endif
 static char* mangleUnderscores(char* str);
 static int lenWithUnderscores(char* str);
 
@@ -859,7 +861,7 @@ get_header_member_with_parent(int parent, int sdsc, int info)
   return ast;
 }
 
-
+#ifdef FLANG_RTE_UNUSED
 static int
 get_array_rank(int sdsc)
 {
@@ -884,6 +886,7 @@ get_array_rank(int sdsc)
 
   return rank;
 }
+#endif
 
 static int
 get_per_dim_member(int sdsc, int dim, int info)
@@ -902,6 +905,7 @@ get_per_dim_member(int sdsc, int dim, int info)
   return ast;
 }
 
+#ifdef FLANG_RTE_UNUSED
 /* If bIsDiv is TRUE, add statements to compute astNum/astDen before std.
  * If bIsDiv is FALSE, add statements to compute astNum%astDen before std.
  * astRecip is the reciprocal of astDen. If astShift is nonzero,
@@ -986,3 +990,4 @@ divmod(LOGICAL bIsDiv, int astNum, int astDen, int astRecip, int astShift,
 
   return astRes;
 }
+#endif

--- a/tools/flang1/flang1exe/scan.c
+++ b/tools/flang1/flang1exe/scan.c
@@ -8792,7 +8792,9 @@ static char *tkp;
 static void _rd_tkline(char **tkbuf, int *tkbuf_sz);
 static int _rd_token(INT *);
 static INT get_num(int);
+#ifdef FLANG_SCAN_UNUSED
 static void get_string(char *);
+#endif
 
 /** \brief trim white space of source line that has continuations and return
  * the index of the last character in the source line.
@@ -9434,6 +9436,7 @@ get_num(int radix)
   return val;
 }
 
+#ifdef FLANG_SCAN_UNUSED
 static void
 get_string(char *dest)
 {
@@ -9449,6 +9452,7 @@ get_string(char *dest)
   }
   dest[i] = '\0';
 }
+#endif
 
 static void
 realloc_stmtb(void)

--- a/tools/flang1/flang1exe/semant.c
+++ b/tools/flang1/flang1exe/semant.c
@@ -77,7 +77,9 @@ static void replace_sdsc_in_bounds(int sdsc, ADSC *ad, int i);
 static int replace_sdsc_in_ast(int sdsc, int ast);
 static void chk_new_param_dt(int, int);
 static int get_vtoff(int, DTYPE);
+#ifdef FLANG_SEMANT_UNUSED
 static int has_length_type_parameter(int);
+#endif
 static int get_highest_param_offset(int);
 static ACL *dup_acl(ACL *src, int sptr);
 static int match_memname(int sptr, int list);
@@ -12696,6 +12698,7 @@ set_aclen(SST *stkptr, int ivl, int flag)
   }
 }
 
+#ifdef FLANG_SEMANT_UNUSED
 static int
 get_actype(SST *stkptr, int ivl)
 {
@@ -12703,6 +12706,7 @@ get_actype(SST *stkptr, int ivl)
                         lenspec[ivl].len, lenspec[ivl].propagated, 0);
   return sem.gdtype;
 }
+#endif
 
 static void
 ctte(int entry, int sptr)
@@ -15175,6 +15179,7 @@ chk_len_parm_expr(int ast, int dtype, int flag)
   return 0;
 }
 
+#ifdef FLANG_SEMANT_UNUSED
 static int
 fix_kind_parm_expr(int ast, int dtype, int offset, int value)
 {
@@ -15204,6 +15209,7 @@ fix_kind_parm_expr(int ast, int dtype, int offset, int value)
 
   return ast;
 }
+#endif
 
 int
 get_len_set_parm_by_name(char *np, int dtype, int *val)
@@ -16127,6 +16133,7 @@ has_type_parameter(int dtype)
   return has_type_parameter2(dtype, 0);
 }
 
+#ifdef FLANG_SEMANT_UNUSED
 static int
 has_length_type_parameter(int dtype)
 {
@@ -16145,6 +16152,7 @@ has_length_type_parameter(int dtype)
 
   return 0;
 }
+#endif
 
 int
 has_length_type_parameter_use(int dtype)

--- a/tools/flang1/flang1exe/semant3.c
+++ b/tools/flang1/flang1exe/semant3.c
@@ -41,7 +41,9 @@ static int do_label;
 static int construct_name;
 static int last_std;
 
+#ifdef FLANG_SEMANT3_UNUSED
 static void add_nullify(int);
+#endif
 static void check_do_term();
 static int gen_logical_if_expr(SST *);
 static int dealloc_tmp(int);
@@ -51,7 +53,9 @@ static int gen_derived_arr_init(int arr_dtype, int strt_std, int end_std);
 static int convert_to_block_forall(int old_forall_ast);
 
 static int find_non_tbp(char *);
+#ifdef FLANG_SEMANT3_UNUSED
 static int gen_sourced_allocation(int astdest, int astsrc);
+#endif
 
 static int construct_association(int lhs_sptr, SST *rhs, int stmt_dtype,
                                  LOGICAL is_class);
@@ -5677,12 +5681,14 @@ get_construct_name(void)
   return construct_name;
 }
 
+#ifdef FLANG_SEMANT3_UNUSED
 static void
 add_nullify(int sptr)
 {
   int ast = add_nullify_ast(mk_id(sptr));
   (void)add_stmt(ast);
 }
+#endif
 
 /* error checking: this is called at a statement that cannot
  * terminate a DO statement. */
@@ -6476,6 +6482,7 @@ gen_init_unl_poly_desc(int dest_sdsc_ast, int src_sdsc_ast, int std)
   }
 }
 
+#ifdef FLANG_SEMANT3_UNUSED
 static int
 gen_sourced_allocation(int astdest, int astsrc)
 {
@@ -6567,6 +6574,7 @@ again:
 
   return std2;
 }
+#endif
 
 /* Predicate: is the right-hand side of an association in an ASSOCIATE
  * or SELECT TYPE statement suitable for a direct association (as

--- a/tools/flang1/flang1exe/semsmp.c
+++ b/tools/flang1/flang1exe/semsmp.c
@@ -39,7 +39,9 @@ static void accel_pragmagen(int, int, int);
 
 static int sched_type(char *);
 static void set_iftype(int, char *, char *, char *);
+#ifdef FLANG_SEMSMP_UNUSED
 static void validate_if(int, char *);
+#endif
 static int cancel_type(char *);
 static int emit_bpar(void);
 static int emit_btarget(int);
@@ -72,7 +74,9 @@ static void check_crit(char *);
 static int check_cancel(int);
 static void check_targetdata(int, char *);
 static void check_valid_data_sharing(int);
+#ifdef FLANG_SEMSMP_UNUSED
 static LOGICAL check_map_data_sharing(int);
+#endif
 static void cray_pointer_check(ITEM *, int);
 static void other_firstlast_check(ITEM *, int);
 static void copyprivate_check(ITEM *, int);
@@ -545,7 +549,9 @@ static LOGICAL has_team = FALSE;
 
 static LOGICAL any_pflsr_private = FALSE;
 
+#ifdef FLANG_SEMSMP_UNUSED
 static void add_pragmasyms(int pragmatype, int pragmascope, ITEM *itemp, int);
+#endif
 static void add_pragma(int pragmatype, int pragmascope, int pragmaarg);
 
 #define OPT_OMP_ATOMIC !XBIT(69,0x1000)
@@ -5818,6 +5824,7 @@ add_pragma(int pragmatype, int pragmascope, int pragmaarg)
   (void)add_stmt(ast);
 }
 
+#ifdef FLANG_SEMSMP_UNUSED
 static void
 add_pragma2(int pragmatype, int pragmascope, int pragmaarg, int pragmaarg2)
 {
@@ -5830,7 +5837,9 @@ add_pragma2(int pragmatype, int pragmascope, int pragmaarg, int pragmaarg2)
   A_ROPP(ast, pragmaarg2);
   (void)add_stmt(ast);
 }
+#endif
 
+#ifdef FLANG_SEMSMP_UNUSED
 static void
 add_pragma3(int pragmatype, int pragmascope, int pragmaarg, int pragmaarg2,
             int pragmaarg3)
@@ -5845,7 +5854,9 @@ add_pragma3(int pragmatype, int pragmascope, int pragmaarg, int pragmaarg2,
   A_PRAGMAARGP(ast, pragmaarg3);
   (void)add_stmt(ast);
 }
+#endif
 
+#ifdef FLANG_SEMSMP_UNUSED
 static void
 add_pragmasyms(int pragmatype, int pragmascope, ITEM *itemp, int docopy)
 {
@@ -5870,7 +5881,9 @@ add_pragmasyms(int pragmatype, int pragmascope, ITEM *itemp, int docopy)
       add_pragma2(prtype, pragmascope, itemp->ast, ast_devcopy);
   }
 }
+#endif
 
+#ifdef FLANG_SEMSMP_UNUSED
 static void
 add_reduction_pragmas(void)
 {
@@ -5949,7 +5962,9 @@ add_reduction_pragmas(void)
     }
   }
 }
+#endif
 
+#ifdef FLANG_SEMSMP_UNUSED
 static void
 add_wait_pragmas(ITEM *itemp)
 {
@@ -5962,6 +5977,7 @@ add_wait_pragmas(ITEM *itemp)
   }
   CL_PRESENT(CL_WAIT) = 0;
 } /* add_wait_pragmas */
+#endif
 
 static void
 accel_pragmagen(int pragma, int pragma1, int pragma2)
@@ -6095,6 +6111,7 @@ set_iftype(int argcnt, char *nm, char *nm2, char *nm3)
   mp_iftype = mp_iftype | type;
 }
 
+#ifdef FLANG_SEMSMP_UNUSED
 static void
 validate_if(int type, char *nm)
 {
@@ -6160,6 +6177,7 @@ validate_if(int type, char *nm)
     }
   }
 }
+#endif
 
 static int
 get_stblk_uplevel_sptr()
@@ -10265,6 +10283,7 @@ check_valid_data_sharing(int sptr)
   }
 }
 
+#ifdef FLANG_SEMSMP_UNUSED
 static LOGICAL
 check_map_data_sharing(int sptr)
 {
@@ -10298,6 +10317,7 @@ check_map_data_sharing(int sptr)
 
   return TRUE;
 }
+#endif
 
 static LOGICAL is_in_omptarget_data(int d)
 {

--- a/tools/flang1/flang1exe/semutil.c
+++ b/tools/flang1/flang1exe/semutil.c
@@ -2330,6 +2330,7 @@ in_save_scope(SPTR sptr)
   return CONSTRUCTSYMG(sptr) ? SAVEG(ENCLFUNCG(sptr)) : sem.savall;
 }
 
+#ifdef FLANG_SEMUTIL_UNUSED
 /* returns 1 if array dtype has one too many subscripts and the first
    subscript in the list is a S_TRIPLE.  Otherwise, returns 0;
 */
@@ -2362,6 +2363,7 @@ is_substring(ITEM *list, int dtype)
 
   return 0;
 }
+#endif
 
 /** \brief Check if a stack entry represents a constant or an expression
            evaluated to a constant.

--- a/tools/flang1/flang1exe/transfrm.c
+++ b/tools/flang1/flang1exe/transfrm.c
@@ -34,7 +34,9 @@ static void find_allocatable_assignment(void);
 static void rewrite_allocatable_assignment(int, int, bool, bool);
 static void handle_allocatable_members(int, int, int, bool);
 static void trans_get_descrs(void);
+#ifdef FLANG_TRANSFRM_UNUSED
 static int trans_getidx(void);
+#endif
 static void trans_clridx(void);
 static void trans_freeidx(void);
 static int collapse_assignment(int, int);
@@ -48,8 +50,10 @@ static void init_finfo(void);
 static void distribute_fval(void);
 static int get_newdist_with_newproc(int dist);
 static void set_initial_s1(void);
+#ifdef FLANG_TRANSFRM_UNUSED
 static LOGICAL contains_non0_scope(int astSrc);
 static LOGICAL is_non0_scope(int sptr);
+#endif
 static void gen_allocated_check(int, int, int, bool, bool, bool);
 static int subscript_allocmem(int aref, int asd);
 static int normalize_subscripts(int oldasd, int oldshape, int newshape);
@@ -2533,6 +2537,7 @@ static struct idxlist {
   struct idxlist *next;
 } * idxlist;
 
+#ifdef FLANG_TRANSFRM_UNUSED
 static int
 trans_getidx(void)
 {
@@ -2550,6 +2555,7 @@ trans_getidx(void)
   idxlist = p;
   return p->idx;
 }
+#endif
 
 static void
 trans_clridx(void)
@@ -2589,6 +2595,7 @@ is_array_type(int sptr)
   return result;
 }
 
+#ifdef FLANG_TRANSFRM_UNUSED
 static int
 find_allocate(int findstd, int findast)
 {
@@ -2605,7 +2612,9 @@ find_allocate(int findstd, int findast)
   }
   return 0;
 } /* find_allocate */
+#endif
 
+#ifdef FLANG_TRANSFRM_UNUSED
 static int
 find_deallocate(int findstd, int findast)
 {
@@ -2620,7 +2629,9 @@ find_deallocate(int findstd, int findast)
   }
   return 0;
 } /* find_deallocate */
+#endif
 
+#ifdef FLANG_TRANSFRM_UNUSED
 /* the function of this routine is to use lhs for user-defined
  * array returning function,
  * allocate (tmp)
@@ -2808,7 +2819,9 @@ use_lhs_for_user_func(int std)
     delete_stmt(dealloc_std);
   return TRUE;
 }
+#endif
 
+#ifdef FLANG_TRANSFRM_UNUSED
 /* if the array bounds, or distribute arguments of this template
  * contain any variables, return TRUE */
 static LOGICAL
@@ -2828,10 +2841,14 @@ variable_template(int tmpl)
   }
   return FALSE;
 } /* variable_template */
+#endif
 
 /* replace dummy arguments in an alignment descriptor with actual arguments */
+#ifdef FLANG_TRANSFRM_UNUSED
 static int find_entry, find_nargs, find_argt, find_dpdsc, find_std;
+#endif
 
+#ifdef FLANG_TRANSFRM_UNUSED
 static void
 find_args(int ast, int *extra)
 {
@@ -2881,7 +2898,9 @@ find_args(int ast, int *extra)
     }
   }
 } /* find_args */
+#endif
 
+#ifdef FLANG_TRANSFRM_UNUSED
 static void
 find_arguments(int std, int entry, int nargs, int argt, int ast)
 {
@@ -2896,7 +2915,9 @@ find_arguments(int std, int entry, int nargs, int argt, int ast)
   find_std = std;
   ast_traverse(ast, NULL, find_args, NULL);
 } /* replace_arguments */
+#endif
 
+#ifdef FLANG_TRANSFRM_UNUSED
 static LOGICAL
 is_non0_scope(int sptr)
 {
@@ -2932,7 +2953,9 @@ is_non0_scope(int sptr)
   }
   return FALSE;
 }
+#endif
 
+#ifdef FLANG_TRANSFRM_UNUSED
 /* This is the callback function for contains_non0_scope(). */
 static LOGICAL
 _contains_non0_scope(int astSrc, LOGICAL *pflag)
@@ -2943,7 +2966,9 @@ _contains_non0_scope(int astSrc, LOGICAL *pflag)
   }
   return FALSE;
 }
+#endif
 
+#ifdef FLANG_TRANSFRM_UNUSED
 /* Return TRUE if astSrc has non zero scope ID somewhere within astSrc.
  */
 static LOGICAL
@@ -2959,7 +2984,9 @@ contains_non0_scope(int astSrc)
   ast_unvisit();
   return result;
 }
+#endif
 
+#ifdef FLANG_TRANSFRM_UNUSED
 static void
 _copy(int ast, int *unused)
 {
@@ -2991,7 +3018,9 @@ _copy(int ast, int *unused)
     }
   }
 } /* _copy */
+#endif
 
+#ifdef FLANG_TRANSFRM_UNUSED
 static int
 copy_nonconst(int ast)
 {
@@ -3006,6 +3035,7 @@ copy_nonconst(int ast)
   newast = ast_rewrite(ast);
   return newast;
 } /* copy_nonconst */
+#endif
 
 /* Make an AST id for the descriptor (SDSC or DESCR) of this symbol. */
 static int

--- a/tools/flang1/flang1exe/vsub.c
+++ b/tools/flang1/flang1exe/vsub.c
@@ -26,7 +26,9 @@
 #include "rte.h"
 
 static int reference_for_temp_lhs_indirection(int, int, int);
+#ifdef FLANG_VSUB_UNUSED
 static int newforall_list(int arr, int forall);
+#endif
 static int forall_semantic(int std);
 static void forall_with_mask(int std);
 static void forall_loop_interchange(int std);
@@ -36,8 +38,10 @@ static void forall_bound_dependence(int std);
 static void forall_bound_dependence_fix(int prevstd, int nextstd);
 static LOGICAL is_mask_for_rhs(int std, int ast);
 static LOGICAL is_legal_lhs_for_mask(int, int);
+#ifdef FLANG_VSUB_UNUSED
 static int make_dos(int std);
 static void make_enddos(int n, int std);
+#endif
 static void scalar_lhs_dependency(int std);
 static void scatter_dependency(int std);
 static void scatter_dependency_assumsz(int std);
@@ -977,6 +981,7 @@ is_legal_rhs(int lhs, int rhs, int forall)
   return TRUE;
 }
 
+#ifdef FLANG_VSUB_UNUSED
 /* This routine takes an array and forall,
  * It returns a list which only has forall index appears
  * in the array subscripts. A(i), forall(i=,j=), return i=..
@@ -1006,6 +1011,7 @@ newforall_list(int arr, int forall)
   }
   return ASTLI_HEAD;
 }
+#endif
 
 static void
 forall_loop_interchange(int std)
@@ -1376,6 +1382,7 @@ is_ugly_pure(int ast)
 
 static int lhsComm; /* Lhs of assignment */
 
+#ifdef FLANG_VSUB_UNUSED
 /* This is to calculate how many DO statements have to be made
    from forall statement and add those before std              */
 
@@ -1413,7 +1420,9 @@ make_dos(int std)
   }
   return n;
 }
+#endif
 
+#ifdef FLANG_VSUB_UNUSED
 /* this is to add n enddo statements before std */
 
 static void
@@ -1427,6 +1436,7 @@ make_enddos(int n, int std)
     add_stmt_before(newast, std);
   }
 }
+#endif
 
 static LOGICAL
 _contains_call(int astx, LOGICAL *pflag)

--- a/tools/flang1/utils/ast/astutil.c
+++ b/tools/flang1/utils/ast/astutil.c
@@ -99,46 +99,6 @@ main(int aargc, char *aargv[])
 }
 
 /**************************************************************/
-static int
-findfield(char *s)
-{
-  int i;
-
-  for (i = 0; i < fieldnum; ++i)
-    if (strcmp(s, fields[i].name) == 0)
-      return i;
-  put_err1(2, "Undefined field name: %s", s);
-  return 0;
-}
-
-struct template
-{
-  int fnum;
-  int hasvalue;
-  char value[32];
-};
-
-static struct template tmplt[20];
-static int ntmplt;
-
-static int
-qscmp1(int *f1, int *f2)
-{
-  int r;
-  if (fields[tmplt[*f1].fnum].flag && fields[tmplt[*f2].fnum].flag)
-    r = fields[tmplt[*f1].fnum].offs - fields[tmplt[*f2].fnum].offs;
-  else if (fields[tmplt[*f1].fnum].flag)
-    return -1;
-  else if (fields[tmplt[*f2].fnum].flag)
-    return 1;
-  else
-    r = fields[tmplt[*f1].fnum].offs - fields[tmplt[*f2].fnum].offs;
-  if (r)
-    return r;
-  return strcmp(fields[tmplt[*f1].fnum].name, fields[tmplt[*f2].fnum].name);
-}
-
-/**************************************************************/
 static int findsym();
 static int addfield(int sharedflag, int flagflag);
 
@@ -608,20 +568,6 @@ chk_overlap(int f1, int f2, int flag)
   return TRUE;
 }
 
-static void
-addsname(int *cursyms, int cursym, int symidx, char *name)
-{
-  int i;
-
-  if (symidx < 0 || symidx >= cursym) {
-    put_err(2, ".SI sname count doesn't match .SM line");
-    return;
-  }
-  i = cursyms[symidx];
-  strncpy(symbols[i].sname, name, 31);
-  symbols[i].sname[31] = 0;
-}
-
 static int
 findsym()
 {
@@ -727,15 +673,6 @@ fixup:
   fields[fieldnum].shared = FALSE;
   fields[fieldnum].flag = FALSE;
   return fieldnum++;
-}
-
-void
-put_err1(int sev, char *msg, char *str)
-{
-  char buff[132];
-
-  sprintf(buff, msg, str);
-  put_err(sev, buff);
 }
 
 /**************************************************************/

--- a/tools/flang2/flang2exe/exp_rte.cpp
+++ b/tools/flang2/flang2exe/exp_rte.cpp
@@ -62,7 +62,9 @@ static int block_str_move(STRDESC *, STRDESC *);
 static int getchartmp(int ili);
 static void _exp_smove(int, int, int, int, DTYPE);
 
+#ifdef FLANG2_EXPRTE_UNUSED
 static int has_desc_arg(int, int);
+#endif
 static int check_desc(int, int);
 static void check_desc_args(int);
 static int exp_type_bound_proc_call(int arg, SPTR descno, int vtoff,
@@ -1191,6 +1193,7 @@ exp_type_bound_proc_call(int arg, SPTR descno, int vtoff, int arglnk)
   return ad4ili(IL_JSRA, ili, arglnk, jsra_mscall_flag, fptr_iface);
 }
 
+#ifdef FLANG2_EXPRTE_UNUSED
 static int
 has_desc_arg(int func, int sptr)
 {
@@ -1206,6 +1209,7 @@ has_desc_arg(int func, int sptr)
   }
   return 0;
 }
+#endif
 
 static int
 check_desc(int func, int sptr)
@@ -1842,6 +1846,7 @@ scan_args:
   } /* end while */
 }
 
+#ifdef FLANG2_EXPRTE_UNUSED
 static int
 get_frame_off(INT off)
 {
@@ -1867,6 +1872,7 @@ get_frame_off(INT off)
   ili = ad_acon(memarg_var, off - MEMARG_OFFSET);
   return ili;
 }
+#endif
 
 /* from exp_c.c */
 static void
@@ -2805,8 +2811,8 @@ init_ainfo(ainfo_t *ap)
 static void
 end_ainfo(ainfo_t *ap)
 {
+  /* NOTHING TO DO */
 }
-#define end_ainfo(ap) /* NOTHING TO DO */
 
 void
 init_arg_ili(int n)

--- a/tools/flang2/flang2exe/expatomics.cpp
+++ b/tools/flang2/flang2exe/expatomics.cpp
@@ -625,7 +625,9 @@ create_atomic_capture_seq(int update_ili, int read_ili, int capture_first)
   ILI_OP st_opcode, arg_opcode;
   int store_pt, store_nme, arg, garg;
   int store_symbol;
+#if defined(TARGET_X8664)
   int argreg = 0;
+#endif
   int update_operand;
   int load_pt1, load_pt2;
   int op1, op2, opc;
@@ -817,7 +819,9 @@ create_atomic_write_seq(int store_ili)
   int store_pt, store_nme;
   ILI_OP arg_opcode;
   ILI_OP intarg_opcode, floatarg_opcode, doublearg_opcode, longarg_opcode;
+#if defined(TARGET_X8664)
   int argreg;
+#endif
   int arg_dt = 0;
 
 #if defined(TARGET_X8664)
@@ -2026,6 +2030,7 @@ typedef struct auto_temp {
   int expr; /**< An ilix for a store into a temporary, or ilix of a constant. */
 } auto_temp;
 
+#ifdef PD_IS_ATOMIC
 /** \brief Generate ILI so that value of an ILI expression can be retrieved
    later.
 
@@ -2073,6 +2078,7 @@ auto_retrieve(auto_temp *temp)
     return temp->expr;
   }
 }
+#endif
 
 #if TARGET_GNU_ATOMICS
 #define MAX_ATOMIC_ARGS 6
@@ -2394,6 +2400,7 @@ ll_make_atomic_compare_xchg(int size_ili, int lhs, int expected,
   return result;
 }
 
+#ifdef FLANG2_EXPATOMICS_UNUSED
 static int
 ll_make_atomic_xchg(int lhs, int expected, int desired, int mem_order)
 {
@@ -2415,6 +2422,7 @@ ll_make_atomic_xchg(int lhs, int expected, int desired, int mem_order)
 
   return result;
 }
+#endif
 
 static int
 _exp_mp_atomic_read(int stc, DTYPE dtype, int* opnd, int* nme)

--- a/tools/flang2/flang2exe/expsmp.cpp
+++ b/tools/flang2/flang2exe/expsmp.cpp
@@ -48,7 +48,9 @@ inline SPTR GetPARUPLEVEL(SPTR sptr) {
 
 static int incrOutlinedCnt(void);
 static int decrOutlinedCnt(void);
+#ifdef FLANG2_EXPSMP_UNUSED
 static int getOutlinedTemp(char *, int);
+#endif
 static int isUnnamedCs(int);
 static int addMpUnp(void);
 static int addMpUnv(void);
@@ -259,6 +261,7 @@ sectionCreateBlock(int nextLabel, SPTR lb, SPTR ub, int myVal)
   return ili;
 }
 
+#ifdef FLANG2_EXPSMP_UNUSED
 static int
 sectionCreateLastblock(int nextLabel, SPTR lastValSym, int myVal)
 {
@@ -272,6 +275,7 @@ sectionCreateLastblock(int nextLabel, SPTR lastValSym, int myVal)
   RFCNTI(nextLabel);
   return ili;
 }
+#endif
 
 void
 section_create_endblock(SPTR endLabel)
@@ -2829,6 +2833,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
 #endif /* end #ifdef IM_BPAR */
 }
 
+#ifdef FLANG2_EXPSMP_UNUSED
 /* opc: IL_DFRDP / IL_DFRSP, depending on result type of call */
 /* Return the ili of a call to a function that returns a result, using ili
  * callili, followed by freeing of the appropriate argument registers with
@@ -2862,6 +2867,7 @@ makeCallResult(ILI_OP opc, int callili)
 
   return ili;
 }
+#endif
 
 SPTR
 lcpu_temp(SC_KIND sc)
@@ -3042,15 +3048,6 @@ exp_mp_func_prologue(bool process_tp)
   }
 }
 
-static void
-no_pad_func(char *fname)
-{
-  int sptr;
-
-  sptr = mkfunc(fname);
-  NOPADP(sptr, 1);
-}
-
 static int
 decrOutlinedCnt(void)
 {
@@ -3072,6 +3069,7 @@ incrOutlinedCnt(void)
   return outlinedCnt;
 }
 
+#ifdef FLANG2_EXPSMP_UNUSED
 static int
 getOutlinedTemp(char *pfx, int dtype)
 {
@@ -3083,6 +3081,7 @@ getOutlinedTemp(char *pfx, int dtype)
   DTYPEP(sym, DT_INT);
   return sym;
 }
+#endif
 
 static int
 isUnnamedCs(int sem)
@@ -3270,17 +3269,6 @@ get_threadprivate_origsize(int sym)
   }
 
   return size;
-}
-
-static int
-getNumSect(int *tab)
-{
-  int i;
-  if (!tab)
-    return 0;
-  for (i = 0; tab[i] != -1; i++) {
-  }
-  return i;
 }
 
 SPTR

--- a/tools/flang2/flang2exe/iliutil.cpp
+++ b/tools/flang2/flang2exe/iliutil.cpp
@@ -85,13 +85,17 @@ static int ad2altili(ILI_OP, int, int, int);
 static int ad3altili(ILI_OP, int, int, int, int);
 static int ad2func_int(ILI_OP, char *, int, int);
 static int gen_sincos(ILI_OP, int, ILI_OP, ILI_OP, MTH_FN, DTYPE, ILI_OP);
+#if defined(TARGET_X8664) || defined(TARGET_POWER)
 static int _newton_fdiv(int, int);
+#endif
 static bool do_newton_sqrt(void);
 static int _pwr2(INT, int);
 static int _kpwr2(INT, INT, int);
 static int _ipowi(int, int);
 static int _xpowi(int, int, ILI_OP);
+#if defined(TARGET_X8664) || defined(TARGET_POWER) || !defined(TARGET_LLVM_ARM)
 static int _frsqrt(int);
+#endif
 static int _mkfunc(char *);
 static int DblIsSingle(SPTR dd);
 static int _lshift_one(int);
@@ -883,6 +887,7 @@ ad_func(ILI_OP result_opc, ILI_OP call_opc, char *func_name, int nargs, ...)
   return ilix;
 }
 
+#if defined(TARGET_X8664)
 static char *
 fmth_name(char *root)
 {
@@ -895,6 +900,8 @@ fmth_name(char *root)
   sprintf(bf, "%s%s", root, suf);
   return bf;
 }
+#endif
+
 /*
  * fast math naming convention:
  *    __g[sv][sdcz]_BASE[L]
@@ -1897,6 +1904,7 @@ ICON(INT v)
   return ilix;
 } /* ICON */
 
+#ifdef FLANG2_ILIUTIL_UNUSED
 static int
 KCON(INT v)
 {
@@ -1907,6 +1915,7 @@ KCON(INT v)
   ilix = ad1ili(IL_KCON, recipsym);
   return ilix;
 } /* KCON */
+#endif
 
 static int
 MULSH(int ilix, int iliy)
@@ -1952,6 +1961,7 @@ MULUH(int ilix, int iliy)
   return t3;
 } /* MULUH */
 
+#ifdef FLANG2_ILIUTIL_UNUSED
 static int
 MULU(int ilix, int iliy)
 {
@@ -1962,6 +1972,7 @@ MULU(int ilix, int iliy)
 
   return t1;
 } /* MULU */
+#endif
 
 static int
 MUL(int ilix, int iliy)
@@ -2003,8 +2014,7 @@ KXSIGN(int ilix, int N)
   return t;
 } /* XSIGN */
 
-#define WSIZE 32
-
+#ifdef FLANG2_ILIUTIL_UNUSED
 static void
 mod_decompose(int d, int *d0, int *k)
 {
@@ -2054,6 +2064,7 @@ test_mod_zero(int n, int d, int sgnd, int cc)
     return 0;
   }
 }
+#endif
 
 static int
 reciprocal_division(int n, INT divisor, int sgnd)
@@ -3298,7 +3309,9 @@ addarth(ILI *ilip)
   case IL_FADD:
     if (ncons == 2 && is_flt0(cons2))
       return op1;
+#ifdef FPSUB2ADD
   like_fadd:
+#endif
     if (!flg.ieee && ncons == 3) {
       xfadd(con1v2, con2v2, &res.numi[1]);
       goto add_rcon;
@@ -3319,7 +3332,9 @@ addarth(ILI *ilip)
   case IL_DADD:
     if (ncons == 2 && is_dbl0(cons2))
       return op1;
+#ifdef FPSUB2ADD
   like_dadd:
+#endif
     if (!flg.ieee && ncons == 3) {
       GETVAL64(num1, cons1);
       GETVAL64(num2, cons2);
@@ -3341,7 +3356,9 @@ addarth(ILI *ilip)
   case IL_SCMPLXADD:
     if (ncons == 2 && IS_FLT0(con2v1) && IS_FLT0(con2v2))
       return op1;
+#ifdef FPSUB2ADD
   like_scmplxadd:
+#endif
     if (!flg.ieee && ncons == 3) {
       xfadd(con1v1, con2v1, &res.numi[0]);
       xfadd(con1v2, con2v2, &res.numi[1]);
@@ -3360,7 +3377,9 @@ addarth(ILI *ilip)
   case IL_DCMPLXADD:
     if (ncons == 2 && IS_DBL0(con2v1) && IS_DBL0(con2v2))
       return op1;
+#ifdef FPSUB2ADD
   like_dcmplxadd:
+#endif
     if (!flg.ieee && ncons == 3) {
       GETVAL64(num1, con1v1);
       GETVAL64(num2, con2v1)
@@ -7178,6 +7197,7 @@ gen_sincos(ILI_OP opc, int op1, ILI_OP sincos_opc, ILI_OP fopc, MTH_FN fn,
   return ilix;
 }
 
+#if defined(TARGET_X8664) || defined(TARGET_POWER)
 static int
 _newton_fdiv(int op1, int op2)
 {
@@ -7194,6 +7214,7 @@ _newton_fdiv(int op1, int op2)
   ilix = ad2ili(IL_FMUL, op1, tmp1);
   return ilix;
 }
+#endif
 
 static bool
 do_newton_sqrt(void)
@@ -7453,15 +7474,6 @@ red_kadd(int ilix, INT con[2])
     break;
   } /*****  end of switch(ILI_OPC(ilix))  *****/
 
-  return 0;
-}
-
-/**
- * \brief constant folds the extended int add ili (eiadd)
- */
-static int
-red_eiadd(int ilix, INT con[2])
-{
   return 0;
 }
 
@@ -8409,7 +8421,9 @@ addbran(ILI *ilip)
     if (ILI_OPC(op2) == IL_FCON && IS_FLT0(ILI_OPND(op2, 1)))
       return ad3ili(IL_FCJMPZ, op1, ilip->opnd[2], ilip->opnd[3]);
 #endif
+#if defined(TARGET_X86)
   nogen_fcjmpz:
+#endif
     if (op1 == op2 && ILI_OPC(op2) == IL_FCON && !_is_nanf(ILI_OPND(op2, 1))) {
       cond = CCRelationILIOpnd(ilip, 2);
       if (cond == CC_EQ || cond == CC_GE || cond == CC_LE || cond == CC_NOTNE ||
@@ -8459,7 +8473,9 @@ addbran(ILI *ilip)
     if (ILI_OPC(op2) == IL_DCON && IS_DBL0(ILI_OPND(op2, 1)))
       return ad3ili(IL_DCJMPZ, op1, ilip->opnd[2], ilip->opnd[3]);
 #endif
+#if defined(TARGET_X86)
   nogen_dcjmpz:
+#endif
     if (op1 == op2 && (ILI_OPC(op2) == IL_DCON) &&
         !_is_nand(ILI_SymOPND(op2, 1))) {
       cond = CCRelationILIOpnd(ilip, 2);
@@ -12475,7 +12491,7 @@ _xpowi(int opn, int pwr, ILI_OP opc)
   return opn;
 }
 
-#if defined(TARGET_X8664) || defined(TARGET_POWER) || defined(TARGET_ARM64)
+#if defined(TARGET_X8664) || defined(TARGET_POWER) || !defined(TARGET_LLVM_ARM)
 static int
 _frsqrt(int x)
 {

--- a/tools/flang2/flang2exe/kmpcutil.cpp
+++ b/tools/flang2/flang2exe/kmpcutil.cpp
@@ -11,7 +11,9 @@
  *
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE // for vasprintf()
+#endif
 #include <stdio.h>
 #undef _GNU_SOURCE
 #include "kmpcutil.h"
@@ -420,6 +422,7 @@ ll_make_kmpc_struct_type(int count, char *name, KMPC_ST_TYPE *meminfo, ISZ_T sz)
   return dtype;
 }
 
+#ifdef FLANG_KMPC_UNUSED
 /*
  * struct ident { i32, i32, i32, i32, char* }
  */
@@ -437,6 +440,7 @@ ll_make_kmpc_ident_type(void)
         ll_make_kmpc_struct_type(5, "_pgi_kmpc_ident_t", meminfo, 0);
   return kmpc_ident_dtype;
 }
+#endif
 
 /* Name 'nm' should be formatted and passed in: use build_kmpc_api_name() */
 static SPTR
@@ -475,6 +479,9 @@ ll_make_kmpc_proto(const char *nm, int kmpc_api, int argc, DTYPE *args)
   return func_sptr;
 }
 
+// TODO: libomp may assume that a non-null ident_t pointer; we should allocate
+// this as a static global and actually pass its address to runtime calls.
+#ifdef FLANG_KMPC_UNUSED
 /* Argument instance representing location information
  * This creates a struct ptr instance (for use as an argument).
  * src/kmp.h:
@@ -510,6 +517,7 @@ make_kmpc_ident_arg(void)
 
   return ad_acon(ident, 0);
 }
+#endif
 
 /* The return value is allocated and maintained locally, please do not call
  * 'free' on this, bad things will probably happen.

--- a/tools/flang2/flang2exe/ll_ftn.cpp
+++ b/tools/flang2/flang2exe/ll_ftn.cpp
@@ -74,25 +74,6 @@ need_charlen(DTYPE dtype)
   return false;
 }
 
-static int
-get_func_altili(int ilix)
-{
-  if (ILI_ALT(ilix) && ILI_OPC(ILI_ALT(ilix)) == IL_GJSR)
-    return ILI_ALT(ilix);
-  return 0;
-}
-
-/**
-   \brief return argument dtype in IL GJSR , expect ili derived from IL_GJSR
- */
-static int
-get_altili_dtype(int param_ili)
-{
-  if (ILI_OPC(param_ili) != IL_NULL)
-    return ILI_OPND(param_ili, 3);
-  return 0;
-}
-
 bool
 is_fastcall(int ilix)
 {
@@ -552,6 +533,7 @@ ll_process_routine_parameters(SPTR func_sptr)
   DBGTRACEOUT("")
 } /* ll_process_routine_parameters */
 
+#ifdef FLANG2_LLFTN_UNUSED
 /*
  * same return value as strcmp(str, pattern); pattern is a lower case
  * string and str may contain upper case characters.
@@ -576,6 +558,7 @@ sem_strcmp(char *str, char *pattern)
     p2++;
   } while (1);
 }
+#endif
 
 int
 is_iso_cptr(DTYPE d_dtype)
@@ -653,6 +636,7 @@ write_llvm_lltype(int sptr)
   write_type(LLTYPE(sptr));
 }
 
+#ifdef FLANG2_LLFTN_UNUSED
 static int
 llvm_args_valid(SPTR func_sptr)
 {
@@ -686,6 +670,7 @@ llvm_args_valid(SPTR func_sptr)
 
   return valid;
 }
+#endif
 
 void
 fix_llvm_fptriface(void)

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1185,6 +1185,7 @@ static const MDTemplate Tmpl_DIExpression[] = {
   { "DIExpression", TF, 0 }
 };
 
+#ifdef FLANG_DEBUGINFO_UNUSED
 static const MDTemplate Tmpl_DILocalVariable[] = {
   { "DILocalVariable", TF, 9 },
   { "tag",                      DWTagField },
@@ -1197,6 +1198,7 @@ static const MDTemplate Tmpl_DILocalVariable[] = {
   { "flags",                    UnsignedField }, /* TBD: DIFlag... */
   { "inlinedAt",                UnsignedField }  /* TBD: NodeField */
 };
+#endif
 
 static const MDTemplate Tmpl_DILocalVariable_38[] = {
   { "DILocalVariable", TF, 8 },

--- a/tools/flang2/flang2exe/llassem_common.cpp
+++ b/tools/flang2/flang2exe/llassem_common.cpp
@@ -39,12 +39,6 @@ union {
   unsigned char byte[4];
 } i32bit;
 
-union {
-  unsigned long i64; /* need to make sure this is 64 bit */
-  double r8;
-  unsigned char byte[8];
-} i64bit;
-
 #include "dtypeutl.h"
 
 AGB_t agb;
@@ -72,15 +66,7 @@ static void put_i8(int);
 static void put_i16(int);
 static void put_r4(INT);
 static void put_r8(int, int);
-static void put_int(INT);
-static void put_int8(INT);
-static void put_float(INT);
-static void put_double(int);
 static void put_cmplx_n(int, int);
-static void put_float_cmplx(int, int);
-static void put_double_cmplx(int, int);
-static void put_string(char *, int);
-static void put_zeroes_bysize(ISZ_T, int);
 static void add_ctor(char *);
 static void write_proc_pointer(SPTR sptr);
 
@@ -770,22 +756,6 @@ put_zeroes(ISZ_T len)
 }
 
 static void
-put_zeroes_bytype(ISZ_T len, char *ttype, char *initval)
-{
-  ISZ_T i;
-  i = len;
-  if (i) {
-    while (1) {
-      fprintf(ASMFIL, "%s %s", ttype, initval);
-      i--;
-      if (i == 0)
-        break;
-      fprintf(ASMFIL, ",");
-    }
-  }
-}
-
-static void
 put_i8(int val)
 {
   int i;
@@ -825,24 +795,6 @@ put_short(int val)
   fprintf(ASMFIL, "i16 %u", val);
 }
 
-static void
-put_int(INT val)
-{
-  fprintf(ASMFIL, "i%d %u", DIR_LONG_SIZE, val);
-}
-
-void
-put_int4(int val)
-{
-  fprintf(ASMFIL, "i32 %u", val);
-}
-
-static void
-put_int8(INT val)
-{
-  fprintf(ASMFIL, "i64 %lu", (unsigned long)val);
-}
-
 /* write:  i8 0x?, i8 0x?, i8 0x?, i8 0x? */
 static void
 put_r4(INT val)
@@ -853,47 +805,6 @@ put_r4(INT val)
     fprintf(ASMFIL, "i8 %u", i32bit.byte[i] & 0xff);
     if (i < 3)
       fprintf(ASMFIL, ",");
-  }
-}
-
-static void
-put_float(INT val)
-{
-  union xx_u xx;
-  union {
-    double d;
-    INT tmp[2];
-  } dtmp, dtmp2;
-  xx.ww = val;
-  fprintf(ASMFIL, "float ");
-  xdble(xx.ww, dtmp2.tmp);
-  xdtomd(dtmp2.tmp, &dtmp.d);
-
-  if (dtmp.tmp[0] == -1) /* pick up the quiet nan */
-    fprintf(ASMFIL, "0x7FF80000");
-  else if (!dtmp.tmp[1])
-    fprintf(ASMFIL, "0x00000000");
-  else
-    fprintf(ASMFIL, "0x%X", dtmp.tmp[1]);
-
-  if (!dtmp.tmp[0] || dtmp.tmp[0] == -1)
-    fprintf(ASMFIL, "00000000");
-  else
-    fprintf(ASMFIL, "%X", dtmp.tmp[0]);
-}
-
-static void
-put_double(int sptr)
-{
-  INT num[2];
-  num[0] = CONVAL1G(sptr);
-  num[1] = CONVAL2G(sptr);
-  fprintf(ASMFIL, "double ");
-
-  if ((num[0] & 0x7ff00000) == 0x7ff00000) /* exponent == 2047 */
-    fprintf(ASMFIL, "0x%08x00000000", num[0]);
-  else {
-    fprintf(ASMFIL, "0x%.8X%.8X", num[0], num[1]);
   }
 }
 
@@ -921,26 +832,6 @@ put_cmplx_n(int sptr, int putval)
   put_r4(CONVAL1G(sptr));
   fprintf(ASMFIL, ",");
   put_r4(CONVAL2G(sptr));
-}
-
-static void
-put_float_cmplx(int sptr, int putval)
-{
-  fprintf(ASMFIL, " {float, float} {");
-  put_float(CONVAL1G(sptr));
-  fprintf(ASMFIL, ",");
-  put_float(CONVAL2G(sptr));
-  fprintf(ASMFIL, "}");
-}
-
-static void
-put_double_cmplx(int sptr, int putval)
-{
-  fprintf(ASMFIL, " {double, double} {");
-  put_double(CONVAL1G(sptr));
-  fprintf(ASMFIL, ",");
-  put_double(CONVAL2G(sptr));
-  fprintf(ASMFIL, "}");
 }
 
 static void

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -998,6 +998,7 @@ lldbg_create_aggregate_members_type(LL_DebugInfo *db, SPTR first, int findex,
   }
 }
 
+#ifdef FLANG_DEBUGINFO_UNUSED
 static bool
 map_sptr_to_mdnode(LL_MDRef *mdnode, LL_DebugInfo *db, int sptr)
 {
@@ -1013,6 +1014,7 @@ map_sptr_to_mdnode(LL_MDRef *mdnode, LL_DebugInfo *db, int sptr)
   }
   return false;
 }
+#endif
 
 /**
    \brief Fill in extra data about a symbol
@@ -1043,6 +1045,7 @@ get_extra_info_for_sptr(const char **display_name, LL_MDRef *scope_mdnode,
 
 }
 
+#ifdef FLANG_DEBUGINFO_UNUSED
 static LL_MDRef
 lldbg_create_enumeration_type_mdnode(LL_DebugInfo *db, LL_MDRef context,
                                      char *name, LL_MDRef fileref, int line,
@@ -1096,6 +1099,7 @@ lldbg_create_enumerator_list(LL_DebugInfo *db, int element)
 
   return llmd_finish(mdb);
 }
+#endif
 
 static LL_MDRef
 lldbg_create_vector_type_mdnode(LL_DebugInfo *db, LL_MDRef context, ISZ_T sz,
@@ -1126,6 +1130,7 @@ lldbg_create_vector_type_mdnode(LL_DebugInfo *db, LL_MDRef context, ISZ_T sz,
   return llmd_finish(mdb);
 }
 
+#ifdef FLANG_DEBUGINFO_UNUSED
 static LL_MDRef
 lldbg_create_derived_type_mdnode(LL_DebugInfo *db, int dw_tag, LL_MDRef context,
                                  char *name, LL_MDRef fileref, int line,
@@ -1155,6 +1160,7 @@ lldbg_create_derived_type_mdnode(LL_DebugInfo *db, int dw_tag, LL_MDRef context,
 
   return llmd_finish(mdb);
 }
+#endif
 
 static LL_MDRef
 lldbg_create_subroutine_type_mdnode(LL_DebugInfo *db, LL_MDRef context,
@@ -2649,6 +2655,7 @@ lldbg_emit_modified_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex)
                          false, false, false);
 }
 
+#ifdef FLANG_DEBUGINFO_UNUSED
 static LL_MDRef
 lldbg_emit_accel_cmblk_type(LL_DebugInfo *db, int cmblk, int findex)
 {
@@ -2698,6 +2705,7 @@ lldbg_emit_accel_function_static_type(LL_DebugInfo *db, SPTR first, int findex)
                                       members_mdnode, type_mdnode);
   return type_mdnode;
 }
+#endif
 
 INLINE static void
 dtype_array_check_set(LL_DebugInfo *db, unsigned at, LL_MDRef md)
@@ -3439,6 +3447,7 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
   db->scope_is_global = savedScopeIsGlobal;
 }
 
+#ifdef FLANG_ACCEL
 static char *
 lldbg_get_addrspace_suffix(int addrspace)
 {
@@ -3451,6 +3460,7 @@ lldbg_get_addrspace_suffix(int addrspace)
     return "_gen";
   }
 }
+#endif
 
 static void
 lldbg_cancel_value_call(LL_DebugInfo *db, SPTR sptr)

--- a/tools/flang2/flang2exe/llopt.cpp
+++ b/tools/flang2/flang2exe/llopt.cpp
@@ -24,6 +24,7 @@
 
 #define DEC_UCOUNT(i) ((i)->tmps->use_count--)
 
+#ifdef TARGET_LLVM_ARM
 static void
 replace_by_call_to_llvm_instrinsic(INSTR_LIST *instr, char *fname,
                                    OPERAND *params)
@@ -138,6 +139,7 @@ optimize_instruction(INSTR_LIST *instr)
     break;
   }
 }
+#endif
 
 void
 optimize_block(INSTR_LIST *last_block_instr)

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -313,15 +313,6 @@ ll_convert_basic_dtype_with_addrspace(LL_Module *module, DTYPE dtype, int addrsp
   return type;
 }
 
-/*
- * Convert a basic non-integer dtype to the corresponding LL_Type in module.
- */
-static LL_Type *
-ll_convert_basic_dtype(LL_Module *module, DTYPE dtype)
-{
-  return ll_convert_basic_dtype_with_addrspace(module, dtype, LL_AddrSp_Default);
-}
-
 #if defined(TARGET_LLVM_X8664)
 /**
  * \brief Convert a SIMD dtype to the corresponding LLVM type.
@@ -360,14 +351,6 @@ ll_convert_simd_dtype(LL_Module *module, DTYPE dtype)
   return ll_get_vector_type(base_type, num_elements);
 }
 #endif
-
-/* Create a dummy function type from the return type. */
-static LL_Type *
-ll_convert_func_dtype(LL_Module *module, DTYPE dtype)
-{
-  LL_Type *ret_type = ll_convert_dtype(module, dtype);
-  return ll_create_function_type(module, &ret_type, 0, true);
-}
 
 /**
    This routine is for use with fortran interfaces, specified by sptr
@@ -1426,19 +1409,6 @@ ll_get_string_buf(int string_len, char *base, int skip_quotes)
   while (len--) {
     *to++ = *from++;
   }
-  return name;
-}
-
-char *
-ll_get_cstring_buf(int sptr, int skip_quotes)
-{
-  char *name = "";
-  char *to, *from;
-  DTYPE dtype = DTYPEG(sptr);
-  int c, len, newlen, index, pos;
-  char buf[11];
-
-  dtype = DTYPEG(sptr);
   return name;
 }
 
@@ -3112,7 +3082,8 @@ get_int_dtype_from_size(int size)
   return DT_NONE;
 }
 
-static int
+#if DEBUG
+int
 struct_typedef_name(DTYPE dtype)
 {
   int sptr;
@@ -3123,7 +3094,9 @@ struct_typedef_name(DTYPE dtype)
   }
   return 0;
 } /* struct_typedef_name */
+#endif
 
+#ifdef FLANG2_LLUTIL_UNUSED
 static char *
 def_name(DTYPE dtype, int tag)
 {
@@ -3157,6 +3130,7 @@ def_name(DTYPE dtype, int tag)
     sprintf(d_name, "%%struct.%s", tag_name);
   return d_name;
 }
+#endif
 
 OPERAND *
 process_symlinked_sptr(int sptr, int total_init_sz, int is_union,
@@ -3332,6 +3306,7 @@ process_ftn_dtype_struct(DTYPE dtype, char *tname, bool printed)
   return def->name;
 }
 
+#ifdef FLANG2_LLUTIL_UNUSED
 static OPERAND *
 add_init_zero_const_op(int sptr, OPERAND *cur_op, ISZ_T *offset,
                        ISZ_T *lastoffset)
@@ -3601,6 +3576,7 @@ add_init_subzero_consts(DTYPE dtype, OPERAND *cur_op, ISZ_T *offset,
   }
   return cur_op;
 }
+#endif
 
 /* Allocate an LL_ABI_Info object with room for nargs arguments. */
 LL_ABI_Info *

--- a/tools/flang2/flang2exe/machreg.cpp
+++ b/tools/flang2/flang2exe/machreg.cpp
@@ -138,6 +138,7 @@ mr_init()
 
 }
 
+#ifdef FLANG_MACHREG_UNUSED
 static int
 mr_isxmm(int rtype)
 {
@@ -148,6 +149,7 @@ mr_isxmm(int rtype)
 #endif
   return (reg[rtype].mach_reg->Class == 'x');
 }
+#endif
 
 void
 mr_reset_numglobals(int reduce_by)
@@ -254,12 +256,14 @@ mr_end()
 
 }
 
+#ifdef FLANG_MACHREG_UNUSED
 void
 static mr_reset_fpregs()
 {
   mach_reg[1].next_global = mach_reg[1].first_global;
   mach_reg[2].next_global = mach_reg[2].first_global;
 }
+#endif
 
 /** \brief Initialize for scanning the entire machine register set used for
  *  rtype.
@@ -337,6 +341,7 @@ int _mr_getnext(int rtype)
   return mreg;
 }
 
+#ifdef FLANG_MACHREG_UNUSED
 /*  RGSET functions   */
 static void
 mr_init_rgset()
@@ -363,6 +368,7 @@ mr_init_rgset()
     bihx = BIH_NEXT(bihx);
   }
 }
+#endif
 
 /** \brief allocate and initialize a RGSET entry.  */
 int
@@ -383,6 +389,7 @@ mr_get_rgset()
   return rgset;
 }
 
+#ifdef FLANG_MACHREG_UNUSED
 static void
 mr_dmp_rgset(int rgseti)
 {
@@ -432,3 +439,4 @@ mr_bset_xmm_rgset(int ili, int bih)
     }
   }
 }
+#endif

--- a/tools/flang2/flang2exe/tgtutil.cpp
+++ b/tools/flang2/flang2exe/tgtutil.cpp
@@ -10,7 +10,9 @@
  *
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE // for vasprintf()
+#endif
 #include <stdio.h>
 #undef _GNU_SOURCE
 #include "dinit.h"

--- a/tools/flang2/flang2exe/upper.cpp
+++ b/tools/flang2/flang2exe/upper.cpp
@@ -59,7 +59,9 @@ static long getlval(char *valname);
 static int getbit(char *bitname);
 
 #define STB_UPPER() (gbl.stbfil != NULL)
+#ifdef FLANG2_UPPER_UNUSED
 static void do_llvm_sym_is_refd(void);
+#endif
 static void build_agoto(void);
 static void free_modvar_alias_list(void);
 static void save_modvar_alias(SPTR sptr, const char *alias_name);
@@ -6390,6 +6392,7 @@ cuda_emu_end(void)
   }
 }
 
+#ifdef FLANG2_UPPER_UNUSED
 /* get the size of STATICS/BSS - this has to be done after fix_datatype so that
    we can get the size of sptr if it is an array. AD_DPTR is done in
    fix_datatype.
@@ -6421,6 +6424,7 @@ do_llvm_sym_is_refd(void)
     }
   }
 }
+#endif
 
 /**
    \brief ...

--- a/tools/shared/ccffinfo.c
+++ b/tools/shared/ccffinfo.c
@@ -182,6 +182,7 @@ xmlopenattri(char *entity, char *shortentity, char *attr, int attrval)
 /*
  * output <entity attr="attrval">
  */
+#ifdef FLANG_CCFFINFO_UNUSED
 static void
 xmlopenattrs(char *entity, char *shortentity, char *attr, char *attrval)
 {
@@ -192,6 +193,7 @@ xmlopenattrs(char *entity, char *shortentity, char *attr, char *attrval)
   else
     fprintf(ccff_file, "<%s %s=\"%s\">\n", entity, attr, attrval);
 } /* xmlopenattrs */
+#endif
 
 /*
  * output <entity attr1="attr1val" attr2="attr2val">
@@ -1328,6 +1330,7 @@ fih_message_ofile(FILE *ofile, int nest, int lineno, int childnest,
   }
 } /* fih_message_ofile */
 
+#ifdef FLANG_CCFFINFO_UNUSED
 /*
  * Format and print message to log file
  */
@@ -1469,6 +1472,7 @@ ifih_message_ofile(FILE *ofile, int nest, int lineno, int childnest,
     }
   }
 } /* ifih_message_ofile */
+#endif
 
 /*
  * output messages for this FIH tag
@@ -1587,6 +1591,7 @@ fih_messages(int fihx, FILE *ofile, int nest)
 #endif
 } /* fih_messages */
 
+#ifdef FLANG_CCFFINFO_UNUSED
 /*
  * output messages for this FIH tag
  */
@@ -1695,6 +1700,7 @@ ifih_messages(int ifihx, FILE *ofile, int nest)
   }
 #endif
 } /* ifih_messages */
+#endif
 
 /*
  *  Remove child include files if there is no message.

--- a/tools/shared/nmeutil.c
+++ b/tools/shared/nmeutil.c
@@ -26,7 +26,9 @@
 #endif
 #include "symfun.h"
 
+#ifdef FLANG_NMEUTIL_UNUSED
 static bool found_rpct(int rpct_nme1, int rpct_nme2);
+#endif
 
 #if DEBUG
 #define asrt(c) \
@@ -839,6 +841,7 @@ add_rpct(int rpct_nme1, int rpct_nme2)
 
 } /* end add_rpct( int rpct_nme1, int rpct_nme2 ) */
 
+#ifdef FLANG_NMEUTIL_UNUSED
 /**
  * This function returns true if there is an RPCT (runtime pointer
  * conflict test) record containing the pair of NMEs (rpct_nme1,
@@ -880,6 +883,7 @@ found_rpct(int rpct_nme1, int rpct_nme2)
   return false; /* not found */
 
 } /* end found_rpct( int rpct_nme1, int rpct_nme2 ) */
+#endif
 
 #ifndef FE90
 /* #if defined(I386) || defined(X86_64) || defined(X86_32) || defined(LX) ||


### PR DESCRIPTION
Work around `-Wunused-function` warnings by guarding unused code with `FLANG_*_UNUSED` macros. Functions that are unused because they are only called by conditionally compiled code are guarded with the same macros as their callers. Functions intended for debugging (e.g. calling within gdb) are guarded with `#if DEBUG` and declared non-static. Trivial unused functions are deleted completely.

I considered the alternative of simply deleting the unused functions, but I was wary of the work it would involve to rewrite or re-enable them in the future, should they be needed again. Adding the `FLANG_*_UNUSED` macros, as a deprecation measure, gives people a chance to think about how the functions could be re-included in the build, while keeping it easy to review future re-enablement patches (they would just be simple deletion of the macros).