### PR TITLE
[flang1] Fix `-Wparentheses` warnings; NFC

### DIFF
--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -8776,7 +8776,7 @@ eval_minval_or_maxval(ACL *arg, DTYPE dtype, AC_INTRINSIC intrin)
   ACL *arg2;
   bool back = FALSE;
 
-  while (arg = arg->next) {
+  while ((arg = arg->next)) {
     if (DT_ISLOG(arg->dtype)) { /* back */
       arg2 = eval_init_expr_item(arg);
       back = arg2->conval;


### PR DESCRIPTION
Place parentheses around assignments in conditions to silence `-Wparentheses` warnings.

In my code review so far, there seems to be only one such case. However, some of the roll-up fixes in subsequent PRs might fix this warning as well. I will move those fixes into this PR as I come across them.