### PR TITLE
[flang1][flang2] Work around warnings with diagnostic pragmas; NFCI

### DIFF
--- a/lib/ArgParser/arg_parser.c
+++ b/lib/ArgParser/arg_parser.c
@@ -106,20 +106,25 @@ destroy_arg_parser(arg_parser_t **parser)
 static void
 deallocate_arg_value(hash_key_t key, hash_data_t value_ptr, void *key_context)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcast-qual"
+  value_t *p = (value_t *)value_ptr;
+  char *k = (char *)key;
+#pragma GCC diagnostic pop
   /* Some of the argument types require deallocation */
-  switch (((value_t *)value_ptr)->type) {
+  switch (p->type) {
   case ARG_ActionMap:
   case ARG_CombinedBoolean:
-    free(((value_t *)value_ptr)->location);
+    free(p->location);
     break;
   case ARG_ReverseBoolean:
-    free((char *)key);
+    free(k);
     break;
   default:
     /* Do nothing */
     break;
   }
-  free((value_t *)value_ptr);
+  free(p);
 }
 
 /** Register a string argument */
@@ -130,7 +135,10 @@ register_string_arg(arg_parser_t *parser, const char *arg_name, char **target,
   /* Set default value */
   *target = (char *)default_value;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcast-qual"
   add_generic_argument(parser, arg_name, ARG_String, (void *)target);
+#pragma GCC diagnostic pop
 }
 
 /** Register a string list argument */
@@ -331,6 +339,8 @@ parse_arguments(const arg_parser_t *parser, int argc, char **argv)
     }
     ++arg; /* skip over '-' */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcast-qual"
     /* All arguments need to be in the data structure */
     if (!hashmap_lookup(parser->flags, arg, (hash_data_t *)&value)) {
       if (parser->fail_on_unknown_args) {
@@ -344,6 +354,7 @@ parse_arguments(const arg_parser_t *parser, int argc, char **argv)
         continue;
       }
     }
+#pragma GCC diagnostic pop
 
     /* Parse argument type */
     switch (value->type) {

--- a/lib/ArgParser/debug_action.c
+++ b/lib/ArgParser/debug_action.c
@@ -54,6 +54,8 @@ add_action(action_map_t *map, const char *keyword, void (*action)(void))
 {
   action_list_t *action_list = NULL;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcast-qual"
   /* Check if there is something in the map already */
   if (hashmap_lookup(map->actions, keyword, (hash_data_t *)&action_list)) {
     /* Add one more element at the end of the list */
@@ -70,6 +72,7 @@ add_action(action_map_t *map, const char *keyword, void (*action)(void))
     /* Add it to the list */
     hashmap_insert(map->actions, keyword, action_list);
   }
+#pragma GCC diagnostic pop
 }
 
 /** Execute action(s) for a given keyword */
@@ -78,6 +81,8 @@ execute_actions_for_keyword(action_map_t *map, const char *keyword)
 {
   action_list_t *action_list = NULL;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcast-qual"
   /* Execute if there is anything for this keyword */
   if (hashmap_lookup(map->actions, keyword, (hash_data_t *)&action_list)) {
     size_t index;
@@ -85,6 +90,7 @@ execute_actions_for_keyword(action_map_t *map, const char *keyword)
       action_list->actions[index]();
     }
   }
+#pragma GCC diagnostic pop
   /* Do nothing is there is no record */
 }
 
@@ -96,6 +102,8 @@ copy_action(const action_map_t *from, const char *keyword_from,
   action_list_t *source_actions = NULL;
   action_list_t *dest_actions = NULL;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcast-qual"
   /* Silently exit if nothing is found in source dataset */
   if (!hashmap_lookup(from->actions, keyword_from,
                       (hash_data_t *)&source_actions)) {
@@ -122,4 +130,5 @@ copy_action(const action_map_t *from, const char *keyword_from,
     /* Add it to the list */
     hashmap_insert(to->actions, keyword_to, dest_actions);
   }
+#pragma GCC diagnostic pop
 }

--- a/tools/flang1/utils/ast/astutil.c
+++ b/tools/flang1/utils/ast/astutil.c
@@ -335,7 +335,9 @@ write_ast()
 done:;
   copy_file(IN4, OUT3); /* copy intast_sym inits created by symtab */
   /* write dinit for ASTB */
-  fprintf(OUT3, "\nASTB astb = {\n");
+  fprintf(OUT3, "\n#pragma GCC diagnostic push\n");
+  fprintf(OUT3, "#pragma GCC diagnostic ignored \"-Wmissing-field-initializers\"\n");
+  fprintf(OUT3, "ASTB astb = {\n");
   fprintf(OUT3, "    {");
   /* char           *atypes[AST_MAX + 1]; */
   j = 6;
@@ -361,8 +363,9 @@ done:;
     }
   }
   fprintf(OUT3, "    },\n");
-
   fprintf(OUT3, "};\n");
+  fprintf(OUT3, "#pragma GCC diagnostic pop\n");
+
   if (checkmode) {
     char ch;
     int s, i, j, sf, x;

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -7945,6 +7945,8 @@ sincos_argument_valid(int ilix)
   return true;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcast-qual"
 INLINE static OPERAND *
 get_last_sincos(int ilix)
 {
@@ -7954,6 +7956,7 @@ get_last_sincos(int ilix)
     return (OPERAND *)data;
   return NULL;
 }
+#pragma GCC diagnostic pop
 
 INLINE static OPERAND *
 gen_llvm_sincos_builtin(int ilix)

--- a/tools/flang2/flang2exe/kmpcutil.cpp
+++ b/tools/flang2/flang2exe/kmpcutil.cpp
@@ -535,6 +535,8 @@ build_kmpc_api_name(int kmpc_api, va_list va)
   #ifndef _WIN64
     assert(NULL != nm, "build_kmpc_api_name: Incorrect return value", 0, ERR_Fatal);
   #endif
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcast-qual"
     /* If the name has already been allocated, use that to save memory */
     if (hashmap_lookup(names, (hash_key_t)nm, (hash_data_t *)&res)) {
       free(nm);
@@ -543,6 +545,7 @@ build_kmpc_api_name(int kmpc_api, va_list va)
       hashmap_insert(names, (hash_key_t)nm, (hash_data_t)nm);
       return nm;
     }
+#pragma GCC diagnostic pop
   } else
     return KMPC_NAME(kmpc_api);
 

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -3979,9 +3979,12 @@ ll_override_type_string(LL_Type *llt, const char *str)
   char *clone = llutil_alloc(strlen(str) + 1);
   strcpy(clone, str);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wcast-qual"
   /* Cast away constness *eww gross*, gcc hates me */
   // FIXME -- this is wrong headed
   ((struct LL_Type_ *)llt)->str = clone;
+#pragma GCC diagnostic pop
 }
 
 /**

--- a/tools/shared/utils/symutil.cpp
+++ b/tools/shared/utils/symutil.cpp
@@ -700,7 +700,9 @@ private:
 
     // write dinit for STB
     out3 << "\nextern STB stb;\n";  // declaration into .h file
-    out4 << "\n#include \"symacc.h\"\n"; // forward declaration of the STB type.
+    out4 << "\n#include \"symacc.h\"\n"; // forward declaration of the STB type
+    out4 << "\n#pragma clang diagnostic ignored "; // work around Clang warning
+    out4 << "\"-Wmissing-field-initializers\"\n";  // (cont'd)
     out4 << "\nSTB stb = {\n    {"; // definition  into .c file
     int j = 6, k;
     for (std::vector<Symbol>::size_type i = 0; i != symbols.size(); ++i) {


### PR DESCRIPTION
This patch adds diagnostic pragmas to parts of the code where fixing compile-time warnings is non-trivial:

1. `-Wcast-qual` warnings for type casts to/from `hash_key_t` and `hash_value_t` due to the const-ness in those typedefs. 
2. `-Wmissing-field-initializers` warnings for structure definitions generated with tools such as `astutil` and `fsymutil`.

Re-designing the hash table API and fixing the code generators is beyond the scope of fixing #1065 and left as future work.