### PR TITLE
[flang2] Delete dead code causing compile-time warnings; NFCI

### DIFF
--- a/tools/flang2/flang2exe/dinit.cpp
+++ b/tools/flang2/flang2exe/dinit.cpp
@@ -3169,10 +3169,7 @@ eval_minval_or_maxval(CONST *arg, DTYPE dtype, int intrin)
     } else if (DT_ISINT(arg->dtype)) { /* dim */
       arg2 = eval_init_expr_item(arg);
       dim = arg2->u1.conval;
-      assert(dim == arg2->u1.conval, "DIM needs to be an integer!!!", 0,
-             ERR_Fatal);
-    }
-    else {
+    } else {
       mask = eval_init_expr_item(arg);
       if (mask != 0 && mask->id == AC_ACONST)
         mask = mask->subc;


### PR DESCRIPTION
An `assert` call in `tools/flang2/flang2exe/dinit.cpp` seems to be ineffectual, and is causing compile-time `-Wsign-compare` warnings. This patch simply deletes it.