### PR TITLE
[runtime] Fix OPEN and UNPACKC call delegation

### DIFF
--- a/runtime/flang/nmlread.c
+++ b/runtime/flang/nmlread.c
@@ -385,7 +385,7 @@ ENTF90IO(LDR_INTERN_INIT, nmlr_intern_init)(
          __INT_T *iostat
          DCLEN(cunit))
 {
-  return ENTF90IO(LDR_INTERN_INITA, nmlr_intern_init)(CADR(cunit), rec_num,
+  return ENTF90IO(LDR_INTERN_INITA, nmlr_intern_inita)(CADR(cunit), rec_num,
                                    bitv, iostat, (__CLEN_T)CLEN(cunit));
 }
 

--- a/runtime/flang/open.c
+++ b/runtime/flang/open.c
@@ -662,7 +662,7 @@ ENTF90IO(OPEN, open) (
   DCLEN(status)    /* length of status */
   DCLEN(dispose))  /* length of dispose */
 {
-  return ENTF90IO(OPEN, open) (unit, bitv, CADR(acc), CADR(action),
+  return ENTF90IO(OPENA, opena) (unit, bitv, CADR(acc), CADR(action),
 		  CADR(blank), CADR(delim), CADR(name), CADR(form), iostat,
 		  CADR(pad), CADR(pos), reclen, CADR(status), CADR(dispose),
 		  (__CLEN_T)CLEN(acc), (__CLEN_T)CLEN(action),

--- a/runtime/flang/pack.c
+++ b/runtime/flang/pack.c
@@ -435,6 +435,6 @@ void ENTFTN(UNPACKC, unpackc)(DCHAR(rb),        /* result char base */
                               DCLEN(vb)         /* vector char len */
                               DCLEN(fb))        /* field char len */
 {
-  ENTFTN(UNPACKC, unpackc)(CADR(rb), CADR(vb), mb, CADR(fb), result, vector,
+  ENTFTN(UNPACKCA, unpackca)(CADR(rb), CADR(vb), mb, CADR(fb), result, vector,
       mask, field, (__CLEN_T)CLEN(rb), (__CLEN_T)CLEN(vb), (__CLEN_T)CLEN(fb));
 }


### PR DESCRIPTION
Functions with 32-bit `CLEN` parameters, e.g. `OPEN` and `UNPACKC`, should delegate to the respective versions with 64-bit `CLEN` parameters, i.e. `OPENA` and `UNPACKCA`, instead of themselves, resulting in infinite recursion.

Also fix a typo in the declaration of `LDR_INTERN_INITA`, ensuring that the uppercase and lowercase versions of the symbol are consistent.