### PR TITLE
[runtime] Declare MATMUL functions in matmul.h; NFCI

### DIFF
--- a/runtime/flang/matmul.h
+++ b/runtime/flang/matmul.h
@@ -9,73 +9,141 @@
  */
 
 void f90_mm_cplx16_str1_mxv_(__CPLX16_T *, __CPLX16_T *, __CPLX16_T *,
-                               __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+                             __INT_T *, __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_cplx16_str1_vxm_(__CPLX16_T *, __CPLX16_T *, __CPLX16_T *,
-                               __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+                             __INT_T *, __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_cplx16_str1_(__CPLX16_T *, __CPLX16_T *, __CPLX16_T *, __INT_T *,
-                           __INT_T *, __INT_T *, __INT_T *, __INT_T *,
-                           __INT_T *, __INT_T *);
+                         __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                         __INT_T *);
 void f90_mm_cplx16_str1_mxv_t_(__CPLX16_T *, __CPLX16_T *, __CPLX16_T *,
-                                 __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+                               __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+
+void f90_mm_cplx16_str1_mxv_i8_(__CPLX16_T *, __CPLX16_T *, __CPLX16_T *,
+                                __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_cplx16_str1_vxm_i8_(__CPLX16_T *, __CPLX16_T *, __CPLX16_T *,
+                                __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_cplx16_str1_i8_(__CPLX16_T *, __CPLX16_T *, __CPLX16_T *, __INT_T *,
+                            __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                            __INT_T *, __INT_T *);
+void f90_mm_cplx16_str1_mxv_t_i8_(__CPLX16_T *, __CPLX16_T *, __CPLX16_T *,
+                                  __INT_T *, __INT_T *, __INT_T *, __INT_T *);
 
 void f90_mm_cplx8_str1_mxv_(__CPLX8_T *, __CPLX8_T *, __CPLX8_T *, __INT_T *,
-                              __INT_T *, __INT_T *, __INT_T *);
+                            __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_cplx8_str1_vxm_(__CPLX8_T *, __CPLX8_T *, __CPLX8_T *, __INT_T *,
-                              __INT_T *, __INT_T *, __INT_T *);
+                            __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_cplx8_str1_(__CPLX8_T *, __CPLX8_T *, __CPLX8_T *, __INT_T *,
-                          __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
-                          __INT_T *);
-void f90_mm_cplx8_str1_mxv_t_(__CPLX8_T *, __CPLX8_T *, __CPLX8_T *,
-                                __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+                        __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                        __INT_T *);
+void f90_mm_cplx8_str1_mxv_t_(__CPLX8_T *, __CPLX8_T *, __CPLX8_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+
+void f90_mm_cplx8_str1_mxv_i8_(__CPLX8_T *, __CPLX8_T *, __CPLX8_T *, __INT_T *,
+                               __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_cplx8_str1_vxm_i8_(__CPLX8_T *, __CPLX8_T *, __CPLX8_T *, __INT_T *,
+                               __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_cplx8_str1_i8_(__CPLX8_T *, __CPLX8_T *, __CPLX8_T *, __INT_T *,
+                           __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                           __INT_T *, __INT_T *);
+void f90_mm_cplx8_str1_mxv_t_i8_(__CPLX8_T *, __CPLX8_T *, __CPLX8_T *,
+                                 __INT_T *, __INT_T *, __INT_T *, __INT_T *);
 
 void f90_mm_int1_str1_mxv_(__INT1_T *, __INT1_T *, __INT1_T *, __INT_T *,
-                             __INT_T *, __INT_T *, __INT_T *);
+                           __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_int1_str1_vxm_(__INT1_T *, __INT1_T *, __INT1_T *, __INT_T *,
-                             __INT_T *, __INT_T *, __INT_T *);
-void f90_mm_int1_str1_(__INT1_T *, __INT1_T *, __INT1_T *, __INT_T *,
-                         __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
-                         __INT_T *);
+                           __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int1_str1_(__INT1_T *, __INT1_T *, __INT1_T *, __INT_T *, __INT_T *,
+                       __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+
+void f90_mm_int1_str1_mxv_i8_(__INT1_T *, __INT1_T *, __INT1_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int1_str1_vxm_i8_(__INT1_T *, __INT1_T *, __INT1_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int1_str1_i8_(__INT1_T *, __INT1_T *, __INT1_T *, __INT_T *,
+                          __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                          __INT_T *);
 
 void f90_mm_int2_str1_mxv_(__INT2_T *, __INT2_T *, __INT2_T *, __INT_T *,
-                             __INT_T *, __INT_T *, __INT_T *);
+                           __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_int2_str1_vxm_(__INT2_T *, __INT2_T *, __INT2_T *, __INT_T *,
-                             __INT_T *, __INT_T *, __INT_T *);
-void f90_mm_int2_str1_(__INT2_T *, __INT2_T *, __INT2_T *, __INT_T *,
-                         __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
-                         __INT_T *);
+                           __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int2_str1_(__INT2_T *, __INT2_T *, __INT2_T *, __INT_T *, __INT_T *,
+                       __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+
+void f90_mm_int2_str1_mxv_i8_(__INT2_T *, __INT2_T *, __INT2_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int2_str1_vxm_i8_(__INT2_T *, __INT2_T *, __INT2_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int2_str1_i8_(__INT2_T *, __INT2_T *, __INT2_T *, __INT_T *,
+                          __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                          __INT_T *);
 
 void f90_mm_int4_str1_mxv_(__INT4_T *, __INT4_T *, __INT4_T *, __INT_T *,
-                             __INT_T *, __INT_T *, __INT_T *);
+                           __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_int4_str1_vxm_(__INT4_T *, __INT4_T *, __INT4_T *, __INT_T *,
-                             __INT_T *, __INT_T *, __INT_T *);
-void f90_mm_int4_str1_(__INT4_T *, __INT4_T *, __INT4_T *, __INT_T *,
-                         __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
-                         __INT_T *);
+                           __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int4_str1_(__INT4_T *, __INT4_T *, __INT4_T *, __INT_T *, __INT_T *,
+                       __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+
+void f90_mm_int4_str1_mxv_i8_(__INT4_T *, __INT4_T *, __INT4_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int4_str1_vxm_i8_(__INT4_T *, __INT4_T *, __INT4_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int4_str1_i8_(__INT4_T *, __INT4_T *, __INT4_T *, __INT_T *,
+                          __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                          __INT_T *);
 
 void f90_mm_int8_str1_mxv_(__INT8_T *, __INT8_T *, __INT8_T *, __INT_T *,
-                             __INT_T *, __INT_T *, __INT_T *);
+                           __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_int8_str1_vxm_(__INT8_T *, __INT8_T *, __INT8_T *, __INT_T *,
-                             __INT_T *, __INT_T *, __INT_T *);
-void f90_mm_int8_str1_(__INT8_T *, __INT8_T *, __INT8_T *, __INT_T *,
-                         __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
-                         __INT_T *);
+                           __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int8_str1_(__INT8_T *, __INT8_T *, __INT8_T *, __INT_T *, __INT_T *,
+                       __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+
+void f90_mm_int8_str1_mxv_i8_(__INT8_T *, __INT8_T *, __INT8_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int8_str1_vxm_i8_(__INT8_T *, __INT8_T *, __INT8_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_int8_str1_i8_(__INT8_T *, __INT8_T *, __INT8_T *, __INT_T *,
+                          __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                          __INT_T *);
 
 void f90_mm_real4_str1_mxv_(__REAL4_T *, __REAL4_T *, __REAL4_T *, __INT_T *,
-                              __INT_T *, __INT_T *, __INT_T *);
+                            __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_real4_str1_vxm_(__REAL4_T *, __REAL4_T *, __REAL4_T *, __INT_T *,
-                              __INT_T *, __INT_T *, __INT_T *);
+                            __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_real4_str1_(__REAL4_T *, __REAL4_T *, __REAL4_T *, __INT_T *,
-                          __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
-                          __INT_T *);
-void f90_mm_real4_str1_mxv_t_(__REAL4_T *, __REAL4_T *, __REAL4_T *,
-                                __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+                        __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                        __INT_T *);
+void f90_mm_real4_str1_mxv_t_(__REAL4_T *, __REAL4_T *, __REAL4_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+
+void f90_mm_real4_str1_mxv_i8_(__REAL4_T *, __REAL4_T *, __REAL4_T *, __INT_T *,
+                               __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_real4_str1_vxm_i8_(__REAL4_T *, __REAL4_T *, __REAL4_T *, __INT_T *,
+                               __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_real4_str1_i8_(__REAL4_T *, __REAL4_T *, __REAL4_T *, __INT_T *,
+                           __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                           __INT_T *, __INT_T *);
+void f90_mm_real4_str1_mxv_t_i8_(__REAL4_T *, __REAL4_T *, __REAL4_T *,
+                                 __INT_T *, __INT_T *, __INT_T *, __INT_T *);
 
 void f90_mm_real8_str1_mxv_(__REAL8_T *, __REAL8_T *, __REAL8_T *, __INT_T *,
-                              __INT_T *, __INT_T *, __INT_T *);
+                            __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_real8_str1_vxm_(__REAL8_T *, __REAL8_T *, __REAL8_T *, __INT_T *,
-                              __INT_T *, __INT_T *, __INT_T *);
+                            __INT_T *, __INT_T *, __INT_T *);
 void f90_mm_real8_str1_(__REAL8_T *, __REAL8_T *, __REAL8_T *, __INT_T *,
-                          __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
-                          __INT_T *);
-void f90_mm_real8_str1_mxv_t_(__REAL8_T *, __REAL8_T *, __REAL8_T *,
-                                __INT_T *, __INT_T *, __INT_T *, __INT_T *);
+                        __INT_T *, __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                        __INT_T *);
+void f90_mm_real8_str1_mxv_t_(__REAL8_T *, __REAL8_T *, __REAL8_T *, __INT_T *,
+                              __INT_T *, __INT_T *, __INT_T *);
+
+void f90_mm_real8_str1_mxv_i8_(__REAL8_T *, __REAL8_T *, __REAL8_T *, __INT_T *,
+                               __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_real8_str1_vxm_i8_(__REAL8_T *, __REAL8_T *, __REAL8_T *, __INT_T *,
+                               __INT_T *, __INT_T *, __INT_T *);
+void f90_mm_real8_str1_i8_(__REAL8_T *, __REAL8_T *, __REAL8_T *, __INT_T *,
+                           __INT_T *, __INT_T *, __INT_T *, __INT_T *,
+                           __INT_T *, __INT_T *);
+void f90_mm_real8_str1_mxv_t_i8_(__REAL8_T *, __REAL8_T *, __REAL8_T *,
+                                 __INT_T *, __INT_T *, __INT_T *, __INT_T *);


### PR DESCRIPTION
Runtime functions written in Fortran are called from C code. Declaring them properly silences a number of `-Wimplicit-function-declaration` warnings.

Also clang-format the file.