### PR TITLE
Add build scripts and switch CI to use them

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -10,7 +10,7 @@ on:
     paths-ignore:
       - '**/.github/workflows/build_flang_arm64.yml'
 
-jobs:       
+jobs:
   build_flang:
     runs-on: ubuntu-20.04
     env:
@@ -62,7 +62,7 @@ jobs:
           cd ../..
           curl -sL https://api.github.com/repos/flang-compiler/classic-flang-llvm-project/actions/workflows/pre-compile_llvm.yml/runs --output runs_llvm.json
           wget --output-document artifacts_llvm `jq -r '.workflow_runs[0].artifacts_url?' runs_llvm.json`
-          
+
           i="0"
           # Keep checking older builds to find the right branch and correct number of artifacts
           while { [ `jq -r '.total_count?' artifacts_llvm` != "3" ] || \
@@ -84,46 +84,14 @@ jobs:
           tar xzf llvm_build.tar.gz
           cd classic-flang-llvm-project/build
           sudo make install/fast
-      
-      - name: Build libpgmath
-        run: |
-          CMAKE_OPTIONS="-DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=${{ env.install_prefix }}/bin/clang \
-            -DCMAKE_CXX_COMPILER=${{ env.install_prefix }}/bin/clang++ \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-          cd runtime/libpgmath
-          mkdir -p build && cd build
-          cmake $CMAKE_OPTIONS ..
-          make -j$(nproc)
-          sudo make install
-          
-      - name: Build Flang
-        run: |
-          mkdir -p build && cd build
-          cmake -DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=${{ env.install_prefix }}/bin/clang \
-            -DCMAKE_CXX_COMPILER=${{ env.install_prefix }}/bin/clang++ \
-            -DCMAKE_Fortran_COMPILER=${{ env.install_prefix }}/bin/flang \
-            -DCMAKE_Fortran_COMPILER_ID=Flang \
-            -DFLANG_INCLUDE_DOCS=ON \
-            -DFLANG_LLVM_EXTENSIONS=ON \
-            -DWITH_WERROR=OFF \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ..
-          make -j$(nproc)
-          sudo make install
 
-      # Copy llvm-lit
+      - name: Build and install flang & libpgmath
+        run: ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n $(nproc) -c -s
+
       - name: Copy llvm-lit
         run: |
           cp ../../classic-flang-llvm-project/build/bin/llvm-lit build/bin/.
-          
+
       - name: Test flang
         run: |
           cd build

--- a/.github/workflows/build_flang_arm64.yml
+++ b/.github/workflows/build_flang_arm64.yml
@@ -50,39 +50,10 @@ jobs:
           git fetch origin ${{github.ref}}:pr_branch
           git checkout pr_branch
 
-      - name: Build libpgmath
+      - name: Build and install flang & libpgmath
         run: |
           cd ${{ env.build_path }}/flang
-          cd runtime/libpgmath
-          mkdir -p build && cd build
-          ls -l
-          pwd
-          cmake -DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_C_COMPILER=${{ env.install_prefix}}/bin/clang \
-            -DCMAKE_CXX_COMPILER=${{ env.install_prefix}}/bin/clang++ \
-            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
-            -DCMAKE_BUILD_TYPE=Release \
-            ..
-          make -j`nproc --ignore=1`
-          make install
-
-      - name: Build Flang
-        run: |
-          cd ${{ env.build_path }}/flang
-          mkdir -p build && cd build
-          cmake -DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=${{ env.install_prefix }}/bin/clang \
-            -DCMAKE_CXX_COMPILER=${{ env.install_prefix }}/bin/clang++ \
-            -DCMAKE_Fortran_COMPILER=${{ env.install_prefix }}/bin/flang \
-            -DCMAKE_Fortran_COMPILER_ID=Flang \
-            -DFLANG_INCLUDE_DOCS=ON \
-            -DFLANG_LLVM_EXTENSIONS=ON \
-            -DWITH_WERROR=OFF \
-            ..
-          make -j`nproc --ignore=1`
-          make install
+          ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n `nproc --ignore=1`
 
       # Copy llvm-lit
       - name: Copy llvm-lit

--- a/build-flang.sh
+++ b/build-flang.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# A POSIX variable
+OPTIND=1         # Reset in case getopts has been used previously in the shell.
+
+# Initialize our own variables:
+TARGET="X86"
+INSTALL_PREFIX="/usr/local"
+NPROC=1
+USE_CCACHE="0"
+USE_SUDO="0"
+
+set -e # Exit the script on first error.
+
+function print_usage {
+    echo "Usage: ./build-flang.sh [options]";
+    echo "";
+    echo "Build and install libpgmath and flang.";
+    echo "Run this script in a directory with flang sources.";
+    echo "Example:";
+    echo "  $ git clone https://github.com/flang-compiler/flang";
+    echo "  $ cd flang";
+    echo "  $ .github/workflows/build-flang.sh -t X86 -p /install/prefix/ -n 2 -s";
+    echo "";
+    echo "Options:";
+    echo "  -t  Target to build for (X86, AArch64, PowerPC). Default: X86";
+    echo "  -p  Install prefix. Default: /usr/local";
+    echo "  -n  Number of parallel jobs. Default: 1";
+    echo "  -c  Use ccache. Default: 0 - do not use ccache";
+    echo "  -s  Use sudo to install. Default: 0 - do not use sudo";
+}
+
+while getopts "t:p:n:c?s?" opt; do
+    case "$opt" in
+        t) TARGET=$OPTARG;;
+        p) INSTALL_PREFIX=$OPTARG;;
+        n) NPROC=$OPTARG;;
+        c) USE_CCACHE="1";;
+        s) USE_SUDO="1";;
+        ?) print_usage; exit 0;;
+    esac
+done
+
+CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_COMPILER=$INSTALL_PREFIX/bin/clang++ \
+    -DCMAKE_C_COMPILER=$INSTALL_PREFIX/bin/clang \
+    -DLLVM_TARGETS_TO_BUILD=$TARGET"
+
+if [ $USE_CCACHE == "1" ]; then
+  echo "Build using ccache"
+  CMAKE_OPTIONS="$CMAKE_OPTIONS \
+      -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+fi
+
+# Build and install libpgmath
+cd runtime/libpgmath
+mkdir -p build && cd build
+cmake $CMAKE_OPTIONS ..
+make -j$NPROC
+if [ $USE_SUDO == "1" ]; then
+  echo "Install with sudo"
+  sudo make install
+else
+  echo "Install without sudo"
+  make install
+fi
+
+cd ../../..
+
+# Build and install flang
+mkdir -p build && cd build
+cmake $CMAKE_OPTIONS \
+      -DCMAKE_Fortran_COMPILER=$INSTALL_PREFIX/bin/flang \
+      -DCMAKE_Fortran_COMPILER_ID=Flang \
+      -DFLANG_INCLUDE_DOCS=ON \
+      -DFLANG_LLVM_EXTENSIONS=ON \
+      -DWITH_WERROR=OFF \
+      ..
+make -j$NPROC
+if [ $USE_SUDO == "1" ]; then
+  echo "Install with sudo"
+  sudo make install
+else
+  echo "Install without sudo"
+  make install
+fi


### PR DESCRIPTION
As discussed in the Wednesday call - build scripts will make it easier to reproduce CI runs for users.
They were tailored with current CI setup in mind and the CI scripts were adjusted to use them.
I was partially inspired by @bryanpkc 's scripts available [here](https://github.com/Huawei-PTLab/classic-flang-llvm-project/wiki). Thanks, Bryan!
A PR to `classic-flang-llvm-project` will follow with similar build scripts introduced there.