### PR TITLE
[DebugInfo] Flang should include compiler options in DW_AT_producer

### DIFF
--- a/test/debug_info/producer.f90
+++ b/test/debug_info/producer.f90
@@ -1,0 +1,7 @@
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !DICompileUnit(language: DW_LANG_Fortran90
+!CHECK-SAME: flags: "'+flang -gdwarf-4 -S -emit-llvm 
+
+program main
+end program main

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -1798,7 +1798,7 @@ lldbg_emit_compile_unit(LL_DebugInfo *db)
     lang_tag = DW_LANG_Fortran90;
     db->comp_unit_mdnode = lldbg_create_compile_unit_mdnode(
         db, lang_tag, get_filename(1), get_currentdir(), db->producer, 1,
-        flg.opt >= 1/*isOptimized Flag*/, "",
+        flg.opt >= 1/*isOptimized Flag*/, flg.cmdline,
         0, &db->llvm_dbg_enum, &db->llvm_dbg_retained, &db->llvm_dbg_sp,
         &db->llvm_dbg_gv, &db->llvm_dbg_imported);
   }

--- a/tools/flang2/flang2exe/main.cpp
+++ b/tools/flang2/flang2exe/main.cpp
@@ -90,7 +90,6 @@ static char *who[] = {"init", "import",   "expand", "", "",
                       "",     "assemble", "xref",   ""};
 #define _N_WHO (sizeof(who) / sizeof(char *))
 static INT xtimes[_N_WHO];
-static char *cmdline = NULL;
 static char *ccff_filename = NULL;
 #include "ccffinfo.h"
 
@@ -669,7 +668,7 @@ init(int argc, char *argv[])
   register_integer_arg(arg_parser, "astype", &flg.astype, 0);
   register_boolean_arg(arg_parser, "recursive", &flg.recursive, false);
   register_integer_arg(arg_parser, "vect", &vect_val, 0);
-  register_string_arg(arg_parser, "cmdline", &cmdline, NULL);
+  register_string_arg(arg_parser, "cmdline", &flg.cmdline, NULL);
   register_boolean_arg(arg_parser, "debug", &flg.debug, false);
 
   flg.linker_directives = (char **)getitem(8, argc * sizeof(char *));
@@ -866,7 +865,7 @@ do_curr_file:
 #if DEBUG
   assert(flg.es == 0, "init:flg.esA", 0, ERR_unused);
 #endif
-  assemble_init(argc, argv, cmdline);
+  assemble_init(argc, argv, flg.cmdline);
 
   gbl.func_count = 0;
   gbl.multi_func_count = gbl.func_count;
@@ -879,7 +878,7 @@ do_curr_file:
 
   if (ccff_filename) {
     ccff_open(ccff_filename, gbl.file_name ? gbl.file_name : gbl.src_file);
-    ccff_build(cmdline, "F90");
+    ccff_build(flg.cmdline, "F90");
   }
 
 }

--- a/tools/shared/utils/global.h
+++ b/tools/shared/utils/global.h
@@ -208,6 +208,7 @@ typedef struct {
   bool trans_inv; /* global equiv to -Mx,7,0x10000 */
   int tpcount;
   int tpvalue[TPNVERSION]; /* target processor(s), for unified binary */
+  char *cmdline; /* contains compiler command line */
 } FLG;
 
 extern FLG flg;


### PR DESCRIPTION
Currently Flang contains only compiler information for DWARF attribute DW_AT_producer.
``````````````
 _llvm-dwarfdump test.o | grep DW_AT_producer_
              DW_AT_producer    (**" F90 Flang - 1.5 2017-05-01"**)
Other compilers include compiler options as well.
_llvm-dwarfdump test.gf.o | grep DW_AT_producer_
DW_AT_producer    (**"GNU Fortran2008 7.5.0 -mtune=generic -march=x86-64 -gdwarf-5 -fintrinsic-modules-path /usr/lib/gcc/x86_64-linux-gnu/7/finclude"**)
``````````````
Current Patch includes compiler options also for Flang
This is done by adding a field "flags", rest is taken care by LLVM back-end.
!2 = distinct !DICompileUnit(language: DW_LANG_Fortran90, file: !3, producer: " F90 Flang - 1.5 2017-05-01", isOptimized: false, **flags: "'+flang -gdwarf-5 producer.f90 -S -emit-llvm'"**, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, retainedTypes: !4, globals: !4, imports: !4)