### PR TITLE
[runtime] Fix compilation warnings; NFCI

### DIFF
--- a/runtime/flang/allo.c
+++ b/runtime/flang/allo.c
@@ -391,9 +391,8 @@ I8(__alloc04)(__NELEM_T nelem, dtype kind, size_t len,
   if (*pointer && I8(__fort_allocated)(*pointer)
       && ISPRESENT(stat) && *stat == 2) {
     int i;
-    char *mp;
+    const char *mp = "array already allocated";
     MP_P_STDIO;
-    mp = "array already allocated";
     for (i = 0; i < errlen; i++)
       errmsg[i] = (*mp ? *mp++ : ' ');
     MP_V_STDIO;
@@ -612,8 +611,6 @@ I8(__fort_kalloc)(__INT8_T nelem, dtype kind, size_t len, __STAT_T *stat,
 int
 I8(__fort_allocated)(char *area)
 {
-  ALLO_HDR *p;
-
   ALLHDR();
 
   if (area) {
@@ -1517,7 +1514,7 @@ I8(__fort_local_kallocate)(long nelem, dtype kind, size_t len, char *base,
 char *
 I8(__fort_dealloc)(char *area, __STAT_T *stat, void (*freefn)(void *))
 {
-  ALLO_HDR *p, *q;
+  ALLO_HDR *p = NULL;
   char msg[80];
 
   ALLHDR();
@@ -1551,7 +1548,7 @@ static char *
 I8(__fort_dealloc03)(char *area, __STAT_T *stat, void (*freefn)(void *),
                      char *errmsg, int errlen)
 {
-  ALLO_HDR *p, *q;
+  ALLO_HDR *p = NULL;
   char msg[80];
 
   ALLHDR();

--- a/runtime/flang/async.c
+++ b/runtime/flang/async.c
@@ -122,9 +122,6 @@ asy_wait(struct asy *asy)
   long len;
   int s;
   int tn;
-  int offset;
-  int n;
-
   struct aiocb *p[1];
 
   if (!(asy->flags & ASY_IOACT)) { /* i/o active? */
@@ -242,7 +239,6 @@ int
 Fio_asy_open(FILE *fp, struct asy **pasy)
 {
   struct asy *asy;
-  char *p;
 #if defined(TARGET_WIN_X8664)
   HANDLE temp_handle;
 #endif

--- a/runtime/flang/atol.c
+++ b/runtime/flang/atol.c
@@ -36,7 +36,7 @@ __fort_atol(char *p)
 }
 
 long
-__fort_strtol(char *str, char **ptr, int base)
+__fort_strtol(const char *str, char **ptr, int base)
 {
   long val;
   char *end;
@@ -61,7 +61,7 @@ __fort_strtol(char *str, char **ptr, int base)
     }
   } else {
     val = 0;
-    end = str;
+    end = NULL;
   }
   if (ptr)
     *ptr = end;

--- a/runtime/flang/buffer.c
+++ b/runtime/flang/buffer.c
@@ -84,15 +84,15 @@ __fort_zopen(char *path)
 
 /* write */
 
-void __fort_zwrite(adr, len) char *adr;
-int len;
+void
+__fort_zwrite(char *adr, int len)
 {
   int ioproc;
   int s;
 
   ioproc = GET_DIST_IOPROC;
   if (GET_DIST_LCPU != ioproc) {
-    if ((len + sizeof(int)) > (bufe - bufp)) {
+    if ((long)(len + sizeof(int)) > (bufe - bufp)) {
       if (len > MAXBUF) {
         __fort_abort("__fort_zwrite: message too big");
       }

--- a/runtime/flang/chn1t1.c
+++ b/runtime/flang/chn1t1.c
@@ -34,8 +34,6 @@ int *sstrs;                                /* destination cpu stride */
   chdr *c; /* channel structure pointer */
   int cpu;
   int lcpu;
-  int n;
-  int m;
   int nmax;
   int r;
   int di, si, ci;

--- a/runtime/flang/chnbcst_loop.c
+++ b/runtime/flang/chnbcst_loop.c
@@ -20,7 +20,6 @@ void __fort_bcstchn(struct chdr *c,
 {
   int lcpu;
   int n;
-  char buf[80];
 
   lcpu = __fort_myprocnum();
 

--- a/runtime/flang/close.c
+++ b/runtime/flang/close.c
@@ -65,8 +65,6 @@ __fortio_close(FIO_FCB *f, int flag)
     else if (f->status == FIO_SCRATCH)
       unlink(f->name);
 #endif
-
-    free(f->name);
   } else { /* stdin, stdout, stderr - just flush */
 #if defined(TARGET_OSX)
     if (f->unit != 5 && f->unit != -5)
@@ -74,6 +72,7 @@ __fortio_close(FIO_FCB *f, int flag)
       if (__io_fflush(f->fp) != 0)
         return __fortio_error(__io_errno());
   }
+  free(f->name);
 
   __fortio_free_fcb(f); /*  free up FCB for later use  */
 

--- a/runtime/flang/cnfg.c
+++ b/runtime/flang/cnfg.c
@@ -31,19 +31,16 @@ extern char *__fort_getenv();
  *                Default is 1 (VAX-style)
  */
 
-FIO_CNFG __fortio_cnfg_ = {
-/* ending '_' so it can be accessed by user */
-/* default_name */
-    "fort.%d",
-
-    /* vax-style */
-    1,  /* odd => true */
-    -1, /* internal value of .TRUE. */
+FIO_CNFG __fortio_cnfg_ = { /* ending '_' so it can be accessed by user */
+    "fort.%d",              /* default_name */
+                            /* vax-style */
+    1,                      /* odd => true */
+    -1,                     /* internal value of .TRUE. */
 };
 
 /* fio access routines */
 
-char *
+const char *
 __get_fio_cnfg_default_name(void)
 {
   return __fortio_cnfg_.default_name;

--- a/runtime/flang/cnfg.h
+++ b/runtime/flang/cnfg.h
@@ -12,14 +12,14 @@
 
 /* declare structure which may alter the configuration */
 typedef struct {
-  char *default_name; /* sprintf string for default file name */
-  int true_mask;      /* 1 => odd is true, -1 => nonzero is true */
-  int ftn_true;       /* -1 ==> VAX; 1 => unix */
+  const char *default_name; /* sprintf string for default file name */
+  int true_mask;            /* 1 => odd is true, -1 => nonzero is true */
+  int ftn_true;             /* -1 ==> VAX; 1 => unix */
 } FIO_CNFG;
 
 #ifdef WINNT
 
-extern char *__get_fio_cnfg_default_name(void);
+extern const char *__get_fio_cnfg_default_name(void);
 extern int __get_fio_cnfg_true_mask(void);
 extern int *__get_fio_cnfg_true_mask_addr(void);
 extern int __get_fio_cnfg_ftn_true(void);

--- a/runtime/flang/const.c
+++ b/runtime/flang/const.c
@@ -66,7 +66,7 @@ int __fort_size_of[__NTYPES] = {
     sizeof(__PROCPTR_T),    /*   F procedure pointer */
 };
 
-char *__fort_typenames[__NTYPES] = {
+const char *__fort_typenames[__NTYPES] = {
     "none",               /*     no type (absent optional argument) */
     "short",              /* C   signed short */
     "unsigned short",     /* C   unsigned short */
@@ -267,7 +267,6 @@ static __REAL8_T unit_real8 = 1.0;
 static __REAL16_T unit_real16 = 1.0;
 static __CPLX8_T unit_cplx8 = {1.0, 0.0};
 static __CPLX16_T unit_cplx16 = {1.0, 0.0};
-static __CPLX32_T unit_cplx32 = {1.0, 0.0};
 
 void *__fort_units[__NTYPES] = {
     (void *)0,    /*  0 __NONE       no type */
@@ -592,7 +591,7 @@ __get_fort_trues(int idx)
   return __fort_trues[idx];
 }
 
-char *
+const char *
 __get_fort_typenames(int idx)
 {
   return __fort_typenames[idx];
@@ -635,7 +634,7 @@ __set_fort_trues(int idx, void *val)
 }
 
 void
-__set_fort_typenames(int idx, char *val)
+__set_fort_typenames(int idx, const char *val)
 {
   __fort_typenames[idx] = val;
 }

--- a/runtime/flang/copy.c
+++ b/runtime/flang/copy.c
@@ -155,8 +155,8 @@ static void I8(copy_xfer)(copy_parm *z,   /* parameter struct */
   DECL_DIM_PTRS(rcd);
   proc *p;
   procdim *pd;
-  int dfmt, lx, n, px, rx;
-  __INT_T i, m, pc, rg0, rp0;
+  int dfmt, lx, px, rx;
+  __INT_T i, m, pc = 0, rg0, rp0;
   __INT_T rpc[MAXDIMS];
 
   /* Determine the maximum span of dimensions that can be
@@ -304,7 +304,7 @@ static void I8(copy_loop)(copy_parm *z,   /* parameter struct */
   DECL_DIM_PTRS(lcd);
   DECL_DIM_PTRS(rcd);
   int lx, rx;
-  __INT_T cl, cn, cs, clof, clos, i, ll, ln, lu, n, off, rl, rn, rtl, rtu, ru;
+  __INT_T cl, cn, cs, clof, clos, i, ll, ln, lu, n, off, rl, rn, ru;
 
   lc = ly->sect;
   lx = ly->axis_map[dim - 1] - 1;

--- a/runtime/flang/cplxf.c
+++ b/runtime/flang/cplxf.c
@@ -15,9 +15,6 @@
 #include <unistd.h>
 #endif
 
-extern double __fort_second();
-extern long __fort_getoptn(char *, long);
-
 /*
  * Hacks to return complex-valued functions.
  * mergec & mergedc for the Cray are defined in miscsup_com.c.

--- a/runtime/flang/cshift.c
+++ b/runtime/flang/cshift.c
@@ -34,7 +34,6 @@ void ENTFTN(CSHIFTS, cshifts)(void *rb,     /* result base */
   __INT_T aolb[MAXDIMS], aoub[MAXDIMS];
   __INT_T rolb[MAXDIMS], roub[MAXDIMS];
   __INT_T dim, extent, i, sabs, shift;
-  __INT_T al, au, rl, ru;
 
   shift = *sb;
   dim = *db;

--- a/runtime/flang/curdir.c
+++ b/runtime/flang/curdir.c
@@ -23,7 +23,6 @@
 #endif
 
 extern char *getcwd();
-extern char *__fort_getopt();
 
 WIN_MSVCRT_IMP char *WIN_CDECL getenv(const char *);
 
@@ -32,7 +31,7 @@ WIN_MSVCRT_IMP char *WIN_CDECL getenv(const char *);
 void __fort_fixmnt(new, old) char *new;
 char *old;
 {
-  char *q;
+  const char *q;
   char s[MAXPATHLEN]; /* substitute patterns */
   char *smat;         /* match string */
   char *srep;         /* replace string */
@@ -54,15 +53,13 @@ char *old;
       snxt++;
     }
     srep = strchr(smat, ':'); /* replace string */
-    if (srep == NULL) {
-      srep = "";
-    } else {
+    if (srep != NULL) {
       *srep = '\0';
       srep++;
     }
     n = strlen(smat); /* match string length */
     if (strncmp(old, smat, n) == 0) {
-      strcpy(new, srep);
+      strcpy(new, srep ? srep : "");
       strcat(new, old + n);
       return;
     }
@@ -95,7 +92,7 @@ void __fort_gethostname(host) char *host;
 #ifndef _WIN64
   struct utsname un;
 #endif
-  char *p;
+  const char *p;
   int s;
 
   p = __fort_getopt("-curhost");

--- a/runtime/flang/dbug.c
+++ b/runtime/flang/dbug.c
@@ -134,7 +134,7 @@ void I8(__fort_show_index)(__INT_T rank, __INT_T *index)
     for (i = 0; i < rank; i++) {
       if (i > 0)
         fprintf(__io_stderr(), ",");
-      fprintf(__io_stderr(), "%d", index[i]);
+      fprintf(__io_stderr(), "%d", (int)index[i]);
     }
     fprintf(__io_stderr(), ")");
   } else
@@ -163,24 +163,22 @@ void I8(__fort_show_section)(F90_Desc *d)
       fprintf(__io_stderr(), ",");
     SET_DIM_PTRS(dd, d, dx);
     if (F90_DPTR_LBOUND_G(dd) != 1)
-      fprintf(__io_stderr(), "%d:", F90_DPTR_LBOUND_G(dd));
-    fprintf(__io_stderr(), "%d", DPTR_UBOUND_G(dd));
+      fprintf(__io_stderr(), "%d:", (int)F90_DPTR_LBOUND_G(dd));
+    fprintf(__io_stderr(), "%d", (int)DPTR_UBOUND_G(dd));
   }
-  fprintf(__io_stderr(), ")[%d]", F90_GSIZE_G(d));
+  fprintf(__io_stderr(), ")[%d]", (int)F90_GSIZE_G(d));
 }
 
-static char *intentnames[4] = {"INOUT", "IN", "OUT", "??"};
+#if !defined(DESC_I8)
+static const char *intentnames[4] = {"INOUT", "IN", "OUT", "??"};
 
-static char *specnames[4] = {"OMITTED", "PRESCRIPTIVE", "DESCRIPTIVE",
-                             "TRANSCRIPTIVE"};
+static const char *specnames[4] = {"OMITTED", "PRESCRIPTIVE", "DESCRIPTIVE",
+                                   "TRANSCRIPTIVE"};
+#endif
 
-static char *dfmtnames[] = {"*",      "BLOCK",     "BLOCK",   "CYCLIC",
-                            "CYCLIC", "GEN_BLOCK", "INDIRECT"};
-
-static char *dfmtabbrev[] = {"*", "BLK", "BLKK", "CYC", "CYCK", "GENB", "IND"};
+static const char *dfmtabbrev[] = {"*", "BLK", "BLKK", "CYC", "CYCK", "GENB", "IND"};
 
 #if !defined(DESC_I8)
-
 void
 __fort_show_flags(__INT_T flags)
 {
@@ -189,7 +187,7 @@ __fort_show_flags(__INT_T flags)
   _io_spec dist_format_spec;
   _io_spec align_target_spec;
 
-  fprintf(__io_stderr(), "flags=0x%x", flags);
+  fprintf(__io_stderr(), "flags=0x%x", (unsigned int)flags);
   if (flags & __ASSUMED_SIZE)
     fprintf(__io_stderr(), ", ASSUMED SIZE");
   if (flags & __SEQUENCE)
@@ -255,12 +253,13 @@ void ENTFTN(SHOW, show)(void *b, F90_Desc *d)
 
   I8(__fort_show_section)(d);
   fprintf(__io_stderr(), "@%p F90_Desc@%p rank=%d %s len=%d\n", b, d,
-          F90_RANK_G(d), GET_DIST_TYPENAMES(F90_KIND_G(d)), F90_LEN_G(d));
+          (int)F90_RANK_G(d), GET_DIST_TYPENAMES(F90_KIND_G(d)), (int)F90_LEN_G(d));
 
   fprintf(__io_stderr(), "lsize=%d pbase=%d lbase=%d scoff=%d\n",
-          F90_LSIZE_G(d), DIST_PBASE_G(d), F90_LBASE_G(d), DIST_SCOFF_G(d));
-
+          (int)F90_LSIZE_G(d), DIST_PBASE_G(d), (int)F90_LBASE_G(d), DIST_SCOFF_G(d));
+#if !defined(DESC_I8)
   __fort_show_flags(F90_FLAGS_G(d));
+#endif
   fprintf(__io_stderr(), "\n");
 
   if (F90_RANK_G(d) > 0) {
@@ -269,11 +268,11 @@ void ENTFTN(SHOW, show)(void *b, F90_Desc *d)
     for (dx = 1; dx <= F90_RANK_G(d); ++dx) {
       SET_DIM_PTRS(dd, d, dx - 1);
       fprintf(__io_stderr(),
-              "%3d%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d\n", dx,
-              F90_DPTR_LBOUND_G(dd), DPTR_UBOUND_G(dd), DIST_DPTR_OLB_G(dd),
-              DIST_DPTR_OUB_G(dd), DIST_DPTR_NO_G(dd), DIST_DPTR_PO_G(dd),
-              DIST_DPTR_LAB_G(dd), DIST_DPTR_UAB_G(dd), F90_DPTR_LSTRIDE_G(dd),
-              DIST_DPTR_LOFFSET_G(dd), F90_DPTR_SSTRIDE_G(dd),
+              "%3d%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d\n", (int)dx,
+              (int)F90_DPTR_LBOUND_G(dd), (int)DPTR_UBOUND_G(dd), (int)DIST_DPTR_OLB_G(dd),
+              (int)DIST_DPTR_OUB_G(dd), DIST_DPTR_NO_G(dd), DIST_DPTR_PO_G(dd),
+              (int)DIST_DPTR_LAB_G(dd), (int)DIST_DPTR_UAB_G(dd), (int)F90_DPTR_LSTRIDE_G(dd),
+              (int)DIST_DPTR_LOFFSET_G(dd), F90_DPTR_SSTRIDE_G(dd),
               F90_DPTR_SOFFSET_G(dd), DIST_DPTR_ASTRIDE_G(dd),
               DIST_DPTR_AOFFSET_G(dd));
     }
@@ -281,7 +280,7 @@ void ENTFTN(SHOW, show)(void *b, F90_Desc *d)
     fprintf(__io_stderr(), "dim   tx tstr toff cost  map olap sect\n");
     for (dx = 1; dx <= F90_RANK_G(d); ++dx) {
       SET_DIM_PTRS(dd, d, dx - 1);
-      fprintf(__io_stderr(), "%3d%5d%5d%5d%5d%5d%5d%5d\n", dx,
+      fprintf(__io_stderr(), "%3d%5d%5d%5d%5d%5d%5d%5d\n", (int)dx,
               DIST_DPTR_TAXIS_G(dd), DIST_DPTR_TSTRIDE_G(dd),
               DIST_DPTR_TOFFSET_G(dd), DIST_DPTR_COFSTR_G(dd),
               (DIST_MAPPED_G(d) >> (dx - 1)) & 1,
@@ -293,9 +292,9 @@ void ENTFTN(SHOW, show)(void *b, F90_Desc *d)
             "dim  tlb  tub dfmt blck cycl  clb  cno   px pcrd pshp pstr\n");
     for (dx = 1; dx <= F90_RANK_G(d); ++dx) {
       SET_DIM_PTRS(dd, d, dx - 1);
-      fprintf(__io_stderr(), "%3d%5d%5d%5s%5d%5d%5d%5d%5d%5d%5d%5d\n", dx,
-              DIST_DPTR_TLB_G(dd), DIST_DPTR_TUB_G(dd), dfmtabbrev[DFMT(d, dx)],
-              DIST_DPTR_BLOCK_G(dd), DIST_DPTR_CYCLE_G(dd), DIST_DPTR_CLB_G(dd),
+      fprintf(__io_stderr(), "%3d%5d%5d%5s%5d%5d%5d%5d%5d%5d%5d%5d\n", (int)dx,
+              (int)DIST_DPTR_TLB_G(dd), (int)DIST_DPTR_TUB_G(dd), dfmtabbrev[DFMT(d, dx)],
+              DIST_DPTR_BLOCK_G(dd), DIST_DPTR_CYCLE_G(dd), (int)DIST_DPTR_CLB_G(dd),
               DIST_DPTR_CNO_G(dd), DIST_DPTR_PAXIS_G(dd), DIST_DPTR_PCOORD_G(dd),
               DIST_DPTR_PSHAPE_G(dd), DIST_DPTR_PSTRIDE_G(dd));
     }
@@ -305,7 +304,7 @@ void ENTFTN(SHOW, show)(void *b, F90_Desc *d)
       for (dx = 1; dx <= F90_RANK_G(d); ++dx) {
         if ((DIST_CACHED_G(d) >> (dx - 1)) & 1) {
           SET_DIM_PTRS(dd, d, dx - 1);
-          fprintf(__io_stderr(), "%3d%5d%5d%5d%5d%5d\n", dx,
+          fprintf(__io_stderr(), "%3d%5d%5d%5d%5d%5d\n", (int)dx,
                   DIST_DPTR_CL_G(dd), DIST_DPTR_CN_G(dd), DIST_DPTR_CS_G(dd),
                   DIST_DPTR_CLOF_G(dd), DIST_DPTR_CLOS_G(dd));
         }
@@ -315,9 +314,11 @@ void ENTFTN(SHOW, show)(void *b, F90_Desc *d)
 
   t = DIST_ALIGN_TARGET_G(d);
   if (t != d) {
-    fprintf(__io_stderr(), "align-target@%x rank=%d pbase=%d\n", t->tag,
-            F90_RANK_G(t), DIST_PBASE_G(t));
+    fprintf(__io_stderr(), "align-target@%x rank=%d pbase=%d\n", (int)t->tag,
+            (int)F90_RANK_G(t), DIST_PBASE_G(t));
+#if !defined(DESC_I8)
     __fort_show_flags(F90_FLAGS_G(t));
+#endif
     fprintf(__io_stderr(), "\n");
 
     if (F90_RANK_G(t) > 0) {
@@ -326,9 +327,9 @@ void ENTFTN(SHOW, show)(void *b, F90_Desc *d)
       for (tx = 1; tx <= F90_RANK_G(t); ++tx) {
         SET_DIM_PTRS(td, t, tx - 1);
         fprintf(__io_stderr(), "%3d%5d%5d%5s%5d%5d%5d%5d%5d%5d%5d%5d%5d%5d\n",
-                tx, F90_DPTR_LBOUND_G(td), DPTR_UBOUND_G(td),
+                (int)tx, (int)F90_DPTR_LBOUND_G(td), (int)DPTR_UBOUND_G(td),
                 dfmtabbrev[DFMT(t, tx)], DIST_DPTR_BLOCK_G(td),
-                DIST_DPTR_CYCLE_G(td), DIST_DPTR_CLB_G(td), DIST_DPTR_CNO_G(td),
+                DIST_DPTR_CYCLE_G(td), (int)DIST_DPTR_CLB_G(td), DIST_DPTR_CNO_G(td),
                 DIST_DPTR_PAXIS_G(td), DIST_DPTR_PCOORD_G(td),
                 DIST_DPTR_PSHAPE_G(td), DIST_DPTR_PSTRIDE_G(td),
                 (DIST_SINGLE_G(d) >> (tx - 1)) & 1, DIST_INFO_G(d, tx - 1));
@@ -337,17 +338,19 @@ void ENTFTN(SHOW, show)(void *b, F90_Desc *d)
   }
 
   p = DIST_DIST_TARGET_G(d);
-  fprintf(__io_stderr(), "dist-target@%x rank=%d size=%d base=%d\n", p->tag,
-          p->rank, p->size, p->base);
+  fprintf(__io_stderr(), "dist-target@%x rank=%d size=%d base=%d\n", (unsigned int)p->tag,
+          (int)p->rank, (int)p->size, (int)p->base);
+#if !defined(DESC_I8)
   __fort_show_flags(p->flags);
+#endif
   fprintf(__io_stderr(), "\n");
 
   if (p->rank > 0) {
     fprintf(__io_stderr(), "dim shape stride coord repl\n");
     for (px = 1; px <= p->rank; ++px) {
       pd = &p->dim[px - 1];
-      fprintf(__io_stderr(), "%3d%6d%7d%6d%5d\n", px, pd->shape, pd->stride,
-              pd->coord, (DIST_REPLICATED_G(d) >> (px - 1)) & 1);
+      fprintf(__io_stderr(), "%3d%6d%7d%6d%5d\n", (int)px, (int)pd->shape, (int)pd->stride,
+              (int)pd->coord, (DIST_REPLICATED_G(d) >> (px - 1)) & 1);
     }
   }
 }
@@ -355,12 +358,8 @@ void ENTFTN(SHOW, show)(void *b, F90_Desc *d)
 #if (defined(DESC_I8) && defined(__PGLLVM__)) || (!defined(DESC_I8) && !defined(__PGLLVM__))
 void ENTF90COMN(SHOW_, show_)(void *b, F90_Desc *d)
 {
-  DECL_HDR_PTRS(t);
-  DECL_DIM_PTRS(td);
   DECL_DIM_PTRS(dd);
-  proc *p;
-  procdim *pd;
-  __INT_T dx, px, tx;
+  __INT_T dx;
   OBJECT_DESC *dest = (OBJECT_DESC *)d;
   TYPE_DESC *dest_td;
 
@@ -386,7 +385,9 @@ void ENTF90COMN(SHOW_, show_)(void *b, F90_Desc *d)
   fprintf(__io_stderr(), "lsize=%d pbase=%d lbase=%d scoff=%d\n",
           F90_LSIZE_G(d), DIST_PBASE_G(d), F90_LBASE_G(d), DIST_SCOFF_G(d));
 
+#if !defined(DESC_I8)
   __fort_show_flags(F90_FLAGS_G(d));
+#endif
   fprintf(__io_stderr(), "\n");
 
   if (F90_RANK_G(d) > 0) {
@@ -405,20 +406,22 @@ void ENTF90COMN(SHOW_, show_)(void *b, F90_Desc *d)
 
 void I8(__fort_describe)(char *b, F90_Desc *d)
 {
-  DECL_HDR_PTRS(t);
-  proc *p;
-  __INT_T dx, px, tx;
+  __INT_T dx;
 
   if (ISSEQUENCE(d)) {
     fprintf(__io_stderr(), "sequence %s at %p = ",
             GET_DIST_TYPENAMES(TYPEKIND(d)), b);
+#if !defined(DESC_I8)
     __fort_print_scalar(b, (int)TYPEKIND(d));
+#endif
     fprintf(__io_stderr(), "\n");
     return;
   } else if (ISSCALAR(d)) {
     fprintf(__io_stderr(), "scalar %s at %p = ",
             GET_DIST_TYPENAMES(TYPEKIND(d)), b);
+#if !defined(DESC_I8)
     __fort_print_scalar(b, (int)TYPEKIND(d));
+#endif
     fprintf(__io_stderr(), "\n");
     return;
   } else if (F90_TAG_G(d) != __DESC) {
@@ -427,16 +430,16 @@ void I8(__fort_describe)(char *b, F90_Desc *d)
   }
 
   if (~F90_FLAGS_G(d) & __TEMPLATE) {
-    fprintf(__io_stderr(), "%s a_%x(", GET_DIST_TYPENAMES(F90_KIND_G(d)), d->tag);
+    fprintf(__io_stderr(), "%s a_%x(", GET_DIST_TYPENAMES(F90_KIND_G(d)), (int)d->tag);
     for (dx = 0; dx < F90_RANK_G(d); ++dx) {
       if (dx > 0)
         fprintf(__io_stderr(), ",");
       if (F90_DIM_LBOUND_G(d, dx) != 1)
-        fprintf(__io_stderr(), "%d:", F90_DIM_LBOUND_G(d, dx));
-      fprintf(__io_stderr(), "%d", DIM_UBOUND_G(d, dx));
+        fprintf(__io_stderr(), "%d:", (int)F90_DIM_LBOUND_G(d, dx));
+      fprintf(__io_stderr(), "%d", (int)DIM_UBOUND_G(d, dx));
     }
     fprintf(__io_stderr(), ") at %p\n", b);
-    fprintf(__io_stderr(), "!hpf$ shadow a_%x(", d->tag);
+    fprintf(__io_stderr(), "!hpf$ shadow a_%x(", (int)d->tag);
     for (dx = 0; dx < F90_RANK_G(d); ++dx) {
       if (dx > 0)
         fprintf(__io_stderr(), ",");
@@ -449,25 +452,26 @@ void I8(__fort_describe)(char *b, F90_Desc *d)
       if (dx > 0)
         fprintf(__io_stderr(), ",");
       if (DIST_DIM_LAB_G(d, dx) != 1)
-        fprintf(__io_stderr(), "%d:", DIST_DIM_LAB_G(d, dx));
-      fprintf(__io_stderr(), "%d", DIST_DIM_UAB_G(d, dx));
+        fprintf(__io_stderr(), "%d:", (int)DIST_DIM_LAB_G(d, dx));
+      fprintf(__io_stderr(), "%d", (int)DIST_DIM_UAB_G(d, dx));
     }
-    fprintf(__io_stderr(), ")[%d] map (", F90_LSIZE_G(d));
+    fprintf(__io_stderr(), ")[%d] map (", (int)F90_LSIZE_G(d));
     for (dx = 0; dx < F90_RANK_G(d); ++dx) {
       if (dx > 0)
         fprintf(__io_stderr(), ")+(");
       if (F90_DIM_LSTRIDE_G(d, dx) != 1)
-        fprintf(__io_stderr(), "%d*", F90_DIM_LSTRIDE_G(d, dx));
-      fprintf(__io_stderr(), "%c", 'i' + dx);
+        fprintf(__io_stderr(), "%d*", (int)F90_DIM_LSTRIDE_G(d, dx));
+      fprintf(__io_stderr(), "%c", (int)('i' + dx));
       if (DIST_DIM_LOFFSET_G(d, dx) != 0)
-        fprintf(__io_stderr(), "%+d", DIST_DIM_LOFFSET_G(d, dx));
+        fprintf(__io_stderr(), "%+d", (int)DIST_DIM_LOFFSET_G(d, dx));
     }
-    fprintf(__io_stderr(), ") lbase=%d scoff=%d\n", F90_LBASE_G(d),
+    fprintf(__io_stderr(), ") lbase=%d scoff=%d\n", (int)F90_LBASE_G(d),
             DIST_SCOFF_G(d));
+#if !defined(DESC_I8)
     __fort_show_flags(F90_FLAGS_G(d));
+#endif
     fprintf(__io_stderr(), "\n");
   }
-
 }
 
 void ENTFTN(DESCRIBE, describe)(void *b, F90_Desc *d)
@@ -501,7 +505,7 @@ static void I8(print_row)(void *ab, __INT_T str, __INT_T cnt, dtype kind)
     for (i = 0; i < cnt; ++i) {
       if (i > 0 && (i & 15) == 0)
         fprintf(__io_stderr(), "\n");
-      fprintf(__io_stderr(), " %4d", ci[i * str]);
+      fprintf(__io_stderr(), " %4d", (int)ci[i * str]);
     }
     break;
   case __INT1:

--- a/runtime/flang/descFioUtil.c
+++ b/runtime/flang/descFioUtil.c
@@ -19,12 +19,8 @@ void I8(__fortio_loop)(fio_parm *z, /* parameter struct */
 {
   DECL_HDR_PTRS(ac);
   DECL_DIM_PTRS(acd);
-  __INT_T *gb, *tempGB = 0; /* for traversing the gen_block when applicable*/
-  int direction, pshape;
-  __INT_T tExtent;
 
-  int blkno, i, k, pcoord;
-  __INT_T m, n, tl, tu;
+  __INT_T n;
 
   ac = z->ac;
   SET_DIM_PTRS(acd, ac, dim - 1);

--- a/runtime/flang/descRW.c
+++ b/runtime/flang/descRW.c
@@ -70,8 +70,8 @@ static void I8(__io_read)(fio_parm *z)
 static void I8(__io_write)(fio_parm *z)
 {
   DECL_HDR_PTRS(ac);
-  char *adr, *buf;
-  int ioproc, owner, str;
+  char *adr;
+  int str;
 
   ac = z->ac;
   adr = I8(__fort_local_address)(z->ab, ac, z->index);

--- a/runtime/flang/dist.c
+++ b/runtime/flang/dist.c
@@ -20,8 +20,6 @@ void *ENTFTN(COMM_START, comm_start)(sked **skp, void *rb, F90_Desc *rd,
 sked *ENTFTN(COMM_COPY, comm_copy)(void *rb, void *sb, F90_Desc *rs,
                                    F90_Desc *ss);
 
-static __INT_T dummyGenBlock = 0;
-
 __INT_T *I8(__fort_new_gen_block)(F90_Desc *d, int dim)
 {
   return &f90DummyGenBlock;
@@ -282,8 +280,6 @@ ENTFTN(OWNER, owner)
 void I8(__fort_describe_replication)(F90_Desc *d, repl_t *r)
 {
   DECL_DIM_PTRS(dd);
-  DECL_HDR_PTRS(t);
-  DECL_DIM_PTRS(td);
   proc *p;
   procdim *pd;
   __INT_T grpi, dx, m, ncopies, ndim, ngrp, plow, px;
@@ -356,7 +352,7 @@ ENTFTN(ISLOCAL_IDX, islocal_idx)
 (F90_Desc *d, __INT_T *dimb, __INT_T *idxb)
 {
   DECL_DIM_PTRS(dd);
-  __INT_T dfmt, dim, idx, pcoord, tidx;
+  __INT_T dim, idx;
 
   dim = *dimb;
   idx = *idxb;
@@ -376,7 +372,7 @@ ENTFTN(ISLOCAL_IDX, islocal_idx)
 int I8(__fort_islocal)(F90_Desc *d, __INT_T *idxv)
 {
   DECL_DIM_PTRS(dd);
-  __INT_T dfmt, dx, pcoord, tidx;
+  __INT_T dfmt, dx;
 
   if (F90_FLAGS_G(d) & __OFF_TEMPLATE)
     return 0;
@@ -394,8 +390,7 @@ ENTFTN(ISLOCAL, islocal)
 (F90_Desc *d, ...)
 {
   va_list va;
-  DECL_DIM_PTRS(dd);
-  __INT_T dx, idxv[MAXDIMS], pcoord, tidx;
+  __INT_T dx, idxv[MAXDIMS];
 
 #if defined(DEBUG)
   if (d == NULL || F90_TAG_G(d) != __DESC)
@@ -417,7 +412,7 @@ void I8(__fort_localize)(F90_Desc *d, __INT_T *idxv, int *cpu, __INT_T *off)
   DECL_DIM_PTRS(dd);
   proc *p;
   procdim *pd;
-  __INT_T dfmt, dx, lab, lidx, lof, offset, owner, pcoord, px, repl, tidx;
+  __INT_T dfmt, dx, lab, lidx, offset, owner, pcoord = 0, px, repl;
 
   owner = DIST_PBASE_G(d);
   offset = 0;
@@ -503,7 +498,7 @@ void ENTFTN(LOCALIZE_DIM, localize_dim)(F90_Desc *d, __INT_T *dimp,
                                         __INT_T *lindexp)
 {
   DECL_DIM_PTRS(dd);
-  __INT_T dim, idx, lab, lidx, lof, pcoord, tidx;
+  __INT_T dim, idx, lab = 0, lidx, pcoord = 0;
 
   dim = *dimp;
   idx = *idxp;
@@ -602,7 +597,7 @@ I8(__fort_local_offset)(F90_Desc *d, __INT_T *idxv)
 void *I8(__fort_local_address)(void *base, F90_Desc *d, __INT_T *idxv)
 {
   DECL_DIM_PTRS(dd);
-  __INT_T dfmt, dx, idx, lidx, lof, offset, pcoord, tidx;
+  __INT_T dfmt, dx, idx, lidx, offset;
 
   if (F90_FLAGS_G(d) & __OFF_TEMPLATE)
     return NULL;
@@ -656,7 +651,7 @@ ENTFTN(LOCALIZE_INDEX, localize_index)
 (F90_Desc *d, __INT_T *dimb, __INT_T *idxb)
 {
   DECL_DIM_PTRS(dd);
-  int dim, idx, lidx, lof;
+  int dim, idx, lidx;
 
   dim = *dimb;
   idx = *idxb;
@@ -685,8 +680,7 @@ static int I8(cyclic_setup)(F90_Desc *d, __INT_T dim, __INT_T l, __INT_T u,
                             __INT_T *plof, __INT_T *plos)
 {
   DECL_DIM_PTRS(dd);
-  __INT_T abstr, ck, cl, cn, cs, cs0, cu, lof, los, los0, m, n, q, r, tl, tu,
-      ts, ts0, x;
+  __INT_T cl = 0, cn = 0, cs, cu, lof = 0, los = 0, n, ts;
 
   SET_DIM_PTRS(dd, d, dim - 1);
 
@@ -1056,7 +1050,7 @@ proc_setup(proc *p)
   }
   p->size = size;
   if (p->base + size > GET_DIST_TCPUS) {
-    sprintf(msg, "Too few processors.  Need %d, got %d.", p->base + size,
+    sprintf(msg, "Too few processors.  Need %d, got %d.", (int)(p->base + size),
             GET_DIST_TCPUS);
     __fort_abort(msg);
   }
@@ -1079,7 +1073,7 @@ void ENTFTN(PROCESSORS, processors)(proc *p, __INT_T *rankp, ...)
 {
   va_list va;
   procdim *pd;
-  __INT_T i, rank, shape[MAXDIMS];
+  __INT_T i, rank;
 
   rank = *rankp;
 #if defined(DEBUG)
@@ -1253,7 +1247,10 @@ void I8(__fort_use_allocation)(F90_Desc *d, __INT_T dim, __INT_T no, __INT_T po,
 {
   DECL_DIM_PTRS(ad);
   DECL_DIM_PTRS(dd);
-  __INT_T aextent, dextent, k, lof;
+  __INT_T k;
+#if defined(DEBUG)
+  __INT_T aextent, dextent;
+#endif
 
 #if defined(DEBUG)
   if (d == NULL || F90_TAG_G(d) != __DESC)
@@ -1487,7 +1484,6 @@ void I8(__fort_set_section)(F90_Desc *d, __INT_T ddim, F90_Desc *a,
 
 void I8(__fort_finish_section)(F90_Desc *d)
 {
-  DECL_DIM_PTRS(dd);
   __INT_T gsize, i;
   __INT_T rank = F90_RANK_G(d);
 
@@ -1613,7 +1609,7 @@ void ENTFTN(SECT, sect)(F90_Desc *d, F90_Desc *a,
   if (flags & (1 << (ax - 1))) {                                               \
     DECL_DIM_PTRS(__dd);                                                       \
     DECL_DIM_PTRS(__ad);                                                       \
-    __INT_T __extent, __myoffset, u, l, s;                                     \
+    __INT_T __extent, u, l, s;                                                 \
     dx++;                                                                      \
     SET_DIM_PTRS(__ad, a, ax - 1);                                             \
     SET_DIM_PTRS(__dd, d, dx - 1);                                             \
@@ -2339,7 +2335,7 @@ void ENTFTN(SECT3v, sect3v)(F90_Desc *d, F90_Desc *a,
   DECL_DIM_PTRS(ad);
   DECL_DIM_PTRS(dd);
   __INT_T ax, dx, rank;
-  __INT_T gsize;
+  __INT_T gsize = 0;
   __INT_T wrk_rank;
 
 #if defined(DEBUG)
@@ -2428,7 +2424,7 @@ F90_Desc *I8(__fort_inherit_template)(F90_Desc *d, __INT_T rank,
                                       F90_Desc *target)
 {
   DECL_HDR_PTRS(t);
-  __INT_T dz, dzr, tz;
+  __INT_T dz, dzr;
 
 #if defined(DEBUG)
   if (rank < 0 || rank > MAXDIMS)
@@ -2851,7 +2847,7 @@ void ENTFTN(KUBOUNDAZ, kuboundaz)(__INT8_T *arr, F90_Desc *pd)
 __INT_T
 ENTFTN(SIZE, size)(__INT_T *dim, F90_Desc *pd)
 {
-  __INT_T size;
+  __INT_T size = 0;
 
   if (F90_TAG_G(pd) != __DESC) {
     return 1;
@@ -2874,7 +2870,7 @@ ENTFTN(KSIZE, ksize)(__INT_T *dim, F90_Desc *pd)
    * -i8 variant of __size
    */
 
-  __INT_T size;
+  __INT_T size = 0;
 
   if (F90_TAG_G(pd) != __DESC)
     __fort_abort("SIZE: arg not associated with array");

--- a/runtime/flang/dynam.c
+++ b/runtime/flang/dynam.c
@@ -87,7 +87,7 @@ ENTFTN(REALIGN, realign)(F90_Desc *ad, __INT_T *p_rank, __INT_T *p_flags,
   DECL_DIM_PTRS(ddd);
   DECL_DIM_PTRS(tdd);
   proc *ap, *tp;
-  __INT_T flags, conform, collapse, m, single = 0;
+  __INT_T flags, collapse, m, single = 0;
   __INT_T taxis[MAXDIMS], tstride[MAXDIMS], toffset[MAXDIMS];
   __INT_T coordinate[MAXDIMS];
   __INT_T ak, i, realign, rank, tk, tm, px, tx;

--- a/runtime/flang/encodefmt.c
+++ b/runtime/flang/encodefmt.c
@@ -755,7 +755,7 @@ ef_putvlist(char *p, int *len)
  * ENTF90IO(DTS_FMTR,dts_fmtr)/ENTF90IO(DTS_FMTW,dts_fmtw)
  * will handle it if it were i4 */
 {
-  char *begin = p, c;
+  char *begin = p;
   char *op = p;
   INT i, j, cnt;
 
@@ -818,6 +818,7 @@ ef_putvlist(char *p, int *len)
 
   *len = p - begin + 1;
 }
+
 /* ----------------------------------------------------------------- */
 
 static ERRCODE ef_putstring(

--- a/runtime/flang/entry.c
+++ b/runtime/flang/entry.c
@@ -30,10 +30,10 @@ extern __INT_T LINENO[];
 /* function stack entry */
 
 struct pent {
-  char *func; /* function name (no \0) */
-  __CLEN_T funcl;  /* length of above */
-  char *file; /* file name (no \0) */
-  __CLEN_T filel;  /* length of above */
+  const char *func; /* function name (no \0) */
+  __CLEN_T funcl;   /* length of above */
+  const char *file; /* file name (no \0) */
+  __CLEN_T filel;   /* length of above */
   int line;   /* line number of function entry */
   int lines;  /* number of lines in function */
   int cline;  /* calling function line number */
@@ -186,7 +186,7 @@ void ENTFTN(TRACEBACK, traceback)() { __fort_traceback(); }
 /* print message with one level call traceback */
 
 void
-__fort_tracecall(char *msg)
+__fort_tracecall(const char *msg)
 {
   struct pent *pe;
   char buf[512];

--- a/runtime/flang/eoshift.c
+++ b/runtime/flang/eoshift.c
@@ -255,7 +255,7 @@ static void I8(eoshift_loop)(char *rb,          /* result base */
   DECL_DIM_PTRS(ssd);
   __INT_T aflags, albase, apbase, arepli, ascoff;
   __INT_T rflags, rlbase, rpbase, rrepli, rscoff;
-  __INT_T ai, array_dim, bstr, l, ri, sstr;
+  __INT_T ai, array_dim, bstr, ri, sstr;
 
   /* shift rank = array rank - 1*/
 
@@ -351,7 +351,8 @@ void ENTFTN(EOSHIFTSZ, eoshiftsz)(char *rb,     /* result base */
 
   shift = *sb;
   dim = *db;
-  bb = (F90_KIND_G(rs) == __STR) ? " " : (char *)GET_DIST_ZED;
+  /* bb is passed to many non-const parameters; just cast it for now. */
+  bb = (F90_KIND_G(rs) == __STR) ? (char *)" " : (char *)GET_DIST_ZED;
 
 #if defined(DEBUG)
   if (__fort_test & DEBUG_EOSH) {
@@ -518,7 +519,7 @@ void ENTFTN(EOSHIFTSA, eoshiftsa)(char *rb,     /* result base */
 {
   DECL_HDR_VARS(ac);
   DECL_HDR_VARS(rc);
-  __INT_T dim, i, shift;
+  __INT_T dim, shift;
 
   shift = *sb;
   dim = *db;
@@ -600,7 +601,8 @@ void ENTFTN(EOSHIFTZ, eoshiftz)(char *rb,     /* result base */
   __INT_T dim;
 
   dim = *db;
-  bb = (F90_KIND_G(rs) == __STR) ? " " : (char *)GET_DIST_ZED;
+  /* bb is passed to many non-const parameters; just cast it for now. */
+  bb = (F90_KIND_G(rs) == __STR) ? (char *)" " : (char *)GET_DIST_ZED;
   bs = (F90_Desc *)&F90_KIND_G(rs);
 
 #if defined(DEBUG)

--- a/runtime/flang/error.c
+++ b/runtime/flang/error.c
@@ -26,7 +26,7 @@ static src_info_struct src_info;
 static int current_unit;
 static INT *iostat_ptr;
 static int iobitv;
-static char *err_str = "?";
+static const char *err_str = "?";
 char *envar_fortranopt;
 
 static char *iomsg; /* pointer for optional IOMSG area */
@@ -42,7 +42,7 @@ typedef struct {
   bool newunit;
   INT *iostat_ptr;
   int iobitv;
-  char *err_str;
+  const char *err_str;
   char *envar_fortranopt;
   char *iomsg;
   __CLEN_T iomsgl;
@@ -225,7 +225,7 @@ save_fmtgbl()
 /* --------------------------------------------------------------- */
 
 extern void
-__fortio_errinit(__INT_T unit, __INT_T bitv, __INT_T *iostat, char *str)
+__fortio_errinit(__INT_T unit, __INT_T bitv, __INT_T *iostat, const char *str)
 {
   if (fioFcbTbls.fcbs == NULL)
     __fortio_init();
@@ -249,7 +249,7 @@ __fortio_errinit(__INT_T unit, __INT_T bitv, __INT_T *iostat, char *str)
 }
 
 extern void
-__fortio_errinit03(__INT_T unit, __INT_T bitv, __INT_T *iostat, char *str)
+__fortio_errinit03(__INT_T unit, __INT_T bitv, __INT_T *iostat, const char *str)
 {
   if (fioFcbTbls.fcbs == NULL)
     __fortio_init();
@@ -302,7 +302,7 @@ __fortio_fmtend(void)
 
 #define X(str) str,
 
-static char *errtxt[] = {
+static const char *errtxt[] = {
     X("xxx")                                           /* 200 */
     X("illegal value for specifier")                   /* ESPEC 201 */
     X("conflicting specifiers")                        /* ECOMPAT 202 */
@@ -378,8 +378,7 @@ int
 __fortio_error(int errval)
 {
   FIO_FCB *fdesc;
-  char *eoln, *txt;
-  int one = 1;
+  const char *eoln, *txt;
   int retval;
 
   assert(errval > 0);
@@ -451,17 +450,17 @@ __fortio_error(int errval)
 /* FIXME: this routine is a duplicate of
  *   runtime/lib/pgftn/error.h:__fio_errmsg
  */
-extern char *
+extern const char *
 __fortio_errmsg(int errval)
 {
-  char *txt;
+  const char *txt;
   static char buf[128];
   if (errval == 0) {
     buf[0] = ' ';
     buf[1] = '\0';
     txt = buf;
   } else if (errval >= FIO_ERROR_OFFSET) {
-    if (errval - FIO_ERROR_OFFSET >= sizeof(errtxt) / sizeof(errtxt[0])) {
+    if ((size_t)(errval - FIO_ERROR_OFFSET) >= sizeof(errtxt) / sizeof(errtxt[0])) {
       sprintf(buf, "get_iostat_msg: iostat value %d is out of range", errval);
       txt = buf;
     } else if ((txt = getenv("LANG")) && strcmp(txt, "japan") == 0)
@@ -489,8 +488,7 @@ int
 __fortio_eoferr(int errval)
 {
   FIO_FCB *fdesc;
-  char *eoln, *txt, *tmp;
-  int one = 1;
+  const char *eoln, *txt;
 
   assert(errval > FIO_ERROR_OFFSET);
 
@@ -539,8 +537,7 @@ int
 __fortio_eorerr(int errval)
 {
   FIO_FCB *fdesc;
-  char *eoln, *txt;
-  int one = 1;
+  const char *eoln, *txt;
 
   assert(errval > FIO_ERROR_OFFSET);
 
@@ -580,7 +577,7 @@ __fortio_eorerr(int errval)
 static void
 ioerrinfo(FIO_FCB *fdesc)
 {
-  char *eoln;
+  const char *eoln;
   FILE *fp; /* stderr */
 
   fp = __io_stderr();
@@ -615,7 +612,7 @@ ioerrinfo(FIO_FCB *fdesc)
     __io_fprintf(fp, " File name = %.*s%s", fioFcbTbls.fnamelen, fioFcbTbls.fname,
                    eoln);
 
-  __io_fprintf(fp, " In source file %.*s,", src_info.len, src_info.name);
+  __io_fprintf(fp, " In source file %.*s,", (int)src_info.len, src_info.name);
   __io_fprintf(fp, " at line number %d%s", src_info.lineno, eoln);
 }
 
@@ -855,7 +852,7 @@ __fortio_init(void)
 
   f->fp = __io_stdin();
   f->unit = -5;
-  f->name = "stdin ";
+  f->name = strdup("stdin ");
   f->reclen = 0;
   f->wordlen = 1;
   f->nextrec = 1;
@@ -886,7 +883,7 @@ __fortio_init(void)
 
   f->fp = __io_stdout();
   f->unit = -6;
-  f->name = "stdout ";
+  f->name = strdup("stdout ");
   f->reclen = 0;
   f->wordlen = 1;
   f->nextrec = 1;
@@ -917,7 +914,7 @@ __fortio_init(void)
 
   f->fp = __io_stdin();
   f->unit = 5;
-  f->name = "stdin ";
+  f->name = strdup("stdin ");
   f->reclen = 0;
   f->wordlen = 1;
   f->nextrec = 1;
@@ -948,7 +945,7 @@ __fortio_init(void)
 
   f->fp = __io_stdout();
   f->unit = 6;
-  f->name = "stdout ";
+  f->name = strdup("stdout ");
   f->reclen = 0;
   f->wordlen = 1;
   f->nextrec = 1;
@@ -979,7 +976,7 @@ __fortio_init(void)
 
   f->fp = __io_stderr();
   f->unit = 0;
-  f->name = "stderr ";
+  f->name = strdup("stderr ");
   f->reclen = 0;
   f->wordlen = 1;
   f->nextrec = 1;

--- a/runtime/flang/error.h
+++ b/runtime/flang/error.h
@@ -11,13 +11,13 @@
 
 void set_gbl_newunit(bool newunit);
 bool get_gbl_newunit();
-void __fortio_errinit(__INT_T unit, __INT_T bitv, __INT_T *iostat, char *str);
-void __fortio_errinit03(__INT_T unit, __INT_T bitv, __INT_T *iostat, char *str);
+void __fortio_errinit(__INT_T unit, __INT_T bitv, __INT_T *iostat, const char *str);
+void __fortio_errinit03(__INT_T unit, __INT_T bitv, __INT_T *iostat, const char *str);
 void __fortio_errend03();
 void __fortio_fmtinit();
 void __fortio_fmtend(void);
 int __fortio_error(int errval);
-char * __fortio_errmsg(int errval);
+const char * __fortio_errmsg(int errval);
 int __fortio_eoferr(int errval);
 int __fortio_eorerr(int errval);
 int __fortio_check_format(void);

--- a/runtime/flang/feddesc.h
+++ b/runtime/flang/feddesc.h
@@ -69,4 +69,7 @@
 #define FED_G0 -54
 #define FED_G0_d -55
 
-void I8(get_vlist_desc)(F90_Desc *sd, __INT_T ubnd);
+/* Users of this header need both versions of get_vlist_desc, but are not
+   dependent on DESC_I8 themselves; explicitly declare both versions here. */
+void get_vlist_desc(F90_Desc *sd, __INT_T ubnd);
+void get_vlist_desc_i8(F90_Desc *sd, __INT_T ubnd);

--- a/runtime/flang/fioMacros.h
+++ b/runtime/flang/fioMacros.h
@@ -296,7 +296,7 @@ extern void *__get_fort_mins(int);
 extern int __get_fort_shifts(int);
 extern int __get_fort_size_of(int);
 extern void *__get_fort_trues(int);
-extern char *__get_fort_typenames(int);
+extern const char *__get_fort_typenames(int);
 extern void *__get_fort_units(int);
 
 extern void __set_fort_maxs(int, void *);
@@ -304,7 +304,7 @@ extern void __set_fort_mins(int, void *);
 extern void __set_fort_shifts(int, int);
 extern void __set_fort_size_of(int, int);
 extern void __set_fort_trues(int, void *);
-extern void __set_fort_typenames(int, char *);
+extern void __set_fort_typenames(int, const char *);
 extern void __set_fort_units(int, void *);
 
 #define GET_DIST_MAXS(idx) __get_fort_maxs(idx)
@@ -341,7 +341,7 @@ extern int __get_fort_tcpus(void);
 extern int *__get_fort_tcpus_addr(void);
 extern int *__get_fort_tids(void);
 extern int __get_fort_tids_elem(int);
-extern char *__get_fort_transnam(void);
+extern const char *__get_fort_transnam(void);
 
 extern void __set_fort_debug(int);
 extern void __set_fort_debugn(int);
@@ -431,7 +431,7 @@ extern void *__fort_maxs[__NTYPES];
 extern void *__fort_mins[__NTYPES];
 extern int __fort_shifts[__NTYPES];
 extern void *__fort_trues[__NTYPES];
-extern char *__fort_typenames[__NTYPES];
+extern const char *__fort_typenames[__NTYPES];
 extern void *__fort_units[__NTYPES];
 
 #define GET_DIST_MAXS(idx) __fort_maxs[idx]
@@ -457,7 +457,7 @@ extern long long int __fort_zed[4];
 #define GET_DIST_ZED __fort_zed
 
 #include "fort_vars.h"
-extern char *__fort_transnam;
+extern const char *__fort_transnam;
 
 #define GET_DIST_HEAPZ 0
 #define GET_DIST_IOPROC 0
@@ -1438,9 +1438,9 @@ void __fort_show_scalar(void *adr, dtype kind);
 __INT_T
 I8(is_nonsequential_section)(F90_Desc *d, __INT_T dim);
 
-void *I8(__fort_create_conforming_mask_array)(char *what, char *ab, char *mb,
-                                             F90_Desc *as, F90_Desc *ms,
-                                             F90_Desc *new_ms);
+void *I8(__fort_create_conforming_mask_array)(const char *what, char *ab,
+                                              char *mb, F90_Desc *as,
+                                              F90_Desc *ms, F90_Desc *new_ms);
 
 void I8(__fort_reverse_array)(char *db, char *ab, F90_Desc *dd, F90_Desc *ad);
 
@@ -1546,9 +1546,9 @@ int I8(__fort_aligned)(F90_Desc *t, __INT_T *tmap, F90_Desc *u, __INT_T *umap);
 
 int I8(__fort_aligned_axes)(F90_Desc *t, int tx, F90_Desc *u, int ux);
 
-void __fort_abort(char *msg);
+void __fort_abort(const char *msg);
 
-void __fort_abortp(char *s);
+void __fort_abortp(const char *s);
 
 void __fort_bcopy(char *to, char *fr, size_t n);
 
@@ -1669,7 +1669,7 @@ void __fort_exit(int s);
 
 /* tracing functions -- entry.c */
 
-void __fort_tracecall(char *msg);
+void __fort_tracecall(const char *msg);
 
 /* utility functions -- util.c */
 
@@ -1697,14 +1697,18 @@ void __fort_ftnstrcpy(char *dst,  /*  destination string, blank-filled */
                      int len,    /*  length of destination space */
                      char *src); /*  null terminated source string  */
 
+const char *__fort_getopt(const char *opt);
+
+long __fort_getoptn(const char *opt, long def);
+
 int __fort_atol(char *p);
 
-long __fort_strtol(char *str, char **ptr, int base);
+long __fort_strtol(const char *str, char **ptr, int base);
 
-void __fort_initndx( int nd, int *cnts, int *ncnts, int *strs, int *nstrs,
+void __fort_initndx(int nd, int *cnts, int *ncnts, int *strs, int *nstrs,
                     int *mults);
 
-int __fort_findndx( int cpu, int nd, int low, int *nstrs, int *mults);
+int __fort_findndx(int cpu, int nd, int low, int *nstrs, int *mults);
 
 void __fort_barrier(void);
 

--- a/runtime/flang/fmtconv.c
+++ b/runtime/flang/fmtconv.c
@@ -31,7 +31,7 @@ static int dbgflag;
 
 static char *conv_int(__BIGINT_T, int *, int *);
 static char *conv_int8(DBLINT64, int *, int *);
-static void put_buf(int, char *, int, int);
+static void put_buf(int, const char *, int, int);
 
 static void conv_e(int, int, int, bool);
 static void conv_en(int, int, bool);
@@ -93,8 +93,9 @@ __fortio_default_convert(char *item, int type,
   switch (type) {
   default:
     assert(0);
-    *lenp = 1;
-    return " ";
+    width = 1;
+    strcpy(conv_bufp, " ");
+    break;
   case __INT1:
     width = 5;
     (void) __fortio_fmt_i((__BIGINT_T)PP_INT1(item), width, 1, plus_flag);
@@ -149,7 +150,9 @@ __fortio_default_convert(char *item, int type,
     break;
   case __WORD16:
     assert(0);
-    return "\0";
+    width = 0;
+    strcpy(conv_bufp, "");
+    break;
   case __CPLX8:
     p = cmplx_buf;
     *p++ = '(';
@@ -237,7 +240,7 @@ __fortio_default_convert(char *item, int type,
       put_buf(width, "F", 1, 0);
     break;
   case __STR:
-    if (item_length >= conv_bufsize) {
+    if (item_length >= (int)conv_bufsize) {
       conv_bufsize = item_length + 128;
       if (conv_bufp != __f90io_conv_buf)
         free(conv_bufp);
@@ -308,10 +311,11 @@ conv_int(__BIGINT_T val, int *lenp, int *negp)
   unsigned int n;
 
   if (val < 0) {
-    if (val == MAX_HX) {
+    if (val == (__BIGINT_T)MAX_HX) {
       *lenp = 10;
       *negp = 1;
-      return MAX_STR;
+      strcpy(tmp, MAX_STR);
+      return tmp;
     }
     neg = 1;
     val = -val;
@@ -394,10 +398,11 @@ conv_int8(DBLINT64 val, int *lenp, int *negp)
     else
       I64_MSH(value) = 0;
   } else if (I64_MSH(value) < 0) {
-    if (I64_MSH(value) == 0x80000000 && I64_LSH(value) == 0) {
+    if (I64_MSH(value) == (int)0x80000000 && I64_LSH(value) == 0) {
       *lenp = 19;
       *negp = 1;
-      return "9223372036854775808";
+      strcpy(tmp, "9223372036854775808");
+      return tmp;
     }
     *negp = 1;
     /* now negate the value */
@@ -439,10 +444,10 @@ static struct {
   __BIGREAL_T zero; /* hide 0.0 from the optimizer here */
 } fpdat = {0, 0, 0, '.', 0, 0, 0, fpbuf, sizeof(fpbuf), 0.0};
 
-static void put_buf(int width,     /* where width (# bytes) */
-                    char *valp,    /* value in string form */
-                    int len,       /* length of value */
-                    int sign_char) /* '-', '+', or 0 (nothing to prepend) */
+static void put_buf(int width,        /* where width (# bytes) */
+                    const char *valp, /* value in string form */
+                    int len,          /* length of value */
+                    int sign_char)    /* '-', '+', or 0 (nothing to prepend) */
 {
   char *bufp;
   int cnt;
@@ -451,7 +456,7 @@ static void put_buf(int width,     /* where width (# bytes) */
   if (DBGBIT(0x1))
     __io_printf("put_buf: width=%d, len=%d, val=%.*s#, sign_char=%d\n", width,
                  len, len, valp, sign_char);
-  if (width >= conv_bufsize) {
+  if (width >= (int)conv_bufsize) {
     conv_bufsize = width + 128;
     if (conv_bufp != __f90io_conv_buf)
       free(conv_bufp);
@@ -1083,7 +1088,6 @@ fp_canon(__BIGREAL_T val, int type, int round)
   }
   fpdat.ndigits = strlen(fpdat.cvtp);
   fpdat.curp = fpdat.buf;
-
 }
 
 /*

--- a/runtime/flang/fmtread.c
+++ b/runtime/flang/fmtread.c
@@ -384,7 +384,6 @@ fr_init(__INT_T *unit,   /* unit number */
   }
 
 /* ---- read first record: */
-init_r:
   if (!g->same_fcb)
     errcode = fr_read_record();
   if (errcode != 0) {
@@ -561,7 +560,7 @@ ENTF90IO(FMTR_INIT03A, fmtr_init03a)
       } else if (__fortio_eq_str(CADR(round), CLEN(round), "COMPATIBLE")) {
         gbl->round = FIO_COMPATIBLE;
       } else if (__fortio_eq_str(CADR(round), CLEN(round),
-                                "PROCESSOR_DEFINED")) {
+                                 "PROCESSOR_DEFINED")) {
         gbl->round = FIO_PROCESSOR_DEFINED;
       } else
         s = __fortio_error(FIO_ESPEC);
@@ -971,7 +970,7 @@ fr_intern_init(char *cunit,      /* pointer to variable or array to read from */
   i = INIT_BUFF_LEN;
   if (w > INIT_BUFF_LEN)
     i = w;
-  if (g->obuff_len < i) {
+  if (g->obuff_len < (long)i) {
     int err;
     err = malloc_obuff(g, (size_t)i);
     if (err)
@@ -1260,7 +1259,6 @@ __f90io_fmt_read(int type,    /* data type (as defined in pghpft.h) */
   char *tmpitem; /* scratch copy of item */
   G *g = gbl;
   FIO_FCB *f;
-  FILE *fp;
   int ist;
   int ret_err = 0;
 
@@ -1478,7 +1476,7 @@ ENTCRF90IO(FMT_READA, fmt_reada)
  DCLEN64(item))
 {
   int typ;
-  int cnt, cpu, i;
+  int cnt;
   int len, str;
   char *adr;
 
@@ -1519,7 +1517,6 @@ fr_read(char *item,      /* where to transfer data to.  The value of item may
   G *g = gbl;
   bool endreached = FALSE;
   int i, w;
-  char* tptr = item;
 
   move_fwd_eor = 0;
   while (TRUE) {
@@ -2732,7 +2729,6 @@ fr_Breadnum(char *item, int type, int item_length)
     break;
 
   default: /*  actually, internal error ..... */
-  fmt_mismatch:
     return __fortio_error(FIO_EMISMATCH);
   }
 
@@ -3254,7 +3250,7 @@ fr_read_record(void)
       if (f->acc == FIO_DIRECT) {
         if (f->nextrec > f->maxrec + 1)
           return FIO_EDREAD; /* attempt to read non-existent rec */
-        if (__io_fread(g->rec_buff, 1, g->rec_len, fp) != g->rec_len)
+        if ((long)__io_fread(g->rec_buff, 1, g->rec_len, fp) != g->rec_len)
           return __io_errno();
       } else { /* sequential read */
         idx = 0;
@@ -3394,7 +3390,6 @@ _f90io_fmtr_end(void)
 __INT_T
 ENTF90IO(FMTR_END, fmtr_end)()
 {
-  int cpu;
   int s = 0;
 
   if (LOCAL_MODE || GET_DIST_LCPU == GET_DIST_IOPROC)
@@ -3430,11 +3425,9 @@ ENTCRF90IO(FMTR_END, fmtr_end)()
 __INT_T
 ENTF90IO(DTS_FMTR,dts_fmtr)(char** cptr, void** iptr, __INT_T* len, F90_Desc* sd, int* flag)
 {
-  int s = 0, i;
+  int i;
   INT code, k, first;
-  __INT_T lbnd = 1;
   __INT_T ubnd = 0;
-  __INT_T lbase, gsize;
   __INT8_T **tptr8 = (__INT8_T **)iptr;
   INT **tptr4 = (INT **)iptr;
   G *g = gbl;

--- a/runtime/flang/fmtwrite.c
+++ b/runtime/flang/fmtwrite.c
@@ -85,7 +85,7 @@ static INT fw_get_val(G *);
 static int fw_writenum(int, char *, int);
 static int fw_OZwritenum(int, char *, int, int);
 static int fw_Bwritenum(char *, int, __CLEN_T);
-static int fw_write_item(char *, int);
+static int fw_write_item(const char *, int);
 static int fw_check_size(long);
 static int fw_write_record(void);
 /* ----------------------------------------------------------------------- */
@@ -339,7 +339,7 @@ ENTF90IO(FMTW_INITA, fmtw_inita)
  DCHAR(advance)   /* 'YES', 'NO', or 'NULL' */
  DCLEN64(advance))
 {
-  G *g, *tmp_gbl;
+  G *g;
   char *advadr;
   __CLEN_T advlen;
   int s = 0;
@@ -426,7 +426,7 @@ ENTF90IO(FMTW_INIT03A, fmtw_init03a)
       } else if (__fortio_eq_str(CADR(round), CLEN(round), "COMPATIBLE")) {
         gbl->round = FIO_COMPATIBLE;
       } else if (__fortio_eq_str(CADR(round), CLEN(round),
-                                "PROCESSOR_DEFINED")) {
+                                 "PROCESSOR_DEFINED")) {
         gbl->round = FIO_PROCESSOR_DEFINED;
       } else
         s = __fortio_error(FIO_ESPEC);
@@ -1847,7 +1847,7 @@ fw_writenum(int code, char *item, int type)
     w = REAL8_W;
     d = REAL8_D;
     if (dval == 0 || (dval > 1e-100 && dval < 1e100)
-        || dval > -1e100 && dval < -1e-100) {
+        || (dval > -1e100 && dval < -1e-100)) {
       e = 2;
     } else {
       e = REAL8_E;
@@ -2581,7 +2581,7 @@ fw_OZbyte(unsigned int c)
 
 /**  \return ERR_FLAG or 0 */
 static int
-fw_write_item(char *p, int len)
+fw_write_item(const char *p, int len)
 {
   G *g = gbl;
   char *q;
@@ -2765,7 +2765,7 @@ ENTF90IO(FMTW_END, fmtw_end)()
 {
   G *g = gbl;
   int ioproc;
-  int i, len, s = 0;
+  int len, s = 0;
 
   ioproc = GET_DIST_IOPROC;
   if ((GET_DIST_LCPU == ioproc) || LOCAL_MODE) {
@@ -2867,11 +2867,8 @@ ENTF90IO(DTS_FMTW,dts_fmtw)(char** cptr, void** iptr, INT * len, F90_Desc* sd, i
 {
   INT code, k, first;
   G *g = gbl;
-  int s = 0;
   int i, errflag;
-  __INT_T lbnd = 1;
   __INT_T ubnd = 0;
-  __INT_T gsize, lbase;
   __INT8_T **tptr8 = (__INT8_T **)iptr;
   INT **tptr4 = (INT **)iptr;
 

--- a/runtime/flang/format-double.c
+++ b/runtime/flang/format-double.c
@@ -1111,8 +1111,8 @@ G_format(char *out, int width,
 
       if (int_part_digits == 0) {
         bool all_frac_zeroes = all_zeroes(frac_part, frac_digits);
-        if (frac_digits > 0 && frac_part[0] == '0' &&
-           (!all_frac_zeroes || next_digit_for_rounding > 0 || is_inexact)
+        if ((frac_digits > 0 && frac_part[0] == '0' &&
+           (!all_frac_zeroes || next_digit_for_rounding > 0 || is_inexact))
            || (frac_digits == 0 && control->scale_factor))
           goto do_E_formatting; /* 0 < |x| < 0.1 */
         if (all_frac_zeroes) {

--- a/runtime/flang/fort_vars.h
+++ b/runtime/flang/fort_vars.h
@@ -24,7 +24,7 @@ typedef	struct	__fort_vars {
 	int64_t	heap_block;	/*  48: prcoessor heap size (not power of 2)  */
 	int32_t	*tids;		/*  56: tid for each processor                */
 	int32_t	dummy1[16];	/*  64:                                       */
-	char	*red_what;	/* 128: !! NOT THREAD-SAFE !!                 */
+	const char *red_what;	/* 128: !! NOT THREAD-SAFE !!                 */
 	int32_t	dummy2[30];	/* 136:                                       */
 } __fort_vars_t;
 

--- a/runtime/flang/fpcvt.c
+++ b/runtime/flang/fpcvt.c
@@ -46,7 +46,7 @@ typedef struct {
 
 static int ufpdnorm(UFP *, int);
 
-static void mtherr(char *, int);
+static void mtherr(const char *, int);
 static void fperror(int x);
 
 /* fperror error msg selectors */
@@ -334,7 +334,7 @@ again:
     manshftr(u->fman, -u->fexp);
   manrnd(u->fman, 64);
   ui64toa(u->fman, s, 0, dp);
-  if (strlen(s) > dp + 2) {
+  if (int(strlen(s)) > dp + 2) {
     u->fman[0] = man[0];
     u->fman[1] = man[1];
     u->fexp = exp2;
@@ -774,12 +774,8 @@ writefmt(char *fmt, int prec, char c)
 char *
 __fortio_ecvt(double value, int ndigit, int *decpt, int *sign, int round)
 {
-  static char buf[30]; /* WARNING: dependency on size in fmtconv.c.
-                        * look for ECVTSIZE */
-  char *s;
   void ufptosci();
-  UFP u;
-  int i, j, carry, n;
+  int i, j;
 
   union ieee ieee_v;
 
@@ -1759,7 +1755,6 @@ e113toe(IEEE128 pe, USHORT *y)
   USHORT r;
   USHORT *p;
   USHORT yy[NI];
-  int i;
 
   ecleaz(yy);
   r = (UINT)pe[0] >> 16;
@@ -2204,10 +2199,13 @@ struct etypdat_tag etypdat = {
     /* eeul 5.7721566490153286060651209008240243104215933593992E-1 */
     {
         0xd1be, 0xc7a4, 0076660, 0063743, 0111704, 0x3ffe,
-    }};
+    },
+
+    /* inf_ok */
+    0};
 
 static void
-mtherr(char *s, int c)
+mtherr(const char *s, int c)
 {
   fperror(c);
 }

--- a/runtime/flang/fstat3f.c
+++ b/runtime/flang/fstat3f.c
@@ -62,7 +62,6 @@ int ENT3F(FSTAT, fstat)(int *lu, int *statb)
   return i;
 #else
   struct stat b;
-  char *p;
   int i;
   void *f;
 

--- a/runtime/flang/fstat643f.c
+++ b/runtime/flang/fstat643f.c
@@ -86,7 +86,6 @@ int ENT3F(FSTAT64, fstat64)(int *lu, long long *statb)
   return i;
 #else
   struct stat b;
-  char *p;
   int i;
   void *f;
 

--- a/runtime/flang/ftncharsup.c
+++ b/runtime/flang/ftncharsup.c
@@ -70,7 +70,7 @@ Ftn_str_copy(int n, char *to, int to_len, ...)
   if (to_len <= 0) {
     return;
   }
-  if (n <= (sizeof(aa) / sizeof(SRC_STR))) {
+  if (n <= (int)(sizeof(aa) / sizeof(SRC_STR))) {
     qq = src_p = aa;
     src_p_allocd = 0;
   } else {
@@ -305,7 +305,7 @@ Ftn_str_copy_klen(int n, char *to, int64_t to_len, ...)
   if (to_len <= 0) {
     return;
   }
-  if (n <= (sizeof(aa) / sizeof(SRC_STR))) {
+  if (n <= (int)(sizeof(aa) / sizeof(SRC_STR))) {
     qq = src_p = aa;
     src_p_allocd = 0;
   } else {

--- a/runtime/flang/ftnexit.c
+++ b/runtime/flang/ftnexit.c
@@ -15,8 +15,6 @@
 #include "fioMacros.h"
 #include "llcrit.h"
 
-extern char *__fort_getopt(char *opt);
-
 void ENTF90(EXIT, exit)(__INT_T *exit_status)
 {
   __fort_exit(ISPRESENT(exit_status) ? *exit_status : 0);
@@ -59,7 +57,7 @@ _f90io_stop(int exit_status, char *str, __CLEN_T str_siz, __LOG_T is_quiet, __LO
     if (is_errorstop)
       fprintf(__io_stderr(), "ERROR STOP ");
 
-    fprintf(__io_stderr(), "%.*s\n", str_siz, str);
+    fprintf(__io_stderr(), "%.*s\n", (int)str_siz, str);
   } else if (__fort_getenv("NO_STOP_MESSAGE") == 0
                  ) {
     if (is_quiet == 0)
@@ -166,7 +164,7 @@ _f90io_pause(char *str, __CLEN_T str_siz)
 {
   MP_P_STDIO;
   if (str)
-    fprintf(__io_stderr(), "FORTRAN PAUSE: %.*s\n", str_siz, str);
+    fprintf(__io_stderr(), "FORTRAN PAUSE: %.*s\n", (int)str_siz, str);
   if (__fort_isatty(__fort_getfd(__io_stdin()))) {
     fprintf(__io_stderr(),
             "FORTRAN PAUSE: enter <return> or <ctrl>d to continue>");

--- a/runtime/flang/ftnmiscsup.c
+++ b/runtime/flang/ftnmiscsup.c
@@ -35,12 +35,12 @@ void
 Ftn_date(char *buf,     /* date buffer */
          INT buf_len)   /* length of date buffer */
 {
-  char loc_buf[9];
+  char loc_buf[10];
   INT idx1;
   time_t ltime;
   struct tm *lt;
-  static char *month[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+  static const char *month[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
   /* procedure */
 

--- a/runtime/flang/gerror3f.c
+++ b/runtime/flang/gerror3f.c
@@ -32,7 +32,7 @@ void ENT3F(GERROR, gerror)(DCHAR(str) DCLEN(str))
 
 void ENT3F(GET_IOSTAT_MSG, get_iostat_msg)(int *ios, DCHAR(str) DCLEN(str))
 {
-  char *p;
+  const char *p;
   p = Ftn_errmsg(*ios);
   __fcp_cstr(CADR(str), CLEN(str), p);
 }
@@ -40,7 +40,7 @@ void ENT3F(GET_IOSTAT_MSG, get_iostat_msg)(int *ios, DCHAR(str) DCLEN(str))
 /* for -Msecond_underscore */
 void ENT3F(GET_IOSTAT_MSG_, get_iostat_msg_)(int *ios, DCHAR(str) DCLEN(str))
 {
-  char *p;
+  const char *p;
   p = Ftn_errmsg(*ios);
   __fcp_cstr(CADR(str), CLEN(str), p);
 }

--- a/runtime/flang/getdrivedirqq3f.c
+++ b/runtime/flang/getdrivedirqq3f.c
@@ -32,7 +32,7 @@ int ENT3F(GETDRIVEDIRQQ, getdrivedirqq)(DCHAR(dir) DCLEN(dir))
 
   q = __fstr2cstr(CADR(dir), CLEN(dir));
   l1 = CLEN(dir) + 1;
-  if (strlen(q) + 1 < l1)
+  if ((int)(strlen(q)) + 1 < l1)
     l1 = strlen(q);
   __cstr_free(q);
   p = GETCWDM(NULL, l1);

--- a/runtime/flang/getenv3f.c
+++ b/runtime/flang/getenv3f.c
@@ -20,7 +20,6 @@ extern void __cstr_free();
 void ENT3F(GETENV, getenv)(DCHAR(en), DCHAR(ev) DCLEN(en) DCLEN(ev))
 {
   char *p, *q;
-  char ch;
 
   q = __fstr2cstr(CADR(en), CLEN(en));
   p = getenv(q);

--- a/runtime/flang/getenvqq3f.c
+++ b/runtime/flang/getenvqq3f.c
@@ -20,7 +20,6 @@ extern void __cstr_free();
 int ENT3F(GETENVQQ, getenvqq)(DCHAR(en), DCHAR(ev) DCLEN(en) DCLEN(ev))
 {
   char *p, *q;
-  char ch;
   int i;
 
   q = __fstr2cstr(CADR(en), CLEN(en));

--- a/runtime/flang/getvolinfo3f.c
+++ b/runtime/flang/getvolinfo3f.c
@@ -53,6 +53,7 @@ extern int ENTNAM(pgdfw_GetVolumeInformation)(
 }
 #endif
 
+#if defined(WIN64) || defined(WIN32)
 static void
 fill(LPSTR p, int ln, int sz)
 {
@@ -63,3 +64,4 @@ fill(LPSTR p, int ln, int sz)
   }
   return;
 }
+#endif

--- a/runtime/flang/global.h
+++ b/runtime/flang/global.h
@@ -355,16 +355,16 @@ WIN_MSVCRT_IMP double WIN_CDECL strtod(const char *, char **);
 /*****  error.c  *****/
 extern VOID set_gbl_newunit(bool newunit);
 extern bool get_gbl_newunit();
-extern VOID __fortio_errinit(__INT_T, __INT_T, __INT_T *, char *);
+extern VOID __fortio_errinit(__INT_T, __INT_T, __INT_T *, const char *);
 extern VOID __fortio_errinit03(__INT_T unit, __INT_T bitv, __INT_T *iostat,
-                               char *str);
+                               const char *str);
 extern VOID __fortio_errend(void);
 extern VOID __fortio_errend03(void);
 extern int f90_old_huge_rec_fmt(void);
 extern int __fortio_error(int);
 extern int __fortio_eoferr(int);
 extern int __fortio_eorerr(int);
-extern char *__fortio_errmsg(int);
+extern const char *__fortio_errmsg(int);
 extern int __fortio_check_format(void);
 extern int __fortio_eor_crlf(void);
 extern VOID __fortio_fmtinit(void);
@@ -392,14 +392,14 @@ extern VOID __fortio_cleanup_fcb(void);
 extern FIO_FCB *__fortio_rwinit(int, int, __INT_T *, int);
 extern FIO_FCB *__fortio_find_unit(int);
 extern int __fortio_zeropad(FILE *, long);
-extern bool __fortio_eq_str(char *, __CLEN_T, char *);
+extern bool __fortio_eq_str(char *, __CLEN_T, const char *);
 extern void *__fortio_fiofcb_asyptr(FIO_FCB *);
 extern bool __fortio_fiofcb_asy_rw(FIO_FCB *);
 extern void __fortio_set_asy_rw(FIO_FCB *, bool);
 extern bool __fortio_fiofcb_stdunit(FIO_FCB *);
 extern FILE *__fortio_fiofcb_fp(FIO_FCB *);
 extern short __fortio_fiofcb_form(FIO_FCB *);
-extern char *__fortio_fiofcb_name(FIO_FCB *);
+extern const char *__fortio_fiofcb_name(FIO_FCB *);
 extern void *__fortio_fiofcb_next(FIO_FCB *);
 
 extern bool __fio_eq_str(char *str, int len, char *pattern);

--- a/runtime/flang/hand.c
+++ b/runtime/flang/hand.c
@@ -14,13 +14,11 @@
 #define write _write
 #endif
 
-extern char *__fort_getopt(char *);
-
 /* signals handled and message strings */
 
 struct sigs {
-  int sig;   /* signal value */
-  char *str; /* message string */
+  int sig;          /* signal value */
+  const char *str;  /* message string */
 };
 
 static struct sigs sigs[] = {
@@ -98,7 +96,8 @@ static void sighand(s) int s;
 void
 __fort_sethand()
 {
-  char *p;
+  const char *p;
+  char *q;
   int n;
 
   p = __fort_getopt("-sigmsg");
@@ -112,12 +111,12 @@ __fort_sethand()
       signal(sigs[n].sig, sighand);
       n++;
     }
-  } else {
-    while (*p != '\0') {
-      n = __fort_strtol(p, &p, 0);
+  } else if (*p != '\0') {
+    do {
+      n = __fort_strtol(p, &q, 0);
       signal(n, sighand);
-      p = (*p == ',' ? p + 1 : p);
-    }
+      p = (*q == ',' ? q + 1 : q);
+    } while (*q != '\0');
   }
 }
 

--- a/runtime/flang/heapinit.c
+++ b/runtime/flang/heapinit.c
@@ -9,9 +9,6 @@
 #include "stdioInterf.h"
 #include "fioMacros.h"
 
-extern char *__fort_getopt();
-extern long __fort_getoptn();
-
 /* handler for bus error */
 
 static void sighand(s) int s;

--- a/runtime/flang/init.c
+++ b/runtime/flang/init.c
@@ -16,13 +16,13 @@
 
 static int tid = 0;
 
-char *__fort_transnam = "rpm1";
+const char *__fort_transnam = "rpm1";
 
 #ifdef WINNT
 
 /* pg access routines for data shared between windows dlls */
 
-char *
+const char *
 __get_fort_transnam(void)
 {
   return __fort_transnam;

--- a/runtime/flang/inquire.c
+++ b/runtime/flang/inquire.c
@@ -22,9 +22,9 @@
 
 static FIO_FCB *f2; /* save fcb for inquire2 */
 
-static void copystr(char *dst, /*  destination string, blank-filled */
-                    int len,   /*  length of destination space */
-                    char *src) /*  null terminated source string  */
+static void copystr(char *dst,       /* destination string, blank-filled */
+                    int len,         /* length of destination space */
+                    const char *src) /* null terminated source string  */
 {
   char *end = dst + len;
   while (dst < end && *src != '\0')
@@ -56,7 +56,7 @@ inquire(__INT_T *unit, char *file_ptr, __INT_T *bitv, __INT_T *iostat,
 {
   FIO_FCB *f;
   __CLEN_T i;
-  char *cp;
+  const char *cp;
   __CLEN_T len, nleadb;
 
   __fortio_errinit03(*unit, *bitv, iostat, "INQUIRE");
@@ -502,8 +502,6 @@ int ENTF90IO(INQUIREA, inquirea)(
   char *schr = 0, *schrp;
   __CLEN_T schr_len = 0;
 
-  int n;
-
   file_ptr = (ISPRESENTC(file) ? CADR(file) : NULL);
   name_ptr = (ISPRESENTC(name) ? CADR(name) : NULL);
   acc_ptr = (ISPRESENTC(acc) ? CADR(acc) : NULL);
@@ -860,8 +858,6 @@ int ENTF90IO(INQUIRE2003A, inquire2003a)(
   int sint[SINTN], *sintp;
   char *schr = 0, *schrp;
   __CLEN_T schr_len = 0;
-
-  int n;
 
   file_ptr = (ISPRESENTC(file) ? CADR(file) : NULL);
   name_ptr = (ISPRESENTC(name) ? CADR(name) : NULL);
@@ -1459,7 +1455,7 @@ ENTF90IO(INQUIRE2A, inquire2a)
      DCLEN64(stream))
 {
   FIO_FCB *f;
-  char *cp;
+  const char *cp;
 
   if (*istat)
     return *istat;
@@ -1677,8 +1673,6 @@ ENTF90IO(INQUIRE03A, inquire03a) (
   __INT8_T sint[SINTN], *sintp;
   char *schr = 0, *schrp;
   __CLEN_T schr_len = 0;
-
-  int n;
 
   file_ptr = (ISPRESENTC(file) ? CADR(file) : NULL);
   name_ptr = (ISPRESENTC(name) ? CADR(name) : NULL);
@@ -2187,8 +2181,6 @@ ENTF90IO(INQUIRE03_2A, inquire03_2a)
   __INT8_T sint[SINTN], *sintp;
   char *schr = 0, *schrp;
   __CLEN_T schr_len = 0;
-
-  int n;
 
   file_ptr = (ISPRESENTC(file) ? CADR(file) : NULL);
   name_ptr = (ISPRESENTC(name) ? CADR(name) : NULL);

--- a/runtime/flang/ipopcnti.c
+++ b/runtime/flang/ipopcnti.c
@@ -11,11 +11,12 @@ int32_t
 __mth_i_ipopcnti(uint32_t u32, int size)
 {
   uint32_t r32 = u32;
-
+#if !defined(TARGET_X8664) && !defined(TARGET_LINUX_POWER)
   static const uint32_t u5s = 0x55555555;
   static const uint32_t u3s = 0x33333333;
   static const uint32_t u7s = 0x07070707;
   static const uint32_t u1s = 0x01010101;
+#endif
 
   r32 = u32;
   if (size == 2) {
@@ -35,7 +36,6 @@ __mth_i_ipopcnti(uint32_t u32, int size)
        : "r"(r32)
        );
 #else
-
   r32 = (r32 & u5s) + (r32 >> 1 & u5s);
   r32 = (r32 & u3s) + (r32 >> 2 & u3s);
   r32 = (r32 & u7s) + (r32 >> 4 & u7s);

--- a/runtime/flang/isatty3f.c
+++ b/runtime/flang/isatty3f.c
@@ -15,8 +15,6 @@ extern int __isatty3f();
 
 int ENT3F(ISATTY, isatty)(int *lu)
 {
-  int u;
-
   if (__isatty3f(*lu))
     return -1; /* .true. */
   return 0;

--- a/runtime/flang/kanjidf.h
+++ b/runtime/flang/kanjidf.h
@@ -9,7 +9,7 @@
  * UTF-8 encoding.  The original encoding was EUC-JP.  Some Japanese
  * speaker should check these strings for correctness.
  */
-static char *kanjitxt[] = {
+static const char *kanjitxt[] = {
     /* 200 */ "ｘｘｘ",
     /* 201 */ "入出力指定子の値が不当です",
     /* 202 */ "入出力指定子に矛盾があります",

--- a/runtime/flang/ldread.c
+++ b/runtime/flang/ldread.c
@@ -440,7 +440,7 @@ ENTF90IO(LDR_INIT03A, ldr_init03a)
       } else if (__fortio_eq_str(CADR(round), CLEN(round), "COMPATIBLE")) {
         gbl->round = FIO_COMPATIBLE;
       } else if (__fortio_eq_str(CADR(round), CLEN(round),
-                                "PROCESSOR_DEFINED")) {
+                                 "PROCESSOR_DEFINED")) {
         gbl->round = FIO_PROCESSOR_DEFINED;
       } else
         s = __fortio_error(FIO_ESPEC);
@@ -699,7 +699,7 @@ ENTF90IO(LDRA, ldra)
  DCLEN64(item))
 {
   int typ;
-  int cnt, cpu, i, ioproc, str;
+  int cnt, ioproc, str;
   __CLEN_T len;
   char *adr;
   int s = 0;
@@ -745,7 +745,7 @@ ENTF90IO(LDR_AA, ldr_aa)
  DCLEN64(item))
 {
   int typ;
-  int cnt, cpu, i, ioproc, str;
+  int cnt, ioproc, str;
   __CLEN_T len;
   char *adr;
   int s = 0;
@@ -789,7 +789,7 @@ ENTF90IO(LDR64_AA, ldr64_aa)
 {
   int typ;
   long cnt;
-  int cpu, i, ioproc, str;
+  int ioproc, str;
   __CLEN_T len;
   char *adr;
   int s = 0;
@@ -833,7 +833,7 @@ ENTCRF90IO(LDRA, ldra)
  DCLEN64(item))
 {
   int typ;
-  int cnt, cpu, i, str;
+  int cnt, str;
   __CLEN_T len;
   char *adr;
 

--- a/runtime/flang/ldwrite.c
+++ b/runtime/flang/ldwrite.c
@@ -72,7 +72,7 @@ static int gbl_size = GBL_SIZE;
 
 /* local functions */
 
-static int write_item(char *, int);
+static int write_item(const char *, int);
 static int write_record(void);
 
 static void
@@ -767,7 +767,7 @@ ENTCRF90IO(LDWA, ldwa) (type, length, stride, CADR(item), (__CLEN_T)CLEN(item));
 /* --------------------------------------------------------------------- */
 
 static int
-write_item(char *p, int len)
+write_item(const char *p, int len)
 {
   int newlen;
   int ret_err;
@@ -934,7 +934,7 @@ __INT_T
 ENTF90IO(LDW_END, ldw_end)()
 {
   int ioproc, len;
-  int i, s = 0;
+  int s = 0;
 
   ioproc = GET_DIST_IOPROC;
   if (LOCAL_MODE || GET_DIST_LCPU == ioproc) {
@@ -958,7 +958,7 @@ ENTF90IO(LDW_END, ldw_end)()
 __INT_T
 ENTCRF90IO(LDW_END, ldw_end)()
 {
-  int i, s = 0;
+  int s = 0;
   s = _f90io_ldw_end();
 
   save_samefcb();

--- a/runtime/flang/map.c
+++ b/runtime/flang/map.c
@@ -13,8 +13,6 @@
 #include <sys/time.h>
 #endif
 
-extern char *__fort_getopt();
-
 /* tid comparison routine called by qsort */
 
 static int
@@ -58,7 +56,8 @@ static void
 __fort_getmap(int *processormap)
 {
   int j, k, m, n, tcpus, *usedmap;
-  char *argp, *endp;
+  const char *argp;
+  char *endp;
 
   /* -map <j>:<m>..<n>,... = map processors <m>..<n> to processors <l>..  */
 

--- a/runtime/flang/mget.c
+++ b/runtime/flang/mget.c
@@ -60,7 +60,7 @@ void ENTFTN(MGET_SCALAR, mget_scalar)(__INT_T *nb, ...)
   char *rb, *ab, *ap;
   DECL_HDR_PTRS(as);
   chdr *ch;
-  int me, np, from, partner, j, k;
+  int me, np, from, partner;
   __INT_T i, n, idx[MAXDIMS];
 
   me = GET_DIST_LCPU;

--- a/runtime/flang/miscsup_com.c
+++ b/runtime/flang/miscsup_com.c
@@ -29,7 +29,6 @@ MP_SEMAPHORE(static, sem);
 #include "type.h"
 
 extern double __fort_second();
-extern long __fort_getoptn(char *, long);
 
 #define time(x) __fort_time(x)
 
@@ -442,8 +441,8 @@ fstrcpy(char *s1, char *s2, __CLEN_T len1, __CLEN_T len2)
   }
 }
 
-static char *month[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+static const char *month[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
 static int
 yr2(int yr)
@@ -3344,7 +3343,7 @@ ENTFTN(TRAILZ, trailz)(void *i, __INT_T *size)
 __INT_T
 ENTFTN(POPCNT, popcnt)(void *i, __INT_T *size)
 {
-  unsigned ui, uj; /* unsigned representation of 'i' */
+  unsigned ui = 0, uj; /* unsigned representation of 'i' */
   __INT8_T ll;
 
   switch (*size) {
@@ -3395,7 +3394,7 @@ ENTFTN(POPCNT, popcnt)(void *i, __INT_T *size)
 __INT_T
 ENTFTN(POPPAR, poppar)(void *i, __INT_T *size)
 {
-  int ii;
+  int ii = 0;
   __INT8_T ll;
 
   switch (*size) {

--- a/runtime/flang/mmcmplx16.c
+++ b/runtime/flang/mmcmplx16.c
@@ -51,11 +51,6 @@ void ENTF90(MMUL_CMPLX16,
   // Local variables
 
   int colsa, rowsa, rowsb, colsb;
-  int ar, ac;
-  int ndx, ndxsav, colchunk, colchunks, rowchunk, rowchunks;
-  int colsb_chunks, colsb_end, colsb_strt;
-  int bufr, bufc, loc, lor;
-  int small_size = SMALL_ROWSA * SMALL_ROWSB * SMALL_COLSB;
   int tindex = 0;
   DOUBLE_COMPLEX_TYPE buffera[SMALL_ROWSA * SMALL_ROWSB];
   DOUBLE_COMPLEX_TYPE bufferb[SMALL_COLSB * SMALL_ROWSB];
@@ -67,7 +62,7 @@ void ENTF90(MMUL_CMPLX16,
   /*
    * Small matrix multiply variables
    */
-  int i, ia, ja, j, k, bk;
+  int i, ja, j, k;
   int astrt, bstrt, cstrt, andx, bndx, cndx, indx, indx_strt;
   /*
    * We will structure this code a bit different from the real code

--- a/runtime/flang/mmcmplx8.c
+++ b/runtime/flang/mmcmplx8.c
@@ -50,11 +50,6 @@ void ENTF90(MMUL_CMPLX8,
   // Local variables
 
   int colsa, rowsa, rowsb, colsb;
-  int ar, ac;
-  int ndx, ndxsav, colchunk, colchunks, rowchunk, rowchunks;
-  int colsb_chunks, colsb_end, colsb_strt;
-  int bufr, bufc, loc, lor;
-  int small_size = SMALL_ROWSA * SMALL_ROWSB * SMALL_COLSB;
   int tindex = 0;
   FLOAT_COMPLEX_TYPE buffera[SMALL_ROWSA * SMALL_ROWSB];
   FLOAT_COMPLEX_TYPE bufferb[SMALL_COLSB * SMALL_ROWSB];
@@ -66,7 +61,7 @@ void ENTF90(MMUL_CMPLX8,
   /*
    * Small matrix multiply variables
    */
-  int i, ia, ja, j, k, bk;
+  int i, ja, j, k;
   int astrt, bstrt, cstrt, andx, bndx, cndx, indx, indx_strt;
   /*
    * We will structure this code a bit different from the real code

--- a/runtime/flang/mmreal4.c
+++ b/runtime/flang/mmreal4.c
@@ -51,11 +51,6 @@ void ENTF90(MMUL_REAL4, mmul_real4)(int ta, int tb, __POINT_T mra,
   // Local variables
 
   int colsa, rowsa, rowsb, colsb;
-  int ar, ac;
-  int ndx, ndxsav, colchunk, colchunks, rowchunk, rowchunks;
-  int colsb_chunks, colsb_end, colsb_strt;
-  int bufr, bufc, loc, lor;
-  int small_size = SMALL_ROWSA * SMALL_ROWSB * SMALL_COLSB;
   int tindex = 0;
   float buffera[SMALL_ROWSA * SMALL_ROWSB];
   float bufferb[SMALL_COLSB * SMALL_ROWSB];
@@ -67,8 +62,8 @@ void ENTF90(MMUL_REAL4, mmul_real4)(int ta, int tb, __POINT_T mra,
   /*
    * Small matrix multiply variables
    */
-  int i, ia, ja, j, k, bk;
-  int astrt, bstrt, cstrt, andx, bndx, cndx, indx, indx_strt;
+  int i, ja, j, k;
+  int astrt = 0, bstrt, cstrt, andx, bndx, cndx, indx, indx_strt;
   /*
    * tindex has the following meaning:
    * ta == 0, tb == 0: tindex = 0

--- a/runtime/flang/mmreal8.c
+++ b/runtime/flang/mmreal8.c
@@ -51,11 +51,6 @@ void ENTF90(MMUL_REAL8, mmul_real8)(int ta, int tb, __POINT_T mra,
   // Local variables
 
   int colsa, rowsa, rowsb, colsb;
-  int ar, ac;
-  int ndx, ndxsav, colchunk, colchunks, rowchunk, rowchunks;
-  int colsb_chunks, colsb_end, colsb_strt;
-  int bufr, bufc, loc, lor;
-  int small_size = SMALL_ROWSA * SMALL_ROWSB * SMALL_COLSB;
   int tindex = 0;
   double buffera[SMALL_ROWSA * SMALL_ROWSB];
   double bufferb[SMALL_COLSB * SMALL_ROWSB];
@@ -67,8 +62,8 @@ void ENTF90(MMUL_REAL8, mmul_real8)(int ta, int tb, __POINT_T mra,
   /*
    * Small matrix multiply variables
    */
-  int i, ia, ja, j, k, bk;
-  int astrt, bstrt, cstrt, andx, bndx, cndx, indx, indx_strt;
+  int i, ja, j, k;
+  int astrt = 0, bstrt, cstrt, andx, bndx, cndx, indx, indx_strt;
   /*
    * tindex has the following meaning:
    * ta == 0, tb == 0: tindex = 0

--- a/runtime/flang/mmul.c
+++ b/runtime/flang/mmul.c
@@ -214,7 +214,7 @@ static __INT_T _0 = 0, _1 = 1, _2 = 2;
 void ENTFTN(DOTPR, dotpr)(char *cb, char *ab0, char *bb0, F90_Desc *cs,
                           F90_Desc *as0, F90_Desc *bs0)
 {
-  char *ab = 0, *bb = 0, *ap, *bp;
+  char *ab = 0, *bb = 0;
   DECL_HDR_PTRS(as);
   DECL_HDR_PTRS(bs);
   DECL_HDR_VARS(as1);
@@ -396,7 +396,6 @@ static void I8(mmul_mxm)(char *cb0, char *ab0, char *bb0, F90_Desc *cs0,
   void (*mmul)();
   __INT_T a0, ai, ais, ajs, b0, bjs, bk, bks, c0, cik, cis, ck, cks, icl, icn,
       il, ilof, in, iu, kcl, kcn, kl, klof, kn, ku, jn;
-  int i;
   int copy_required;
 
   kind = F90_KIND_G(as0);

--- a/runtime/flang/mmulcplx16_t.c
+++ b/runtime/flang/mmulcplx16_t.c
@@ -170,8 +170,8 @@ void ENTF90(MATMUL_CPLX16,
   /* transpose s1 */
   {
     __INT_T dest_offset;
-    __INT_T s1_d1_base, s1_d1_offset, s1_m_delta, s1_d2_base, s1_n_delta,
-        s2_d1_base, s2_n_delta, s2_d2_base, s2_k_delta, d_d1_base, d_m_delta,
+    __INT_T s1_d1_base, s1_d1_offset, s1_m_delta, s1_n_delta,
+        s2_n_delta, s2_d2_base, s2_k_delta, d_d1_base, d_m_delta,
         d_d2_base, d_k_delta;
     __INT_T k;
     __INT_T l;

--- a/runtime/flang/mmulcplx8_t.c
+++ b/runtime/flang/mmulcplx8_t.c
@@ -170,8 +170,8 @@ void ENTF90(MATMUL_CPLX8,
   /* transpose s1 */
   {
     __INT_T dest_offset;
-    __INT_T s1_d1_base, s1_d1_offset, s1_m_delta, s1_d2_base, s1_n_delta,
-        s2_d1_base, s2_n_delta, s2_d2_base, s2_k_delta, d_d1_base, d_m_delta,
+    __INT_T s1_d1_base, s1_d1_offset, s1_m_delta, s1_n_delta,
+        s2_n_delta, s2_d2_base, s2_k_delta, d_d1_base, d_m_delta,
         d_d2_base, d_k_delta;
     __INT_T k;
     __INT_T l;

--- a/runtime/flang/mmulreal4_t.c
+++ b/runtime/flang/mmulreal4_t.c
@@ -170,8 +170,8 @@ void ENTF90(MATMUL_REAL4,
   /* transpose s1 */
   {
     __INT_T dest_offset;
-    __INT_T s1_d1_base, s1_d1_offset, s1_m_delta, s1_d2_base, s1_n_delta,
-        s2_d1_base, s2_n_delta, s2_d2_base, s2_k_delta, d_d1_base, d_m_delta,
+    __INT_T s1_d1_base, s1_d1_offset, s1_m_delta, s1_n_delta,
+        s2_n_delta, s2_d2_base, s2_k_delta, d_d1_base, d_m_delta,
         d_d2_base, d_k_delta;
     __INT_T k;
     __INT_T l;

--- a/runtime/flang/mmulreal8_t.c
+++ b/runtime/flang/mmulreal8_t.c
@@ -170,8 +170,8 @@ void ENTF90(MATMUL_REAL8,
   /* transpose s1 */
   {
     __INT_T dest_offset;
-    __INT_T s1_d1_base, s1_d1_offset, s1_m_delta, s1_d2_base, s1_n_delta,
-        s2_d1_base, s2_n_delta, s2_d2_base, s2_k_delta, d_d1_base, d_m_delta,
+    __INT_T s1_d1_base, s1_d1_offset, s1_m_delta, s1_n_delta,
+        s2_n_delta, s2_d2_base, s2_k_delta, d_d1_base, d_m_delta,
         d_d2_base, d_k_delta;
     __INT_T k;
     __INT_T l;

--- a/runtime/flang/nmlwrite.c
+++ b/runtime/flang/nmlwrite.c
@@ -64,13 +64,10 @@ typedef struct {
 
 static G static_gbl[GBL_SIZE];
 static G *gbl = &static_gbl[0];
-static G *gbl_head = &static_gbl[0];
-static int gbl_avl = 0;
-static int gbl_size = GBL_SIZE;
 
 static int emit_eol(void);
 static int write_nml_val(NML_DESC **, NML_DESC *, char *);
-static int write_item(char *, int);
+static int write_item(const char *, int);
 static int write_char(int);
 static int eval(int, char *, NML_DESC *, NML_DESC **);
 static int eval_dtio(int, char *, NML_DESC *, NML_DESC **);
@@ -79,7 +76,6 @@ static int I8(eval_dtio_sb)(NML_DESC **, NML_DESC *, char *, int);
 static int dtio_write_scalar(NML_DESC **, NML_DESC *, char *, int);
 
 static SB sb;
-static TRI tri;
 
 /* ---------------------------------------------------------------- */
 
@@ -174,7 +170,8 @@ ENTF90IO(NMLW_INIT03A, nmlw_init03a)(__INT_T *istat,
         gbl->sign = FIO_PLUS;
       } else if (__fortio_eq_str(CADR(sign), CLEN(sign), "SUPPRESS")) {
         gbl->sign = FIO_SUPPRESS;
-      } else if (__fortio_eq_str(CADR(sign), CLEN(sign), "PROCESSOR_DEFINED")) {
+      } else if (__fortio_eq_str(CADR(sign), CLEN(sign),
+                                 "PROCESSOR_DEFINED")) {
         gbl->sign = FIO_PROCESSOR_DEFINED;
       } else
         s = __fortio_error(FIO_ESPEC);
@@ -235,7 +232,7 @@ _f90io_nmlw_intern_init(char *cunit,      /* pointer to variable or array to
 
 /** \brief Internal file namelist write initialization
  *
- * \param rec_num - number of records in internal file; 0 if the file is an assumed size character array 
+ * \param rec_num - number of records in internal file; 0 if the file is an assumed size character array
  * \param bitv - same as for ENTF90IO(open_)
  * \param iostat - same as for ENTF90IO(open_)
  */
@@ -310,7 +307,9 @@ ENTCRF90IO(NMLW_INTERN_INIT, nmlw_intern_init)(
 static int
 emit_eol(void)
 {
+#if defined(WINNT)
   int ret_err;
+#endif
 
   if (!internal_file) {
 #if defined(WINNT)
@@ -339,7 +338,7 @@ emit_eol(void)
 static void
 I8(fillup_sb)(int v, NML_DESC *descp, char *loc_addr)
 {
-  int i, k;
+  int i;
   F90_Desc *sd = get_descriptor(descp);
   DECL_DIM_PTRS(acd);
 
@@ -364,7 +363,7 @@ write_nml_val(NML_DESC **NextDescp, NML_DESC *descp, char *loc_addr)
   int num_consts;
   __POINT_T *desc_dims, new_ndims;
   __POINT_T actual_ndims;
-  int i, j, k;
+  int j, k;
   char *p;
   int len;
   int ret_err;
@@ -490,7 +489,7 @@ write_nml_val(NML_DESC **NextDescp, NML_DESC *descp, char *loc_addr)
 }
 
 static int
-write_item(char *p, int len)
+write_item(const char *p, int len)
 {
   int newlen;
 
@@ -552,9 +551,8 @@ write_char(int ch)
 static int
 I8(eval_sb)(NML_DESC **NextDescp, NML_DESC *descp, char *loc_addr, int d)
 {
-  int j, err, k;
-  __BIGINT_T offset, baseoffset;
-  char *new_addr;
+  int err, k;
+  char *new_addr = NULL;
   NML_DESC *next_descp;
   __POINT_T *desc_dims;
   __POINT_T actual_ndims;
@@ -626,9 +624,8 @@ I8(eval_sb)(NML_DESC **NextDescp, NML_DESC *descp, char *loc_addr, int d)
 static int
 I8(eval_dtio_sb)(NML_DESC **NextDescp, NML_DESC *descp, char *loc_addr, int d)
 {
-  int j, err, k;
-  __BIGINT_T offset, baseoffset;
-  char *new_addr;
+  int err, k;
+  char *new_addr = NULL;
   NML_DESC *next_descp;
   __POINT_T *desc_dims;
   __POINT_T actual_ndims;
@@ -923,7 +920,7 @@ dtio_write_scalar(NML_DESC **NextDescp, NML_DESC *descp, char *loc_addr,
   __INT_T tmp_iostat = 0;
   __INT_T *iostat;
   __INT_T *unit;
-  void (*dtio)(char *, INT *, char *, INT *, INT *, char *, F90_Desc *,
+  void (*dtio)(char *, INT *, const char *, INT *, INT *, char *, F90_Desc *,
                F90_Desc *, __CLEN_T, __CLEN_T);
   char *dtv;
   F90_Desc *dtv_sd;
@@ -935,9 +932,8 @@ dtio_write_scalar(NML_DESC **NextDescp, NML_DESC *descp, char *loc_addr,
   __CLEN_T iomsglen = 250;
   static char iomsg[250];
   int k, num_consts, ret_err, j;
-  char *iotype = "NAMELIST";
+  const char *iotype = "NAMELIST";
   char *start_addr;
-  char *mem_addr;
   __POINT_T *desc_dims, new_ndims;
   __POINT_T actual_ndims;
 

--- a/runtime/flang/olap.c
+++ b/runtime/flang/olap.c
@@ -464,7 +464,10 @@ static void I8(olap_copy)(char *adr0, F90_Desc *as, olap_sked *o, int len)
 {
   DECL_DIM_PTRS(dd);
   char *adr1, *adr2;
-  __INT_T ak, i, m, n, nl, nu, l, u;
+  __INT_T ak, m, n, nl, nu, l, u;
+#if defined(DEBUG)
+  __INT_T i;
+#endif
 
   SET_DIM_PTRS(dd, as, o->dim - 1);
 
@@ -530,7 +533,7 @@ static void I8(olap_loop)(char *adr0, F90_Desc *as, olap_sked *o, int len,
 {
   DECL_DIM_PTRS(dd);
   char *adr1;
-  __INT_T ak, bl, bn, bu, cl, cn, gap, clof;
+  __INT_T ak, bl, bn, bu, cl, cn, clof;
 
   if (dim == o->dim)
     --dim;

--- a/runtime/flang/open.c
+++ b/runtime/flang/open.c
@@ -48,7 +48,7 @@ __fortio_open(int unit, int action_flag, int status_flag, int dispose_flag,
              __CLEN_T namelen)
 {
   char *q;
-  char *perms;
+  const char *perms;
   char bfilename[MAX_NAMELEN + 1];
   char *filename;
   int long_name;

--- a/runtime/flang/ptr.c
+++ b/runtime/flang/ptr.c
@@ -46,8 +46,8 @@ I8(nullify)(char *pb, F90_Desc *pd, dtype kind, __CLEN_T len)
 void
 ENTFTN(NULLIFY, nullify)(char *pb, F90_Desc *pd)
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
 
   if (F90_TAG_G(pd) == __NONE)
     return; /* already disassociated */
@@ -87,8 +87,8 @@ ENTFTN(NULLIFY_CHAR, nullify_char)(DCHAR(pb), F90_Desc *pd DCLEN(pb))
 void
 ENTFTN(NULLIFYX, nullifyx)(char **pb, F90_Desc *pd)
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
 
   if (F90_TAG_G(pd) == __NONE)
     return; /* already disassociated */
@@ -160,8 +160,8 @@ void
 ENTFTN(PTR_ASGN, ptr_asgn)(char *pb, F90_Desc *pd, char *tb, F90_Desc *td,
                             __INT_T lb[])
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASGN: invalid descriptor");
@@ -187,8 +187,8 @@ ENTFTN(PTR_ASGN_CHARA, ptr_asgn_chara)(DCHAR(pb), F90_Desc *pd, DCHAR(tb),
                                      F90_Desc *td,
                                      __INT_T lb[] DCLEN64(pb) DCLEN64(tb))
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASGN: invalid descriptor");
@@ -224,8 +224,7 @@ I8(ptr_assign)(char *pb, F90_Desc *pd, dtype kind, __CLEN_T len, char *tb,
                F90_Desc *td, int sectflag)
 {
   DECL_DIM_PTRS(tdd);
-  __POINT_T *off;
-  char *p, **ptr;
+  char **ptr;
   __INT_T i;
   __INT_T gsize;
 
@@ -363,8 +362,8 @@ ENTFTN(PTR_ASSIGN_CHARA, ptr_assign_chara)
          (DCHAR(pb), F90_Desc *pd, DCHAR(tb), F90_Desc *td,
          __INT_T *sectflag DCLEN64(pb) DCLEN64(tb))
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASSIGN: invalid descriptor");
@@ -402,8 +401,8 @@ ENTFTN(PTR_ASSIGNX, ptr_assignx)
         (char *pb, F90_Desc *pd, char *tb, F90_Desc *td, __INT_T *sectflag,
          __INT_T *targetlen, __INT_T *targettype)
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASSIGN: invalid descriptor");
@@ -435,8 +434,8 @@ ENTFTN(PTR_ASSIGN_CHARXA, ptr_assign_charxa)
           __INT_T *sectflag, __CLEN_T *targetlen,
           __INT_T *targettype DCLEN64(pb) DCLEN64(tb))
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASSIGN: invalid descriptor");
@@ -476,9 +475,8 @@ void
 ENTFTN(PTR_ASSIGN_ASSUMESHP, ptr_assign_assumeshp)
          (char *pb, F90_Desc *pd, char *tb, F90_Desc *td, __INT_T *sectflag)
 {
-  dtype kind;
-  __CLEN_T len;
-  int i;
+  dtype kind = 0;
+  __CLEN_T len = 0;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASSIGN: invalid descriptor");
@@ -508,9 +506,8 @@ ENTFTN(PTR_ASSIGN_CHAR_ASSUMESHPA, ptr_assign_char_assumeshpa)
          (DCHAR(pb), F90_Desc *pd, DCHAR(tb), F90_Desc *td,
           __INT_T *sectflag DCLEN64(pb) DCLEN64(tb))
 {
-  dtype kind;
-  __CLEN_T len;
-  int i;
+  dtype kind = 0;
+  __CLEN_T len = 0;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASSIGN: invalid descriptor");
@@ -545,7 +542,6 @@ ENTFTN(PTR_ASSIGN_CHAR_ASSUMESHP, ptr_assign_char_assumeshp)
 void
 ENTFTN(PTR_FIX_ASSUMESHP1, ptr_fix_assumeshp1)(F90_Desc *sd, __INT_T lb1)
 {
-  int ii;
   __INT_T lbase;
 
   lbase = 1;
@@ -558,7 +554,6 @@ void
 ENTFTN(PTR_FIX_ASSUMESHP2, ptr_fix_assumeshp2)(F90_Desc *sd, __INT_T lb1,
                                                __INT_T lb2)
 {
-  int ii;
   __INT_T lbase;
 
   lbase = 1;
@@ -573,7 +568,6 @@ void
 ENTFTN(PTR_FIX_ASSUMESHP3, ptr_fix_assumeshp3)(F90_Desc *sd, __INT_T lb1,
                                                __INT_T lb2, __INT_T lb3)
 {
-  int ii;
   __INT_T lbase;
 
   lbase = 1;
@@ -749,8 +743,6 @@ I8(ptr_assn)(char *pb, F90_Desc *pd, dtype kind, __CLEN_T len, char *tb,
              F90_Desc *td, int sectflag)
 {
   DECL_DIM_PTRS(tdd);
-  __POINT_T *off;
-  char *p, **ptr;
   void *res;
   __INT_T i;
   __INT_T gsize;
@@ -866,7 +858,7 @@ ENTFTN(PTR_ASSN, ptr_assn)(char *pb, F90_Desc *pd, char *tb, F90_Desc *td,
 {
   dtype kind;
   __CLEN_T len;
-  void *res;
+  void *res = 0;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASSN: invalid descriptor");
@@ -944,8 +936,8 @@ ENTFTN(PTR_ASSN_CHARA, ptr_assn_chara)
          (DCHAR(pb), F90_Desc *pd, DCHAR(tb), F90_Desc *td,
           __INT_T *sectflag DCLEN64(pb) DCLEN64(tb))
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
   void *res;
 
   if (pd == NULL || td == NULL) {
@@ -985,8 +977,8 @@ ENTFTN(PTR_ASSN_CHARA, ptr_assn_dchara)
          (DCHAR(pb), F90_Desc *pd, DCHAR(tb), F90_Desc *td,
           __INT_T *sectflag DCLEN64(pb) DCLEN64(tb))
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
   void *res;
 
   if (pd == NULL || td == NULL) {
@@ -1026,8 +1018,8 @@ ENTFTN(PTR_ASSNXA, ptr_assnxa)
          (char *pb, F90_Desc *pd, char *tb, F90_Desc *td, __INT_T *sectflag,
           __CLEN_T *targetlen, __INT_T *targettype)
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
   void *res;
 
   if (pd == NULL || td == NULL) {
@@ -1070,8 +1062,8 @@ ENTFTN(PTR_ASSN_CHARXA,
        __INT_T *sectflag, __CLEN_T *targetlen,
       __INT_T *targettype DCLEN64(pb) DCLEN64(tb))
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
   void *res;
 
   if (pd == NULL || td == NULL) {
@@ -1115,8 +1107,8 @@ ENTFTN(PTR_ASSN_DCHARXA, ptr_assn_dcharxa)
          (DCHAR(pb), F90_Desc *pd, DCHAR(tb), F90_Desc *td, __INT_T *sectflag,
           __CLEN_T *targetlen, __INT_T *targettype DCLEN64(pb) DCLEN64(tb))
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
   void *res;
 
   if (pd == NULL || td == NULL) {
@@ -1158,10 +1150,9 @@ void *
 ENTFTN(PTR_ASSN_ASSUMESHP, ptr_assn_assumeshp)
          (char *pb, F90_Desc *pd, char *tb, F90_Desc *td, __INT_T *sectflag)
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
   void *res;
-  int i;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASSN: invalid descriptor");
@@ -1192,10 +1183,9 @@ ENTFTN(PTR_ASSN_CHAR_ASSUMESHPA, ptr_assn_char_assumeshpa)
          (DCHAR(pb), F90_Desc *pd, DCHAR(tb), F90_Desc *td,
           __INT_T *sectflag DCLEN64(pb) DCLEN64(tb))
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
   void *res;
-  int i;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASSN: invalid descriptor");
@@ -1235,10 +1225,9 @@ ENTFTN(PTR_ASSN_DCHAR_ASSUMESHPA, ptr_assn_dchar_assumeshpa)
   (DCHAR(pb), F90_Desc *pd, DCHAR(tb), F90_Desc *td,
     __INT_T *sectflag DCLEN64(pb) DCLEN64(tb))
 {
-  dtype kind;
-  __CLEN_T len;
+  dtype kind = 0;
+  __CLEN_T len = 0;
   void *res;
-  int i;
 
   if (pd == NULL || td == NULL) {
     __fort_abort("PTR_ASSN: invalid descriptor");
@@ -1285,7 +1274,7 @@ ENTFTN(PTR_SHAPE_ASSNX, ptr_shape_assnx)
   F90_Desc *new_td = 0;
   __INT_T dimflags = 0, stride[MAXDIMS], *lb = 0, *ub = 0;
   int notSet = 0;
-  int f, i, reshape;
+  int i, reshape;
   __INT_T lbase = 0, tstride;
   int sz = *rank;
   int extent_diff;
@@ -1411,7 +1400,7 @@ ENTFTN(PTR_SHAPE_ASSN, ptr_shape_assn)
   }
 
   if (rank && *rank) {
-    int f, i, reshape;
+    int i, reshape;
     __INT_T lbase = 0, tstride, old_lbase;
     int sz = *rank;
 
@@ -1654,8 +1643,6 @@ I8(__fort_associated)(char *pb, F90_Desc *pd, char *tb, F90_Desc *td,
   DECL_DIM_PTRS(tdd);
   char *adr;
   __INT_T i, pextent, poff, textent, toff;
-  OBJECT_DESC *ad;
-  TYPE_DESC *atd;
 
       /* FS#20453 - disable FS#17427 patch below. It appears to no longer be
        * needed and this fixes UMRs in oop567 - oop570 f90_correct tests.

--- a/runtime/flang/query.c
+++ b/runtime/flang/query.c
@@ -159,9 +159,9 @@ static void I8(store_vector_int)(void *ab, F90_Desc *as, int *vector,
   }
 }
 
-static void ftnstrcpy(char *dst, /*  destination string, blank-filled */
-                      size_t len,   /*  length of destination space */
-                      char *src) /*  null terminated source string  */
+static void ftnstrcpy(char *dst,       /* destination string, blank-filled */
+                      size_t len,      /* length of destination space */
+                      const char *src) /* null terminated source string  */
 {
   char *end = dst + len;
   while (dst < end && *src != '\0')
@@ -183,7 +183,7 @@ void ENTFTN(DIST_ALIGNMENT,
   DECL_DIM_PTRS(ad);
   proc *p;
   procdim *pd;
-  __INT_T aextent, i, idm, ncp, px, rank, textent, vector[MAXDIMS];
+  __INT_T i, idm, ncp, px, rank, vector[MAXDIMS];
 
   rank = (F90_TAG_G(alignee) == __DESC) ? F90_RANK_G(alignee) : 0;
 
@@ -265,7 +265,7 @@ void ENTFTN(DIST_DISTRIBUTIONA, dist_distributiona)(
   proc *p;
   procdim *pd;
   __INT_T i, rank, vector[MAXDIMS];
-  char *src;
+  const char *src;
   __CLEN_T len;
 
   if (F90_TAG_G(distributee) == __DESC) {
@@ -397,7 +397,7 @@ void ENTFTN(DIST_TEMPLATEA,
   proc *p;
   __INT_T i, rank, n_alnd, ux;
   __INT_T alignee_axis[MAXDIMS], vector[MAXDIMS];
-  char *src;
+  const char *src;
   __CLEN_T len;
 
   if (F90_TAG_G(alignee) == __DESC) {
@@ -585,7 +585,7 @@ void ENTFTN(GLOBAL_DISTRIBUTIONA, global_distributiona)(
   proc *p;
   procdim *pd;
   __INT_T i, rank, vector[MAXDIMS];
-  char *src;
+  const char *src;
   __CLEN_T len;
 
   if (F90_TAG_G(array_s) == __DESC) {
@@ -722,7 +722,7 @@ void ENTFTN(GLOBAL_TEMPLATEA, global_templatea)(
   proc *p;
   __INT_T i, rank, n_alnd, ux;
   __INT_T alignee_axis[MAXDIMS], vector[MAXDIMS];
-  char *src;
+  const char *src;
   __CLEN_T len;
 
   if (F90_TAG_G(array_s) == __DESC) {
@@ -871,7 +871,7 @@ void ENTFTN(GLOBAL_SIZE, global_size)(void *size_b, void *array_b, void *dim_b,
 {
   DECL_HDR_PTRS(g);
   DECL_DIM_PTRS(gd);
-  __INT_T i, dim, rank, size;
+  __INT_T dim, rank, size;
 
   if (F90_TAG_G(array_s) == __DESC) {
     g = DIST_ACTUAL_ARG_G(array_s);
@@ -1002,10 +1002,9 @@ void ENTFTN(LOCAL_TO_GLOBAL,
   DECL_HDR_PTRS(gs);
   DECL_DIM_PTRS(gsd);
   DECL_DIM_PTRS(asd);
-  __INT_T i, j, local, gof, procno, *procs;
-  __INT_T index[MAXDIMS], pcoord[MAXDIMS];
-  __INT_T lb, ub, lof;
-  __INT_T lboffset, adjindex, cyclenum, cyclepos, gstride;
+  __INT_T i;
+  __INT_T index[MAXDIMS];
+  __INT_T lboffset, adjindex, cyclenum, cyclepos;
 
   if (F90_TAG_G(array_s) != __DESC)
     __fort_abort("LOCAL_TO_GLOBAL: argument must be array");
@@ -1165,9 +1164,8 @@ void ENTFTN(GLOBAL_TO_LOCAL,
   DECL_DIM_PTRS(asd); /* local array dimensions */
   DECL_HDR_PTRS(gs);  /* global section */
   DECL_DIM_PTRS(gsd); /* global section dimensions */
-  proc *p;
   repl_t repl; /* replication descriptor */
-  __INT_T i, j, local, lof, n, procno;
+  __INT_T i, j, local, lof, procno;
   __INT_T *procs;
   __INT_T gindex[MAXDIMS], lindex[MAXDIMS], pcoord[MAXDIMS];
 

--- a/runtime/flang/rdst.c
+++ b/runtime/flang/rdst.c
@@ -13,6 +13,7 @@
 
 #include "stdioInterf.h"
 #include "fioMacros.h"
+#include "mpalloc.h"
 
 extern char *__fstr2cstr();
 
@@ -28,7 +29,9 @@ ENTFTN(TEMPLATE, template)(F90_Desc *dd, __INT_T *p_rank,
 #endif
 static void store_int_kind(void *, __INT_T *, int);
 static void ftn_msgcpy(char*, const char*, int);
-static char *intents[] = {"INOUT", "IN", "OUT", "??"};
+#if defined(DEBUG)
+static const char *intents[] = {"INOUT", "IN", "OUT", "??"};
+#endif
 
 /** \brief Compare alignments and local storage sequences.  Return true if all
    elements of s1 are ultimately aligned to elements of s2 that reside
@@ -274,7 +277,7 @@ invalid_flags(int flags)
 #endif
 
 static void
-copy_in_abort(char *msg)
+copy_in_abort(const char *msg)
 {
   char str[120];
   sprintf(str, "COPY_IN: %s", msg);
@@ -302,12 +305,8 @@ ENTFTN(QOPY_IN, qopy_in)(char **dptr, __POINT_T *doff, char *dbase,
   va_list va;
   DECL_HDR_PTRS(au); /* (a)ctual, (d)ummy, (t)arget, (u)ltimate */
   DECL_DIM_PTRS(add);
-  DECL_DIM_PTRS(aud);
   DECL_DIM_PTRS(ddd);
-  DECL_DIM_PTRS(tdd);
-  DECL_DIM_PTRS(tud);
-  char *af, *db, *df;
-  chdr *ch;
+  char *db, *df;
 
   dtype kind;
   __INT_T conform, collapse, single;
@@ -777,6 +776,7 @@ ENTFTN(QOPY_IN, qopy_in)(char **dptr, __POINT_T *doff, char *dbase,
 
 /* copy dummy array back to actual argument */
 
+#if defined(DEBUG)
 static void
 copy_out_abort(char *msg)
 {
@@ -784,6 +784,7 @@ copy_out_abort(char *msg)
   sprintf(str, "COPY_OUT: %s", msg);
   __fort_abort(str);
 }
+#endif
 
 void I8(__fort_copy_out)(void *ab,     /**< actual base address */
                         void *db,     /**< dummy base address */
@@ -793,10 +794,6 @@ void I8(__fort_copy_out)(void *ab,     /**< actual base address */
 {
   DECL_HDR_VARS(c);
   DECL_HDR_PTRS(cd); /* descriptor to use for copy */
-  DECL_DIM_PTRS(add);
-  DECL_DIM_PTRS(ddd);
-  char *af, *df;
-  chdr *ch;
   __INT_T actual_extent[MAXDIMS], dummy_extent, i, intent;
   __INT_T wrk_rank;
 
@@ -952,7 +949,6 @@ ENTFTN(TEMPLATE, template)
   DECL_HDR_PTRS(td);
   DECL_HDR_PTRS(tu);
   DECL_DIM_PTRS(tdd);
-  DECL_DIM_PTRS(ddd);
   proc *tp;
 
   __INT_T rank, flags, isstar = 0;
@@ -1202,7 +1198,6 @@ ENTF90(TEMPLATE, template)(F90_Desc *dd, __INT_T *p_rank, __INT_T *p_flags,
                            __INT_T *p_kind, __INT_T *p_len, ...)
 {
   va_list va;
-  proc *tp;
 
   __INT_T rank, flags, len;
   dtype kind;
@@ -1300,11 +1295,8 @@ void
 ENTF90(TEMPLATE1, template1)(F90_Desc *dd, __INT_T *p_flags, __INT_T *p_kind,
                              __INT_T *p_len, __INT_T *p_l1, __INT_T *p_u1)
 {
-  proc *tp;
-
   __INT_T rank, flags, len;
   dtype kind;
-  __INT_T i;
   __INT_T gsize, lbase;
 
   rank = 1;
@@ -1354,11 +1346,8 @@ ENTF90(TEMPLATE2, template2)(F90_Desc *dd, __INT_T *p_flags,
                                   __INT_T *p_l1, __INT_T *p_u1, __INT_T *p_l2,
                                   __INT_T *p_u2)
 {
-  proc *tp;
-
   __INT_T rank, flags, len;
   dtype kind;
-  __INT_T i;
   __INT_T gsize, lbase;
 
   rank = 2;
@@ -1409,11 +1398,8 @@ ENTF90(TEMPLATE3, template3)(F90_Desc *dd, __INT_T *p_flags,
                              __INT_T *p_l1, __INT_T *p_u1, __INT_T *p_l2,
                              __INT_T *p_u2, __INT_T *p_l3, __INT_T *p_u3)
 {
-  proc *tp;
-
   __INT_T rank, flags, len;
   dtype kind;
-  __INT_T i;
   __INT_T gsize, lbase;
 
   rank = 3;
@@ -1462,9 +1448,7 @@ ENTF90(TEMPLATE3, template3)(F90_Desc *dd, __INT_T *p_flags,
 void ENTF90(TEMPLATE1V, template1v)(F90_Desc *dd, __INT_T flags, dtype kind,
                                     __INT_T len, __INT_T l1, __INT_T u1)
 {
-  proc *tp;
-
-  __INT_T rank, i;
+  __INT_T rank;
   __INT_T gsize, lbase;
 
   rank = 1;
@@ -1512,9 +1496,7 @@ ENTF90(TEMPLATE2V, template2v)(F90_Desc *dd, __INT_T flags, __INT_T kind,
                                __INT_T len, __INT_T l1, __INT_T u1,
                                __INT_T l2, __INT_T u2)
 {
-  proc *tp;
-
-  __INT_T rank, i;
+  __INT_T rank;
   __INT_T gsize, lbase;
 
   rank = 2;
@@ -1564,9 +1546,7 @@ ENTF90(TEMPLATE3V, template3v)(F90_Desc *dd, __INT_T flags, __INT_T kind,
                                __INT_T l2, __INT_T u2, __INT_T l3,
                                __INT_T u3)
 {
-  proc *tp;
-
-  __INT_T rank, i;
+  __INT_T rank;
   __INT_T gsize, lbase;
 
   rank = 3;
@@ -1614,12 +1594,11 @@ void
 ENTFTN(INSTANCE, instance)(F90_Desc *dd, F90_Desc *td, __INT_T *p_kind,
                            __INT_T *p_len, __INT_T *p_collapse, ...)
 {
-  va_list va;
   DECL_HDR_PTRS(tu);
   DECL_DIM_PTRS(tdd);
 
   dtype kind;
-  __INT_T collapse, i, len, no[MAXDIMS], po[MAXDIMS];
+  __INT_T i, len;
 
 #if defined(DEBUG)
   if (dd == NULL)
@@ -2777,7 +2756,7 @@ ENTF90(CONTIGERROR, contigerror)(void *ptr, F90_Desc *pd, __INT_T lineno,
     dim = I8(is_nonsequential_section)(pd, F90_RANK_G(pd));
     sprintf(str, "Runtime Error at %s, line %d: Pointer assignment of "
                  "noncontiguous target (dimension %d) to CONTIGUOUS pointer "
-                 "%s\n", srcfil, lineno, dim, ptrnam); 
+                 "%s\n", srcfil, (int)lineno, dim, ptrnam);
     __fort_abort(str);
 }
 

--- a/runtime/flang/red.c
+++ b/runtime/flang/red.c
@@ -33,7 +33,7 @@ __fort_red_unimplemented()
 }
 
 void
-__fort_red_abort(char *msg)
+__fort_red_abort(const char *msg)
 {
   char str[80];
 
@@ -152,8 +152,7 @@ void I8(__fort_red_scalar)(red_parm *z, char *rb, char *ab, char *mb,
                           red_enum op)
 {
   DECL_DIM_PTRS(asd);
-  __INT_T ao, i, len, m, p, q;
-  int loop;
+  __INT_T ao, i, m, p, q;
 
   z->rb = rb;
   z->rs = rs;
@@ -215,8 +214,7 @@ void I8(__fort_red_scalarlk)(red_parm *z, char *rb, char *ab, char *mb,
                             __INT_T *xb, red_enum op)
 {
   DECL_DIM_PTRS(asd);
-  __INT_T ao, i, len, m, p, q;
-  int loop;
+  __INT_T ao, i, m, p, q;
 
   z->rb = rb;
   z->rs = rs;
@@ -354,9 +352,9 @@ static void I8(red_array_loop)(red_parm *z, __INT_T rof, __INT_T aof, int rdim,
 
     ap = z->ab + ao * F90_LEN_G(as);
     if (z->l_fn_b) {
-      z->l_fn_b(rp, acn, ap, ahop, mp, mhop, lp, li, ls, z->len, z->back);
+      z->l_fn_b(rp, acn, ap, ahop, mp, mhop, (__INT_T *)lp, li, ls, z->len, z->back);
     } else {
-      z->l_fn(rp, acn, ap, ahop, mp, mhop, lp, li, ls, z->len);
+      z->l_fn(rp, acn, ap, ahop, mp, mhop, (__INT_T *)lp, li, ls, z->len);
     }
 
     return;
@@ -417,9 +415,9 @@ static void I8(red_array_loop)(red_parm *z, __INT_T rof, __INT_T aof, int rdim,
 
       ap = z->ab + ao * F90_LEN_G(as);
       if (z->l_fn_b) {
-        z->l_fn_b(rp, abn, ap, ahop, mp, mhop, lp, li, 1, z->len, z->back);
+        z->l_fn_b(rp, abn, ap, ahop, mp, mhop, (__INT_T *)lp, li, 1, z->len, z->back);
       } else {
-        z->l_fn(rp, abn, ap, ahop, mp, mhop, lp, li, 1, z->len);
+        z->l_fn(rp, abn, ap, ahop, mp, mhop, (__INT_T *)lp, li, 1, z->len);
       }
     }
     acl += DIST_DPTR_CS_G(asd);
@@ -440,8 +438,7 @@ void I8(__fort_kred_scalarlk)(red_parm *z, char *rb, char *ab, char *mb,
                              __INT8_T *xb, red_enum op)
 {
   DECL_DIM_PTRS(asd);
-  __INT_T ao, i, len, m, p, q;
-  int loop;
+  __INT_T ao, i, m, p, q;
 
   z->rb = rb;
   z->rs = rs;
@@ -667,7 +664,7 @@ void I8(__fort_red_array)(red_parm *z, char *rb0, char *ab, char *mb, char *db,
   DECL_HDR_VARS(rs1);
   char *rb = 0, *xb, *zb;
   __INT_T flags, kind, len, rank, _1 = 1;
-  int i, n, rc, rl;
+  int i, rc, rl;
   __INT_T ao, ro;
 
   z->dim = I8(__fort_fetch_int)(db, ds);
@@ -859,7 +856,7 @@ void I8(__fort_red_arraylk)(red_parm *z, char *rb0, char *ab, char *mb, char *db
   DECL_HDR_VARS(rs1);
   char *rb = 0, *xb, *zb;
   __INT_T flags, kind, len, rank, _1 = 1;
-  int i, n, rc, rl;
+  int i, rc, rl;
   __INT_T ao, ro;
 
   z->dim = I8(__fort_fetch_int)(db, ds);
@@ -1050,7 +1047,7 @@ void I8(__fort_kred_arraylk)(red_parm *z, char *rb0, char *ab, char *mb,
   DECL_HDR_VARS(rs1);
   char *rb = 0, *xb, *zb;
   __INT_T flags, kind, len, rank, _1 = 1;
-  int i, n, rc, rl;
+  int i, rc, rl;
   __INT_T ao, ro;
 
   z->dim = I8(__fort_fetch_int)(db, ds);
@@ -1246,7 +1243,6 @@ void ENTFTN(REDUCE_DESCRIPTOR,
                                F90_Desc *ad,   /* array descriptor */
                                __INT_T *dimb)  /* dimension */
 {
-  DECL_DIM_PTRS(rdd);
   DECL_DIM_PTRS(add);
   DECL_HDR_PTRS(td);
   dtype kind;
@@ -1292,9 +1288,9 @@ void ENTFTN(REDUCE_DESCRIPTOR,
   I8(__fort_finish_descriptor)(rd);
 }
 
-void *I8(__fort_create_conforming_mask_array)(char *what, char *ab, char *mb,
-                                             F90_Desc *as, F90_Desc *ms,
-                                             F90_Desc *new_ms)
+void *I8(__fort_create_conforming_mask_array)(const char *what, char *ab,
+                                              char *mb, F90_Desc *as,
+                                              F90_Desc *ms, F90_Desc *new_ms)
 {
 
   /* Create a conforming mask array. Returns a pointer to the

--- a/runtime/flang/red.h
+++ b/runtime/flang/red.h
@@ -66,7 +66,7 @@ typedef struct {
 
 void __fort_red_unimplemented();
 
-void __fort_red_abort(char *msg);
+void __fort_red_abort(const char *msg);
 
 void I8(__fort_red_scalar)(red_parm *z, char *rb, char *ab, char *mb,
                           F90_Desc *rs, F90_Desc *as, F90_Desc *ms, __INT_T *xb,
@@ -93,7 +93,7 @@ void I8(__fort_kred_arraylk)(red_parm *z, char *rb0, char *ab, char *mb,
                             F90_Desc *ds, red_enum op);
 
 void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
-                             F90_Desc *hd, char *what, void (*fn[__NTYPES])());
+                             F90_Desc *hd, const char *what, void (*fn[__NTYPES])());
 
 /* prototype local reduction function (name beginning with l_):
 
@@ -128,7 +128,7 @@ void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
    ATYP = accumulator type
 */
 
-#define ARITHFN(OP, NAME, RTYP, ATYP)                                          \
+#define ARITHFN_L(OP, NAME, RTYP, ATYP)                                          \
   static void l_##NAME(RTYP *r, __INT_T n, RTYP *v, __INT_T vs, __LOG_T *m,    \
                        __INT_T ms, __INT_T *loc, __INT_T li, __INT_T ls,       \
                        __INT_T len)                                            \
@@ -148,7 +148,9 @@ void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
       }                                                                        \
     }                                                                          \
     *r = x;                                                                    \
-  }                                                                            \
+  }
+
+#define ARITHFN_G(OP, NAME, RTYP, ATYP)                                        \
   static void g_##NAME(__INT_T n, RTYP *lr, RTYP *rr, void *lv, void *rv)      \
   {                                                                            \
     __INT_T i;                                                                 \
@@ -181,7 +183,7 @@ void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
 
 /* note: all, any, parity, and count do not have mask arguments */
 
-#define LOGFN(OP, NAME, RTYP)                                                  \
+#define LOGFN_L(OP, NAME, RTYP)                                                  \
   static void l_##NAME(RTYP *r, __INT_T n, RTYP *v, __INT_T vs, __LOG_T *m,    \
                        __INT_T ms, __INT_T *loc, __INT_T li, __INT_T ls,       \
                        __INT_T len)                                            \
@@ -194,7 +196,9 @@ void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
       x = x OP((v[i] & mask_log) != 0);                                        \
     }                                                                          \
     *r = (RTYP)(x ? GET_DIST_TRUE_LOG : 0);                                   \
-  }                                                                            \
+  }
+
+#define LOGFN_G(OP, NAME, RTYP)                                                \
   static void g_##NAME(__INT_T n, RTYP *lr, RTYP *rr, void *lv, void *rv,      \
                        __INT_T len)                                            \
   {                                                                            \
@@ -790,7 +794,6 @@ static void l_ ## NAME(RTYP *r, __INT_T n, RTYP *v, __INT_T vs, \
       __INT4_T *loc, __INT_T li, __INT_T ls, __INT_T len, __LOG_T back)        \
   {                                                                            \
     __INT4_T i, j, ahop, t_loc = 0;                                            \
-    RTYP *val = v;                                                             \
     __LOG##N##_T mask_log;                                                     \
     if (!back && *loc != 0)                                                    \
       return;                                                                  \
@@ -895,7 +898,6 @@ static void l_ ## NAME(RTYP *r, __INT_T n, RTYP *v, __INT_T vs, \
       __INT8_T *loc, __INT_T li, __INT_T ls, __INT_T len, __LOG_T back)        \
   {                                                                            \
     __INT_T i, j, ahop, t_loc = 0;                                             \
-    RTYP *val = v;                                                             \
     __LOG##N##_T mask_log;                                                     \
     if (!back && *loc != 0)                                                    \
       return;                                                                  \

--- a/runtime/flang/red_all.c
+++ b/runtime/flang/red_all.c
@@ -15,14 +15,14 @@
 
 static __INT_T mask_desc = __LOG; /* scalar mask descriptor */
 
-LOGFN(&, all_log1, __LOG1_T)
-LOGFN(&, all_log2, __LOG2_T)
-LOGFN(&, all_log4, __LOG4_T)
-LOGFN(&, all_log8, __LOG8_T)
-LOGFN(&, all_int1, __INT1_T)
-LOGFN(&, all_int2, __INT2_T)
-LOGFN(&, all_int4, __INT4_T)
-LOGFN(&, all_int8, __INT8_T)
+LOGFN_G(&, all_log1, __LOG1_T)
+LOGFN_G(&, all_log2, __LOG2_T)
+LOGFN_G(&, all_log4, __LOG4_T)
+LOGFN_G(&, all_log8, __LOG8_T)
+LOGFN_G(&, all_int1, __INT1_T)
+LOGFN_G(&, all_int2, __INT2_T)
+LOGFN_G(&, all_int4, __INT4_T)
+LOGFN_G(&, all_int8, __INT8_T)
 
 LOGFNLKN(&, all_log1, __LOG1_T, 1)
 LOGFNLKN(&, all_log2, __LOG2_T, 1)

--- a/runtime/flang/red_any.c
+++ b/runtime/flang/red_any.c
@@ -15,14 +15,14 @@
 
 static __INT_T mask_desc = __LOG; /* scalar mask descriptor */
 
-LOGFN(|, any_log1, __LOG1_T)
-LOGFN(|, any_log2, __LOG2_T)
-LOGFN(|, any_log4, __LOG4_T)
-LOGFN(|, any_log8, __LOG8_T)
-LOGFN(|, any_int1, __INT1_T)
-LOGFN(|, any_int2, __INT2_T)
-LOGFN(|, any_int4, __INT4_T)
-LOGFN(|, any_int8, __INT8_T)
+LOGFN_G(|, any_log1, __LOG1_T)
+LOGFN_G(|, any_log2, __LOG2_T)
+LOGFN_G(|, any_log4, __LOG4_T)
+LOGFN_G(|, any_log8, __LOG8_T)
+LOGFN_G(|, any_int1, __INT1_T)
+LOGFN_G(|, any_int2, __INT2_T)
+LOGFN_G(|, any_int4, __INT4_T)
+LOGFN_G(|, any_int8, __INT8_T)
 
 LOGFNLKN(|, any_log1, __LOG1_T, 1)
 LOGFNLKN(|, any_log2, __LOG2_T, 1)

--- a/runtime/flang/red_count.c
+++ b/runtime/flang/red_count.c
@@ -46,15 +46,6 @@ static __INT_T mask_desc = __LOG; /* scalar mask descriptor */
     *r = x;                                                                    \
   }
 
-COUNTFN(count_log1, __LOG1_T)
-COUNTFN(count_log2, __LOG2_T)
-COUNTFN(count_log4, __LOG4_T)
-COUNTFN(count_log8, __LOG8_T)
-COUNTFN(count_int1, __INT1_T)
-COUNTFN(count_int2, __INT2_T)
-COUNTFN(count_int4, __INT4_T)
-COUNTFN(count_int8, __INT8_T)
-
 COUNTFNLKN(count_log1, __LOG1_T, 1)
 COUNTFNLKN(count_log2, __LOG2_T, 1)
 COUNTFNLKN(count_log4, __LOG4_T, 1)

--- a/runtime/flang/red_findloc.c
+++ b/runtime/flang/red_findloc.c
@@ -118,7 +118,6 @@ void ENTFTN(FINDLOCS, findlocs)(__INT_T *rb, char *ab, char *val, char *mb,
   red_parm z;
   double vb[4];
   char *strvb;
-  int len;
 
   INIT_RED_PARM(z);
   __fort_red_what = "FINDLOC";

--- a/runtime/flang/red_iany.c
+++ b/runtime/flang/red_iany.c
@@ -14,14 +14,14 @@
 #include "fioMacros.h"
 #include "red.h"
 
-ARITHFN(|, iany_log1, __LOG1_T, __LOG1_T)
-ARITHFN(|, iany_log2, __LOG2_T, __LOG2_T)
-ARITHFN(|, iany_log4, __LOG4_T, __LOG4_T)
-ARITHFN(|, iany_log8, __LOG8_T, __LOG8_T)
-ARITHFN(|, iany_int1, __INT1_T, __INT1_T)
-ARITHFN(|, iany_int2, __INT2_T, __INT2_T)
-ARITHFN(|, iany_int4, __INT4_T, __INT4_T)
-ARITHFN(|, iany_int8, __INT8_T, __INT8_T)
+ARITHFN_G(|, iany_log1, __LOG1_T, __LOG1_T)
+ARITHFN_G(|, iany_log2, __LOG2_T, __LOG2_T)
+ARITHFN_G(|, iany_log4, __LOG4_T, __LOG4_T)
+ARITHFN_G(|, iany_log8, __LOG8_T, __LOG8_T)
+ARITHFN_G(|, iany_int1, __INT1_T, __INT1_T)
+ARITHFN_G(|, iany_int2, __INT2_T, __INT2_T)
+ARITHFN_G(|, iany_int4, __INT4_T, __INT4_T)
+ARITHFN_G(|, iany_int8, __INT8_T, __INT8_T)
 
 ARITHFNLKN(|, iany_log1, __LOG1_T, __LOG1_T, 1)
 ARITHFNLKN(|, iany_log2, __LOG2_T, __LOG2_T, 1)

--- a/runtime/flang/red_norm2.c
+++ b/runtime/flang/red_norm2.c
@@ -64,7 +64,6 @@ void F90_I8(stride_1_norm2_real8) (__POINT_T *src_pointer, __INT_T *size, __REAL
 
 void ENTFTN(NORM2_NODIM, norm2_nodim) (__POINT_T *result, __POINT_T *src, __INT4_T * pfr, _DIST_TYPE *result_kind, F90_Desc *src_desc) {
   char error_msg[50];
-
   if (src_desc->kind == __REAL8) {
     switch(src_desc->rank) {
       case 1:
@@ -89,7 +88,7 @@ void ENTFTN(NORM2_NODIM, norm2_nodim) (__POINT_T *result, __POINT_T *src, __INT4
         F90_NORM2(nodim_7_real8) (result, src, pfr, src_desc);
         break;
       default:
-        sprintf(error_msg, "Rank : %d, can not be less than 1 or greater 7\n", src_desc->rank);
+        sprintf(error_msg, "Rank : %d, can not be less than 1 or greater 7\n", (int)src_desc->rank);
         __fort_abort(error_msg);
     }
   } else if (src_desc->kind == __REAL4) {
@@ -116,14 +115,14 @@ void ENTFTN(NORM2_NODIM, norm2_nodim) (__POINT_T *result, __POINT_T *src, __INT4
         F90_NORM2(nodim_7_real4) (result, src, src_desc);
         break;
       default:
-        sprintf(error_msg, "Rank : %d, can not be less than 1 or greater 7\n", src_desc->rank);
+        sprintf(error_msg, "Rank : %d, can not be less than 1 or greater 7\n", (int)src_desc->rank);
         __fort_abort(error_msg);
     }
   } else if (src_desc->len == 0) {
     // empty array case
     *result = 0.0;
   } else {
-    sprintf(error_msg, "Unsupported type %d for norm2\n", src_desc->kind);
+    sprintf(error_msg, "Unsupported type %d for norm2\n", (int)src_desc->kind);
     __fort_abort(error_msg);
   }
 }
@@ -159,7 +158,7 @@ void ENTFTN(NORM2, norm2) (__POINT_T *result, __POINT_T *src, __INT4_T * pfr, __
         F90_NORM2(dim_7_real8) (result, src, pfr, dim, result_desc, src_desc);
         break;
       default:
-        sprintf(error_msg, "Rank : %d, can not be less than 1 or greater 7\n", src_desc->rank);
+        sprintf(error_msg, "Rank : %d, can not be less than 1 or greater 7\n", (int)src_desc->rank);
         __fort_abort(error_msg);
     }
   } else if (src_desc->kind == __REAL4) {
@@ -186,14 +185,14 @@ void ENTFTN(NORM2, norm2) (__POINT_T *result, __POINT_T *src, __INT4_T * pfr, __
         F90_NORM2(dim_7_real4) (result, src, dim, result_desc, src_desc);
         break;
       default:
-        sprintf(error_msg, "Rank : %d, can not be less than 1 or greater 7\n", src_desc->rank);
+        sprintf(error_msg, "Rank : %d, can not be less than 1 or greater 7\n", (int)src_desc->rank);
         __fort_abort(error_msg);
     }
   } else if (src_desc->len == 0) {
     // empty array case
     *result = 0.0;
   } else {
-    sprintf(error_msg, "Unsupported type %d for norm2\n", src_desc->kind);
+    sprintf(error_msg, "Unsupported type %d for norm2\n", (int)src_desc->kind);
     __fort_abort(error_msg);
   }
 }

--- a/runtime/flang/red_sum.c
+++ b/runtime/flang/red_sum.c
@@ -13,7 +13,7 @@
 #include "fioMacros.h"
 #include "red.h"
 
-#define CSUMFN(NAME, RTYP, ATYP)                                               \
+#define CSUMFN_L(NAME, RTYP, ATYP)                                             \
   static void l_##NAME(RTYP *r, __INT_T n, RTYP *v, __INT_T vs, __LOG_T *m,    \
                        __INT_T ms, __INT_T *loc, __INT_T li, __INT_T ls)       \
   {                                                                            \
@@ -35,7 +35,9 @@
     }                                                                          \
     r->r = xr;                                                                 \
     r->i = xi;                                                                 \
-  }                                                                            \
+  }
+
+#define CSUMFN_G(NAME, RTYP, ATYP)                                             \
   static void g_##NAME(__INT_T n, RTYP *lr, RTYP *rr, void *lv, void *rv)      \
   {                                                                            \
     __INT_T i;                                                                 \
@@ -70,16 +72,16 @@
     r->i = xi;                                                                 \
   }
 
-ARITHFN(+, sum_int1, __INT1_T, long)
-ARITHFN(+, sum_int2, __INT2_T, long)
-ARITHFN(+, sum_int4, __INT4_T, long)
-ARITHFN(+, sum_int8, __INT8_T, __INT8_T)
-ARITHFN(+, sum_real4, __REAL4_T, __REAL4_T)
-ARITHFN(+, sum_real8, __REAL8_T, __REAL8_T)
-ARITHFN(+, sum_real16, __REAL16_T, __REAL16_T)
-CSUMFN(sum_cplx8, __CPLX8_T, __REAL4_T)
-CSUMFN(sum_cplx16, __CPLX16_T, __REAL8_T)
-CSUMFN(sum_cplx32, __CPLX32_T, __REAL16_T)
+ARITHFN_G(+, sum_int1, __INT1_T, long)
+ARITHFN_G(+, sum_int2, __INT2_T, long)
+ARITHFN_G(+, sum_int4, __INT4_T, long)
+ARITHFN_G(+, sum_int8, __INT8_T, __INT8_T)
+ARITHFN_G(+, sum_real4, __REAL4_T, __REAL4_T)
+ARITHFN_G(+, sum_real8, __REAL8_T, __REAL8_T)
+ARITHFN_G(+, sum_real16, __REAL16_T, __REAL16_T)
+CSUMFN_G(sum_cplx8, __CPLX8_T, __REAL4_T)
+CSUMFN_G(sum_cplx16, __CPLX16_T, __REAL8_T)
+CSUMFN_G(sum_cplx32, __CPLX32_T, __REAL16_T)
 
 ARITHFNLKN(+, sum_int1, __INT1_T, long, 1)
 ARITHFNLKN(+, sum_int2, __INT2_T, long, 1)

--- a/runtime/flang/reduct.c
+++ b/runtime/flang/reduct.c
@@ -92,7 +92,7 @@ static void
    template.  */
 
 static void
-global_reduce_abort(char *what, char *msg)
+global_reduce_abort(const char *what, const char *msg)
 {
   char str[120];
   sprintf(str, "GLOBAL_%s: %s", what, msg);
@@ -100,7 +100,7 @@ global_reduce_abort(char *what, char *msg)
 }
 
 void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
-                             F90_Desc *hd, char *what, void (*fn[__NTYPES])())
+                             F90_Desc *hd, const char *what, void (*fn[__NTYPES])())
 {
   DECL_HDR_PTRS(ht); /* align-target */
   DECL_DIM_PTRS(hdd);
@@ -138,7 +138,7 @@ void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
     /* all processors allocate same size temporary buffer */
 
     bufsiz = ALIGNR(cnt * len); /* round up buffer size */
-    if (bufsiz > sizeof(buf))
+    if (bufsiz > (int)(sizeof(buf)))
       tmp = (char *)__fort_gmalloc(bufsiz);
     else
       tmp = (char *)buf;
@@ -341,7 +341,6 @@ void I8(__fort_reduce_section)(void *vec1, dtype typ1, int len1, void *vec2,
                               int dim, F90_Desc *a)
 {
   DECL_DIM_PTRS(ad);
-  proc *p;
   char *tmp1, *tmp2; /* temporary buffer pointers */
   double buf1[4], buf2[4];
   __INT_T bit, cpu, i, it, mask, n, offgrid, pr, np, pc, pl, pe[MAXDIMS],
@@ -379,14 +378,14 @@ void I8(__fort_reduce_section)(void *vec1, dtype typ1, int len1, void *vec2,
   /* allocate temporary buffers */
 
   n = cnt * len1;
-  if (n > sizeof(buf1))
+  if (n > (int)(sizeof(buf1)))
     tmp1 = (char *)__fort_gmalloc(n);
   else
     tmp1 = (char *)buf1;
 
   if (vec2 != NULL) {
     n = cnt * len2;
-    if (n > sizeof(buf2))
+    if (n > (int)(sizeof(buf2)))
       tmp2 = (char *)__fort_gmalloc(n);
     else
       tmp2 = (char *)buf2;
@@ -472,7 +471,6 @@ void I8(__fort_replicate_result)(void *vec1, dtype typ1, int len1, void *vec2,
 {
   DECL_HDR_PTRS(t);
   DECL_DIM_PTRS(td);
-  proc *ap;
   __INT_T fromcpu, fromidx, i, mask, me, np, offgrid, p0, pc, pr, pe[MAXDIMS],
       ps[MAXDIMS];
 

--- a/runtime/flang/rnum.c
+++ b/runtime/flang/rnum.c
@@ -6321,7 +6321,6 @@ void ENTFTN(RSEED, rseed)(void *size, __INT_T *putb, __INT_T *getb,
                           F90_Desc *sized, F90_Desc *putd, F90_Desc *getd)
 {
   int i, j, no_args_present, vhi, vlo;
-  __INT_T *la;
   int list[LONG_LAG][2];
   __INT_T extent, index;
   char *static_seed;

--- a/runtime/flang/scatter.c
+++ b/runtime/flang/scatter.c
@@ -61,7 +61,7 @@ extern void local_scatter_WRAPPER();
 static __INT_T id_map[MAXDIMS] = {1, 2, 3, 4, 5, 6, 7};
 
 static void
-gathscat_abort(char *what, char *msg)
+gathscat_abort(const char *what, const char *msg)
 {
   char str[80];
   sprintf(str, "%s: %s", what, msg);
@@ -72,7 +72,7 @@ gathscat_abort(char *what, char *msg)
 
 typedef struct {
   sked sked;            /* schedule header */
-  char *what;           /* "GATHER"/"XXX_SCATTER" */
+  const char *what;     /* "GATHER"/"XXX_SCATTER" */
   void (*gathscatfn)(); /* local gather-scatter-reduction function */
   void (*scatterfn)();  /* local scatter-reduction function */
   chdr *repchn;         /* replication channel */
@@ -91,7 +91,7 @@ static void I8(gathscat_start)(gathscat_sked *sk, char *rb, char *sb,
                                F90_Desc *rd, F90_Desc *sd)
 {
   char *rp, *sp, *bufr, *bufs;
-  int cpu, i, j, k, lcpu, m, nr, ns, tcpus;
+  int cpu, j, k, lcpu, m, nr, ns, tcpus;
 
   double t;
   if (__fort_test & DEBUG_TIME)
@@ -216,10 +216,9 @@ gathscat_free(gathscat_sked *sk)
 static void I8(gathscat_element)(gathscat_parm *z, __INT_T uoff, __INT_T xoff[])
 {
   gathscat_dim *zd;
-  __INT_T *xp;
   DECL_HDR_PTRS(ud);
   DECL_HDR_PTRS(vd);
-  int cpu, k, ux, vx, xx;
+  int cpu, k, ux, vx;
   __INT_T roff;
   __INT_T vi[MAXDIMS];
 
@@ -534,10 +533,10 @@ sked *I8(__fort_gathscat)(gathscat_parm *z)
   DECL_HDR_PTRS(rd);
   DECL_HDR_PTRS(xd);
   DECL_F90_DIM_PTR(mdd);
-  DECL_DIST_DIM_PTR(mdd);
+  DECL_DIST_DIM_PTR(mdd) = NULL;
   DECL_DIM_PTRS(udd);
   DECL_F90_DIM_PTR(xdd);
-  DECL_DIST_DIM_PTR(xdd);
+  DECL_DIST_DIM_PTR(xdd) = NULL;
   xstuff *x;
 
   int *countbuf, *countr, *counts, *goff, *head, *loff, *next, *offr, *offs,
@@ -545,7 +544,9 @@ sked *I8(__fort_gathscat)(gathscat_parm *z)
 
   int alike, cpu, different, incoming, i, j, k, m, n, nr, ns;
   int lclcnt, lcpu, maxcnt, tempz, tcpus, u_covers_v, v_covers_u;
+#if defined(DEBUG)
   int has_gb = 0;
+#endif
   __INT_T mx, uoff, ux, vx, xx, xoff[MAXDIMS + 1];
 
   repl_t u_repl; /* unvectored array replication descriptor */
@@ -1170,8 +1171,9 @@ zero_lsize_ok_for_gen_block:
   return &sk->sked;
 }
 
-void *I8(__fort_adjust_index_array)(char *what, char *idx_array, char *src,
-                                   int dim, F90_Desc *is, F90_Desc *bs)
+void *I8(__fort_adjust_index_array)(const char *what, char *idx_array,
+                                    char *src, int dim, F90_Desc *is,
+                                    F90_Desc *bs)
 {
 
   /* Adjust Index array for scatter routines. This needs to be called
@@ -1250,9 +1252,9 @@ void *I8(__fort_adjust_index_array)(char *what, char *idx_array, char *src,
   return idx_array;
 }
 
-void *I8(__fort_create_conforming_index_array)(char *what, char *ab, void *ib,
-                                              F90_Desc *as, F90_Desc *is,
-                                              F90_Desc *new_is)
+void *I8(__fort_create_conforming_index_array)(const char *what, char *ab,
+                                               void *ib, F90_Desc *as,
+                                               F90_Desc *is, F90_Desc *new_is)
 {
 
   /* Create a conforming index array. Returns a pointer to the

--- a/runtime/flang/scatter.h
+++ b/runtime/flang/scatter.h
@@ -43,7 +43,7 @@ struct gathscat_dim {
 };
 
 struct gathscat_parm {
-  char *what; /* "GATHER"/"XXX_SCATTER" */
+  const char *what;           /* "GATHER"/"XXX_SCATTER" */
   void (*xfer_request)(struct chdr *, int, void *, long, long, int,
                        long); /* scatter: __fort_sendl; gather: __fort_recvl */
   void (*xfer_respond)(struct chdr *, int, void *, long, long, int,
@@ -101,9 +101,10 @@ void *ENTFTN(COMM_START, comm_start)();
 void ENTFTN(COMM_FINISH, comm_finish)();
 void ENTFTN(COMM_FREE, comm_free)();
 
-void *I8(__fort_adjust_index_array)(char *what, char *idx_array, char *src,
-                                   int dim, F90_Desc *is, F90_Desc *bs);
+void *I8(__fort_adjust_index_array)(const char *what, char *idx_array,
+                                    char *src, int dim, F90_Desc *is,
+                                    F90_Desc *bs);
 
-void *I8(__fort_create_conforming_index_array)(char *what, char *ab, void *ib,
-                                              F90_Desc *as, F90_Desc *is,
-                                              F90_Desc *new_is);
+void *I8(__fort_create_conforming_index_array)(const char *what, char *ab,
+                                               void *ib, F90_Desc *as,
+                                               F90_Desc *is, F90_Desc *new_is);

--- a/runtime/flang/scatter_maxval.c
+++ b/runtime/flang/scatter_maxval.c
@@ -376,7 +376,6 @@ sked *ENTFTN(COMM_MAXVAL_SCATTER,
   gathscat_parm z;
   int i;
   va_list va;
-  sked *sk;
 
   /* result is vectored, array is unvectored */
 

--- a/runtime/flang/scatter_minval.c
+++ b/runtime/flang/scatter_minval.c
@@ -375,7 +375,6 @@ sked *ENTFTN(COMM_MINVAL_SCATTER,
   gathscat_parm z;
   int i;
   va_list va;
-  sked *sk;
 
   /* result is vectored, array is unvectored */
 

--- a/runtime/flang/spread.c
+++ b/runtime/flang/spread.c
@@ -177,7 +177,7 @@ void ENTFTN(SPREADCSA,
 {
   __CLEN_T size;
   size = CLEN(sb);
-  ENTFTN(SPREADS,spreads)(CADR(rb), CADR(sb), dimb, ncopiesb, &size,
+  ENTFTN(SPREADS,spreads)(CADR(rb), CADR(sb), dimb, ncopiesb, (__INT_T *)&size,
 			    rd, sd, dimd, ncopiesd, szd);
 }
 /* 32 bit CLEN version */
@@ -212,7 +212,6 @@ void ENTFTN(SPREAD_DESCRIPTOR,
                                __INT_T *dimb,     /* dimension */
                                __INT_T *ncopiesb) /* ncopies base */
 {
-  DECL_DIM_PTRS(rdd);
   DECL_DIM_PTRS(sdd);
   DECL_HDR_PTRS(td);
   __INT_T dim, extent, m, ncopies, offset, rx, sx, tx;

--- a/runtime/flang/stat.c
+++ b/runtime/flang/stat.c
@@ -17,7 +17,6 @@
 #define write _write
 #endif
 
-extern char *__fort_getopt();
 extern void __fort_gettb();
 
 static struct tb tb0 = {/* stats at beginning of program */
@@ -58,10 +57,10 @@ __fort_stat_init(void)
 
 /* scale byte quantity */
 
-static char *
+static const char *
 scale_bytes(double d, double *ds)
 {
-  char *s;
+  const char *s;
 
   s = "B";
   if (d >= 1024) {
@@ -86,10 +85,10 @@ scale_bytes(double d, double *ds)
 
 /* scale byte quantity, beginning with kilobytes */
 
-static char *
+static const char *
 scale_kbytes(double d, double *ds)
 {
-  char *s;
+  const char *s;
 
   d = (d + 1023) / 1024;
   s = "KB";
@@ -181,7 +180,7 @@ static void mem(tbp) struct tb *tbp;
   double tsbrk;   /* total heap used (local) */
   double tgsbrk;  /* total heap used (global) */
   int i, quiet, tcpus;
-  char *s_sbrk, *s_gsbrk;
+  const char *s_sbrk, *s_gsbrk;
   double d_sbrk, d_gsbrk;
   char buf[256];
 
@@ -233,7 +232,7 @@ static void msg(tbp) struct tb *tbp;
   int i, quiet, tcpus;
   double ds, dr, dc, dst, drt, dct;
   double mst, mrt, mct, ast, art, act;
-  char *ss, *sr, *sc, *as, *ar, *ac;
+  const char *ss, *sr, *sc, *as, *ar, *ac;
   double d;
   char buf[256];
 

--- a/runtime/flang/trace.c
+++ b/runtime/flang/trace.c
@@ -8,9 +8,6 @@
 #include "stdioInterf.h"
 #include "fioMacros.h"
 
-char *__fort_getopt(char *opt);
-long __fort_strtol(char *str, char **ptr, int base); /* atol.c */
-
 static int tracing = 0;
 static int call_level = 0;
 
@@ -18,7 +15,8 @@ static int call_level = 0;
 int
 __fort_trac_init(void)
 {
-  char *p, *q;
+  const char *p;
+  char *q;
   int n;
 
   p = __fort_getopt("-trace");
@@ -46,7 +44,7 @@ __fort_trac_function_entry(int line, int lines, int cline, char *func,
   ++call_level;
   if (tracing)
     printf("%d: %.*s %.*s (%.*s:%d..%d) called from line %d\n", GET_DIST_LCPU,
-           call_level, dots, funcl, func, filel, file, line, line + lines - 1,
+           call_level, dots, (int)funcl, func, (int)filel, file, line, line + lines - 1,
            cline);
 }
 

--- a/runtime/flang/type.c
+++ b/runtime/flang/type.c
@@ -288,14 +288,12 @@ int ENTF90(POLY_CONFORM_TYPES, poly_conform_types)(char *ab, F90_Desc *ad,
                                                    F90_Desc *bd, __INT_T flag)
 {
   /* Possible return values. Do not change the integer values */
-  typedef enum {
+  enum {
     NOT_BIG_ENOUGH = -1, /* not conformable, not big enough */
     BIG_ENOUGH = 0,      /* not conformable but big enough */
     CONFORMABLE = 1      /* conformable */
-  } CONFORM_TYPES;
+  };
 
-  OBJECT_DESC *src = (OBJECT_DESC *)bd;
-  OBJECT_DESC *dest = (OBJECT_DESC *)ad;
   TYPE_DESC *src_td, *dest_td;
   int src_sz, dest_sz;
   int src_is_array = 0, dest_is_array = 0;
@@ -701,9 +699,8 @@ process_final_procedures(char *area, F90_Desc *sd)
   if (src_td->layout) {
     LAYOUT_DESC *ld = src_td->layout;
     F90_Desc *fd;
-    char *ptr1[1] = {0};
     char *ptr2[1] = {0};
-    char *cb, *db;
+    char *cb;
     __LOG_T g1;
     for (; ld->tag != 0; ld++) {
       if ((ld->tag != 'T' && ld->tag != 'D' && ld->tag != 'P' &&
@@ -793,9 +790,8 @@ void ENTF90(DEALLOC_POLY_MBR03A,
 
     LAYOUT_DESC *ld = src_td->layout;
     F90_Desc *fd;
-    char *ptr1[1] = {0};
     char *ptr2[1] = {0};
-    char *cb, *db;
+    char *cb;
     __LOG_T g1;
 
     for (; ld->tag != 0; ld++) {
@@ -862,7 +858,6 @@ void ENTF90(DEALLOC_POLY03A, dealloc_poly03a)(F90_Desc *sd, __STAT_T *stat,
 
     LAYOUT_DESC *ld = src_td->layout;
     F90_Desc *fd;
-    char *ptr1[1] = {0};
     char *ptr2[1] = {0};
     char *cb;
     __LOG_T g1;
@@ -922,9 +917,10 @@ sourced_alloc_and_assign(char *ab, char *bb, TYPE_DESC *td)
   char *cb, *db;
   __INT_T one = 1;
   __INT_T zero = 0;
-  __INT_T len, i;
+  __INT_T len;
   __INT_T kind = __NONE;
-  char *errmsg = "sourced_alloc_and_assign: malloc error";
+  /* Cannot use const char * here, to be compatible with DCHAR(). */
+  char *errmsg = (char *)"sourced_alloc_and_assign: malloc error";
 
   if (td == 0 || td->layout == 0) {
     return;
@@ -1126,7 +1122,6 @@ void ENTF90(POLY_ASN, poly_asn)(char *ab, F90_Desc *ad, char *bb, F90_Desc *bd,
    */
 
   OBJECT_DESC *src = (OBJECT_DESC *)bd;
-  OBJECT_DESC *dest = (OBJECT_DESC *)ad;
   TYPE_DESC *src_td, *dest_td;
   int src_sz, dest_sz, sz;
   int dest_is_array, src_is_array, i;
@@ -1242,6 +1237,7 @@ void I8(__fort_dump_type)(TYPE_DESC *d)
     break;
   case __LOG4:
     fprintf(__io_stderr(), "__LOG4'\n");
+    break;
   case __LOG8:
     fprintf(__io_stderr(), "__LOG8'\n");
     break;
@@ -1318,14 +1314,14 @@ void I8(__fort_dump_type)(TYPE_DESC *d)
     fprintf(__io_stderr(), "__PROCPTR'\n");
     break;
   default:
-    fprintf(__io_stderr(), "unknown (%d)'\n", d->obj.baseTag);
+    fprintf(__io_stderr(), "unknown (%d)'\n", (int)d->obj.baseTag);
     return;
   }
 
-  fprintf(__io_stderr(), "Size: %d\n", d->obj.size);
+  fprintf(__io_stderr(), "Size: %d\n", (int)d->obj.size);
   fprintf(__io_stderr(), "Type Descriptor:\n\t'%s'\n", d->name);
   if (d->obj.level > 0) {
-    __INT_T offset, level;
+    __INT_T level;
     fprintf(__io_stderr(), "(Child Type)\n");
     fprintf(__io_stderr(), "Parent Descriptor%s\n",
             (d->obj.level == 1) ? ":" : "s:");
@@ -1350,7 +1346,7 @@ void I8(__fort_dump_type)(TYPE_DESC *d)
       }
       fprintf(__io_stderr(),
         "  tag=%c offset=%d desc_offset=%d length=%d declType=%p\n",
-        ld->tag, ld->offset, ld->desc_offset, ld->length, ld->declType);
+        (int)ld->tag, (int)ld->offset, (int)ld->desc_offset, (int)ld->length, ld->declType);
     }
   }
 }
@@ -1696,10 +1692,9 @@ ENTF90(SAME_INTRIN_TYPE_AS, same_intrin_type_as)
 (void *ab, OBJECT_DESC *ad, void *bb, __INT_T intrin_type, __INT_T flag, ...)
 
 {
-  TYPE_DESC *atd;
   TYPE_DESC *btd;
   OBJECT_DESC *t1, *t2;
-  __LOG_T g1, g2;
+  __LOG_T g1;
   va_list va;
 
   if (!ad)
@@ -1742,10 +1737,9 @@ ENTF90(KSAME_INTRIN_TYPE_AS, ksame_intrin_type_as)
 (void *ab, OBJECT_DESC *ad, void *bb, __INT_T intrin_type, __INT_T flag, ...)
 
 {
-  TYPE_DESC *atd;
   TYPE_DESC *btd;
   OBJECT_DESC *t1, *t2;
-  __LOG_T g1, g2;
+  __LOG_T g1;
   va_list va;
 
   if (!ad)
@@ -1833,7 +1827,6 @@ static int has_intrin_type(F90_Desc *dd)
 {
   int i;
   OBJECT_DESC *td = (OBJECT_DESC *)dd; 
-  int is_intrin_type = 0;
 
   if (td->type == NULL)
     return 0;
@@ -1850,27 +1843,26 @@ static int has_intrin_type(F90_Desc *dd)
 void ENTF90(INIT_UNL_POLY_DESC, init_unl_poly_desc)(F90_Desc *dd, F90_Desc *sd,
                                                     __INT_T kind)
 {
-  OBJECT_DESC *od = (OBJECT_DESC *)sd;
-    if (sd && F90_TAG_G(sd) == __DESC) {
-      __fort_bcopy((char *)dd, (char *)sd, SIZE_OF_RANK_n_ARRAY_DESC(F90_RANK_G(sd)));
-      SET_F90_DIST_DESC_PTR(dd, F90_RANK_G(dd));
-      /* check for align-target to self */
-      if (DIST_ALIGN_TARGET_G(dd) == dd) {
-        DIST_ALIGN_TARGET_P(dd, dd);
-      }
-      dd->kind = kind;
-    } else {
-      dd->len = (sd && (sd->tag == __DESC || sd->tag == __POLY)) ? sd->len : 0;
-      dd->tag = __POLY;
-      dd->rank = 0;
-      dd->lsize = 0;
-      dd->gsize = 0;
-      dd->kind = kind;
-      if (sd && (sd->tag == __DESC || sd->tag == __POLY || 
-          has_intrin_type(sd))) {
-        ENTF90(SET_TYPE, set_type)(dd, sd);
-      }
+  if (sd && F90_TAG_G(sd) == __DESC) {
+    __fort_bcopy((char *)dd, (char *)sd, SIZE_OF_RANK_n_ARRAY_DESC(F90_RANK_G(sd)));
+    SET_F90_DIST_DESC_PTR(dd, F90_RANK_G(dd));
+    /* check for align-target to self */
+    if (DIST_ALIGN_TARGET_G(dd) == dd) {
+      DIST_ALIGN_TARGET_P(dd, dd);
     }
+    dd->kind = kind;
+  } else {
+    dd->len = (sd && (sd->tag == __DESC || sd->tag == __POLY)) ? sd->len : 0;
+    dd->tag = __POLY;
+    dd->rank = 0;
+    dd->lsize = 0;
+    dd->gsize = 0;
+    dd->kind = kind;
+    if (sd && (sd->tag == __DESC || sd->tag == __POLY ||
+        has_intrin_type(sd))) {
+      ENTF90(SET_TYPE, set_type)(dd, (struct object_desc *)sd);
+    }
+  }
 }
 
 void ENTF90(INIT_FROM_DESC, init_from_desc)(void *object,

--- a/runtime/flang/unf.c
+++ b/runtime/flang/unf.c
@@ -134,7 +134,7 @@ static int gbl_size = GBL_SIZE;
 static int
 adjust_fpos(FIO_FCB *cur_file, long offset, int whence)
 {
-  int retval;
+  int retval = 0;
 
   if (cur_file->asy_rw) {
     Fio_asy_fseek(cur_file->asyptr, offset, whence);
@@ -438,7 +438,6 @@ __f90io_unf_read(int type,    /* Type of data */
                  char *item,  /* where to xfer data */
                  __CLEN_T item_length)
 {
-  int i;         /* loop index */
   size_t nbytes; /* number of bytes to read from current record */
   size_t resid;  /* number of bytes to read from following records */
   int offset;    /* offset into item */
@@ -1425,7 +1424,6 @@ __f90io_usw_read(int type,   /* Type of data */
                  char *item, /* where to xfer data */
                  __CLEN_T item_length)
 {
-  long i;        /* loop index */
   size_t nbytes; /* number of bytes to read from current record */
   size_t resid;  /* number of bytes to read from following records */
   int offset;    /* offset into item */
@@ -1845,7 +1843,7 @@ nonunit_cp:
     /* ??? one copy per byte.  Maybe optimize later */
     for (j = 0; j < item_length; j++)
       *buf_ptr++ = *item++;
-      __fortio_swap_bytes(buf_ptr - item_length, type, 1);
+    __fortio_swap_bytes(buf_ptr - item_length, type, 1);
 
     rw_size += item_length;
   }

--- a/runtime/flang/usrio_smp.c
+++ b/runtime/flang/usrio_smp.c
@@ -38,12 +38,12 @@ static struct {
 /* open file */
 
 int
-__fort_par_open(char *fn, char *par)
+__fort_par_open(const char *fn, const char *par)
 {
   int nflags;
   int mode;
   int fd;
-  char *p;
+  const char *p;
 
   nflags = 0;
   mode = 0666;
@@ -65,8 +65,10 @@ __fort_par_open(char *fn, char *par)
       p += 5;
       nflags |= O_CREAT;
       if (*p == '=') {
+        char *q;
         p++;
-        mode = strtol(p, &p, 0);
+        mode = strtol(p, &q, 0);
+        p = q;
       }
     } else if (strncmp(p, "trunc", 5) == 0) {
       p += 5;
@@ -102,7 +104,6 @@ __CLEN_T
 __fort_par_read(int fd, char *adr, __CLEN_T cnt, int str, int typ,
                 __CLEN_T ilen, int own)
 {
-  long l;
   int s;
 
   if (fds[fd].flags & I_WRITE) {
@@ -120,7 +121,7 @@ __fort_par_read(int fd, char *adr, __CLEN_T cnt, int str, int typ,
     if (s == -1) {
       __fort_abortp("parallel i/o");
     }
-    if (s != (cnt * ilen)) {
+    if (s != (int)(cnt * ilen)) {
       __fort_abort("parallel i/o: partial read");
     }
   } else {

--- a/runtime/flang/util.c
+++ b/runtime/flang/util.c
@@ -186,7 +186,7 @@ int I8(__fort_fetch_int_element)(void *b, F90_Desc *d, int i)
 {
   double tmp[2];
   __INT_T idx;
-  int val;
+  int val = 0;
 
   if (F90_RANK_G(d) != 1)
     __fort_abort("fetch_int_element: non-unit rank");
@@ -249,7 +249,6 @@ void I8(__fort_store_int_element)(void *b, F90_Desc *d, int i, int val)
 void I8(__fort_fetch_int_vector)(void *b, F90_Desc *d, int *vec, int veclen)
 {
   double tmp[2];
-  dtype kind;
   __INT_T i;
 
   if (F90_RANK_G(d) != 1)

--- a/runtime/flang/utils.c
+++ b/runtime/flang/utils.c
@@ -73,7 +73,7 @@ __fortio_fiofcb_form(FIO_FCB *f)
   return f->form;
 }
 
-extern char *
+extern const char *
 __fortio_fiofcb_name(FIO_FCB *f)
 {
   return f->name;
@@ -465,11 +465,11 @@ __fortio_zeropad(FILE *fp, long len)
 
 /* --------------------------------------------------------------- */
 
+/* return TRUE if string 'str' of length 'len' is equal to 'pattern'. */
 extern bool __fortio_eq_str(
-    /* return TRUE if string 'str' of length 'len' is equal to 'pattern'. */
-
-    char *str, /* user specified string, not null terminated */
-    __CLEN_T len, char *pattern) /* upper case, null terminated string */
+    char *str,           /* user-specified string, not null terminated */
+    __CLEN_T len,        /* maximum number of characters to comprae */
+    const char *pattern) /* upper case, null terminated string */
 {
   char c1, c2;
 

--- a/runtime/flang/utils3f.h
+++ b/runtime/flang/utils3f.h
@@ -6,5 +6,5 @@
  */
 
 
-void __fcp_cstr(char *to, int to_len, char *from);
+void __fcp_cstr(char *to, int to_len, const char *from);
 

--- a/runtime/flang/utilsi64.c
+++ b/runtime/flang/utilsi64.c
@@ -272,18 +272,8 @@ __fort_i64toax(DBLINT64 from, char *to, int count, int sign, int radix)
                       * to be shifted */
   int msd;           /* index of the most-signingicant digit in to */
   int num_bits;      /* number of bits to be shifted */
-  DBLINT64 quot;        /* the quotient part of a 64 bit division */
-  DBLINT64 remain;      /* the remainder part of a 64 bit division */
   DBLINT64 temp_from;   /* temp from (=(abs(from)) */
   DBLINT64 temp64;      /* temporary 64 bit integer */
-
-  /* 64 bit integer equal to 10 */
-  static DBLINT64 ten64 = {0, 10};
-
-  /* the result of dividing a 64 bit unsigned integer with only the
-   * sign bit on by 10
-   */
-  static INT msbdiv10[2] = {0xccccccc, 0xcccccccc};
 
   if ((from[0] == 0) && (from[1] == 0)) {
     msd = count - 1;
@@ -419,8 +409,6 @@ __fort_i64toax(DBLINT64 from, char *to, int count, int sign, int radix)
 static int toi64(char *s, DBLINT64 toi, char *end, int radix)
 {
   DBLINT64 base; /* 64 bit integer equal to radix */
-  DBLINT64 diff; /* difference between 2 64 bit integers, used
-               * in determining if overflow has occured */
   DBLINT64 num;  /* numerical value of a particular digit */
   DBLINT64 to;
   int negate;
@@ -431,7 +419,6 @@ static int toi64(char *s, DBLINT64 toi, char *end, int radix)
 
   /* maximum 64-bit signed integer */
   static DBLINT64 max_int = {0x7fffffff, 0xffffffff};
-  static DBLINT64 max_neg = {0x80000000, 0};
 
   OVL8 pto;
 

--- a/runtime/flang/version.c
+++ b/runtime/flang/version.c
@@ -16,12 +16,12 @@
 #endif
 
 static struct {
-  char *lib;  /* library */
-  char *host; /* host */
-  char *vsn;  /* version number */
-  char *bld;  /* build number */
-  char *dvsn; /* date-based version number */
-  char *copyright;
+  const char *lib;  /* library */
+  const char *host; /* host */
+  const char *vsn;  /* version number */
+  const char *bld;  /* build number */
+  const char *dvsn; /* date-based version number */
+  const char *copyright;
 } version = {
     LIBRARY, VHOST,
     VSN,     BLD,

--- a/runtime/flang/wait.c
+++ b/runtime/flang/wait.c
@@ -27,7 +27,6 @@ __INT_T *iostat;
 __INT_T *id;
 {
   FIO_FCB *f;
-  int i;
   int s = 0;
 
   __fort_status_init(bitv, iostat);

--- a/runtime/flang/xfer.c
+++ b/runtime/flang/xfer.c
@@ -363,8 +363,6 @@ __fort_getgbuf(long len)
 void
 __fort_chn_prune(struct chdr *c)
 {
-  struct ccpu *cp;
-  struct ccpu ccpu;
   int n;
   int m;
 

--- a/runtime/flangrti/aarch64/dumpregs.c
+++ b/runtime/flangrti/aarch64/dumpregs.c
@@ -15,7 +15,7 @@
 
 typedef struct {
     size_t  ro;     // Register offset in to mcontext_t structure
-    char    *s;     // Symbolic name of register
+    const char *s;  // Symbolic name of register
 } xregs_t;
 
 

--- a/runtime/flangrti/trace.c
+++ b/runtime/flangrti/trace.c
@@ -62,7 +62,7 @@ dbg_stop_before_exit(void)
 #endif
 
 void
-__abort(int sv, char *msg)
+__abort(int sv, const char *msg)
 {
   char cmd[128];
   char *p;

--- a/runtime/include/stdioInterf.h
+++ b/runtime/include/stdioInterf.h
@@ -106,7 +106,7 @@ extern void *__aligned_malloc(size_t, size_t); /* pgmemalign.c */
 extern void __aligned_free(void *);
 extern int __fenv_fegetzerodenorm(void);
 
-void __abort(int sv, char *msg);
+void __abort(int sv, const char *msg);
 void __abort_trace(int skip);
 void __abort_sig_init(void);
 


### PR DESCRIPTION
Fix the Flang code base so that `WITH_WERROR=on` can be used at CMake time to enable stricter linting. This patch mainly addresses the following types of warnings:

- `-Wcast-qual` warnings as a result of mixing `char *` fields and parameters with `const char *` values, especially string literals. Most of these can be trivially fixed by changing the type of the fields/parameters in question to `const char *`. Tricky cases are handled with `strdup` or explicit casts.

- `-Wunused-variable` and `-Wsometimes-uninitialized` warnings. Unused variables are deleted, and ones that are used conditionally are initialized with sensible defaults.

- `-Wmissing-field-initializers` warnings for partial initializers in data structure definitions.

- `-Wformat` warnings (e.g. `"%d"` vs. `"%ld"`, `"%p"` for non-`void *` arguments).

This patch depends on previous patches listed in #1065.