### PR TITLE
Fix a segmentation fault related to assumed length character functions.

### DIFF
--- a/test/f90_correct/inc/assumed_len_char_01.mk
+++ b/test/f90_correct/inc/assumed_len_char_01.mk
@@ -1,0 +1,28 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test assumed_len_char_01  ########
+
+
+assumed_len_char_01: run
+
+
+build:  $(SRC)/assumed_len_char_01.f90
+	-$(RM) assumed_len_char_01.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/assumed_len_char_01.f90 -o assumed_len_char_01.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) assumed_len_char_01.$(OBJX) check.$(OBJX) $(LIBS) -o assumed_len_char_01.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test assumed_len_char_01
+	assumed_len_char_01.$(EXESUFFIX)
+
+verify: ;
+
+assumed_len_char_01.run: run
+

--- a/test/f90_correct/lit/assumed_len_char_01.sh
+++ b/test/f90_correct/lit/assumed_len_char_01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/assumed_len_char_01.f90
+++ b/test/f90_correct/src/assumed_len_char_01.f90
@@ -1,0 +1,60 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for function which return assumed-length character.
+
+character(len=*) function func1()
+  func1 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+end function func1
+
+character(len=*) function func2(str3)
+  character(len=3), intent(in) :: str3
+  func2 = str3//'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+end function func2
+
+subroutine test1(i)
+  integer :: i
+  character(len=i) :: str
+  character(len=i) :: func1
+  str = func1()
+  if (str .ne. 'ABCDEFGHIJKLMNOPQRST') STOP 1
+end subroutine test1
+
+subroutine test2(i)
+  integer :: i
+  character(len=i) :: str
+  character(len=i), external :: func1
+  str = func1()
+  if (str .ne. 'ABCDEFGHIJKLMNOPQRST') STOP 2
+end subroutine test2
+
+subroutine test3(i, str4)
+  integer :: i
+  character(len=3) :: str4
+  character(len=i) :: str
+  character(len=i) :: func2
+  str = func2(str4)
+  if (str .ne. '$*$ABCDEFGHIJKLMNOPQ') STOP 3
+end subroutine test3
+
+subroutine test4(i, str5)
+  integer :: i
+  character(len=3) :: str5
+  character(len=i) :: str
+  character(len=i), external :: func2
+  str = func2(str5)
+  if (str .ne. '## ABCDEFGHIJKLMNOPQ') STOP 4
+end subroutine test4
+
+program p
+  character(len=3) :: str1, str2
+  str1 = '$*$'
+  str2 = '##'
+  call test1(20)
+  call test2(20)
+  call test3(20, str1)
+  call test4(20, str2)
+  print *, 'PASS'
+end program

--- a/tools/flang1/flang1exe/semutil.c
+++ b/tools/flang1/flang1exe/semutil.c
@@ -2038,6 +2038,24 @@ mkvarref(SST *stktop, ITEM *list)
         SST_SYMP(stktop, sptr);
         goto really_an_entry;
       }
+      if (STYPEG(sptr) == ST_IDENT && SCG(sptr) == SC_LOCAL && AUTOBJG(sptr)) {
+        /* Remove from automatic data list */
+        int curr = gbl.autobj;
+        if (curr == sptr) {
+          gbl.autobj = AUTOBJG(sptr);
+        } else {
+          while (curr > NOSYM) {
+            int next = AUTOBJG(curr);
+            if (next == sptr)
+              break;
+            curr = next;
+          }
+          if (curr > NOSYM) {
+            AUTOBJP(curr, AUTOBJG(sptr));
+          }
+        }
+        AUTOBJP(sptr, 0);
+      }
       /* must be a function reference */
       STYPEP(sptr, ST_PROC);
       FWDREFP(sptr, 1); /* FS1551, see resolve_fwd_refs() below */

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -14213,6 +14213,16 @@ add_autobj(int sptr)
 {
   static int last_autobj;
 
+  if (last_autobj > NOSYM && AUTOBJG(last_autobj) > NOSYM) {
+    /* last_autobj is invalid */
+    int next;
+    last_autobj = 0;
+    next = gbl.autobj;
+    while (next > NOSYM) {
+      last_autobj = next;
+      next = AUTOBJG(next);
+    }
+  }
   if (gbl.autobj == NOSYM)
     /* first automatic array */
     gbl.autobj = sptr;

--- a/tools/flang2/flang2exe/exp_rte.cpp
+++ b/tools/flang2/flang2exe/exp_rte.cpp
@@ -3273,7 +3273,7 @@ exp_call(ILM_OP opc, ILM *ilmp, int curilm)
   int argopc;
   int cfunc;
   int cfunc_nme;
-  DTYPE dtype;
+  DTYPE dtype, dtype1;
   int val_flag;
   int arglnk;
   int func_addr;
@@ -3297,6 +3297,7 @@ exp_call(ILM_OP opc, ILM *ilmp, int curilm)
     /* Q&D for the absence of prototypes/signatures for our run-time
      * routines. -- 9/19/14, do it for user functions too!
      */
+    dtype1 = DTYPEG(exp_call_sym);
     DTYPEP(exp_call_sym, DT_NONE);
     break;
   case IM_CHFUNC:
@@ -3999,6 +4000,17 @@ exp_call(ILM_OP opc, ILM *ilmp, int curilm)
 
     default:
       gargili = ILM_RESULT(ilm1);
+      /* As for function which return assumed-length character,
+         use A_CALL and process its second argument(length of character) here */
+      if ((opc == IM_CALL) && (dtype1 == DT_ASSCHAR) && (nargs == (ngargs - 2))) {
+        if (CHARLEN_64BIT) {
+          gargili = sel_iconv(gargili, 1);
+          add_to_args(IL_ARGKR, gargili);
+        } else {
+          add_to_args(IL_ARGIR, gargili);
+        }
+        break;
+      }
       if (ILM_RESTYPE(ilm1) == ILM_ISCHAR) {
         str1 = getstr(ilm1);
         if (str1->next)

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -2830,7 +2830,6 @@ lldbg_create_deferred_len_string_type_mdnode(LL_DebugInfo *db, SPTR sptr,
   if (SDSCG(REVMIDLNKG(sptr)) && (DTY(DTYPEG(sptr)) == TY_PTR)) {
     /* get the array descriptor */
     SPTR sdscsptr = SDSCG(REVMIDLNKG(sptr));
-    LL_Type *dataloctype = LLTYPE(sdscsptr);
     BLKINFO *blk_info = get_lexical_block_info(db, sdscsptr, true);
     LL_MDRef file_mdnode;
     if (ll_feature_debug_info_need_file_descriptions(&db->module->ir))
@@ -2919,7 +2918,7 @@ lldbg_create_deferred_len_string_type_mdnode(LL_DebugInfo *db, SPTR sptr,
 
       /* emit an @llvm.dbg.declare with required !DIExpression */
       LL_MDRef expr_mdnode = lldbg_emit_expression_mdnode(db, 2, add, v1);
-      insert_llvm_dbg_declare(mdLen, sdscsptr, dataloctype,
+      insert_llvm_dbg_declare(mdLen, sdscsptr, (LL_Type *) NULL,
                             make_mdref_op(expr_mdnode), OPF_NONE);
 
       mdLenExp = lldbg_emit_empty_expression_mdnode(db);


### PR DESCRIPTION
When an assumed length character function is not external,  its symbol type will at first be set to `ST_IDENT` and the `AUTOBJ` field will be set to `1`. When a invocation of it is encountered, its symbol type will be modified to `ST_PROC`. But its `AUTOBJ` 
remains `1` which will causes a segmentation fault later.

This patch fixes the issue by removing the function from the automatic data list and setting its `AUTOBJ` to `0`.

The other issue is that flang sets the return length as `0` for assumed length character functions, causing an ICE afterwards.

This patch fixes it by modifying the ast type of the function (from ‘A_FUNC’ to `A_CALL`), and adding code to process the argument for the length.