### PR TITLE
Prevent illegal argument accessing during procedure exporting.

### DIFF
--- a/test/f90_correct/inc/proc_ptr.mk
+++ b/test/f90_correct/inc/proc_ptr.mk
@@ -1,0 +1,28 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test proc_ptr  ########
+
+
+proc_ptr: run
+
+
+build:  $(SRC)/proc_ptr.f90
+	-$(RM) proc_ptr.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/proc_ptr.f90 -o proc_ptr.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) proc_ptr.$(OBJX) check.$(OBJX) $(LIBS) -o proc_ptr.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test proc_ptr
+	proc_ptr.$(EXESUFFIX)
+
+verify: ;
+
+proc_ptr.run: run
+

--- a/test/f90_correct/lit/proc_ptr.sh
+++ b/test/f90_correct/lit/proc_ptr.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/proc_ptr.f90
+++ b/test/f90_correct/src/proc_ptr.f90
@@ -1,0 +1,30 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test the fix for segment fault about procedure pointer when all the following
+! three conditions are satisfied:
+! 1) module procedue used as proc-interface
+! 2) keyword RESULT appears
+! 3) none dummy argument
+
+module m
+  procedure(g), pointer :: f
+contains
+  function g() result(z)
+    integer :: z(3)
+    z = (/1, 2, 3/)
+  end function
+end module
+
+program test
+  use m
+  implicit none
+  integer :: a(3)
+  f => g
+  a = f()
+  if (.not. all(a .eq. (/1, 2, 3/))) STOP 1
+
+  print *, 'PASS'
+end program

--- a/tools/flang1/flang1exe/exterf.c
+++ b/tools/flang1/flang1exe/exterf.c
@@ -682,7 +682,10 @@ export_some_procedure(int sptr)
   if (fval) {
     dpdsc = DPDSCG(sptr);
     DTYPEP(sptr, DTYPEG(fval));
-    if (aux.dpdsc_base[dpdsc] == FVALG(sptr)) {
+    /* If PARAMCT equals zero, it is illegal to access the beginning of the
+     * argument list of the function.
+     */
+    if (PARAMCTG(sptr) > 0 && aux.dpdsc_base[dpdsc] == FVALG(sptr)) {
       DPDSCP(sptr, dpdsc + 1);
       PARAMCTP(sptr, PARAMCTG(sptr) - 1);
     }


### PR DESCRIPTION
When exporting a procedure, if `PARAMCT` is not positive (e.g., when a name of a function is used as the procedure interface in a procedure declaration statement before the function is defined and later the function declartion statement has a `RESULT` clause
and zero dummy arguments, `PARAMCT` will be 0), then it should be illegal to access the beginning of the argument list of the function. zero or negative  Failing to prevent this kind of illegal access will cause a segmentation fault.

This patch fixes the bug by checking whether `PARAMCT` is greater than 0 before accessing the argument list.