### PR TITLE
Make use of 'nounwind', 'readnone', 'willreturn' LLVM-IR attributes

### DIFF
--- a/test/llvm_ir_correct/sincos.f90
+++ b/test/llvm_ir_correct/sincos.f90
@@ -1,0 +1,49 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! RUN: %flang --target=aarch64-unknown-linux-gnu -Kieee -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang --target=aarch64-unknown-linux-gnu -Kieee -r8 -S -emit-llvm %s -o - | FileCheck %s
+! REQUIRES: aarch64
+
+subroutine testA(r1,r2,r3,r4,r5,r6)
+! CHECK-LABEL: @testa
+! CHECK: call float @__ps_sin_1(float
+! CHECK: call double @__pd_sin_1(double
+  real(kind=4) :: r1
+  real(kind=4) :: r2
+  real(kind=8) :: r3
+  real(kind=8) :: r4
+
+  r2 = sin(r1)*cos(r1)
+  r4 = sin(r3)*cos(r3)
+
+  r2 = sin(r1)
+  r4 = sin(r3)
+end subroutine
+
+subroutine testB(r1,r2,r3,r4,r5,r6)
+! CHECK-LABEL: @testb
+! CHECK: call float @__ps_cos_1(float
+! CHECK: call double @__pd_cos_1(double
+  real(kind=4) :: r1
+  real(kind=4) :: r2
+  real(kind=8) :: r3
+  real(kind=8) :: r4
+
+  r2 = sin(r1)*cos(r1)
+  r4 = sin(r3)*cos(r3)
+
+  r2 = cos(r1)
+  r4 = cos(r3)
+end subroutine
+
+! Ensure the math routines are declared like pure functions.
+
+! CHECK: declare double @__pd_sin_1(double) #[[ATTR_ID:[0-9]+]]
+! CHECK: declare double @__pd_cos_1(double) #[[ATTR_ID]]
+
+! CHECK: declare float @__ps_sin_1(float) #[[ATTR_ID]]
+! CHECK: declare float @__ps_cos_1(float) #[[ATTR_ID]]
+
+! CHECK: attributes #[[ATTR_ID]] = { nounwind readnone }

--- a/test/llvm_ir_correct/sincos.f90
+++ b/test/llvm_ir_correct/sincos.f90
@@ -46,4 +46,4 @@ end subroutine
 ! CHECK: declare float @__ps_sin_1(float) #[[ATTR_ID]]
 ! CHECK: declare float @__ps_cos_1(float) #[[ATTR_ID]]
 
-! CHECK: attributes #[[ATTR_ID]] = { nounwind readnone }
+! CHECK: attributes #[[ATTR_ID]] = { nounwind readnone willreturn }

--- a/tools/flang2/flang2exe/cgllvm.h
+++ b/tools/flang2/flang2exe/cgllvm.h
@@ -91,6 +91,7 @@ typedef enum {
 #define EXF_INTRINSIC 1
 #define EXF_STRUCT_RETURN 2
 #define EXF_VARARG 4
+#define EXF_PURE 8
 
 #define IS_OLD_STYLE_CAND(s) (DEFDG(sptr) || CCSYMG(sptr))
 

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -12766,7 +12766,7 @@ write_extern_fndecl(struct LL_FnProto_ *proto)
       if (proto->intrinsic_decl_str) {
         print_token(proto->intrinsic_decl_str);
         if (proto->abi && proto->abi->is_pure)
-          print_token(" nounwind readnone");
+          print_token(" nounwind readnone willreturn");
         print_nl();
       } else {
         print_token("declare");
@@ -12774,9 +12774,7 @@ write_extern_fndecl(struct LL_FnProto_ *proto)
           print_token(" extern_weak");
         print_function_signature(0, proto->fn_name, proto->abi, false);
         if (proto->abi->is_pure)
-          print_token(" nounwind");
-        if (proto->abi->is_pure)
-          print_token(" readnone");
+          print_token(" nounwind readnone willreturn");
         if ((!flg.ieee || XBIT(216, 1)) && proto->abi->fast_math)
           print_token(" \"no-infs-fp-math\"=\"true\" "
                       "\"no-nans-fp-math\"=\"true\" "

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -127,7 +127,8 @@ OPERAND *gen_call_as_llvm_instr(int sptr, int ilix);
  */
 OPERAND *gen_call_to_builtin(int ilix, char *fname, OPERAND *params,
                              LL_Type *return_ll_type, INSTR_LIST *Call_Instr,
-                             LL_InstrName i_name);
+                             LL_InstrName i_name,
+                             unsigned flags);
 
 /**
    \brief ...


### PR DESCRIPTION
It turned out we are losing crucial optimization opportunities by not marking callsites for runtime library math functions with 'nounwind', 'readnone' and 'willreturn' attributes of LLVM-IR. These two patches are fixing that.
