### PR TITLE
Add more checkings for derived types in COMMON statements

### DIFF
--- a/test/f90_correct/inc/common_02.mk
+++ b/test/f90_correct/inc/common_02.mk
@@ -1,0 +1,15 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build: $(SRC)/$(TEST).f90
+	@echo ------------------------------------ building test $(TEST)
+	-$(FC) -c $(SRC)/$(TEST).f90 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ nothing to run for test $(TEST)
+
+verify: $(TEST).rslt
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f90 $(TEST).rslt $(FC)
+

--- a/test/f90_correct/lit/common_02.sh
+++ b/test/f90_correct/lit/common_02.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/common_02.f90
+++ b/test/f90_correct/src/common_02.f90
@@ -1,0 +1,72 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for derived type in COMMON.
+
+block data
+  integer :: x = 10
+  common /comm6/ x
+end block data
+
+program test
+  use iso_c_binding
+  implicit none
+
+  type type1
+    integer :: t1
+  end type type1
+
+  type type2
+    sequence
+    integer, allocatable, dimension(:) :: t2
+  end type type2
+
+  type type3
+    sequence
+    type(type2) :: t3
+  end type type3
+
+  type type4
+    sequence
+    integer, allocatable :: t4
+  end type type4
+
+  type type5
+    sequence
+    type(type4) :: t5
+  end type type5
+
+  type, bind(c) :: type6
+    integer :: i = 10
+  end type type6
+
+  type :: type7(k)
+    sequence
+    integer, kind :: k = 4
+    integer(kind=k) :: i = 10
+  end type type7
+
+  !{error "PGF90-S-0155-Derived type shall have the BIND attribute or the SEQUENCE attribute in COMMON - a_type1"}
+  common /comm1/ a_type1
+  !{error "PGF90-S-0155-Derived type cannot have allocatable attribute in COMMON - b_type2"}
+  common /comm2/ b_type2
+  !{error "PGF90-S-0155-Derived type cannot have allocatable attribute in COMMON - c_type3"}
+  common /comm3/ c_type3
+  !{error "PGF90-S-0155-Derived type cannot have allocatable attribute in COMMON - d_type4"}
+  common /comm4/ d_type4
+  !{error "PGF90-S-0155-Derived type cannot have allocatable attribute in COMMON - array_type5"}
+  common /comm5/ array_type5
+  !{error "PGF90-S-0155-Derived type cannot have default initialization in COMMON - e_type6"}
+  common /comm6/ e_type6
+  !{error "PGF90-S-0155-Derived type cannot have default initialization in COMMON - f_type7"}
+  common /comm7/ f_type7
+
+  type(type1) :: a_type1
+  type(type2) :: b_type2
+  type(type3) :: c_type3
+  type(type4) :: d_type4
+  type(type5) :: array_type5(5)
+  type(type6) :: e_type6
+  type(type7(4)) :: f_type7
+end

--- a/tools/flang1/flang1exe/semant.h
+++ b/tools/flang1/flang1exe/semant.h
@@ -1010,6 +1010,7 @@ void sem_fini(void);
 int gen_set_type(int dest_ast, int src_ast, int std, LOGICAL insert_before,
                  LOGICAL intrin_type);
 int mk_set_type_call(int arg0, int arg1, LOGICAL intrin_type);
+int has_init_value(SPTR);
 
 /* semant.c */
 void semant_init(int noparse);

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -5444,7 +5444,7 @@ clean_struct_default_init(int sptr)
   }
 }
 
-static int
+int
 has_init_value(SPTR sptr)
 {
   if (sptr < DTC_DEFAULT_CNT) {

--- a/tools/flang2/flang2exe/llassem.cpp
+++ b/tools/flang2/flang2exe/llassem.cpp
@@ -1674,14 +1674,20 @@ write_comm(void)
 
     first_data = 1;
     process_sptr(sptr);
-    if ((cmsym = get_ag(sptr)) == 0)
+    if ((cmsym = get_ag(sptr)) == 0) {
+      DSRTP(sptr, NULL);
       continue; /* name conflict occurred */
+    }
 
-    if (!DINITG(sptr)) /* process this only when dinit */
+    if (!DINITG(sptr)) { /* process this only when dinit */
+      DSRTP(sptr, NULL);
       continue;
+    }
 
-    if (AG_DSIZE(cmsym))
+    if (AG_DSIZE(cmsym)) {
+      DSRTP(sptr, NULL);
       continue; /* already init'd, get_ag issues error */
+    }
 
     AG_DSIZE(cmsym) = SIZEG(sptr);
 


### PR DESCRIPTION
This patch fixes two problems:
1. When two or more `COMMON` blocks with the same name have objects with default initialization, flang will execute each 
    initialization more than once. The first pass will carry out normally, whereas the others will be rejected in the `write_comm` 
    function, leaving the `DSRT` pointer un-nullified, ultimately causing a segmentation fault.
2. If a common-block-object is of a derived type, the type shall have the BIND attribute or the SEQUENCE attribute and it shall 
    have no default initialization. A common-block-object shall not be a derived-type object with an ultimate component that is 
    allocatable. flang fails to enforce the above restrictions on derived types.

This patch fixes the 2 problems above by setting `DSRT` to `NULL` at the right time and capturing/reporting the aforementioned
syntactical error.