### PR TITLE
[scutil] Fix a couple of minor compilation warnings; NFCI

### DIFF
--- a/lib/scutil/host-fp-folding.c
+++ b/lib/scutil/host-fp-folding.c
@@ -59,7 +59,9 @@ fold_sanity_check(void)
  *  C99 feature: alert the compiler that the following code cares about
  *  the dynamic floating-point environment.
  */
+#ifndef __aarch64__
 #pragma STDC FENV_ACCESS ON
+#endif
 
 /*
  *  Configure "denormal inputs are zero" and "flush denormal results to zero"

--- a/lib/scutil/legacy-folding-api.c
+++ b/lib/scutil/legacy-folding-api.c
@@ -1940,7 +1940,7 @@ xqfixu64(IEEE128 q, DBLUINT64 u)
   float128_t y;
   unwrap_q(&y, q);
   check(fold_uint64_from_real128(&x, &y));
-  wrap_l(u, &x);
+  wrap_u(u, &x);
 }
 
 void


### PR DESCRIPTION
- Do not use `STDC FENV_ACCESS` pragma on AArch64 which is not supported by GCC and Clang.
- Use unsigned wrap function for `DBLUINT64`.