### PR TITLE
Fix an ICE issue caused by const propagation

### DIFF
--- a/test/f90_correct/inc/const_prop.mk
+++ b/test/f90_correct/inc/const_prop.mk
@@ -1,0 +1,26 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test const_prop  ########
+
+
+const_prop: run
+
+build:  $(SRC)/const_prop.f90
+	-$(RM) const_prop.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) -O2 $(LDFLAGS) $(SRC)/const_prop.f90 -o const_prop.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) const_prop.$(OBJX) check.$(OBJX) $(LIBS) -o const_prop.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test dt00
+	const_prop.$(EXESUFFIX)
+
+verify: ;
+
+const_prop.run: run

--- a/test/f90_correct/lit/const_prop.sh
+++ b/test/f90_correct/lit/const_prop.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/const_prop.f90
+++ b/test/f90_correct/src/const_prop.f90
@@ -1,0 +1,20 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! test constant propagation optimization
+
+program test
+real(8) :: weight
+real(8), allocatable, dimension(:) :: a
+
+allocate(a(8))
+
+weight = 1._8
+a = weight + a
+
+write(*, *) 'PASS'
+
+end program test

--- a/tools/flang1/flang1exe/ast.c
+++ b/tools/flang1/flang1exe/ast.c
@@ -4333,7 +4333,8 @@ ast_rewrite(int ast)
       if (rank != rank1) {
         if (rank == 0)
           rank = rank1;
-        dtype = get_array_dtype(rank, DDTG(A_DTYPEG(ast)));
+        /* Make the dtype of new ast the same as the old one. */
+        dtype = dtype_with_shape(A_DTYPEG(ast), A_SHAPEG(ast));
       }
       astnew = mk_convert(lop, dtype);
     }


### PR DESCRIPTION
When an ast rewrite is performed during constant propagation optimization, we make the dtype of new ast be the same as the original.
Consider following ast tree:
```
 +-- ast:31  atype:7:convert  shape:1  dtype:58:array deferred
     nobounds (z_b_0:z_b_1) of double precision
   +-- ast:29  atype:1:ident shape:0  dtype:10:double precision
        sptr:680=weigh_cyl
```
If ast 29 is replaced by ast y, ast 31 will be rewrited to new ast x, and the dtype of new ast x should be as some as ast 31.