### PR TITLE
Hide original alias for a renamed subprogram instead of making it private

### DIFF
--- a/test/f90_correct/inc/rename01.mk
+++ b/test/f90_correct/inc/rename01.mk
@@ -1,0 +1,20 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test rename01  ########
+
+build:
+	@echo ------------------------------------ building test $(TEST)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	./$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/rename01.sh
+++ b/test/f90_correct/lit/rename01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/rename01.f90
+++ b/test/f90_correct/src/rename01.f90
@@ -1,0 +1,46 @@
+! Code based on the reproducer from https://github.com/flang-compiler/flang/issues/1014
+
+! Declare module a which contains subroutine sub
+module a
+  implicit none
+  interface sub
+    module procedure sub
+  end interface
+
+contains
+
+  subroutine sub(i)
+    implicit none
+    integer, intent(in) :: i
+
+    ! Make sure that the sub subroutine is linked and called correctly.
+    integer :: result(1)
+    integer :: expect(1)
+    result(1) = i
+    expect(1) = 10
+    call check(result, expect, 1)
+  end subroutine
+
+end module
+
+! module b uses a, so now sub is available through a and b
+module b
+  use a
+  implicit none
+  private
+  public :: sub
+end module
+
+! module c uses b - so now sub is available though a, b and c
+module c
+  use b
+  implicit none
+end module
+
+program x
+  use c, sub2=> sub ! rename sub to sub2...
+  use b             ! ... but then use b - sub is still available
+  implicit none
+
+  call sub(10) ! call sub (thanks to "use b")
+end program

--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -729,7 +729,7 @@ apply_use(MODULE_ID m_id)
         if (STYPEG(sptr) == ST_ALIAS && STYPEG(SYMLKG(sptr)) == ST_PROC) {
           /* hide original alias for a renamed subprogram */
           int s;
-          PRIVATEP(sptr, 1); /* hide original alias for a renamed subprogram */
+          HIDDENP(sptr, 1); /* hide original alias for a renamed subprogram */
           HIDDENP(SYMLKG(sptr), 1); /* hide subprogram itself,
                                          doesn't seem to be necessary */
           for (s = first_hash(sptr); s; s = HASHLKG(s)) {


### PR DESCRIPTION
Fixes https://github.com/flang-compiler/flang/issues/1014 (linker error).
Test added, based on @pawosm-arm 's reproducer, to cover the problematic scenario.

The comment in the code suggests that the symbol should be hidden, but instead it sets it to be private.

Actually, even after removing the whole "hiding" `if` clause from line 729-740 I got all tests to pass just fine and I fail to see the purpose of this code snippet at all.
However, following the golden rule of working with legacy code I propose to make the smallest possible change that fixes our issue and leave the rest of the code intact.