### PR TITLE
win: Fix io function names

### DIFF
--- a/runtime/flang/backspace.c
+++ b/runtime/flang/backspace.c
@@ -65,7 +65,7 @@ _f90io_backspace(__INT_T *unit, __INT_T *bitv, __INT_T *iostat, int swap_bytes)
   if (f->nonadvance) {
     f->nonadvance = FALSE;
 #if defined(WINNT)
-    if (__fortio_binary_mode(f->fp))
+    if (__io_binary_mode(f->fp))
       __io_fputc('\r', f->fp);
 #endif
     __io_fputc('\n', f->fp);

--- a/runtime/flang/close.c
+++ b/runtime/flang/close.c
@@ -39,7 +39,7 @@ __fortio_close(FIO_FCB *f, int flag)
   if (f->nonadvance) {
     f->nonadvance = FALSE;
 #if defined(WINNT)
-    if (__fortio_binary_mode(f->fp))
+    if (__io_binary_mode(f->fp))
       __io_fputc('\r', f->fp);
 #endif
     __io_fputc('\n', f->fp);

--- a/runtime/flang/error.c
+++ b/runtime/flang/error.c
@@ -829,7 +829,7 @@ win_set_binary(FIO_FCB *f)
 
   fil = f->fp;
   if (!__fort_isatty(__fort_getfd(fil))) {
-    __fortio_setmode_binary(fil);
+    __io_setmode_binary(fil);
   }
 }
 #endif

--- a/runtime/flang/fmtwrite.c
+++ b/runtime/flang/fmtwrite.c
@@ -2687,7 +2687,7 @@ fw_write_record(void)
         if (!(g->suppress_crlf)) {
 /* append carriage return */
 #if defined(WINNT)
-          if (__fortio_binary_mode(f->fp))
+          if (__io_binary_mode(f->fp))
             __io_fputc('\r', f->fp);
 #endif
           /*                    if (g->max_pos > 0)*/

--- a/runtime/flang/ldwrite.c
+++ b/runtime/flang/ldwrite.c
@@ -870,7 +870,7 @@ write_record(void)
     }
   } else { /* sequential write: append carriage return */
 #if defined(WINNT)
-    if (__fortio_binary_mode(fcb->fp))
+    if (__io_binary_mode(fcb->fp))
       if (FWRITE("\r", 1, 1, fcb->fp) != 1)
         return __io_errno();
 #endif

--- a/runtime/flang/nmlwrite.c
+++ b/runtime/flang/nmlwrite.c
@@ -314,7 +314,7 @@ emit_eol(void)
 
   if (!internal_file) {
 #if defined(WINNT)
-    if (__fortio_binary_mode(f->fp)) {
+    if (__io_binary_mode(f->fp)) {
       ret_err = write_char('\r');
       if (ret_err)
         return ret_err;

--- a/runtime/flang/rewind.c
+++ b/runtime/flang/rewind.c
@@ -45,7 +45,7 @@ _f90io_rewind(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
     if (f->nonadvance) {
       f->nonadvance = FALSE;
 #if defined(WINNT)
-      if (__fortio_binary_mode(f->fp))
+      if (__io_binary_mode(f->fp))
         __io_fputc('\r', f->fp);
 #endif
       __io_fputc('\n', f->fp);


### PR DESCRIPTION
Use the existing io functions such as __io_binary_mode and
__io_setmode_binary.