### PR TITLE
[flang1] Set type length for a derived type member

### DIFF
--- a/test/f90_correct/inc/string_array_pointer_6.mk
+++ b/test/f90_correct/inc/string_array_pointer_6.mk
@@ -1,0 +1,18 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build: $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/string_array_pointer_7.mk
+++ b/test/f90_correct/inc/string_array_pointer_7.mk
@@ -1,0 +1,18 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build: $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/string_array_pointer_6.sh
+++ b/test/f90_correct/lit/string_array_pointer_6.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/string_array_pointer_7.sh
+++ b/test/f90_correct/lit/string_array_pointer_7.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/string_array_pointer_6.f90
+++ b/test/f90_correct/src/string_array_pointer_6.f90
@@ -1,0 +1,38 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! Check that the type length of a string array pointer inside type is set
+! correctly when allocating it from a source.
+
+program string_array_pointer_test_6
+  implicit none
+  character(:), pointer :: array(:, :)
+  character(:), pointer :: array2(:)
+  type t1
+    character(:), pointer :: ptr(:)
+  end type t1
+  type(t1) :: var1, var2
+
+  allocate(var1%ptr(1), source = "hello world")
+  allocate(array2(1), source = "hello world")
+  allocate(var2%ptr(1), source = array2)
+  allocate(array(1, 3), source = "hello")
+
+  if (len(var1%ptr) /= 11) stop 1
+  if (len(var1%ptr(1)) /= 11) stop 2
+  if (len(array2) /= 11) stop 3
+  if (len(var2%ptr) /= 11) stop 4
+  if (len(var2%ptr(1)) /= 11) stop 5
+  if (len(array) /= 5) stop 6
+  if (all(var1%ptr /= ["hello world"])) stop 7
+  if (var1%ptr(1) /= "hello world") stop 8
+  if (array2(1) /= "hello world") stop 9
+  if (all(var2%ptr /= ["hello world"])) stop 10
+  if (var2%ptr(1) /= "hello world") stop 11
+  if (array(1, 3) /= "hello") stop 12
+
+  print *, 'PASS'
+end program

--- a/test/f90_correct/src/string_array_pointer_7.f90
+++ b/test/f90_correct/src/string_array_pointer_7.f90
@@ -1,0 +1,29 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! Check that the type length of a string array pointer inside type is set
+! correctly when pointing to a target.
+
+program string_array_pointer_test_7
+  implicit none
+  character(:), allocatable, target :: array(:)
+  type t1
+    character(:), pointer :: ptr(:)
+  end type t1
+  type(t1) :: var
+
+  allocate(array(1), source = "hello world")
+  var%ptr(1:1)=>array
+
+  if (len(array) /= 11) stop 1
+  if (len(var%ptr) /= 11) stop 2
+  if (len(var%ptr(1)) /= 11) stop 3
+  if (array(1) /= "hello world") stop 4
+  if (all(var%ptr /= ["hello world"])) stop 5
+  if (var%ptr(1) /= "hello world") stop 6
+
+  print *, 'PASS'
+end program

--- a/tools/flang1/flang1exe/dpm_out.c
+++ b/tools/flang1/flang1exe/dpm_out.c
@@ -1801,7 +1801,10 @@ emit_alnd_secd(int sptr, int memberast, LOGICAL free_flag, int std,
           sizeAst = sym_mkfunc_nodesc(mkRteRtnNm(RTE_lena), astb.bnd.dtype);
           sizeAst = begin_call(A_FUNC, sizeAst, 1);
           add_arg(target_ast);
-          ARGT_ARG(A_ARGSG(STD_AST(STD_PREV(std))), 4) = sizeAst;
+          if (STYPEG(sptr) == ST_MEMBER)
+            ARGT_ARG(A_ARGSG(STD_AST(STD_PREV(STD_PREV(std)))), 4) = sizeAst;
+          else
+            ARGT_ARG(A_ARGSG(STD_AST(STD_PREV(std))), 4) = sizeAst;
         }
       }
     }


### PR DESCRIPTION
The test case is generated from the issue #1059.
```
program testsize
  implicit none
  type t1
    character(:), pointer :: ptr(:)
  end type t1
  type(t1) :: var
  character(:), pointer :: ptr2(:)

  allocate(var%ptr(1), source="hello world")
  allocate(ptr2(3), source="hello")

  print *, var%ptr
  print *, var%ptr(1)
  print *, ptr2(3)
end program testsize
```

The breakpoint is set at function `convert_template_instance` in outconv.c, and the type descriptor set statements for `allocate(var%ptr(1), source="hello world")` are dumped as follows:
```
(gdb) b convert_template_instance
...
(gdb) p dsstds(0,0)
subprogram 1 testsize:
std:1    ast:66    lineno:9           var%ptr$sd(11_8) = 1_8
std:2    ast:67    lineno:9           var%ptr$sd(12_8) = 1_8
std:4    ast:79    lineno:9           var%ptr$sd(4_8) = 11_8
std:36   ast:191   lineno:9           call f90_template_i8(var%ptr$sd,1_8,65538_8,0_8,0_8,var%ptr$sd(11_8),var%ptr$sd(11_8) + (var%ptr$sd(12_8) - 1_8))
std:37   ast:193   lineno:9           call f90_set_intrin_type_i8(var%ptr$sd,%val(14))
std:38   ast:201   lineno:9           call fort_instance_i8(var%ptr$sd,var%ptr$sd,14_8,f90_lena(var%ptr),0_8)
std:39   ast:202   lineno:9           call f90_set_intrin_type_i8(var%ptr$sd,%val(14))
std:3    ast:75    lineno:9           allocate(var%ptr(var%ptr$sd(11_8):var%ptr$sd(11_8)+(var%ptr$sd(12_8)-1_8)), source='hello world', firstalloc)
```

The function `f90_set_intrin_type_i8` is generated twice, which is redundant. The first `f90_set_intrin_type_i8` is not necessary, and it will block the conversion of `f90_template_i8` and `fort_instance_i8` in function `convert_template_instance`. Remove the function `f90_set_intrin_type_i8` generation and the functions `f90_template_i8` and `fort_instance_i8` will be converted as follows:
```
(gdb) p dsstds(0,0)
subprogram 1 testsize:
std:1    ast:66    lineno:9           var%ptr$sd(11_8) = 1_8
std:2    ast:67    lineno:9           var%ptr$sd(12_8) = 1_8
std:4    ast:79    lineno:9           var%ptr$sd(4_8) = 11_8
std:36   ast:191   lineno:9           call f90_template1_i8(var%ptr$sd,65538_8,14_8,f90_lena(var%ptr),var%ptr$sd(11_8),var%ptr$sd(11_8) + (var%ptr$sd(12_8) - 1_8))
std:38   ast:201   lineno:9           call f90_set_intrin_type_i8(var%ptr$sd,%val(14))
std:3    ast:75    lineno:9           allocate(var%ptr(var%ptr$sd(11_8):var%ptr$sd(11_8)+(var%ptr$sd(12_8)-1_8)), source='hello world', firstalloc)
```

Now the length and kind are set for var%ptr$sd correctly.