### PR TITLE
Fix the ICE caused by source-allocating a class(*) array from an array of deferred length character strings. See issue #713.

### DIFF
--- a/test/f90_correct/inc/alloc_unpoly_str_01.mk
+++ b/test/f90_correct/inc/alloc_unpoly_str_01.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/inc/alloc_unpoly_str_02.mk
+++ b/test/f90_correct/inc/alloc_unpoly_str_02.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/alloc_unpoly_str_01.sh
+++ b/test/f90_correct/lit/alloc_unpoly_str_01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/alloc_unpoly_str_02.sh
+++ b/test/f90_correct/lit/alloc_unpoly_str_02.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/alloc_unpoly_str_01.f90
+++ b/test/f90_correct/src/alloc_unpoly_str_01.f90
@@ -1,0 +1,47 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! related to Flang github issue #713
+
+program test
+  implicit none
+  class(*), allocatable :: a
+  character(:), allocatable :: b
+  character(:), allocatable :: c
+
+  b = 'ab'
+  c = 'abc'
+  if (len(b) /= 2) stop 1
+
+  allocate(a, source = b)
+
+  select type (a)
+  type is (character(*))
+    if (len(a) /= len(b)) stop 2
+    if (a /= b) stop 3
+  class default
+    stop 4
+  end select
+  deallocate(a)
+
+  call sub(a, c)
+  print *, 'PASS'
+
+contains
+  subroutine sub(x, y)
+    class(*), allocatable :: x
+    character(:), allocatable :: y
+
+    allocate(character(len(y)) :: x)
+    select type (x)
+    type is (character(*))
+      if (len(x) /= len(y)) stop 5
+    class default
+      stop 6
+    end select
+    deallocate(x)
+  end subroutine
+end
+

--- a/test/f90_correct/src/alloc_unpoly_str_02.f90
+++ b/test/f90_correct/src/alloc_unpoly_str_02.f90
@@ -1,0 +1,51 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! related to Flang github issue #713
+
+program test
+  implicit none
+  class(*), allocatable :: a(:, :)
+  character(:), allocatable :: b(:, :)
+  character(:), allocatable :: c(:, :)
+
+  b = reshape(['ab', 'cd', 'ef', 'gh', 'ij', 'kl'], [2, 3])
+  c = reshape(['abc', 'def', 'ghi', 'jkl', 'imn', 'opq'], [3, 2])
+  if (len(b) /= 2) stop 1
+
+  allocate(a, source = b)
+
+  select type (a)
+  type is (character(*))
+    if (len(a) /= len(b)) stop 2
+    if (size(a) /= size(b)) stop 3
+    if (any(shape(a) /= shape(b))) stop 4
+    if (any(a /= b)) stop 5
+  class default
+    stop 6
+  end select
+  deallocate(a)
+
+  call sub(a, c)
+  print *, 'PASS'
+
+contains
+  subroutine sub(x, y)
+    class(*), allocatable :: x(:, :)
+    character(:), allocatable :: y(:, :)
+
+    allocate(character(len(y)) :: x(lbound(y, 1) : ubound(y, 1),&
+                                    lbound(y, 2) : ubound(y, 2)))
+    select type (x)
+    type is (character(*))
+      if (len(x) /= len(y)) stop 7
+      if (size(x) /= size(y)) stop 8
+      if (any(shape(x) /= shape(y))) stop 9
+    class default
+      stop 10
+    end select
+    deallocate(x)
+  end subroutine
+end

--- a/tools/flang1/flang1exe/semant3.c
+++ b/tools/flang1/flang1exe/semant3.c
@@ -3822,17 +3822,17 @@ errorstop_shared:
         ast = rewrite_ast_with_new_dtype(ast, dtype);
         itemp->ast = rewrite_ast_with_new_dtype(itemp->ast, dtype);
         dest = memsym_of_ast(itemp->ast);
-        if (SDSCG(dest) && DTY(dtype) == TY_CHAR && is_unl_poly(dest)) {
+        if (SDSCG(dest) && DTY(DDTG(dtype)) == TY_CHAR && is_unl_poly(dest)) {
           /* FS#20580: Set up destination descriptor where
            * unlimited polymorphic object is getting allocated
            * with a string.
            */
           int val, assn, dast;
 
-          if (string_length(dtype)) {
-            val = mk_cval1(string_length(dtype), DT_INT);
+          if (string_length(DDTG(dtype))) {
+            val = mk_cval1(string_length(DDTG(dtype)), DT_INT);
           } else {
-            val = DTY(dtype + 1);
+            val = DTY(DDTG(dtype) + 1);
           }
 
           if (val) {
@@ -4077,7 +4077,8 @@ errorstop_shared:
                   dty2 = DTY(dty2 + 1);
                   if (DTY(dest_dtype) == TY_ARRAY) {
                     int dty = DTY(dest_dtype + 1);
-                    if (DTY(dty) == TY_DERIVED && UNLPOLYG(DTY(dty + 3))) {
+                    if (DTY(dty) == TY_DERIVED && UNLPOLYG(DTY(dty + 3)) &&
+                        dty2 != DT_DEFERCHAR) {
                       new_sym = get_unl_poly_sym(dty2);
                       chkstruct(DTYPEG(new_sym));
                       dest_dtype = dup_array_dtype(dest_dtype);
@@ -4220,7 +4221,7 @@ errorstop_shared:
                                  : mk_id(get_type_descr_arg(gbl.currsub, src));
 
                   gen_init_unl_poly_desc(dast, sast, 0);
-                } else if (SDSCG(dest) && DTY(src_dtype) == TY_CHAR &&
+                } else if (SDSCG(dest) && DTY(DDTG(src_dtype)) == TY_CHAR &&
                            is_unl_poly(dest)) {
 
                   /* FS#20580: Set up destination descriptor where
@@ -4229,13 +4230,12 @@ errorstop_shared:
                    */
                   int val, assn, dty, dast, sast;
 
-                  if (string_length(src_dtype)) {
-                    val = mk_cval1(string_length(src_dtype), DT_INT);
+                  if (string_length(DDTG(src_dtype))) {
+                    val = mk_cval1(string_length(DDTG(src_dtype)), DT_INT);
                   } else {
-                    dty = src_dtype;
+                    dty = DDTG(src_dtype);
                     val = DTY(dty + 1);
                   }
-
                   if (val) {
                     dast =
                         check_member(dest_sdsc_ast, get_byte_len(SDSCG(dest)));
@@ -4254,25 +4254,27 @@ errorstop_shared:
                   assn = mk_assn_stmt(dast, val, DT_INT);
                   add_stmt(assn);
 
-                  val = mk_cval1(0, DT_INT);
-                  dast =
-                      check_member(dest_sdsc_ast, get_desc_rank(SDSCG(dest)));
-                  assn = mk_assn_stmt(dast, val, DT_INT);
-                  add_stmt(assn);
-                  dast =
-                      check_member(dest_sdsc_ast, get_desc_lsize(SDSCG(dest)));
-                  assn = mk_assn_stmt(dast, val, DT_INT);
-                  add_stmt(assn);
+                  if (DTY(src_dtype) != TY_ARRAY) {
+                    val = mk_cval1(0, DT_INT);
+                    dast =
+                        check_member(dest_sdsc_ast, get_desc_rank(SDSCG(dest)));
+                    assn = mk_assn_stmt(dast, val, DT_INT);
+                    add_stmt(assn);
+                    dast =
+                        check_member(dest_sdsc_ast, get_desc_lsize(SDSCG(dest)));
+                    assn = mk_assn_stmt(dast, val, DT_INT);
+                    add_stmt(assn);
 
-                  dast =
-                      check_member(dest_sdsc_ast, get_desc_gsize(SDSCG(dest)));
-                  assn = mk_assn_stmt(dast, val, DT_INT);
-                  add_stmt(assn);
+                    dast =
+                        check_member(dest_sdsc_ast, get_desc_gsize(SDSCG(dest)));
+                    assn = mk_assn_stmt(dast, val, DT_INT);
+                    add_stmt(assn);
 
-                  val = mk_cval1(ty_to_lib[TY_CHAR], DT_INT);
-                  dast = check_member(dest_sdsc_ast, get_kind(SDSCG(dest)));
-                  assn = mk_assn_stmt(dast, val, DT_INT);
-                  add_stmt(assn);
+                    val = mk_cval1(ty_to_lib[TY_CHAR], DT_INT);
+                    dast = check_member(dest_sdsc_ast, get_kind(SDSCG(dest)));
+                    assn = mk_assn_stmt(dast, val, DT_INT);
+                    add_stmt(assn);
+                  }
                 }
 
                 if ((dest_ast && A_TYPEG(dest_ast) == A_SUBSCR) ||


### PR DESCRIPTION
It also fixes the length parameter not being correctly assigned problem mentioned at the end of issue #713.

This patch piggybacks the logic to handle source-allocating a class(*) array from an array of deferred length character strings on the code handling source-allocating an unlimited_polymorphic array from a string.