### PR TITLE
Fix 2 bugs related to passing a polymorphic array as an argument to a function

### DIFF
--- a/test/f90_correct/inc/array_section.mk
+++ b/test/f90_correct/inc/array_section.mk
@@ -1,0 +1,26 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test array_section ########
+
+
+array_section: run
+
+build:  $(SRC)/array_section.f90
+	-$(RM) array_section.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/array_section.f90 -o array_section.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) array_section.$(OBJX) $(LIBS) -o array_section.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test array_section
+	array_section.$(EXESUFFIX)
+
+verify: ;
+
+array_section.run: run
+

--- a/test/f90_correct/inc/class.mk
+++ b/test/f90_correct/inc/class.mk
@@ -1,0 +1,26 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test class ########
+
+
+class: run
+
+build:  $(SRC)/class.f90
+	-$(RM) class.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/class.f90 -o class.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) class.$(OBJX) $(LIBS) -o class.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test class
+	class.$(EXESUFFIX)
+
+verify: ;
+
+class.run: run
+

--- a/test/f90_correct/lit/array_section.sh
+++ b/test/f90_correct/lit/array_section.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/class.sh
+++ b/test/f90_correct/lit/class.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/array_section.f90
+++ b/test/f90_correct/src/array_section.f90
@@ -1,0 +1,39 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+program p
+  type t
+    integer :: n
+  end type
+  integer :: i, j
+  type(t) :: a(10)
+  integer :: result(21), expect(21)
+  data expect /1, 2, 3, 4, 5, 6, 7, 8, 9, 10, &
+               3, 4, 5, 6, 7, 8, 9, &
+               5, 6, 7, 8 /
+  result = 0
+  j = 1
+  forall (i = 1 : 10)
+    a(i)%n = i
+  end forall
+
+  call sub1(a)
+
+  if(any(result.ne.expect)) STOP 1
+  print *,'PASS'
+
+contains
+  recursive  subroutine sub1(arr)
+    class(t), dimension(:) :: arr
+    integer :: k
+    if (size(arr) < 2) return
+
+    do k = 1, size(arr)
+      result(j) = arr(k)%n
+      j = j + 1
+    end do
+
+    call sub1(arr(3:size(arr)-1))
+  end subroutine
+end program

--- a/test/f90_correct/src/class.f90
+++ b/test/f90_correct/src/class.f90
@@ -1,0 +1,71 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+module type_def
+    implicit none
+    type, abstract :: t
+    contains
+      procedure, nopass :: recursub
+      procedure(assign_operator), deferred :: copy
+    end type t
+
+    abstract interface
+        subroutine assign_operator(left, right)
+            import :: t
+            class(t), intent(in) :: right
+            class(t), intent(inout) :: left
+        end subroutine assign_operator
+    end interface
+
+    type, extends(t) :: tt
+        integer :: m
+    contains
+      procedure :: copy => copy_sub
+    end type tt
+
+contains
+recursive subroutine recursub(array)
+    class(t), dimension(:) :: array
+    class(t), allocatable :: tmp
+    integer :: j
+
+    j = size(array)
+    allocate(tmp, source = array(1))
+    if(size(array) < 2) return
+
+    call array(1)%copy(array(j))
+    call array(j)%copy(tmp)
+
+    call recursub(array(2:j-1))
+end subroutine recursub
+
+subroutine copy_sub(left, right)
+    class(tt), intent(inout) :: left
+    class(t), intent(in) :: right
+
+    select type (right)
+        type is (tt)
+            select type (left)
+                type is (tt)
+                    left = right
+            end select
+    end select
+end subroutine copy_sub
+
+end module type_def
+
+program test
+    use type_def
+    implicit none
+    type(tt), dimension(20) :: array
+    integer, dimension(20) :: init_value
+    data init_value / 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, &
+                     11, 12, 13, 14, 15, 16, 17, 18, 19, 20 /
+
+    array%m = init_value
+    call recursub(array)
+
+    if(any(array%m .ne. init_value(20:1:-1))) STOP 1
+    print *, 'PASS'
+end program test

--- a/tools/flang1/flang1exe/dpm_out.c
+++ b/tools/flang1/flang1exe/dpm_out.c
@@ -2212,7 +2212,8 @@ set_type_in_descriptor(int descriptor_ast, int sptr, DTYPE dtype0,
     int argt = mk_argt(2), astnew;
     int func_ast = mk_id(sym_mkfunc_nodesc(mkRteRtnNm(func), DT_NONE));
     ARGT_ARG(argt, 0) = descriptor_ast;
-    ARGT_ARG(argt, 1) = type_ast;
+    ARGT_ARG(argt, 1) = (SCG(sptr) == SC_DUMMY && CLASSG(sptr)) ?
+                        mk_id(get_type_descr_arg(gbl.currsub, sptr)) : type_ast;
     astnew = mk_func_node(A_CALL, func_ast, 2, argt);
     add_stmt_before(astnew, before_std);
   }
@@ -3917,8 +3918,10 @@ make_simple_template_from_ast(int ast, int std, LOGICAL need_type_in_descr)
         glb = diff_lbnd(dtype, i, glb, descr);
         gub = diff_lbnd(dtype, i, gub, descr);
       }
-      ARGT_ARG(argt, cargs++) = astb.bnd.zero;
-      ARGT_ARG(argt, cargs++) = mk_binop(OP_SUB, gub, glb, astb.bnd.dtype);
+      ARGT_ARG(argt, cargs++) = astb.bnd.one;
+      ARGT_ARG(argt, cargs++) = mk_binop(OP_ADD, mk_binop(OP_SUB,
+                                                 gub, glb, astb.bnd.dtype),
+                                         astb.bnd.one, astb.bnd.dtype);
       ++j;
     }
   }

--- a/tools/flang1/flang1exe/rest.c
+++ b/tools/flang1/flang1exe/rest.c
@@ -879,6 +879,9 @@ transform_section_arg(int ele, int std, int callast, int entry, int *descr,
       sec = make_simple_template_from_ast(secss, std,
                                           needs_type_in_descr(entry, argnbr));
       retval = first_element_from_section(ele);
+      if (SCG(sptr) == SC_DUMMY && CLASSG(sptr)) {
+        retval = gen_poly_element_arg(retval, sptr, std);
+      }
       if (POINTERG(sptr) && is_whole_array(ele)) {
         retval = A_LOPG(retval);
       }
@@ -1609,7 +1612,14 @@ transform_call(int std, int ast)
              * compute its address based on the polymorphic size of the
              * object.
              */
-             ARGT_ARG(newargt, newi) = gen_poly_element_arg(ele, sptr, std);
+            /* Use temporary variable instead of assign directly.
+             * Compiling with gcc may cause the direct assignment to fail,
+             * but clang not. because the function gen_poly_element_arg()
+             * will change astb.argt.stg_base in mk_argt() when there are not
+             * enough room for "argt".
+             */
+            int element_addr = gen_poly_element_arg(ele, sptr, std);
+            ARGT_ARG(newargt, newi) = element_addr;
           } else if (A_TYPEG(ele) == A_SUBSCR) {
             /* This case occurs when we branch from
              * the A_SUBSCR case below to the class_arg label above.


### PR DESCRIPTION
This patch fixes 2 errors:
1. When a polymorphic array is passed as an argument, flang directly uses the element type in the declaration statement of the dummy array to create the function calling node.
2. When a section of a polymorphic array is passed as an argument, flang doesn't get the first element correctly.

This patch fixes the 1st bug by adding a new ast node to obtain the actual element type if necessary and it fixes the 2nd error by calling `get_poly_element_arg` to get the correct first element.