### PR TITLE
Fix errors related to empty structure constructors nested in an array constructor.

### DIFF
--- a/test/f90_correct/inc/empty_type_01.mk
+++ b/test/f90_correct/inc/empty_type_01.mk
@@ -1,0 +1,20 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/empty_type_01.sh
+++ b/test/f90_correct/lit/empty_type_01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/empty_type_01.f90
+++ b/test/f90_correct/src/empty_type_01.f90
@@ -1,0 +1,40 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! test for empty type.
+
+module m
+implicit none
+  type empty
+  end type empty
+contains
+  integer function func(a)
+    type(empty), intent(in) :: a(:)
+    character(10) :: str = 'abcdefghij'
+    write(str, *) a
+    if (str /= '') STOP 1
+    func = size(a)
+  end
+end module m
+
+program test
+    use m
+    implicit none
+    integer, parameter :: n = 3
+    integer :: rst(n), expect(n)
+    type(empty), parameter :: e1 = empty()
+    type(empty), parameter :: e3(3) = [empty(), empty(), e1]
+
+    rst = 0
+    expect(1) = 1
+    expect(2) = 2
+    expect(3) = 3
+
+    rst(1) = func([empty()])
+    rst(2) = func([empty(), e1])
+    rst(3) = func(e3)
+
+    call check(rst, expect, n)
+end program test

--- a/tools/flang1/flang1exe/dinit.c
+++ b/tools/flang1/flang1exe/dinit.c
@@ -331,9 +331,11 @@ dinit_data(VAR *ivl, ACL *ict, int dtype)
           int ni; /* number of elements consumed by a constant */
 
           ni = 1;
-          if (ivl && DTY(ivl->u.varref.dtype) == TY_DERIVED && !POINTERG(sptr))
+          if (ivl && DTY(ivl->u.varref.dtype) == TY_DERIVED &&
+              !is_zero_size_typedef(ivl->u.varref.dtype) && !POINTERG(sptr))
             dinit_data(ivl->u.varref.subt, ict->subc, ict->dtype);
-          else if (member && DTY(ict->dtype) == TY_DERIVED && !POINTERG(sptr))
+          else if (member && DTY(ict->dtype) == TY_DERIVED &&
+                   !is_zero_size_typedef(ict->dtype) && !POINTERG(sptr))
             if (ict->subc) {
               /* derived type member-by-member initialization */
               dinit_data(NULL, ict->subc, ict->dtype);

--- a/tools/flang1/flang1exe/dtypeutl.c
+++ b/tools/flang1/flang1exe/dtypeutl.c
@@ -422,6 +422,27 @@ is_empty_typedef(DTYPE dtype)
   return FALSE;
 }
 
+/** \brief Check for special case of zero-size typedef which may nest have
+    zero-size typedef compnents or zero-size array compnents.
+ */
+LOGICAL
+is_zero_size_typedef(DTYPE dtype)
+{
+  if (dtype <= DT_NONE)
+    return FALSE;
+  dtype = is_array_dtype(dtype) ? DTY(dtype + 1) : dtype;
+
+  switch (DTY(dtype)) {
+  case TY_DERIVED:
+  case TY_UNION:
+  case TY_STRUCT:
+    return (DTY(dtype + 2) == 0);
+  default:
+    return FALSE;
+  }
+  return FALSE;
+}
+
 static LOGICAL
 is_recursive_dtype(int sptr, struct visit_list **visited)
 {

--- a/tools/flang1/flang1exe/dtypeutl.h
+++ b/tools/flang1/flang1exe/dtypeutl.h
@@ -17,6 +17,7 @@ int target_kind(DTYPE dtype);
 ISZ_T size_of(DTYPE dtype);
 int string_length(DTYPE dtype);
 LOGICAL is_empty_typedef(DTYPE dtype);
+LOGICAL is_zero_size_typedef(DTYPE dtype);
 LOGICAL no_data_components(DTYPE dtype);
 ISZ_T size_of_var(int sptr);
 INT size_ast(int sptr, DTYPE dtype);

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -4794,7 +4794,7 @@ rewrite_acl(ACL *aclp, DTYPE dtype, int parent_acltype)
   ACL *prev_aclp = NULL;
   ACL *ret_aclp = aclp;
   ACL *sav_aclp = NULL;
-  if (no_data_components(dtype)) {
+  if (no_data_components(dtype) && !is_zero_size_typedef(dtype)) {
     return 0;
   }
   if (parent_acltype == AC_SCONST) {
@@ -4866,7 +4866,7 @@ rewrite_acl(ACL *aclp, DTYPE dtype, int parent_acltype)
     case AC_TYPEINIT:
       wrk_aclp->subc =
           rewrite_acl(cur_aclp->subc, cur_aclp->dtype, cur_aclp->id);
-      if (!wrk_aclp->subc) {
+      if (!wrk_aclp->subc && !is_zero_size_typedef(wrk_dtype)) {
         return 0;
       }
       if (DTY(wrk_dtype) == TY_ARRAY && parent_acltype != AC_ACONST) {

--- a/tools/flang2/flang2exe/dinit.cpp
+++ b/tools/flang2/flang2exe/dinit.cpp
@@ -579,7 +579,8 @@ dinit_varref(VAR *ivl, SPTR member, CONST *ict, DTYPE dtype,
     *repeat = ict->repeatc;
   }
   do {
-    if (no_data_components(DDTG(DTYPEG(sptr)))) {
+    if (no_data_components(DDTG(DTYPEG(sptr))) &&
+        !is_zero_size_typedef(DDTG(DTYPEG(sptr)))) {
       break;
     }
     if (ict == NULL) {
@@ -607,6 +608,8 @@ dinit_varref(VAR *ivl, SPTR member, CONST *ict, DTYPE dtype,
           if (DTY(DTYPEG(sptr)) == TY_ARRAY && offset) {
             dinit_put(DINIT_OFFSET, offset);
             dinit_data(NULL, ict->subc, ict->dtype, 0);
+          } else if (is_zero_size_typedef(DDTG(ivl->u.varref.dtype))) {
+            dinit_put(DINIT_OFFSET, offset);
           } else {
             dinit_data(NULL, ict->subc, ict->dtype, offset);
           }
@@ -5405,7 +5408,7 @@ eval_init_expr_item(CONST *cur_e)
   case AC_SCONST:
     new_e = clone_init_const(cur_e, true);
     new_e->subc = eval_init_expr(new_e->subc);
-    if (new_e->subc->dtype == cur_e->dtype) {
+    if (new_e->subc && new_e->subc->dtype == cur_e->dtype) {
       new_e->subc = new_e->subc->subc;
     }
     break;
@@ -5430,7 +5433,7 @@ eval_init_expr(CONST *e)
     case AC_SCONST:
       new_e = clone_init_const(cur_e, true);
       new_e->subc = eval_init_expr(new_e->subc);
-      if (new_e->subc->dtype == cur_e->dtype) {
+      if (new_e->subc && new_e->subc->dtype == cur_e->dtype) {
         new_e->subc = new_e->subc->subc;
       }
       break;

--- a/tools/flang2/flang2exe/dtypeutl.cpp
+++ b/tools/flang2/flang2exe/dtypeutl.cpp
@@ -138,6 +138,19 @@ is_empty_typedef(DTYPE dtype)
   return (mem <= NOSYM);
 }
 
+bool
+is_zero_size_typedef(DTYPE dtype)
+{
+  if (dtype <= DT_NONE)
+    return false;
+  dtype = is_array_dtype(dtype) ? DTySeqTyElement(dtype) : dtype;
+
+  if (DTY(dtype) != TY_UNION && DTY(dtype) != TY_STRUCT)
+    return false;
+
+  return (DTyAlgTySize(dtype) == 0);
+}
+
 static bool
 is_recursive(int sptr, struct visit_list **visited)
 {

--- a/tools/flang2/flang2exe/dtypeutl.h
+++ b/tools/flang2/flang2exe/dtypeutl.h
@@ -63,6 +63,11 @@ bool is_array_dtype(DTYPE dtype);
  */
 bool is_empty_typedef(DTYPE dtype);
 
+/** \brief Check for special case of zero-size typedef which may nest have
+    zero-size typedef compnents or zero-size array compnents.
+ */
+bool is_zero_size_typedef(DTYPE dtype);
+
 /**
    \brief ...
  */

--- a/tools/flang2/flang2exe/llassem.cpp
+++ b/tools/flang2/flang2exe/llassem.cpp
@@ -584,6 +584,10 @@ get_struct_from_dsrt2(SPTR sptr, DSRT *dsrtp, ISZ_T size, int *align8,
 
   for (; dsrtp; dsrtp = dsrtp->next) {
     loc_base = dsrtp->offset; /* assumes this is a DINIT_LOC */
+
+    if (is_zero_size_typedef(DDTG(DTYPEG(dsrtp->sptr))))
+      continue;
+
     if (dsrtp->sectionindex != DATA_SEC) {
       switch (dsrtp->sectionindex) {
       case NVIDIA_FATBIN_SEC:
@@ -1285,6 +1289,10 @@ process_dsrt(DSRT *dsrtp, ISZ_T size, char *cptr, bool stop_at_sect, ISZ_T addr)
     } else {
       is_char = false;
     }
+
+    if (is_zero_size_typedef(DDTG(DTYPEG(dsrtp->sptr))))
+      continue;
+
     if (dsrtp->sectionindex != DATA_SEC) {
       gbl.func_count = dsrtp->func_count;
     } else {
@@ -2833,6 +2841,11 @@ dinits(void)
           break;
         if (dsrtp->offset == item->offset) {
           int sptr = dsrtp->sptr;
+
+          if (is_zero_size_typedef(DDTG(DTYPEG(sptr))) ||
+              is_zero_size_typedef(DDTG(DTYPEG(item->sptr))))
+            continue;
+
           if (sptr && DTY(DTYPEG(sptr)) == TY_ARRAY && SCG(sptr) == SC_STATIC &&
               extent_of(DTYPEG(sptr)) == 0)
             goto Continue;


### PR DESCRIPTION
The problem occurs：
    1.When an array constructor with an empty structure constructor is passed as an argument to a function，flang2 will generate wrong IR to use an undefined type named 'struct.STATICS*';
    2.When an array constructor has several empty structure constructors, semantic analysis handling the empty structure construct will be prevented with bogus error "F90-S-0069-Illegal implied DO expression".

This patch fixes the 1st bug by skipping over unnecessary processing when the element type is an empty drived data type in flang2. This patch fixes the 2nd bug by not processing the components in the function `dinit_data` from file 'dinit.c' and returning the real ACL pointer instead of 0 in `rewrite_acl` from file 'semutil2.c'.