### PR TITLE
Fix bugs pertaining to an array constructor with an implied-do containing an expression that is a function call returning an array.

### DIFF
--- a/runtime/flang/allo.c
+++ b/runtime/flang/allo.c
@@ -936,6 +936,37 @@ ENTF90(ALLOC03_CHK, alloc03_chk)(__INT_T *nelem, __INT_T *kind, __INT_T *len,
 }
 
 void
+ENTF90(REALLOC_ARR_IN_IMPLIED_DO, realloc_arr_in_impiled_do)(char **ptr,
+                         F90_Desc *ad, F90_Desc *dd)
+{
+  int i, total_extent;
+  char *tmp = NULL;
+  __NELEM_T old_size;
+
+  if (F90_LSIZE_G(dd) * F90_LEN_G(dd) <= 0)
+    return; /* no need to realloc */
+
+  old_size = F90_LSIZE_G(ad) * F90_LEN_G(ad);
+  total_extent = 1;
+  for (i = 0; i < F90_RANK_G(dd) ; i++) {
+    total_extent *= F90_DIM_EXTENT_G(dd, i);
+  }
+
+  F90_LSIZE_G(ad) += F90_LSIZE_G(dd);
+  F90_GSIZE_G(ad) += F90_GSIZE_G(dd);
+
+  ad->dim[0].extent += total_extent;
+
+  (void)I8(__fort_allocate)(F90_LSIZE_G(ad), F90_KIND_G(ad), F90_LEN_G(ad), 0,
+                            &tmp, 0);
+  if (old_size > 0)
+    __fort_bcopy(tmp, *ptr, old_size);
+
+  I8(__fort_deallocate)(*ptr);
+  *ptr = tmp;
+}
+
+void
 ENTF90(ALLOC04A, alloc04a)(__NELEM_T *nelem, __INT_T *kind, __INT_T *len,
                          __STAT_T *stat, char **pointer, __POINT_T *offset,
                          __INT_T *firsttime, __NELEM_T *align,

--- a/test/f90_correct/inc/implied_do1.mk
+++ b/test/f90_correct/inc/implied_do1.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/implied_do1.sh
+++ b/test/f90_correct/lit/implied_do1.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/implied_do1.f90
+++ b/test/f90_correct/src/implied_do1.f90
@@ -1,0 +1,70 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for implied-do containing function call
+
+program p
+  implicit none
+  integer :: i, j
+  integer :: cmp1(12) = [5, 10, 1, 5, 10, 2, 2, 5, 10, 3, 3, 3]
+  integer :: cmp2(12) = [5, 10, 1, 1, 5, 10, 2, 2, 5, 10, 3, 3]
+  integer :: cmp3(17) = [3, 4, 1, 3, 4, 2, 2, 3, 4, 2, 2, 3, 4, 4, 4, 4, 4]
+
+  if (size(cmp1) /= size((/ ((/ 5, 10, gen (i) /), i = 1, 3) /))) &
+    STOP 1
+  if (any(shape(cmp1) /= shape((/ ((/ 5, 10, gen (i) /), i = 1, 3) /)))) &
+    STOP 2
+  if (any(lbound(cmp1) /= lbound((/ ((/ 5, 10, gen (i) /), i = 1, 3) /)))) &
+    STOP 3
+  if (any(ubound(cmp1) /= ubound((/ ((/ 5, 10, gen (i) /), i = 1, 3) /)))) &
+    STOP 4
+  if (any(cmp1 /= (/ ((/ 5, 10, gen (i) /), i = 1, 3) /))) &
+    STOP 5
+
+  if (size(cmp2) /= size((/ ((/ 5, 10, gen2 (i) /), i = 1, 3) /))) &
+    STOP 6
+  if (any(shape(cmp2) /= shape((/ ((/ 5, 10, gen2 (i) /), i = 1, 3) /)))) &
+    STOP 7
+  if (any(lbound(cmp2) /= lbound((/ ((/ 5, 10, gen2 (i) /), i = 1, 3) /)))) &
+    STOP 8
+  if (any(ubound(cmp2) /= ubound((/ ((/ 5, 10, gen2 (i) /), i = 1, 3) /)))) &
+    STOP 9
+  if (any(cmp2 /= (/ ((/ 5, 10, gen2 (i) /), i = 1, 3) /))) &
+    STOP 10
+
+  if (size(cmp3) /= size((/((3, 4, gen3(i, j), i = 1, 2), j = 1, 2)/))) &
+    STOP 11
+  if (any(shape(cmp3) /= shape((/((3, 4, gen3(i, j), i = 1, 2), j = 1, 2)/)))) &
+    STOP 12
+  if (any(lbound(cmp3) /= lbound((/((3, 4, gen3(i, j), i = 1, 2), j = 1, 2)/)))) &
+    STOP 13
+  if (any(ubound(cmp3) /= ubound((/((3, 4, gen3(i, j), i = 1, 2), j = 1, 2)/)))) &
+    STOP 14
+  if (any(cmp3 /= (/((3, 4, gen3(i, j), i = 1, 2), j = 1, 2)/))) &
+    STOP 15
+
+  print *, "PASS"
+contains
+  function gen (n) result(z)
+    integer, dimension (:), pointer :: z
+    integer :: n
+    allocate (z (n))
+    z = n
+  end function gen
+
+  function gen2 (n) result(z)
+    integer, dimension (2) :: z
+    integer :: n
+    z = n
+  end function gen2
+
+  function gen3(n1, n2) result(z)
+    integer, pointer :: z(:,:)
+    integer :: n1, n2
+    allocate(z(n1, n2))
+    z = n1*n2
+  end function gen3
+
+end program

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -990,6 +990,7 @@ typedef struct {
   int indx_tmpid[MAXDIMS];  /* id ast of subscripting temporary */
   int level;                /* implied do nesting level */
   int width;
+  LOGICAL func_in_do;       /* func call found in ac-value-list */
 } _ACS;
 
 static _ACS acs;
@@ -1668,10 +1669,25 @@ init_sptr_w_acl(int in_sptr, ACL *aclp)
     /* converts AC_AST to AC_IEXPR. */
     aclp->subc = rewrite_acl(aclp->subc, aclp->dtype, aclp->id);
   } else {
+    int std;
     if (sem.arrdim.ndefer) {
       ALLOCATE_ARRAYS = 0; /* allocate for these array temps is done here */
     }
 
+    if (sem.arrdim.ndefer && sem.arrfn.sptr > NOSYM &&
+        sem.arrfn.return_value &&
+        ADD_DEFER(A_DTYPEG(sem.arrfn.return_value)) &&
+        aclp->id == AC_ACONST && aclp->subc->id == AC_IDO) {
+      /* The ACL is an array constructor that contains implied-do loop, and
+       * there is a function call that returns a deferred-length array.
+       * Create an allocatable array temp in case of that the function call
+       * appears in the loop body and causes the size of the resulting array to
+       * be determined at runtime.
+       */
+      sptr = acs.tmp = get_adjlr_arr_temp(acs.arrtype);
+      get_static_descriptor(acs.tmp);
+      get_all_descriptors(acs.tmp);
+    } else
       sptr = acs.tmp = get_arr_temp(acs.arrtype, FALSE, FALSE, FALSE);
     ALLOCATE_ARRAYS = 1;
     if (sem.arrdim.ndefer) {
@@ -1680,11 +1696,41 @@ init_sptr_w_acl(int in_sptr, ACL *aclp)
       /* assign values to the bounds temporaries and allocate the
        * array.
        */
+      std = STD_PREV(0);
       gen_allocate_array(acs.tmp);
+      std = STD_NEXT(std);
     }
 
+    acs.func_in_do = FALSE;
     /* generate code to assign aclp values to the temporary */
     constructf90(acs.tmp, aclp);
+
+    /* If the function call returns a deferred-length array and appears in the
+     * loop body, the bounds of the function return array is uninitialized when
+     * used in the allocation of array temp. Here we set the function return
+     * array to be zero-sized before the allocation.
+     */
+    if (acs.func_in_do && sem.arrdim.ndefer &&
+        SDSCG(A_SPTRG(sem.arrfn.return_value))) {
+      int sdsc, dtype, i;
+
+      sdsc = SDSCG(A_SPTRG(sem.arrfn.return_value));
+      dtype = A_DTYPEG(sem.arrfn.return_value);
+      for (i = 0; i < ADD_NUMDIM(dtype); i++) {
+        int lb = lbound_of(dtype, i);
+        int extnt = ADD_EXTNTAST(dtype, i);
+        assert(A_TYPEG(lb) == A_SUBSCR, "init_sptr_w_acl: lb not subs", lb,
+               ERR_Fatal);
+        assert(memsym_of_ast(lb) == sdsc, "init_sptr_w_acl: lb not sdsc", lb,
+               ERR_Fatal);
+        assert(A_TYPEG(extnt) == A_SUBSCR, "init_sptr_w_acl: extnt not subs",
+               extnt, ERR_Fatal);
+        assert(memsym_of_ast(extnt) == sdsc, "init_sptr_w_acl: extnt not sdsc",
+               extnt, ERR_Fatal);
+        (void)add_stmt_before(mk_assn_stmt(lb, astb.bnd.one, astb.bnd.dtype), std);
+        (void)add_stmt_before(mk_assn_stmt(extnt, astb.bnd.zero, astb.bnd.dtype), std);
+      }
+    }
     acs.tmp = sptr; /* if we recursed, asc.tmp may have changed */
   }
 
@@ -2630,6 +2676,8 @@ _constructf90(int base_id, int in_indexast, bool in_array, ACL *aclp)
   int indexast;
   INT cnt;
   LOGICAL sdscismbr;
+  int argt = 0;
+  int argt_count = 0;
 
   indexast = in_indexast;
 
@@ -2948,6 +2996,40 @@ _constructf90(int base_id, int in_indexast, bool in_array, ACL *aclp)
           ast = ast_rewrite_indices(ast);
           (void)add_stmt(ast);
           break;
+        }
+
+        /* In the loop generated from implied-do loop, we encoutered the AST
+         * used as the return value to replace the function call.
+         */
+        if (acs.level && sem.arrfn.sptr > NOSYM &&
+            sem.arrfn.return_value == SST_ASTG(stkp)) {
+          acs.func_in_do = TRUE;
+          if (sem.arrfn.call_std) {
+            /* The function call stmt generated in func_call2() was added
+             * outside the loop generated from implied-do loop, we should move
+             * the call stmt into loop.
+             */
+            ast = STD_AST(sem.arrfn.call_std);
+            ast = ast_rewrite_indices(ast);
+            (void)add_stmt(ast);
+            remove_stmt(sem.arrfn.call_std);
+            sem.arrfn.call_std = 0;
+          }
+          if (ADD_DEFER(SST_DTYPEG(stkp)) && SDSCG(A_SPTRG(SST_ASTG(stkp)))) {
+            /* If the function call returns deferred-length array, we use the
+             * sum of the current length of the array temp and the length of
+             * the array returned by the function as the length of the array
+             * temp after reallocation.
+             */
+            argt_count = 3;
+            argt = mk_argt(argt_count);
+            ARGT_ARG(argt, 0) = mk_id(MIDNUMG(memsym_of_ast(base_id)));
+            ARGT_ARG(argt, 1) = mk_id(SDSCG(memsym_of_ast(base_id)));
+            ARGT_ARG(argt, 2) = mk_id(SDSCG(A_SPTRG(SST_ASTG(stkp))));
+            ast = mk_func_node(A_CALL, mk_id(sym_mkfunc(mkRteRtnNm(
+                RTE_realloc_arr_in_impiled_do), DT_ADDR)), argt_count, argt);
+            (void)add_stmt(ast);
+          }
         }
 
         tmpid = get_subscripting_tmp(indexast);

--- a/tools/shared/rtlRtns.c
+++ b/tools/shared/rtlRtns.c
@@ -298,6 +298,7 @@ FtnRteRtn ftnRtlRtns[] = {
     {"real16", "", false, ""},
     {"real4", "", false, ""},
     {"real8", "", false, ""},
+    {"realloc_arr_in_impiled_do", "", true, ""},
     {"repeata", "", false, ""},
     {"rrspacing", "", false, ""},
     {"rrspacingd", "", false, ""},

--- a/tools/shared/rtlRtns.h
+++ b/tools/shared/rtlRtns.h
@@ -303,6 +303,7 @@ typedef enum {
   RTE_real16,
   RTE_real4,
   RTE_real8,
+  RTE_realloc_arr_in_impiled_do,
   RTE_repeata,
   RTE_rrspacing,
   RTE_rrspacingd,


### PR DESCRIPTION
When an implied-do loop in an array constructor contains in its value list a function call that returns an array, flang at present handles the function call once outside the loop and then inserts the returned values into the final array repeatedly during the loop, causing wrong result.

This patch fixes the bug by invoking the function and inserting the results in each iteration of the loop.