### PR TITLE
[flang1] Fix bug in poly str pointer

### DIFF
--- a/test/f90_correct/inc/poly_ptr_to_str_1.mk
+++ b/test/f90_correct/inc/poly_ptr_to_str_1.mk
@@ -1,0 +1,27 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test poly_ptr_to_str_1  ########
+
+
+poly_ptr_to_str_1: run
+
+
+build:  $(SRC)/poly_ptr_to_str_1.f90
+	-$(RM) poly_ptr_to_str_1.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/poly_ptr_to_str_1.f90 -o poly_ptr_to_str_1.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) poly_ptr_to_str_1.$(OBJX) -o poly_ptr_to_str_1.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test poly_ptr_to_str_1
+	poly_ptr_to_str_1.$(EXESUFFIX)
+
+verify: ;
+
+poly_ptr_to_str_1.run: run
+

--- a/test/f90_correct/inc/poly_ptr_to_str_2.mk
+++ b/test/f90_correct/inc/poly_ptr_to_str_2.mk
@@ -1,0 +1,27 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test poly_ptr_to_str_2  ########
+
+
+poly_ptr_to_str_2: run
+
+
+build:  $(SRC)/poly_ptr_to_str_2.f90
+	-$(RM) poly_ptr_to_str_2.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/poly_ptr_to_str_2.f90 -o poly_ptr_to_str_2.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) poly_ptr_to_str_2.$(OBJX) -o poly_ptr_to_str_2.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test poly_ptr_to_str_2
+	poly_ptr_to_str_2.$(EXESUFFIX)
+
+verify: ;
+
+poly_ptr_to_str_2.run: run
+

--- a/test/f90_correct/lit/poly_ptr_to_str_1.sh
+++ b/test/f90_correct/lit/poly_ptr_to_str_1.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/poly_ptr_to_str_2.sh
+++ b/test/f90_correct/lit/poly_ptr_to_str_2.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/poly_ptr_to_str_1.f90
+++ b/test/f90_correct/src/poly_ptr_to_str_1.f90
@@ -1,0 +1,31 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Checking for polymorphic pointer inside type pointing to string target.
+
+program poly_ptr_to_str_1
+
+  type t
+    class(*), pointer :: val
+  end type t
+
+  type(t) :: x
+  character(:), allocatable :: s
+  character(3), target :: a = 'foo'
+
+  x%val => a
+
+  select type (val => x%val)
+  type is (character(*))
+    s = val
+  end select
+
+  if (.not.allocated(s)) stop 1
+  if (len(s) /= 3) stop 2
+  if (s /= 'foo') stop 3
+
+  write(*, *) 'PASS'
+end
+

--- a/test/f90_correct/src/poly_ptr_to_str_2.f90
+++ b/test/f90_correct/src/poly_ptr_to_str_2.f90
@@ -1,0 +1,33 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Checking for polymorphic pointer inside type pointing to string pointer.
+
+program poly_ptr_to_str_2
+
+  type t
+    class(*), pointer :: val
+  end type t
+
+  type(t) :: x
+  character(3), target :: a = 'foo'
+  character(:), pointer :: b
+  character(:), allocatable :: s
+
+  b => a
+  x%val => b
+
+  select type (val => x%val)
+  type is (character(*))
+    s = val
+  end select
+
+  if (.not.allocated(s)) stop 1
+  if (len(s) /= 3) stop 2
+  if (s /= 'foo') stop 3
+
+  write(*, *) 'PASS'
+end
+

--- a/tools/flang1/flang1exe/symutl.c
+++ b/tools/flang1/flang1exe/symutl.c
@@ -77,7 +77,7 @@ get_next_sym_dt(const char *basename, const char *purpose, int encldtype)
 int
 get_len_of_deferchar_ast(int ast)
 {
-  int sdsc, sdsc_ast;
+  int sdsc, sdsc_ast, sptr;
   int sdscofmem_ast;
   int first;
   int subs[1];
@@ -94,8 +94,13 @@ get_len_of_deferchar_ast(int ast)
     return get_byte_len(sdsc);
   }
 
-  /* this can be done partly by calling check_member() */
-  sdsc = SDSCG(A_SPTRG(A_MEMG(first)));
+  /* The length is set in type descriptor for a polymorphic derived type
+   * member, and it is set in section descriptor for other cases. */
+  sptr = A_SPTRG(A_MEMG(first));
+  if (CLASSG(sptr))
+    sdsc = get_member_descriptor(sptr);
+  else
+    sdsc = SDSCG(sptr);
   sdsc_ast = mk_id(sdsc);
   sdscofmem_ast = mk_member(A_PARENTG(first), sdsc_ast, A_DTYPEG(sdsc_ast));
 


### PR DESCRIPTION
This patch fixes the bug in polymorphic string pointer when the polymorphic variable is a derived member.
```
program poly_ptr_to_str_2
  type t
    class(*), pointer :: val
  end type t
  type(t) :: x
  character(3), target :: a = 'foo'
  character(:), pointer :: b
  character(:), allocatable :: s

  b => a
  x%val => b
  select type (val => x%val)
  type is (character(*))
    s = val
  end select
end
```

The statements are dumped with breakpoint set at function `lower` as follows:
```
(gdb) b lower
...
(gdb) p dsstds(0,0)
subprogram 1 poly_ptr_to_str_2:
std:1    ast:22    lineno:17          b$sd(4_8) = 3_8
std:2    ast:23    lineno:17          call .ptr2_assign(b,b$sd,a,14_8,0_8)
std:3    ast:34    lineno:18          x%val$sd(4_8) = len(b)
std:21   ast:84    lineno:18          if (loc(x) .ne. 0_8) call f90_set_intrin_type_i8(x%val$td,%val(14))
std:4    ast:35    lineno:18          call .ptr2_assign(x%val,val$sd,b,33_8,0_8)
std:5    ast:43    lineno:19          call f90_init_unl_poly_desc_i8(val$sd1,x%val$td,%val(43))
std:22   ast:89    lineno:19          if (loc(x) .ne. 0_8) call f90_set_type_i8(val$sd1,x%val$td)
std:6    ast:44    lineno:19          call .ptr2_assign(val,val$sd1,x%val,33_8,0_8)
std:23   ast:90    lineno:19          call f90_init_unl_poly_desc_i8(val$sd1,x%val$td,%val(43))
std:7    ast:47    lineno:19          val$sd1(4_8) = x%val$td(4_8)
std:15   ast:71    lineno:19          z_d_0 = f90_same_intrin_type_as_i8(val,val$sd1,%val(0),%val(14),%val(1),poly_ptr_to_str_2$$$$$_f03_unl_poly$0$$$$td)
std:16   ast:73    lineno:19          if (z_d_0 .eq. -1) goto 99998
std:9    ast:49    lineno:20          goto 99999
std:10   ast:51    lineno:20          continue
std:11   ast:53    lineno:20          call .ptr2_assign(val,val$sd4,val,14_8,0_8)
std:12   ast:57    lineno:20          val$sd4(3_8) = 14
std:13   ast:59    lineno:20          val$sd4(4_8) = val$sd1(4_8)
std:25   ast:93    lineno:21          if (allocated(s)) then
std:26   ast:96    lineno:21          if (len(s) .ne. len(val)) then
std:27   ast:100   lineno:21          deallocate(s)
std:28   ast:103   lineno:21          s$sd(4_8) = len(val)
std:29   ast:104   lineno:21          allocate(s, firstalloc)
std:30   ast:105   lineno:21          endif
std:31   ast:106   lineno:21          else
std:32   ast:107   lineno:21          s$sd(4_8) = len(val)
std:33   ast:108   lineno:21          allocate(s, firstalloc)
std:34   ast:111   lineno:21          call f90_set_intrin_type_i8(s$sd,%val(14_8))
std:35   ast:112   lineno:21          endif
std:14   ast:62    lineno:21          s = val
std:17   ast:76    lineno:22          continue
std:20   ast:78    lineno:29          continue
std:19   ast:77    lineno:29          end
$1 = void
```

The third statement `x%val$sd(4_8) = len(b)` assigns the string length info into the section descriptor of `x%val`. However, the type descriptor `x%val$td` is used to initialize the unlimited polymorphic descriptor in fifth statement. So, the type descriptor `x%val$td` should be used to store the type info of string when the polymorphic variable is a derived member.