### PR TITLE
[DebugInfo] Suppress debugloc for actual argument bitcast

### DIFF
--- a/test/debug_info/procedure_argument.f90
+++ b/test/debug_info/procedure_argument.f90
@@ -1,0 +1,31 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! check function pointer bitcast instructions should not have debug location
+!CHECK-NOT: bitcast i32* @.C{{[0-9]+}}_example_func to i64*, !dbg {{![0-9]+}}
+!CHECK-NOT: bitcast i32* @.C{{[0-9]+}}_example_func1 to i8*, !dbg {{![0-9]+}}
+!CHECK-NOT: bitcast [8 x i8]* @.C{{[0-9]+}}_example_func1 to i8*, !dbg {{![0-9]+}}
+!CHECK-NOT: bitcast void ()* @f90io_src_info03a to void (i8*, i8*, i64)*, !dbg {{![0-9]+}}
+!CHECK-NOT: bitcast i32 ()* @f90io_print_init to i32 (i8*, i8*, i8*, i8*)*, !dbg {{![0-9]+}}
+!CHECK-NOT: bitcast i32 ()* @f90io_sc_i_ldw to i32 (i32, i32)*, !dbg {{![0-9]+}}
+
+program example
+  implicit none
+
+  call func()
+contains
+  subroutine func()
+    call func1()
+    call func2(2)
+  end
+  subroutine func1()
+    integer :: i = 1
+    call func3()
+    print *, i
+  end
+  subroutine func2(j)
+    integer :: j, k
+    k = j
+  end
+  subroutine func3()
+  end
+end


### PR DESCRIPTION
This patch fixes the bug in debug location when using gdb and addr2line dump the line number. Compile the code and run it with gdb 10.1 as follows:
```
program example
  implicit none

  call func()
contains
  subroutine func()
    call func1()
    call func2(2)
  end
  subroutine func1()
    integer :: i = 1
    call func3()
    print *, i
  end
  subroutine func2(j)
    integer :: j, k
    k = j
  end
  subroutine func3()
  end
end
```

```
$ flang case.f90 -g && gdb ./a.out
...
(gdb) b func3
...
(gdb) run
...
(gdb) bt
#0  example::func3 () at case.f90:30
#1  0x00000000004009b8 in example::func1 () at case.f90:22
#2  0x0000000000400988 in example::func () at case.f90:17
#3  0x0000000000400968 in example () at case.f90:14
#4  0x0000000000400a98 in main (argc=1, argv=0xffffffffdfa8) at /home/qpx/llvm-project/flang/runtime/flangmain/flangmain.c:59
#5  0x0000ffffbedbfae0 in __libc_start_main () from /lib64/libc.so.6
#6  0x0000000000400884 in _start ()
```

Then, open another terminal and run the following command:
```
$ addr2line -p -f -e /home/qpx/case1/a.out 0x00000000004009b8
example_func1 at /home/qpx/case1/case.f90:?
```

The line number info is missing. To look at the assembly code, I find out that the bitcast debug info of `print *` causes the problem, which is  ` .loc    1 0 0 is_stmt 0         // case.f90:0:0`.

```
        .loc    1 22 1 prologue_end             // case.f90:22:1
        bl      example_func3
        .loc    1 0 0 is_stmt 0                 // case.f90:0:0
        adrp    x0, .C304_example_func1
        add     x0, x0, :lo12:.C304_example_func1
        adrp    x1, .C302_example_func1
        add     x1, x1, :lo12:.C302_example_func1
        mov     w8, #8
        mov     w2, w8
        .loc    1 23 1 is_stmt 1                // case.f90:23:1
        bl      f90io_src_info03a
        .loc    1 0 0 is_stmt 0                 // case.f90:0:0
        adrp    x0, .C305_example_func1
        add     x0, x0, :lo12:.C305_example_func1
        mov     x1, xzr
        adrp    x3, .C283_example_func1
        add     x3, x3, :lo12:.C283_example_func1
        .loc    1 23 1                          // case.f90:23:1
        mov     x2, x3
        bl      f90io_print_init
```

So, I think flang should not generate debug location metadata for bitcast instructions on actual arguments passed to a procedure call.