### PR TITLE
[DebugInfo] Remove "_V_" from parameter names in case of byvalue para…

### DIFF
--- a/test/debug_info/byval-name.f90
+++ b/test/debug_info/byval-name.f90
@@ -1,0 +1,19 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!Verify the IR contains _V_ (flang)convention naming and the
+! operation using them are well formed.
+!CHECK: sub_(i32 [[PREFIXED_ARG_NAME:%_V_arg_abc.arg]])
+!CHECK: [[PREFIXED_LOCAL_NAME:%_V_arg_abc.addr]] = alloca i32, align 4
+!CHECK: call void @llvm.dbg.declare(metadata i32* [[PREFIXED_LOCAL_NAME]]
+!CHECK: store i32 [[PREFIXED_ARG_NAME]], i32* [[PREFIXED_LOCAL_NAME]], align 4
+
+!Verify the DebugInfo metadata contains prefix _V_ truncated names.
+!CHECK: DILocalVariable(name: "arg_abc"
+!CHECK-NOT: DILocalVariable(name: "_V_arg_abc"
+
+subroutine sub(arg_abc)
+      integer,value :: arg_abc
+      integer :: abc_local
+      abc_local = arg_abc
+      print*, arg_abc
+end subroutine

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -13192,7 +13192,7 @@ process_formal_arguments(LL_ABI_Info *abi)
     /* Make a name for the real LLVM IR argument. This will also be used by
      * build_routine_and_parameter_entries(). */
     arg_op->string = (char *)ll_create_local_name(
-        llvm_info.curr_func, "%s%s", get_llvm_name(arg->sptr), suffix);
+        llvm_info.curr_func, "%s%s", SYMNAME(arg->sptr), suffix);
 
     /* Emit code in the entry block that saves the argument into the local
      * variable. */

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -3622,8 +3622,9 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
       flags = 0;
     }
     var_mdnode = lldbg_create_local_variable_mdnode(
-        db, DW_TAG_auto_variable, blk_info->mdnode, symname, file_mdnode, 0, 0,
-        type_mdnode, flags, fwd, sptr);
+        db, DW_TAG_auto_variable, blk_info->mdnode,
+        PASSBYVALG(sptr) ? SYMNAME(MIDNUMG(sptr)) : symname,
+        file_mdnode, 0, 0, type_mdnode, flags, fwd, sptr);
   }
   return var_mdnode;
 }
@@ -3698,7 +3699,13 @@ lldbg_emit_param_variable(LL_DebugInfo *db, SPTR sptr, int findex, int parnum,
 #endif
   } else {
     symname = (char *)lldbg_alloc(sizeof(char) * (strlen(SYMNAME(sptr)) + 1));
-    strcpy(symname, SYMNAME(sptr));
+    /* In pass by value case flang creates a dummy variable with name
+     * prefixed with "_V_". For debug info creation we are using the
+     * absolute name. */
+    if (PASSBYVALG(sptr))
+      strcpy(symname, SYMNAME(MIDNUMG(sptr)));
+    else
+      strcpy(symname, SYMNAME(sptr));
   }
   flags = set_dilocalvariable_flags(sptr);
   var_mdnode = lldbg_create_local_variable_mdnode(


### PR DESCRIPTION
…meters

flang frontend prefixes "_V_" to the name of variables when parameters
are passed by value. These names are translated to LLVM-IR then to actual
object resulting in incorrect(from perspective of source level debugging)
debug-info.

This patch fixs this by replacing the symbol name to actual symbol name
at LLVM-IR translation(flang2) level. Benefit for this approach is that,
frontend(flang1) is unaware/un-touched by this patch.

For typical byvalue test case:
Incorrect dwarf:
0x0000004c:       DW_TAG_formal_parameter
                    DW_AT_location      (DW_OP_fbreg +52)
                    DW_AT_name  ("_V_foo")
                    DW_AT_type  (0x00000090 "integer")

After this patch:
0x0000004c:       DW_TAG_formal_parameter
                    DW_AT_location      (DW_OP_fbreg +52)
                    DW_AT_name  ("foo")
                    DW_AT_type  (0x00000090 "integer")