### PR TITLE
[flang1] Fix bug in TK_G0FORMAT token pattern matching (encountered in workloads WAVEWATCH III and CMAQ)

### DIFF
--- a/test/f90_correct/inc/format_specification.mk
+++ b/test/f90_correct/inc/format_specification.mk
@@ -1,0 +1,27 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test format_specification  ########
+
+
+format_specification: run
+
+
+build:  $(SRC)/format_specification.f90
+	-$(RM) format_specification.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/format_specification.f90 -o format_specification.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) format_specification.$(OBJX) -o format_specification.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test format_specification
+	format_specification.$(EXESUFFIX)
+
+verify: ;
+
+format_specification.run: run
+

--- a/test/f90_correct/lit/format_specification.sh
+++ b/test/f90_correct/lit/format_specification.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/format_specification.f90
+++ b/test/f90_correct/src/format_specification.f90
@@ -1,0 +1,28 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Checking for the token type "TK_G0FORMAT" (I0) and
+! the special case of the token type "I" + "<integer>" (I02),
+! while the normal case is I2.
+
+program example
+   integer :: i = 1, j = 2, k = 3
+   character(len=2) :: expect(3) = (/'1 ', ' 2', ' 3'/)
+   character(len=2) :: res
+
+   write(res, 10) i
+   if (res .ne. expect(1)) stop 1
+   write(res, 20) j
+   if (res .ne. expect(2)) stop 2
+   write(res, 30) k
+   if (res .ne. expect(3)) stop 3
+
+   print *, 'PASS'
+
+10 FORMAT (I0)
+20 FORMAT (I02)
+30 FORMAT (I2)
+end
+

--- a/tools/flang1/flang1exe/scan.c
+++ b/tools/flang1/flang1exe/scan.c
@@ -4535,7 +4535,7 @@ alpha(void)
       default:
         break;
       }
-    } else if (id[1] == '0') {
+    } else if (id[1] == '0' && id[2] == 0) {
       if (*cp == ' ' || *cp == ',' || *cp == ')') {
         tkntyp = TK_G0FORMAT; /* G0 */
         idlen += 1;


### PR DESCRIPTION
The following test case is generated from the workload WAVEWATCH III 6.07.1 (https://github.com/NOAA-EMC/WW3) and CMAQ 4.7.1 (https://github.com/USEPA/CMAQ).
```
program example
   integer :: i = 1, j = 2, k = 3
   character(len=2) :: expect(3) = (/'1 ', ' 2', ' 3'/)
   character(len=2) :: res

   write(res, 10) i
   if (res .ne. expect(1)) stop 1
   write(res, 20) j
   if (res .ne. expect(2)) stop 2
   write(res, 30) k
   if (res .ne. expect(3)) stop 3
   print *, 'PASS'

10 FORMAT (I0)
20 FORMAT (I02)
30 FORMAT (I2)
end
```
In format specification, the token type TK_G0FORMAT is for I0, not for I02 or I002, or something like that. Fix the token pattern matching of TK_G0FORMAT by checking if the next identifier of '0' in id buffer is null.