### PR TITLE
Fix adding ST_MODPROC case in function mkvarref()

### DIFF
--- a/test/f90_correct/inc/pure_function.mk
+++ b/test/f90_correct/inc/pure_function.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test pure_function  ########
+
+build:
+	@echo ------------------------------------ building test $(TEST)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	./$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/pure_function.sh
+++ b/test/f90_correct/lit/pure_function.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/pure_function.f90
+++ b/test/f90_correct/src/pure_function.f90
@@ -1,0 +1,54 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! Check that the type order between the declaration of "pure function" and its implementation
+! doesnt produce a compilation error
+! Test related to fix for issue #1016
+
+module pureFunction
+  implicit none
+  private
+  public :: func, other_func
+  type :: foo
+    integer :: mydim
+  end type
+
+contains
+
+subroutine func(tparam, oparam)
+  integer, intent(in) :: tparam
+  integer, dimension(other_func(tparam, 10)), intent(out), optional :: oparam
+
+  oparam = 42
+end subroutine
+
+pure function other_func(tparam, idim)
+  integer, intent(in) :: tparam
+  integer, intent(in) :: idim
+  integer :: other_func
+
+  other_func = min(tparam, idim)
+end function
+
+end module
+
+program testPureFunction
+	use pureFunction
+	implicit none
+
+	integer :: result(1)
+	integer :: expect
+	integer :: param1
+  
+
+	param1 = 20	
+	call func(param1,result)
+	expect = 42
+
+	call check(result, expect, 1)
+	print *,result, expect, param1
+
+end program

--- a/tools/flang1/flang1exe/semutil.c
+++ b/tools/flang1/flang1exe/semutil.c
@@ -2008,7 +2008,7 @@ mkvarref(SST *stktop, ITEM *list)
       /* subscripts specified for non-array variable */
       error(76, 3, gbl.lineno, SYMNAME(sptr), CNULL);
       goto add_base;
-
+    case ST_MODPROC:
     case ST_PROC:
       if (FVALG(sptr) == 0 && DTYPEG(sptr) == 0) {
         error(84, 3, gbl.lineno, SYMNAME(sptr),


### PR DESCRIPTION
Adding ST_MODPROC to switch() options in mkvarref() to fix an issue
relating Pure Function not being properly detected.

The issue occours because the pure function type has assignated
ST_MODPROC and is not recognized.
In the case of the Workaround, the type is ST_PROC. Debug reveald
that the assignated types are correct, but the probem is that
ST_MODPROC has no action defined, hence an error in the compiler.
The soluton is to add ST_MODPROC into the same section as ST_PROC
in order to perfom the same actions

Fixes #1016