### PR TITLE
[flang1] Fix inline code for size intrinsic for negative strides.

### DIFF
--- a/test/f90_correct/inc/size_intrin.mk
+++ b/test/f90_correct/inc/size_intrin.mk
@@ -1,0 +1,19 @@
+# Call to "size" intrinsic is inlined
+#
+########## Make rule for test size_intrin.f90 ########
+nearest_intrin: run
+
+build:  $(SRC)/size_intrin.f90
+	-$(RM) size_intrin.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/size_intrin.f90 -o size_intrin.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) size_intrin.$(OBJX) check.$(OBJX) $(LIBS) -o size_intrin.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test size_intrin
+	size_intrin.$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/size_intrin.sh
+++ b/test/f90_correct/lit/size_intrin.sh
@@ -1,0 +1,6 @@
+# Call to "size" intrinsic is inlined
+#
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/size_intrin.f90
+++ b/test/f90_correct/src/size_intrin.f90
@@ -1,0 +1,13 @@
+! Call to "size" intrinsic is inlined
+program size_intrin
+  integer :: array(10) = 0
+  integer , parameter :: n = 3
+  integer :: result(n) , expect(n)
+  expect(1) = 10
+  expect(2) = 10
+  expect(3) = 0
+  result(1) = size(array(1:10:1),1)
+  result(2) = size(array(10:1:-1),1)
+  result(3) = size(array(1:10:-1),1)
+  call checkf(result,expect,n)
+end program size_intrin

--- a/tools/flang1/flang1exe/ast.c
+++ b/tools/flang1/flang1exe/ast.c
@@ -2491,7 +2491,11 @@ extent_of_shape(int shape, int dim)
         return astb.bnd.zero;
     }
   } else {
-    int mask = mk_binop(OP_GE, ub, lb, astb.bnd.dtype);
+    /* 'a' is calculated as ((ub - lb + s) / s)
+     * which works for negative strides as well.
+     * Negative results are converted to zero.
+     */
+    int mask = mk_binop(OP_GE, a, astb.bnd.zero, astb.bnd.dtype);
     a = mk_merge(a, astb.bnd.zero, mask, astb.bnd.dtype);
   }
 

--- a/tools/flang1/flang1exe/outconv.c
+++ b/tools/flang1/flang1exe/outconv.c
@@ -751,7 +751,11 @@ size_shape(int shape, int i)
   a = mk_binop(OP_SUB, argu, argl, astb.bnd.dtype);
   a = mk_binop(OP_ADD, a, args, astb.bnd.dtype);
   a = mk_binop(OP_DIV, a, args, astb.bnd.dtype);
-  mask = mk_binop(OP_GE, argu, argl, DT_LOG);
+  /* 'a' is calculated as ((ub - lb + s) / s)
+   * which works for negative strides as well.
+   * Negative results are converted to zero.
+   */
+  mask = mk_binop(OP_GE, a, astb.bnd.zero, DT_LOG);
   a = mk_merge(a, astb.bnd.zero, mask, astb.bnd.dtype);
   if (astb.bnd.dtype != stb.user.dt_int) {
     /* -i8: type of size is integer*8 so convert result */


### PR DESCRIPTION
Please consider below testcase
```````````````````
program test
  integer:: arr (1:10) = 0
  integer :: s1=1
  integer :: arrsize
  arrsize = size (arr(10:1:-s1),1)
  print *, arrsize
program test
```````````````````
which gives zero as result in place of expected 10.

The flang1 generates
```````````````````
i0: BOS l5 n1 n0
i4: FILE n5 n1 n1000
i8: BASE s629
i10: BASE s628
i12: ILD i10
i14: INEG i12
i16: ITOI8 i14
i18: KCON s631
i20: KADD i16 i18
i23: KDIV i20 i16
i26: KCON s610
i28: KCON s612
i30: KCON s627
i32: KCMP i28 i30   !<------ compares lowerbound and upperbound
i35: GE i32
i37: KMERGE i23 i26 i35  !<-- return i26 (zero) in case lb > ub,
                         !   which is wrong in case of negative stride
i41: I8TOI i37
i43: IST i8 i41
```````````````````
i32 should compare i23 against zero.

This code is compile time calculated and later converted to this llvm ir by flang2
```````````````````
store i32 0, i32* %arrsize_301, align 4, !dbg !18     <-------- zero assigned to arrsize
```````````````````
The flang1 inlines simple instances of size intrinsic which does a wrong
compare between lbound and ubound which should be between result and zero.
This is fixed now.