### PR TITLE
flang2: handle atomic load of logical variables of various size correctly

### DIFF
--- a/test/llvm_ir_correct/omp_atomic_load_logical.f90
+++ b/test/llvm_ir_correct/omp_atomic_load_logical.f90
@@ -1,0 +1,71 @@
+!* Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+!* See https://llvm.org/LICENSE.txt for license information.
+!* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! RUN: %flang -O0 -fopenmp -Hy,69,0x1000 -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -i8 -O0 -fopenmp -Hy,69,0x1000 -S -emit-llvm %s -o - | FileCheck %s
+
+module omp_atomic_load_logical
+  use, intrinsic :: iso_fortran_env, &
+                    only: logical64, logical32, logical16, logical8
+  implicit none
+  logical(logical8) :: l8 = .false.
+  logical(logical16) :: l16 = .false.
+  logical(logical32) :: l32 = .false.
+  logical(logical64) :: l64 = .false.
+
+contains
+
+subroutine sub8
+  implicit none
+  logical(kind(l8)) :: v
+
+  v = .false.
+  do
+!$OMP ATOMIC READ
+    v = l8
+! //CHECK: load atomic i8, i8*
+    if (v) exit
+  end do
+end subroutine
+
+subroutine sub16
+  implicit none
+  logical(kind(l16)) :: v
+
+  v = .false.
+  do
+!$OMP ATOMIC READ
+    v = l16
+! //CHECK: load atomic i16, i16*
+    if (v) exit
+  end do
+end subroutine
+
+subroutine sub32
+  implicit none
+  logical(kind(l32)) :: v
+
+  v = .false.
+  do
+!$OMP ATOMIC READ
+    v = l32
+! //CHECK: load atomic i32, i32*
+    if (v) exit
+  end do
+end subroutine
+
+subroutine sub64
+  implicit none
+  logical(kind(l64)) :: v
+
+  v = .false.
+  do
+!$OMP ATOMIC READ
+    v = l64
+! //CHECK: load atomic i64, i64*
+    if (v) exit
+  end do
+end subroutine
+
+end module

--- a/tools/flang2/flang2exe/iliutil.cpp
+++ b/tools/flang2/flang2exe/iliutil.cpp
@@ -1556,10 +1556,12 @@ ldst_msz(DTYPE dtype, ILI_OP *ld, ILI_OP *st, MSZ *siz)
 
   switch (DTY(dtype)) {
   case TY_BINT:
+  case TY_BLOG:
   case TY_CHAR:
     *siz = MSZ_SBYTE;
     break;
   case TY_SINT:
+  case TY_SLOG:
   case TY_NCHAR:
     *siz = MSZ_SHWORD;
     break;
@@ -1574,6 +1576,7 @@ ldst_msz(DTYPE dtype, ILI_OP *ld, ILI_OP *st, MSZ *siz)
     *st = IL_STSCMPLX;
     return;
   case TY_INT8:
+  case TY_LOG8:
     *siz = MSZ_I8;
     *ld = IL_LDKR;
     *st = IL_STKR;
@@ -1615,6 +1618,7 @@ ldst_msz(DTYPE dtype, ILI_OP *ld, ILI_OP *st, MSZ *siz)
     }
     break;
   case TY_INT:
+  case TY_LOG:
   default:
     *siz = MSZ_WORD;
     break;


### PR DESCRIPTION
This issue was haunting our OpenMP ATOMIC examples involving LOGICAL types. Finally I've found some time to fix it for good.