### PR TITLE
[Flang1] Fix bug in exporting iso_fortran_env (encountered in CP2K #896)

### DIFF
--- a/test/llvm_ir_correct/iso_fortran_env_functions.f90
+++ b/test/llvm_ir_correct/iso_fortran_env_functions.f90
@@ -1,0 +1,26 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Simply check the file compiles with no error.
+!
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+! CHECK: version_var
+! CHECK: options_var
+
+module usermod
+  use iso_fortran_env
+end module usermod
+
+program cp2k
+  use usermod
+  use iso_fortran_env, only: compiler_version, compiler_options
+  implicit none
+  character(len=:), allocatable :: version_var
+  character(len=:), allocatable :: options_var
+  version_var = compiler_version()
+  options_var = compiler_options()
+  print *, version_var
+  print *, options_var
+end program cp2k

--- a/tools/flang1/flang1exe/exterf.c
+++ b/tools/flang1/flang1exe/exterf.c
@@ -532,9 +532,9 @@ export_iso_fortran_env_libraries(void)
 
   if (exportb.iso_fortran_env_library) {
     sptr = lookupsymbol("compiler_options");
-    lzprintf(outlz, "B %d %s %s\n", sptr, "iso_c_binding", SYMNAME(sptr));
+    lzprintf(outlz, "B %d %s %s\n", sptr, "iso_fortran_env", SYMNAME(sptr));
     sptr = lookupsymbol("compiler_version");
-    lzprintf(outlz, "B %d %s %s\n", sptr, "iso_c_binding", SYMNAME(sptr));
+    lzprintf(outlz, "B %d %s %s\n", sptr, "iso_fortran_env", SYMNAME(sptr));
   }
 }
 


### PR DESCRIPTION
The following test case is generated from the workload CP2K and reported by issue #896.
```
module usermod
  use iso_fortran_env
end module usermod

program cp2k
  use usermod
  use iso_fortran_env, only: compiler_version, compiler_options
  implicit none
  character(len=:), allocatable :: version_var
  character(len=:), allocatable :: options_var
  version_var = compiler_version()
  options_var = compiler_options()
  print *, version_var
  print *, options_var
end program cp2k
```
The functions `compier_version` and `compier_options` are exported in `iso_c_binding` library, which is shown in `usermod.mod` when compiling the code. The stype of the two functions is set to `ST_INTRIN` when they are imported by entering the if branch of `iso_c_binding`, which leads to the error.
```
$ flang test.f90
(error message)
$ head -n 10 test.f90
...
B 606 iso_c_binding compiler_options
B 607 iso_c_binding compiler_version
...
```
