### PR TITLE
Ignore all build directories which starts with 'build'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build/
+build*/
 
 VERSION
 .vscode


### PR DESCRIPTION
Often it is necessary to manage more build diretories in parallel which
are not handled in gitignore file. So this PR aims to extend the build pattern
with an 'asterisk' to match any build diretories which starts with build.