### PR TITLE
win: Define ssize_t on Windows

### DIFF
--- a/runtime/include/memops.h
+++ b/runtime/include/memops.h
@@ -14,7 +14,12 @@ extern "C" {
 #endif
 
 #if defined(INLINE_MEMOPS)
+#ifdef _WIN64
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
 #include <sys/types.h>
+#endif
 
 static inline void
 __attribute__((always_inline))


### PR DESCRIPTION
ssize_t is not available type on Windows, so
it needs to use SSIZE_T from Windows Data Types.