### PR TITLE
win: include winsock header for timeval structure

### DIFF
--- a/runtime/flang/miscsup_com.c
+++ b/runtime/flang/miscsup_com.c
@@ -18,6 +18,8 @@
 #ifndef _WIN64
 #include <sys/time.h>
 #include <unistd.h>
+#else
+#include <winsock.h> // timeval
 #endif
 #include "stdioInterf.h"
 #include "fioMacros.h"


### PR DESCRIPTION
On Windows timeval structure comes from 'winsock.h'.