### PR TITLE
[scutil] Delete tmpf and use tmpfile instead; NFC

### DIFF
--- a/include/legacy-util-api.h
+++ b/include/legacy-util-api.h
@@ -37,9 +37,6 @@ extern "C" {
 #include <direct.h>
 #endif
 
-/* See tmpfile(3). */
-FILE *tmpf(char *ignored);
-
 /* Copy to 'basename' the final path component, less any undesirable suffix. */
 void basenam(const char *orig_path, const char *optional_suffix,
              char *basename);

--- a/lib/scutil/path-utils.c
+++ b/lib/scutil/path-utils.c
@@ -95,12 +95,6 @@ fndpath(const char *target, char *path, size_t max_length, const char *dirlist)
   return -1;
 }
 
-FILE *
-tmpf(char *ignored)
-{
-  return tmpfile();
-}
-
 char *
 mkperm(char *pattern, const char *oldext, const char *newext)
 {

--- a/tools/flang1/flang1exe/accpp.c
+++ b/tools/flang1/flang1exe/accpp.c
@@ -1202,7 +1202,7 @@ accpp(void)
   if (XBIT(123, 2) || XBIT(123, 8)) {
     int count;
     if (gbl.dependfil == NULL) {
-      if ((gbl.dependfil = tmpf("a")) == NULL)
+      if ((gbl.dependfil = tmpfile()) == NULL)
         errfatal(5);
     }
     count = strlen(gbl.module) + strlen(gbl.src_file) + 6;

--- a/tools/flang1/flang1exe/dinit.c
+++ b/tools/flang1/flang1exe/dinit.c
@@ -63,7 +63,7 @@ dinit(VAR *ivl, ACL *ict)
   char *ptr;
 
   if (astb.df == NULL) {
-    if ((astb.df = tmpf("b")) == NULL)
+    if ((astb.df = tmpfile()) == NULL)
       errfatal(5);
     sem.dinit_nbr_inits = 0;
   }
@@ -1657,7 +1657,7 @@ void rw_dinit_state(RW_ROUTINE, RW_FILE)
   seq_astb_df = 0;
   if (ISREAD()) {
     if (astb.df == NULL) {
-      if ((astb.df = tmpf("b")) == NULL)
+      if ((astb.df = tmpfile()) == NULL)
         errfatal(5);
     } else {
       nw = fseek(astb.df, 0L, 0);

--- a/tools/flang1/flang1exe/dinitutl.c
+++ b/tools/flang1/flang1exe/dinitutl.c
@@ -36,7 +36,7 @@ dinit_put(int dtype, INT conval)
   int n;
 
   if (mode != 'w') { /* create a new file */
-    if ((df = tmpf("b")) == NULL)
+    if ((df = tmpfile()) == NULL)
       errfatal(5);
     mode = 'w';
 #if DEBUG

--- a/tools/flang1/flang1exe/fpp.c
+++ b/tools/flang1/flang1exe/fpp.c
@@ -737,7 +737,7 @@ fpp(void)
   if (XBIT(123, 2) || XBIT(123, 8)) {
     int count;
     if (gbl.dependfil == NULL) {
-      if ((gbl.dependfil = tmpf("a")) == NULL)
+      if ((gbl.dependfil = tmpfile()) == NULL)
         errfatal(5);
     }
     count = strlen(gbl.module) + strlen(gbl.src_file) + 6;

--- a/tools/flang1/flang1exe/interf.c
+++ b/tools/flang1/flang1exe/interf.c
@@ -3896,7 +3896,7 @@ put_data_statement(int lineno, int anyivl, int anyict, lzhandle *fdlz,
   ACL *ict;
 
   if (astb.df == NULL) {
-    astb.df = tmpf("b");
+    astb.df = tmpfile();
     if (astb.df == NULL)
       errfatal(5);
   }

--- a/tools/flang1/flang1exe/lower.c
+++ b/tools/flang1/flang1exe/lower.c
@@ -149,7 +149,7 @@ lower(int staticinit)
     case 1:
       /* an outer subprogram that contains others */
       /* create a temporary file */
-      lowersym.lowerfile = tmpf("l");
+      lowersym.lowerfile = tmpfile();
       if (lowersym.lowerfile == NULL) {
         error(0, 4, 0, "could not open temporary ILM symbol file", "");
       }

--- a/tools/flang1/flang1exe/lowerilm.c
+++ b/tools/flang1/flang1exe/lowerilm.c
@@ -65,7 +65,7 @@ void
 lower_ilm_header(void)
 {
   /* open the output file */
-  lower_ilm_file = tmpf("i");
+  lower_ilm_file = tmpfile();
   if (lower_ilm_file == NULL) {
     error(0, 4, 0, "could not open temporary ILM file", "");
   }

--- a/tools/flang1/flang1exe/main.c
+++ b/tools/flang1/flang1exe/main.c
@@ -1129,7 +1129,7 @@ init(int argc, char *argv[])
           else if ((gbl.cppfil = fopen(cppfile, "w")) == NULL)
             errfatal(5);
         } else {
-          if ((gbl.cppfil = tmpf("a")) == NULL)
+          if ((gbl.cppfil = tmpfile()) == NULL)
             errfatal(5);
         }
         fpp();

--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -574,7 +574,7 @@ apply_use(MODULE_ID m_id)
   /* -MD option:  Print list of include files to file <program>.d */
   if (sem.which_pass == 0 && ((XBIT(123, 2) || XBIT(123, 8)))) {
     if (gbl.dependfil == NULL) {
-      if ((gbl.dependfil = tmpf("a")) == NULL)
+      if ((gbl.dependfil = tmpfile()) == NULL)
         errfatal(5);
     } else
       fprintf(gbl.dependfil, "\\\n  ");
@@ -1289,7 +1289,7 @@ end_module(void)
   }
   if (sem.which_pass == 0 && ((XBIT(123, 2) || XBIT(123, 8)))) {
     if (gbl.moddependfil == NULL) {
-      if ((gbl.moddependfil = tmpf("a")) == NULL)
+      if ((gbl.moddependfil = tmpfile()) == NULL)
         errfatal(5);
     }
     if (!XBIT(123, 0x40000)) {

--- a/tools/flang1/flang1exe/scan.c
+++ b/tools/flang1/flang1exe/scan.c
@@ -445,7 +445,7 @@ scan_init(FILE *fd)
       errfatal(5);
   } else
 #endif
-      if ((astb.astfil = tmpf("b")) == NULL)
+      if ((astb.astfil = tmpfile()) == NULL)
     errfatal(5);
 
   put_astfil(FR_SRC, gbl.file_name, TRUE);
@@ -7294,7 +7294,7 @@ push_include(char *p)
       /* -MD option:  Print list of include files to file <program>.d */
       if (XBIT(123, 2) || XBIT(123, 8)) {
         if (gbl.dependfil == NULL) {
-          if ((gbl.dependfil = tmpf("a")) == NULL)
+          if ((gbl.dependfil = tmpfile()) == NULL)
             errfatal(5);
         } else
           fprintf(gbl.dependfil, "\\\n  ");
@@ -7407,7 +7407,7 @@ scan_include(char *str)
       /* -MD option:  Print list of include files to file <program>.d */
       if (XBIT(123, 2) || XBIT(123, 8)) {
         if (gbl.dependfil == NULL) {
-          if ((gbl.dependfil = tmpf("a")) == NULL)
+          if ((gbl.dependfil = tmpfile()) == NULL)
             errfatal(5);
         } else
           fprintf(gbl.dependfil, "\\\n  ");

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -12963,7 +12963,7 @@ save_host_state(int wherefrom)
       fseek(state_file, 0L, 0);
     }
   } else {
-    state_file = tmpf("b");
+    state_file = tmpfile();
     if (state_file == NULL)
       errfatal(5);
   }
@@ -13107,7 +13107,7 @@ restore_host_state(int whichpass)
     /* write the 'append' symbols into the 'append_file' */
     state_append_file_full = TRUE;
     if (!state_append_file) {
-      state_append_file = tmpf("b");
+      state_append_file = tmpfile();
       if (state_append_file == NULL)
         errfatal(5);
       state_file_position = 0;
@@ -13299,7 +13299,7 @@ save_module_state1()
   if (modstate_file) {
     fseek(modstate_file, 0L, 0);
   } else {
-    modstate_file = tmpf("m");
+    modstate_file = tmpfile();
     if (modstate_file == NULL)
       errfatal(5);
   }
@@ -13326,7 +13326,7 @@ save_imported_modules_state()
   if (modsave_file) {
     fseek(modsave_file, 0L, 0);
   } else {
-    modsave_file = tmpf("m");
+    modsave_file = tmpfile();
     if (modsave_file == NULL)
       errfatal(5);
   }
@@ -13422,7 +13422,7 @@ reset_module_state()
   } else {
     /* export the module-contained subprogram */
     if (!modstate_append_file) {
-      modstate_append_file = tmpf("m");
+      modstate_append_file = tmpfile();
       if (modstate_append_file == NULL)
         errfatal(5);
     } else {

--- a/tools/flang1/flang1exe/xref.c
+++ b/tools/flang1/flang1exe/xref.c
@@ -38,7 +38,7 @@ xrefinit(void)
   baseptr = NULL;
 
   /* create temporary file and open it for writing */
-  if ((fd = tmpf("b")) == NULL)
+  if ((fd = tmpfile()) == NULL)
     errfatal(5);
 }
 

--- a/tools/flang2/flang2exe/dinit.cpp
+++ b/tools/flang2/flang2exe/dinit.cpp
@@ -101,7 +101,7 @@ dinit(VAR *ivl, CONST *ict)
   ILM_T *p;
 
   if (df == NULL) {
-    if ((df = tmpf("b")) == NULL)
+    if ((df = tmpfile()) == NULL)
       errfatal(F_0005_Unable_to_open_temporary_file);
   }
   ptr = (char *)ivl;

--- a/tools/flang2/flang2exe/dinitutl.cpp
+++ b/tools/flang2/flang2exe/dinitutl.cpp
@@ -49,7 +49,7 @@ dinit_put(DTYPE dtype, ISZ_T conval)
   if (mode == 'e') {
     mode = 'w';
   } else if (mode == ' ') {
-    if ((df = tmpf("b")) == NULL)
+    if ((df = tmpfile()) == NULL)
       errfatal(F_0005_Unable_to_open_temporary_file);
     mode = 'w';
   } else if (mode != 'w') {

--- a/tools/flang2/flang2exe/main.cpp
+++ b/tools/flang2/flang2exe/main.cpp
@@ -831,7 +831,7 @@ do_curr_file:
   gbl.ilmfil = gbl.objfil = NULL;
   if (!flg.es && (flg.object || flg.code)) {
     /* create temporary file for ilms */
-    if ((gbl.ilmfil = tmpf("b")) == NULL)
+    if ((gbl.ilmfil = tmpfile()) == NULL)
       errfatal((error_code_t)5);
   }
   /* process listing file */

--- a/tools/flang2/flang2exe/xref.cpp
+++ b/tools/flang2/flang2exe/xref.cpp
@@ -38,7 +38,7 @@ xrefinit(void)
   baseptr = NULL;
 
   /* create temporary file and open it for writing */
-  if ((fd = tmpf("b")) == NULL)
+  if ((fd = tmpfile()) == NULL)
     errfatal(F_0005_Unable_to_open_temporary_file);
 }
 


### PR DESCRIPTION
`tmpf` is a wrapper for `tmpfile(3)`, which is declared in stdio.h. `tmpf` accepts and ignores a string argument, and in all uses of the function, string literals are passed to it. This has caused a `-Wunused-parameter` warning and multiple `-Wincompatible-pointer-types-discards-qualifiers` or `-Wwritable-strings` warnings.

Since the wrapper doesn't seem to serve any purpose, we should just delete it and use `tmpfile` directly.