### PR TITLE
libomp and libpgmath are dependencies of flangrti's downstream flang

### DIFF
--- a/runtime/flangrti/CMakeLists.txt
+++ b/runtime/flangrti/CMakeLists.txt
@@ -88,14 +88,14 @@ if (NOT DEFINED LIBOMP_EXPORT_DIR)
     FLANG_LIBOMP
     NAMES omp libomp
     HINTS ${CMAKE_BINARY_DIR}/lib)
-  target_link_libraries(flangrti_shared PRIVATE ${FLANG_LIBOMP})
+  target_link_libraries(flangrti_shared PUBLIC ${FLANG_LIBOMP})
 endif()
 
 find_library(
   LIBPGMATH
   NAMES pgmath libpgmath
   HINTS ${CMAKE_BINARY_DIR}/lib)
-target_link_libraries(flangrti_shared PRIVATE ${LIBPGMATH})
+target_link_libraries(flangrti_shared PUBLIC ${LIBPGMATH})
 
 if( ${TARGET_ARCHITECTURE} STREQUAL "aarch64" )
   target_compile_definitions(flangrti_static PRIVATE TARGET_LINUX_ARM)


### PR DESCRIPTION
Since flang runtime library has fortran files and they depend on
libomp and libpgmath, and libflang is the only dowsntream of
flangrti, marking the links as public makes sure libomp and
libpgmath are linked transitively.