### PR TITLE
Removing CI build workflow for release_100 from classic-llvm-flang

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -21,13 +21,8 @@ jobs:
         cc: [clang]
         cpp: [clang++]
         version: [10, 11]
-        llvm_branch: [release_100, release_11x, release_12x]
+        llvm_branch: [release_11x, release_12x]
         include:
-          - target: X86
-            cc: gcc
-            cpp: g++
-            version: 10
-            llvm_branch: release_100
           - target: X86
             cc: gcc
             cpp: g++


### PR DESCRIPTION
CI workflow for release_11x and release12x still enabled, Flang workflow not broken