### PR TITLE
[feature][flang1] Support implied-shape array

### DIFF
--- a/test/f90_correct/inc/implied_shape_array_01.mk
+++ b/test/f90_correct/inc/implied_shape_array_01.mk
@@ -1,0 +1,25 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test implied_shape_array_01  ########
+
+
+implied_shape_array_01: run
+
+
+build:  $(SRC)/implied_shape_array_01.f08
+	-$(RM) implied_shape_array_01.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/implied_shape_array_01.f08 -o implied_shape_array_01.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) implied_shape_array_01.$(OBJX) check.$(OBJX) $(LIBS) -o implied_shape_array_01.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test implied_shape_array_01
+	implied_shape_array_01.$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/implied_shape_array_02.mk
+++ b/test/f90_correct/inc/implied_shape_array_02.mk
@@ -1,0 +1,14 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build: $(SRC)/$(TEST).f08
+	@echo ------------------------------------ building test $(TEST)
+	-$(FC) -c $(SRC)/$(TEST).f08 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ nothing to run for test $(TEST)
+
+verify: $(TEST).rslt
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f08 $(TEST).rslt $(FC)

--- a/test/f90_correct/inc/implied_shape_array_03.mk
+++ b/test/f90_correct/inc/implied_shape_array_03.mk
@@ -1,0 +1,14 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build: $(SRC)/$(TEST).f08
+	@echo ------------------------------------ building test $(TEST)
+	-$(FC) -c $(SRC)/$(TEST).f08 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ nothing to run for test $(TEST)
+
+verify: $(TEST).rslt
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f08 $(TEST).rslt $(FC)

--- a/test/f90_correct/inc/implied_shape_array_io.mk
+++ b/test/f90_correct/inc/implied_shape_array_io.mk
@@ -1,0 +1,25 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test implied_shape_array_io  ########
+
+
+implied_shape_array_io: run
+
+
+build:  $(SRC)/implied_shape_array_io.f08
+	-$(RM) implied_shape_array_io.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/implied_shape_array_io.f08 -o implied_shape_array_io.$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) implied_shape_array_io.$(OBJX) check.$(OBJX) $(LIBS) -o implied_shape_array_io.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test implied_shape_array_io
+	implied_shape_array_io.$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/implied_shape_array_01.sh
+++ b/test/f90_correct/lit/implied_shape_array_01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/implied_shape_array_02.sh
+++ b/test/f90_correct/lit/implied_shape_array_02.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/implied_shape_array_03.sh
+++ b/test/f90_correct/lit/implied_shape_array_03.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/implied_shape_array_io.sh
+++ b/test/f90_correct/lit/implied_shape_array_io.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/implied_shape_array_01.f08
+++ b/test/f90_correct/src/implied_shape_array_01.f08
@@ -1,0 +1,48 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! test for implied-shape array
+
+program test
+  implicit none
+  integer, parameter :: n = 26
+  real, parameter :: a1(5:*) = sin((/1.1, 2.2, 3.3, 4.4, 5.5/)) * 1.234
+  real, dimension(*), parameter :: a2 = a1
+  character(len=*), parameter :: a3(*) = (/character(len=5) ::                 &
+                                           "a", "bb", "ccc", "dddd", "eeeee"/)
+  integer, parameter :: a4(5:*, *) = reshape((/1, 10, 100, 1000, 10000,        &
+                                               2, 20, 200, 2000, 20000/),      &
+                                             (/2, 5/))
+  integer, parameter :: a5(*, *) = reshape((/1, 10, 100, 1000, 10000,          &
+                                             2, 20, 200, 2000, 20000/),        &
+                                           (/2, 5/))
+  integer, parameter :: a6(*, *, *) = reshape((/1, 2, 3, 4, 5, 6, 7, 8/),      &
+                                              (/2, 2, 2/))
+  integer :: rslt(n), expt(n)
+
+  expt = (/                    &
+           5, 9, 5,            &
+           1, 5, 5,            &
+           1, 5, 5,            &
+           5, 1, 6, 5, 10,     &
+           1, 1, 2, 5, 10,     &
+           1, 1, 1, 2, 2, 2, 8 &
+          /)
+
+  rslt(1:9) = (/                                  &
+                lbound(a1), ubound(a1), size(a1), &
+                lbound(a2), ubound(a2), size(a2), &
+                lbound(a3), ubound(a3), size(a3)  &
+               /)
+  rslt(10:14) = (/ lbound(a4, dim=1), lbound(a4, dim=2), &
+                   ubound(a4, dim=1), ubound(a4, dim=2), size(a4) /)
+  rslt(15:19) = (/ lbound(a5, dim=1), lbound(a5, dim=1), &
+                   ubound(a5, dim=1), ubound(a5, dim=2), size(a5) /)
+  rslt(20:26) = (/ lbound(a6, dim=1), lbound(a6, dim=2), &
+                   lbound(a6, dim=3), ubound(a6, dim=1), &
+                   ubound(a6, dim=2), ubound(a6, dim=3), size(a6) /)
+
+  call check(rslt, expt, n)
+
+end program test

--- a/test/f90_correct/src/implied_shape_array_02.f08
+++ b/test/f90_correct/src/implied_shape_array_02.f08
@@ -1,0 +1,47 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! test for implied-shape array
+
+integer function func(arg)
+  integer, intent(in) :: arg
+  func = 2*arg
+end function
+
+program test
+  implicit none
+  type t
+    integer :: m
+  end type
+  type(t) p
+  integer :: l
+  integer :: func
+  integer, parameter :: a(3, 3) = reshape((/1, 10, 100, 2, 20, 200, 3, 30, 300/),&
+                                          (/3, 3/))
+  !{error "PGF90-S-0155-Implied-shape array must be initialized with an array of the same rank - a1"}
+  integer, parameter :: a1(*, *, 3) = a
+  !{error "PGF90-S-0155-Implied-shape array must be initialized with an array of the same rank - a2"}
+  integer, parameter :: a2(*) = reshape((/1, 10/), (/1, 1/))
+  !{error "PGF90-S-0048-Illegal use of '*' in declaration of array"}
+  !{error "PGF90-S-0048-Illegal use of '*' in declaration of array"}
+  !{error "PGF90-S-0155-Implied-shape array must have the PARAMETER attribute - a3"}
+  integer :: a3(*, *, *)
+  !{error "PGF90-S-0048-Illegal use of '*' in declaration of array"}
+  !{error "PGF90-S-0155-Implied-shape array must have the PARAMETER attribute - a4"}
+  integer :: a4(*, *) = a
+  !{error "PGF90-S-0143-a5 requires initializer"}
+  integer, parameter :: a5(*)
+  !{error "PGF90-S-0155-Implied-shape array must be initialized with a constant array - a6"}
+  integer, parameter :: a6(*) = 0
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a7"}
+  integer, parameter :: a7(l:*) = (/1, 10/)
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a8"}
+  integer, parameter :: a8(2*l:*) = (/1, 10/)
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a9"}
+  integer, parameter :: a9(-l:*) = (/1, 10/)
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a10"}
+  integer, parameter :: a10(p%m:*) = (/1, 10/)
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a11"}
+  integer, parameter :: a11(func(l):*) = (/1, 10/)
+end program test

--- a/test/f90_correct/src/implied_shape_array_03.f08
+++ b/test/f90_correct/src/implied_shape_array_03.f08
@@ -1,0 +1,57 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! test for implied-shape array
+
+integer function func(arg)
+  integer, intent(in) :: arg
+  func = 2*arg
+end function
+
+program test
+  implicit none
+  type t
+    integer :: m
+  end type
+  type(t) p
+  integer :: l
+  integer :: func
+  integer, parameter :: a(3, 3) = reshape((/1, 10, 100, 2, 20, 200, 3, 30, 300/),&
+                                          (/3, 3/))
+  !{error "PGF90-S-0155-Implied-shape array must be initialized with a constant array - a1"}
+  integer, parameter :: a1(*, *) = 0
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a2"}
+  integer, parameter :: a2(l:*, *) = reshape((/1, 10, 100, 2, 20, 200, 3, 30, 300/),&
+                                             (/3, 3/))
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a3"}
+  integer, parameter :: a3(l:*, *) = a
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a4"}
+  integer, parameter :: a4(3*l:*, *) = a
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a5"}
+  integer, parameter :: a5(-l:*, *) = a
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a6"}
+  integer, parameter :: a6(p%m:*, *) = a
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a7"}
+  integer, parameter :: a7(func(l):*, *) = a
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a8"}
+  integer, parameter :: a8(l:*, l:*) = reshape((/1, 10, 100, 2, 20, 200, 3, 30, 300/),&
+                                               (/3, 3/))
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a9"}
+  integer, parameter :: a9(l:*, l:*) = a
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a10"}
+  integer, parameter :: a10(3*l:*, 3*l:*) = a
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a11"}
+  integer, parameter :: a11(-l:*, -l:*) = a
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a12"}
+  integer, parameter :: a12(p%m:*, p%m:*) = a
+  !{error "PGF90-S-0155-Implied-shape array lower bound is not constant - a13"}
+  integer, parameter :: a13(func(l):*, func(l):*) = a
+  !{error "PGF90-S-0155-Implied-shape array must be initialized with a constant array - a14"}
+  integer, parameter :: a14(*, *, *) = 0
+  !{error "PGF90-S-0155-Implied-shape array must be initialized with an array of the same rank - a15"}
+  integer, parameter :: a15(*, *, *) = a
+  !{error "PGF90-S-0155-Implied-shape array must be initialized with an array of the same rank - a16"}
+  integer, parameter :: a16(*, *, *) = reshape((/1, 10, 100, 2, 20, 200, 3, 30, 300/),&
+                                               (/3, 3/))
+end program test

--- a/test/f90_correct/src/implied_shape_array_io.f08
+++ b/test/f90_correct/src/implied_shape_array_io.f08
@@ -1,0 +1,46 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for IO with the whole implied-shape array.
+
+program test
+   implicit none
+   integer :: i, length
+   character(len = 6) :: str
+   character(len = 12) :: str2
+   character(len = 40) :: str3
+   integer, parameter :: arr1(1:*) = (/(i, i = 1, 6)/)
+   character, parameter :: arr2(1:*) = (/'a', 'b', 'c', 'd', 'e', 'f'/)
+   integer, parameter :: arr3(1:*) = [10, 11, 12, 13, 14, 15]
+   character, parameter :: arr4(1:*) = ['A', 'B', 'C', 'D', 'E', 'F']
+   integer, parameter :: arr5(1:*,1:*) = reshape((/(i, i = 1, 20)/), (/ 4, 5 /))
+
+   write(str, 10) arr1
+   if (str .ne. '123456') stop 1
+   write(str, 20) arr2
+   if (str .ne. 'abcdef') stop 2
+   write(str2, 30) arr3
+   if (str2 .ne. '101112131415') stop 3
+   write(str, 20) arr4
+   if (str .ne. 'ABCDEF') stop 4
+   write(str3, 40) arr5
+   if (str3 .ne. ' 1 2 3 4 5 6 7 8 91011121314151617181920') stop 5
+
+   inquire(IOLENGTH = length) arr1
+   if (length .ne. 24) stop 6
+   inquire(IOLENGTH = length) arr2
+   if (length .ne. 6) stop 7
+   inquire(IOLENGTH = length) arr3
+   if (length .ne. 24) stop 8
+   inquire(IOLENGTH = length) arr4
+   if (length .ne. 6) stop 9
+   inquire(IOLENGTH = length) arr5
+   if (length .ne. 80) stop 10
+
+   print *, 'PASS'
+10 FORMAT (6I1)
+20 FORMAT (6A1)
+30 FORMAT (6I2)
+40 FORMAT (20I2)
+end

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -545,7 +545,7 @@ _mk_arrdsc(int start_of_base)
       break;
     default:
       /* S_STAR: "*" was specified for this upper bound. */
-      if (i + 1 != sem.arrdim.ndim)
+      if (i + 1 != sem.arrdim.ndim && !is_parameter_context())
         error(48, 3, gbl.lineno, CNULL, CNULL);
       AD_UPAST(ad, i) = sem.bounds[i].upast; /* == NULL */
       AD_ASSUMSZ(ad) = 1;


### PR DESCRIPTION
Support `implied-shape array` feature of F2008.

An implied-shape array is a named constant that is declared with each upper bound given as
an asterisk. It takes its shape from its constant expression2, for example,
```
integer, parameter :: order(0:*) = [0, 1, 2, 3]
```
Also fix the issue #893