### PR TITLE
[DebugInfo] Support dereferencing of scalar pointer variable inside gdb

### DIFF
--- a/test/debug_info/scalar_allocatable.f90
+++ b/test/debug_info/scalar_allocatable.f90
@@ -1,0 +1,16 @@
+!RUN: %flang %s -g -S -emit-llvm -o - | FileCheck %s
+
+!Ensure that for an allocatable variable, we're taking the type of
+!allocatable variable as DW_TAG_pointer_type.
+!CHECK: call void @llvm.dbg.declare(metadata double** %{{.*}}, metadata ![[DILocalVariable:[0-9]+]], metadata !DIExpression())
+!CHECK: ![[DILocalVariable]] = !DILocalVariable(name: "alcvar"
+!CHECK-SAME: type: ![[PTRTYPE:[0-9]+]]
+!CHECK: ![[PTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[TYPE:[0-9]+]]
+!CHECK: ![[TYPE]] = !DIBasicType(name: "double precision",{{.*}}
+
+program main
+  real(kind=8), allocatable :: alcvar
+  allocate(alcvar)
+  alcvar = 7.7
+  print *, alcvar
+end program main

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -10923,6 +10923,22 @@ create_global_initializer(GBL_LIST *gitem, const char *flag_str,
 }
 
 /**
+   \brief Check if sptr is the midnum of a scalar and scalar has POINTER/ALLOCATABLE attribute
+   \param sptr  A symbol
+ */
+bool
+pointer_scalar_need_debug_info(SPTR sptr)
+{
+  if ((sptr > NOSYM) && REVMIDLNKG(sptr)) {
+    SPTR scalar_sptr = (SPTR)REVMIDLNKG(sptr);
+    if ((POINTERG(scalar_sptr) || ALLOCATTRG(scalar_sptr)) &&
+        ((STYPEG(scalar_sptr) == ST_VAR) || (STYPEG(scalar_sptr) == ST_STRUCT)))
+      return true;
+  }
+  return false;
+}
+
+/**
    \brief Check if sptr is the midnum of an array and the array has descriptor 
    \param sptr  A symbol
  */
@@ -11304,7 +11320,7 @@ process_extern_variable_sptr(SPTR sptr, ISZ_T off)
 INLINE static void
 addDebugForLocalVar(SPTR sptr, LL_Type *type)
 {
-  if (need_debug_info(sptr)) {
+  if (need_debug_info(sptr) || pointer_scalar_need_debug_info(sptr)) {
     /* Dummy sptrs are treated as local (see above) */
     if (ll_feature_debug_info_ver90(&cpu_llvm_module->ir) &&
         ftn_array_need_debug_info(sptr)) {

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -287,5 +287,11 @@ void insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode, SPTR sptr,
                            LL_Type *type);
 
 
+/**
+   \brief Check if sptr is the midnum of a scalar and scalar has POINTER/ALLOCATABLE attribute
+   \param sptr  A symbol
+ */
+bool pointer_scalar_need_debug_info(SPTR sptr);
+
 int get_parnum(SPTR sptr);
 #endif

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -3580,7 +3580,23 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
     file_mdnode = get_filedesc_mdnode(db, findex);
   else
     file_mdnode = lldbg_emit_file(db, findex);
-  if (ll_feature_debug_info_ver90(&db->module->ir) &&
+
+  SPTR new_sptr = (SPTR)REVMIDLNKG(sptr);
+  /* If it's an associate statement, associating another variable
+   * take the pointer to type of associated variable.*/
+  if (new_sptr && CCSYMG(sptr) && !SDSCG(new_sptr) &&
+      ADDRTKNG(new_sptr)) {
+    type_mdnode = lldbg_emit_type(db, DTYPEG(new_sptr), sptr, findex, false,
+                                  false, false);
+    DBLINT64 align = {0};
+    DBLINT64 offset = {0};
+    offset[0] = offset[1] = 0;
+    align[1] = ((alignment(DT_CPTR) + 1) * 8);
+    type_mdnode = lldbg_create_pointer_type_mdnode(
+        db, lldbg_emit_compile_unit(db), "", ll_get_md_null(), 0,
+        (ZSIZEOF(DT_CPTR) * 8), align, offset, 0, type_mdnode);
+
+  } else if (ll_feature_debug_info_ver90(&db->module->ir) &&
       (ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr))
     type_mdnode =
         lldbg_emit_type(db, __POINT_T, sptr, findex, false, false, false);
@@ -3620,13 +3636,15 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
     } else {
       fwd = ll_get_md_null();
     }
-    if (ll_feature_debug_info_ver90(&db->module->ir)) {
+    if (ll_feature_debug_info_ver90(&db->module->ir) &&
+        !pointer_scalar_need_debug_info(sptr)) {
       if (SDSCG(sptr))
         sptr = SDSCG(sptr);
-    } else if (ftn_array_need_debug_info(sptr)) {
+    } else if (ftn_array_need_debug_info(sptr) ||
+               pointer_scalar_need_debug_info(sptr)) {
       SPTR array_sptr =(SPTR)REVMIDLNKG(sptr);
-      /* Overwrite the symname and flags to represent the user defined array
-       * instead of a compiler generated symbol of array pointer.
+      /* Overwrite the symname and flags to represent the user defined array or
+       * scalar, instead of a compiler generated symbol of array or scalar pointer
        */
       symname = (char *)lldbg_alloc(strlen(SYMNAME(array_sptr)) + 1);
       strcpy(symname, SYMNAME(array_sptr));


### PR DESCRIPTION
Please consider below testcase
````
program main
integer, pointer :: sclrptr
allocate(sclrptr)
sclrptr = 9
print *, sclrptr
end
`````
After the fix.
Flang produced binary behaves same as gfortran as below.
```````````
(gdb) p sclrptr
$3 = (PTR TO -> ( integer )) 0x605280
(gdb) p *sclrptr
$4 = 9
```````````