### PR TITLE
[DebugInfo] Debug support for procedure pointer

### DIFF
--- a/test/debug_info/allocated_nodup.f90
+++ b/test/debug_info/allocated_nodup.f90
@@ -10,7 +10,7 @@
 !CHECK-SAME: baseType: [[FUNPTRTYPE:![0-9]+]]
 !CHECK: [[FUNPTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[FUNTYPE:![0-9]+]]
 !CHECK: [[FUNTYPE]] = !DISubroutineType(types: [[FUNSIGNATURE:![0-9]+]])
-!CHECK: [[FUNSIGNATURE]] = !{[[DTYPE]]}
+!CHECK: [[FUNSIGNATURE]] = !{[[DTYPE]]
 
 module pdt
   type dtype

--- a/test/debug_info/procedure_pointer.f90
+++ b/test/debug_info/procedure_pointer.f90
@@ -1,0 +1,60 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !DIGlobalVariable(name: "gsubptr"
+!CHECK-SAME: type: [[SPTRTYPE:![0-9]+]]
+!CHECK: !DIGlobalVariable(name: "gfunptr"
+!CHECK-SAME: type: [[FPTRTYPE:![0-9]+]]
+!CHECK: [[FPTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[FUNTYPE:![0-9]+]]
+!CHECK: [[FUNTYPE]] = !DISubroutineType(types: [[FPARLIST:![0-9]+]])
+!CHECK: [[FPARLIST]] = !{[[INTTYPE:![0-9]+]], [[INTTYPE]], [[REALTYPE:![0-9]+]]}
+!CHECK: [[INTTYPE]] = !DIBasicType(name: "integer"
+!CHECK: [[REALTYPE]] = !DIBasicType(name: "real"
+!CHECK: [[SPTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[SUBTYPE:![0-9]+]]
+!CHECK: [[SUBTYPE]] = !DISubroutineType(types: [[SPARLIST:![0-9]+]])
+!CHECK: [[SPARLIST]] = !{null, [[REALTYPE]]}
+!CHECK: !DILocalVariable(name: "lsubptr"
+!CHECK-SAME: type: [[SPTRTYPE]]
+!CHECK: !DILocalVariable(name: "lfunptr"
+!CHECK-SAME: type: [[FPTRTYPE]]
+
+program test
+
+  interface
+    integer function fun (farg1, farg2)
+      integer :: farg1
+      real :: farg2
+    end function fun
+    subroutine sub (sarg)
+      real :: sarg
+    end subroutine
+  end interface
+
+  procedure(fun), pointer:: gfunptr => NULL()
+  procedure(fun), pointer:: lfunptr
+  procedure(sub), pointer:: gsubptr => NULL()
+  procedure(sub), pointer:: lsubptr
+
+  gfunptr => fun
+  lfunptr => fun
+  print *, gfunptr (3, 2.5)
+  print *, lfunptr (3, 2.5)
+
+  gsubptr => sub
+  lsubptr => sub
+  call gsubptr (2.5)
+  call lsubptr (2.5)
+
+end program test
+
+subroutine sub (a)
+  real :: a, res
+  res = 2.1 * a
+  print *, res
+end subroutine
+
+integer function fun (x, y)
+  implicit none
+  integer :: x
+  real :: y
+  fun = x + y + 1
+end function fun

--- a/test/debug_info/procptr_ptrarg.f90
+++ b/test/debug_info/procptr_ptrarg.f90
@@ -1,0 +1,25 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !DIDerivedType(tag: DW_TAG_member, name: "proc1"
+!CHECK-SAME: baseType: [[SPTRTYPE:![0-9]+]]
+!CHECK: [[SPTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[SUBTYPE:![0-9]+]]
+!CHECK: [[SUBTYPE]] = !DISubroutineType(types: [[ARGLIST:![0-9]+]]
+!CHECK: [[ARGLIST]] = !{null, [[ARG1:![0-9]+]]
+!CHECK: [[ARG1]] = !DICompositeType(tag: DW_TAG_array_type
+!CHECK-SAME: dataLocation:
+!CHECK-SAME: associated:
+
+program main
+  interface
+    subroutine sub1(arg11)
+      integer, pointer :: arg11(:)
+    end subroutine
+  end interface
+  type type1
+    procedure(sub1), pointer, nopass :: proc1
+  end type
+  type type2
+    type(type1) :: mem1
+  end type type2
+  type(type2) :: arg1
+end program main

--- a/test/debug_info/scalar_allocatable.f90
+++ b/test/debug_info/scalar_allocatable.f90
@@ -1,0 +1,16 @@
+!RUN: %flang %s -g -S -emit-llvm -o - | FileCheck %s
+
+!Ensure that for an allocatable variable, we're taking the type of
+!allocatable variable as DW_TAG_pointer_type.
+!CHECK: call void @llvm.dbg.declare(metadata double** %{{.*}}, metadata ![[DILocalVariable:[0-9]+]], metadata !DIExpression())
+!CHECK: ![[DILocalVariable]] = !DILocalVariable(name: "alcvar"
+!CHECK-SAME: type: ![[PTRTYPE:[0-9]+]]
+!CHECK: ![[PTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[TYPE:[0-9]+]]
+!CHECK: ![[TYPE]] = !DIBasicType(name: "double precision",{{.*}}
+
+program main
+  real(kind=8), allocatable :: alcvar
+  allocate(alcvar)
+  alcvar = 7.7
+  print *, alcvar
+end program main

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -10993,6 +10993,22 @@ create_global_initializer(GBL_LIST *gitem, const char *flag_str,
 }
 
 /**
+   \brief Check if sptr is the midnum of a scalar and scalar has POINTER/ALLOCATABLE attribute
+   \param sptr  A symbol
+ */
+bool
+pointer_scalar_need_debug_info(SPTR sptr)
+{
+  if ((sptr > NOSYM) && REVMIDLNKG(sptr)) {
+    SPTR scalar_sptr = (SPTR)REVMIDLNKG(sptr);
+    if ((POINTERG(scalar_sptr) || ALLOCATTRG(scalar_sptr)) &&
+        ((STYPEG(scalar_sptr) == ST_VAR) || (STYPEG(scalar_sptr) == ST_STRUCT)))
+      return true;
+  }
+  return false;
+}
+
+/**
    \brief Check if sptr is the midnum of an array and the array has descriptor 
    \param sptr  A symbol
  */
@@ -11375,7 +11391,7 @@ process_extern_variable_sptr(SPTR sptr, ISZ_T off)
 INLINE static void
 addDebugForLocalVar(SPTR sptr, LL_Type *type)
 {
-  if (need_debug_info(sptr)) {
+  if (need_debug_info(sptr) || pointer_scalar_need_debug_info(sptr)) {
     /* Dummy sptrs are treated as local (see above) */
     if (ll_feature_debug_info_ver90(&cpu_llvm_module->ir) &&
         ftn_array_need_debug_info(sptr)) {

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -11035,7 +11035,9 @@ needDebugInfoFilt(SPTR sptr)
     return true;
   /* Fortran case needs to be revisited when we start to support debug, for now
    * just the obvious case */
-  return (!CCSYMG(sptr) || DCLDG(sptr) || ftn_array_need_debug_info(sptr));
+  return (!CCSYMG(sptr) || DCLDG(sptr) ||
+          is_procedure_ptr((SPTR)REVMIDLNKG(sptr)) ||
+          ftn_array_need_debug_info(sptr));
 }
 #ifdef OMP_OFFLOAD_LLVM
 INLINE static bool

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -290,5 +290,11 @@ void insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode, SPTR sptr,
                            LL_Type *type);
 
 
+/**
+   \brief Check if sptr is the midnum of a scalar and scalar has POINTER/ALLOCATABLE attribute
+   \param sptr  A symbol
+ */
+bool pointer_scalar_need_debug_info(SPTR sptr);
+
 int get_parnum(SPTR sptr);
 #endif

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -1836,6 +1836,32 @@ lldbg_emit_file(LL_DebugInfo *db, int findex)
   return get_file_mdnode(db, findex);
 }
 
+static LOGICAL
+is_procedure_dtype(DTYPE dtype) {
+  return dtype > DT_NONE && DTY(dtype) == TY_PROC;
+}
+
+static LOGICAL
+is_procedure_ptr_dtype(DTYPE dtype) {
+  return ((dtype > DT_NONE) && (DTY(dtype) == TY_PTR) &&
+          is_procedure_dtype(DTySeqTyElement(dtype)));
+}
+
+LOGICAL
+is_procedure_ptr(SPTR sptr) {
+  if (sptr > NOSYM && (POINTERG(sptr))) {
+    switch (STYPEG(sptr)) {
+    case ST_PROC:
+    case ST_ENTRY:
+      /* subprograms aren't considered to be procedure pointers */
+      break;
+    default:
+      return is_procedure_ptr_dtype(DTYPEG(sptr));
+    }
+  }
+  return FALSE;
+}
+
 static LL_MDRef
 lldbg_emit_parameter_list(LL_DebugInfo *db, DTYPE dtype, DTYPE ret_dtype,
                           SPTR sptr, int findex)
@@ -1864,8 +1890,10 @@ lldbg_emit_parameter_list(LL_DebugInfo *db, DTYPE dtype, DTYPE ret_dtype,
           lldbg_emit_modified_type(db, ret_dtype, SPTR_NULL, findex);
     else
 #endif
+      /* Reference is used in case of non basic type */
       retval_mdnode =
-          lldbg_emit_type(db, ret_dtype, SPTR_NULL, findex, true, false, true);
+          lldbg_emit_type(db, ret_dtype, SPTR_NULL, findex,
+                          !DT_ISBASIC(ret_dtype), false, true);
   } else {
     if (ll_feature_debug_info_pre34(&db->module->ir))
       retval_mdnode = ll_get_md_null();
@@ -2965,8 +2993,11 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
             return type_mdnode;
           }
         }
-        type_mdnode = lldbg_emit_type(db, DTySeqTyElement(dtype), sptr, findex,
-                                      false, false, false);
+        type_mdnode = lldbg_emit_type(db, DTySeqTyElement(dtype),
+                                      is_procedure_ptr(sptr)
+                                          ? DTyInterface(DTySeqTyElement(dtype))
+                                          : sptr,
+                                      findex, false, false, false);
         sz = (ZSIZEOF(dtype) * 8);
         align[1] = ((alignment(dtype) + 1) * 8);
         align[0] = 0;
@@ -3067,7 +3098,20 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                 SPTR datasptr = MIDNUMG(sptr);
                 if (datasptr == NOSYM)
                   datasptr = SYMLKG(sptr);
-                if ((SCG(datasptr) == SC_DUMMY) && !db->cur_subprogram_mdnode) {
+                if ((SCG(sptr) == SC_DUMMY) || ((SCG(datasptr) == SC_DUMMY) &&
+                                                !db->cur_subprogram_mdnode)) {
+                  const unsigned zero =
+                      lldbg_encode_expression_arg(LL_DW_OP_int, 0);
+                  const unsigned constu =
+                      lldbg_encode_expression_arg(LL_DW_OP_constu, 0);
+                  dataloc = lldbg_emit_expression_mdnode(db, 2, constu, zero);
+                  if (ll_feature_debug_info_ver90(&db->module->ir)) {
+                    is_live = lldbg_emit_expression_mdnode(db, 2, constu, zero);
+                    if (ALLOCATTRG(sptr))
+                      allocated = is_live;
+                    else
+                      associated = is_live;
+                  }
                   // If cur_subprogram_md is not yet ready, we are interested
                   // only in type. datalocation is about value than type. So
                 } else {
@@ -3364,8 +3408,10 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
   SPTR new_sptr = (SPTR)REVMIDLNKG(sptr);
   get_extra_info_for_sptr(&display_name, &scope_mdnode, &type_mdnode, db, sptr);
   if (ll_feature_debug_info_ver90(&cpu_llvm_module->ir) && CCSYMG(sptr) &&
-      new_sptr && (STYPEG(new_sptr) == ST_ARRAY) &&
-      (POINTERG(new_sptr) || ALLOCATTRG(new_sptr)) && SDSCG(new_sptr)) {
+      new_sptr &&
+      (is_procedure_ptr(new_sptr) ||
+       ((STYPEG(new_sptr) == ST_ARRAY) &&
+        (POINTERG(new_sptr) || ALLOCATTRG(new_sptr)) && SDSCG(new_sptr)))) {
     type_mdnode = lldbg_emit_type(db, DTYPEG(new_sptr), new_sptr, findex, false,
                                   false, false);
     display_name = SYMNAME(new_sptr);
@@ -3594,9 +3640,15 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
   /* If it's an associate statement, associating another variable
    * take the pointer to type of associated variable.*/
   if (new_sptr && CCSYMG(sptr) && !SDSCG(new_sptr) &&
-      ADDRTKNG(new_sptr)) {
-    type_mdnode = lldbg_emit_type(db, DTYPEG(new_sptr), sptr, findex, false,
-                                  false, false);
+      (ADDRTKNG(new_sptr) || is_procedure_ptr(new_sptr))) {
+    if (is_procedure_ptr(new_sptr))
+      type_mdnode =
+          lldbg_emit_type(db, DTySeqTyElement(DTYPEG(new_sptr)),
+                          DTyInterface(DTySeqTyElement(DTYPEG(new_sptr))),
+                          findex, false, false, false);
+    else
+      type_mdnode = lldbg_emit_type(db, DTYPEG(new_sptr), sptr, findex, false,
+                                    false, false);
     DBLINT64 align = {0};
     DBLINT64 offset = {0};
     offset[0] = offset[1] = 0;

--- a/tools/flang2/flang2exe/lldebug.h
+++ b/tools/flang2/flang2exe/lldebug.h
@@ -279,6 +279,9 @@ void lldbg_reset_module(LL_DebugInfo *db);
 /// \brief Get the debug location mdnode of the current procedure.
 LL_MDRef lldbg_get_subprogram_line(LL_DebugInfo *db);
 
+/// \brief Return TRUE if SPTR is pointer to procedure.
+LOGICAL is_procedure_ptr(SPTR sptr);
+
 /// \brief Get parameter mdnode for SPTR
 LL_MDRef get_param_mdnode(LL_DebugInfo *db, int sptr);
 #endif /* LLDEBUG_H_ */


### PR DESCRIPTION
Please consider below test
`````````
program test
  interface
    subroutine sub (sarg)
      real :: sarg
    end subroutine
  end interface
  procedure(sub), pointer:: gsubptr => NULL()

  gsubptr => sub
  call gsubptr (2.5)
end program test

subroutine sub (a)
  real :: a, res
  res = 2.1 * a
  print *, res
end subroutine
`````````

After the patch (inside debugger)
`````````
    10        call gsubptr (2.5)
    (gdb) pt gsubptr
    type = PTR TO -> ( void () (real) )
`````````

Prerequisite for this PR is : https://github.com/flang-compiler/flang/pull/1140 (first commit of current PR)