### PR TITLE
[DebugInfo] Missing debug info when one of the module variable is renamed

### DIFF
--- a/test/debug_info/usemodule.f90
+++ b/test/debug_info/usemodule.f90
@@ -1,0 +1,50 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: [[VAR1:![0-9]+]] = distinct !DIGlobalVariable(name: "var1"
+!CHECK: [[MYMOD:![0-9]+]] = !DIModule(scope: {{![0-9]+}}, name: "mymod"
+!CHECK: [[VAR2:![0-9]+]] = distinct !DIGlobalVariable(name: "var2"
+!CHECK: [[VAR3:![0-9]+]] = distinct !DIGlobalVariable(name: "var3"
+
+!CHECK: !DIImportedEntity(tag: DW_TAG_imported_module, scope: [[USE_ALL:![0-9]+]], entity: [[MYMOD]]
+!CHECK: [[USE_ALL]] = distinct !DISubprogram(name: "use_all"
+
+!CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: [[USE_RESTRICTED:![0-9]+]], entity: [[VAR1]]
+!CHECK: [[USE_RESTRICTED]] = distinct !DISubprogram(name: "use_restricted"
+
+!CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: [[USE_RENAMED:![0-9]+]], entity: [[VAR3]]
+!CHECK: [[USE_RENAMED]] = distinct !DISubprogram(name: "use_renamed"
+!CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: [[USE_RENAMED:![0-9]+]], entity: [[VAR2]]
+!CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4", scope: [[USE_RENAMED:![0-9]+]], entity: [[VAR1]]
+
+!CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4", scope: [[USE_RESTRICTED_RENAMED:![0-9]+]], entity: [[VAR1]]
+!CHECK: [[USE_RESTRICTED_RENAMED]] = distinct !DISubprogram(name: "use_restricted_renamed"
+
+module mymod
+  integer :: var1 = 11
+  integer :: var2 = 12
+  integer :: var3 = 13
+end module mymod
+
+Program main
+  call use_all()
+  call use_restricted()
+  call use_renamed()
+  call use_restricted_renamed()
+  contains
+    subroutine use_all()
+      use mymod
+      print *, var1
+    end subroutine use_all
+    subroutine use_restricted()
+      use mymod, ONLY: var1
+      print *, var1
+    end subroutine use_restricted
+    subroutine use_renamed()
+      use mymod, var4 => var1
+      print *, var4
+    end subroutine use_renamed
+    subroutine use_restricted_renamed()
+      use mymod, ONLY: var4 => var1
+      print *, var4
+    end subroutine use_restricted_renamed
+end program main

--- a/tools/flang1/flang1exe/lowersym.c
+++ b/tools/flang1/flang1exe/lowersym.c
@@ -3954,6 +3954,7 @@ lower_symbol(int sptr)
     putbit("frommod", frommod);
     putbit("modcmn", MODCMNG(sptr));
     putsym("scope", SCOPEG(sptr));
+    putbit("restricted", RESTRICTEDG(SCOPEG(sptr)));
     putbit("device", 0);
     putbit("constant", 0);
     putbit("create", 0);

--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -548,6 +548,7 @@ apply_use(MODULE_ID m_id)
   used->module = import_module(use_fd, use_file_name, used->module,
                                INCLUDE_PRIVATES, save_sem_scope_level);
   DINITP(used->module, TRUE);
+  RESTRICTEDP(used->module, used->unrestricted ? 0 : 1);
   dbg_dump("apply_use", 0x2000);
 
   if ((seen_contains && sem.mod_cnt) || gbl.internal > 1 || sem.interface) {

--- a/tools/flang1/utils/symtab/symtab.n
+++ b/tools/flang1/utils/symtab/symtab.n
@@ -1297,8 +1297,8 @@ Flags2
 If set, common block is a compiler-created module common block
 .FL THREAD
 If set, common block is \f(CWTHREADPRIVATE\fP (overloaded with L3F)
-.FL RESERVED_f62 f62
-reserved
+.FL RESTRICTED f62
+Set for restricted use of module.
 .FL STDCALL f63
 Set if this common block has DVF's
 .cw STDCALL

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -13981,17 +13981,29 @@ add_debug_cmnblk_variables(LL_DebugInfo *db, SPTR sptr)
   scope = SCOPEG(sptr);
   for (var = CMEMFG(sptr); var > NOSYM; var = SYMLKG(var)) {
     if ((!SNAME(var)) || strcmp(SNAME(var), SYMNAME(var))) {
+      if (gbl.rutype != RU_BDATA && NEEDMODG(scope) &&
+          lookup_modvar_alias(var)) {
+        has_alias = true;
+        break;
+      }
+    }
+  }
+  for (var = CMEMFG(sptr); var > NOSYM; var = SYMLKG(var)) {
+    if ((!SNAME(var)) || strcmp(SNAME(var), SYMNAME(var))) {
       if (CCSYMG(sptr)) {
         debug_name = new_debug_name(SYMNAME(scope), SYMNAME(var), NULL);
       } else {
         debug_name = new_debug_name(SYMNAME(scope), SYMNAME(sptr),
                                     SYMNAME(var));
       }
-      if (gbl.rutype != RU_BDATA && 
-          NEEDMODG(scope) && lookup_modvar_alias(var)) {
+      if (gbl.rutype != RU_BDATA && NEEDMODG(scope) &&
+          (lookup_modvar_alias(var) ||
+           (has_alias && !RESTRICTEDG(sptr)))) {
         /* This is a DECLARATION to be imported to a subroutine
-         * later in lldbg_emit_subprogram(). */
-        has_alias = true;
+         * later in lldbg_emit_subprogram().
+         * Case 1: Aliased members of restricted / non-restricted modules.
+         * Case 2: All members of non-restricted module if it has atlease one
+         *         aliased member. */
         lldbg_add_pending_import_entity(db, var, IMPORTED_DECLARATION);
       }
       if (hashset_lookup(sptr_added, debug_name))

--- a/tools/flang2/flang2exe/upper.cpp
+++ b/tools/flang2/flang2exe/upper.cpp
@@ -2019,9 +2019,8 @@ read_symbol(void)
                  nomixedstrlen, target, param, thread, task, tqaln, typed,
     uplevel, vararg, Volatile, fromMod, modcmn, elemental;
   SPTR parent;
-  int internref,
-                 Class, denorm, Scope, vtable, iface, vtoff, tbplnk, invobj,
-                 invobjinc, reref, libm, libc, tls, etls;
+  int internref, Class, denorm, Scope, restricted, vtable, iface, vtoff, tbplnk,
+      invobj, invobjinc, reref, libm, libc, tls, etls;
   int reflected, mirrored, create, copyin, resident, acclink, devicecopy,
       devicesd, devcopy;
   int unlpoly, allocattr, f90pointer, final, finalized, kindparm;
@@ -2382,6 +2381,7 @@ read_symbol(void)
     fromMod = getbit("frommod");
     modcmn = getbit("modcmn");
     Scope = getval("scope");
+    restricted = getbit("restricted");
     if (cudaflags) {
       device = getbit("device");
       constant = getbit("constant");
@@ -2421,6 +2421,7 @@ read_symbol(void)
     FROMMODP(newsptr, fromMod);
     MODCMNP(newsptr, modcmn);
     SCOPEP(newsptr, Scope);
+    RESTRICTEDP(newsptr, restricted);
 
     CMEMFP(newsptr, member);
     SIZEP(newsptr, size);

--- a/tools/flang2/utils/symtab/symtab.n
+++ b/tools/flang2/utils/symtab/symtab.n
@@ -375,6 +375,8 @@ Set for a label that marks the beginning of a lexical scope for symbols.
 Set for a label that marks the beginning of a lexical scope for symbols.
 .FL SWIGNORE f94
 Set for a label that is part of switch statement and it is replaced by optimizer.
+.FL RESTRICTED f95
+Set for restricted use of module.
 .lp
 .ul
 Flags2


### PR DESCRIPTION
Currently ILM file generated by Flang1 does not distinguish between
below two casese
1. Renamed use
use mymod, var_z => var_y
2. Restricted and renamed use
use mymod, ONLY: var_z => var_y
In both the cases debug info generated for case-2.

Please consider below testcase
``````````````````````` 
module mod1
  integer :: var_x = 30, var_y = 31
  real :: var_f = 30.1
end module mod1
program p1
use mod1,var_z => var_x ! rename var_x with var_z, unable to access var_y now in gdb
  integer::aa=100
  print *,var_z
end
```````````````````````
Without this patch, Flang generated binary behaves inside debugger as
```````````````````````
gdb) print var_y^M
No symbol "var_y" in current context.
```````````````````````
Now Flang1 is modified to preserve restricted use status in f62 and Flang2 preserves in f95.
Now for non-restricted case debug info is generated for other (non aliased) variables as well