### PR TITLE
[DebugInfo] Debug support for module defined in a different file

### DIFF
--- a/test/debug_info/use_only_test.f90
+++ b/test/debug_info/use_only_test.f90
@@ -1,0 +1,15 @@
+!RUN: %flang -g -S -emit-llvm %s_mod.f90 %s
+!RUN: cat use_only_test.ll | FileCheck %s
+
+!CHECK: [[MOD_VAR:![0-9]+]] = distinct !DIGlobalVariable(name: "mod_var"
+!CHECK: distinct !DICompileUnit
+!CHECK-SAME: imports: [[IMPLIST:![0-9]+]]
+!CHECK: [[IMPLIST]] = !{[[IMPORT:![0-9]+]]
+!CHECK: [[IMPORT]] = !DIImportedEntity(tag: DW_TAG_imported_declaration
+!CHECK-SAME: entity: [[MOD_VAR]]
+
+program main
+  use use_only_mod, only: mod_var
+  implicit none
+  print*, mod_var
+end

--- a/test/debug_info/use_only_test.f90_mod.f90
+++ b/test/debug_info/use_only_test.f90_mod.f90
@@ -1,0 +1,7 @@
+!! This file is compiled with other test use_only_test.f90
+!! Below run is just to satisfy test framework as run is must for 
+!! testcase to exist in this directory.
+!RUN: true
+module use_only_mod
+  integer :: mod_var = 10
+end module use_only_mod

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -3424,7 +3424,9 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
         llObjtodbgAddUnique(*listp, db->gbl_obj_exp_mdnode);
     }
     ll_add_global_debug(db->module, sptr, mdref);
-    if (gbl.rutype == RU_BDATA && sc == SC_CMBLK) {
+    // `RU_SUBR/RU_PROG/RU_FUNC` is set for modules imported from different
+    // CompileUnits. For same compilation unit, 'RU_BDATA' is set.
+    if (sc == SC_CMBLK) {
       const char *modvar_name;
       if (CCSYMG(MIDNUMG(sptr))) {
         modvar_name = new_debug_name(SYMNAME(ENCLFUNCG(sptr)),


### PR DESCRIPTION
Please consider below testcases.
use_only_test.f90_mod.f90
````
module use_only_mod
  integer :: mod_var = 10
end module use_only_mod
````
use_only_test.f90
````
program main
  use use_only_mod, only: mod_var
  implicit none
  print*, mod_var
end
````
Without this patch, executable behaves inside debugger as
````
Breakpoint 1, main () at use_only_test.f90:4
4         print*, mod_var
(gdb) p mod_var
No symbol "mod_var" in current context.
````