### PR TITLE
[runtime] Use const char * where applicable; NFCI

### DIFF
--- a/runtime/flang/allo.c
+++ b/runtime/flang/allo.c
@@ -391,9 +391,8 @@ I8(__alloc04)(__NELEM_T nelem, dtype kind, size_t len,
   if (*pointer && I8(__fort_allocated)(*pointer)
       && ISPRESENT(stat) && *stat == 2) {
     int i;
-    char *mp;
+    const char *mp = "array already allocated";
     MP_P_STDIO;
-    mp = "array already allocated";
     for (i = 0; i < errlen; i++)
       errmsg[i] = (*mp ? *mp++ : ' ');
     MP_V_STDIO;

--- a/runtime/flang/atol.c
+++ b/runtime/flang/atol.c
@@ -36,7 +36,7 @@ __fort_atol(char *p)
 }
 
 long
-__fort_strtol(char *str, char **ptr, int base)
+__fort_strtol(const char *str, char **ptr, int base)
 {
   long val;
   char *end;
@@ -61,7 +61,7 @@ __fort_strtol(char *str, char **ptr, int base)
     }
   } else {
     val = 0;
-    end = str;
+    end = NULL;
   }
   if (ptr)
     *ptr = end;

--- a/runtime/flang/cnfg.c
+++ b/runtime/flang/cnfg.c
@@ -31,19 +31,16 @@ extern char *__fort_getenv();
  *                Default is 1 (VAX-style)
  */
 
-FIO_CNFG __fortio_cnfg_ = {
-/* ending '_' so it can be accessed by user */
-/* default_name */
-    "fort.%d",
-
-    /* vax-style */
-    1,  /* odd => true */
-    -1, /* internal value of .TRUE. */
+FIO_CNFG __fortio_cnfg_ = { /* ending '_' so it can be accessed by user */
+    "fort.%d",              /* default_name */
+                            /* vax-style */
+    1,                      /* odd => true */
+    -1,                     /* internal value of .TRUE. */
 };
 
 /* fio access routines */
 
-char *
+const char *
 __get_fio_cnfg_default_name(void)
 {
   return __fortio_cnfg_.default_name;

--- a/runtime/flang/cnfg.h
+++ b/runtime/flang/cnfg.h
@@ -12,14 +12,14 @@
 
 /* declare structure which may alter the configuration */
 typedef struct {
-  char *default_name; /* sprintf string for default file name */
-  int true_mask;      /* 1 => odd is true, -1 => nonzero is true */
-  int ftn_true;       /* -1 ==> VAX; 1 => unix */
+  const char *default_name; /* sprintf string for default file name */
+  int true_mask;            /* 1 => odd is true, -1 => nonzero is true */
+  int ftn_true;             /* -1 ==> VAX; 1 => unix */
 } FIO_CNFG;
 
 #ifdef WINNT
 
-extern char *__get_fio_cnfg_default_name(void);
+extern const char *__get_fio_cnfg_default_name(void);
 extern int __get_fio_cnfg_true_mask(void);
 extern int *__get_fio_cnfg_true_mask_addr(void);
 extern int __get_fio_cnfg_ftn_true(void);

--- a/runtime/flang/const.c
+++ b/runtime/flang/const.c
@@ -66,7 +66,7 @@ int __fort_size_of[__NTYPES] = {
     sizeof(__PROCPTR_T),    /*   F procedure pointer */
 };
 
-char *__fort_typenames[__NTYPES] = {
+const char *__fort_typenames[__NTYPES] = {
     "none",               /*     no type (absent optional argument) */
     "short",              /* C   signed short */
     "unsigned short",     /* C   unsigned short */
@@ -592,7 +592,7 @@ __get_fort_trues(int idx)
   return __fort_trues[idx];
 }
 
-char *
+const char *
 __get_fort_typenames(int idx)
 {
   return __fort_typenames[idx];
@@ -635,7 +635,7 @@ __set_fort_trues(int idx, void *val)
 }
 
 void
-__set_fort_typenames(int idx, char *val)
+__set_fort_typenames(int idx, const char *val)
 {
   __fort_typenames[idx] = val;
 }

--- a/runtime/flang/cplxf.c
+++ b/runtime/flang/cplxf.c
@@ -15,9 +15,6 @@
 #include <unistd.h>
 #endif
 
-extern double __fort_second();
-extern long __fort_getoptn(char *, long);
-
 /*
  * Hacks to return complex-valued functions.
  * mergec & mergedc for the Cray are defined in miscsup_com.c.

--- a/runtime/flang/curdir.c
+++ b/runtime/flang/curdir.c
@@ -23,7 +23,6 @@
 #endif
 
 extern char *getcwd();
-extern char *__fort_getopt();
 
 WIN_MSVCRT_IMP char *WIN_CDECL getenv(const char *);
 
@@ -32,7 +31,7 @@ WIN_MSVCRT_IMP char *WIN_CDECL getenv(const char *);
 void __fort_fixmnt(new, old) char *new;
 char *old;
 {
-  char *q;
+  const char *q;
   char s[MAXPATHLEN]; /* substitute patterns */
   char *smat;         /* match string */
   char *srep;         /* replace string */
@@ -54,15 +53,13 @@ char *old;
       snxt++;
     }
     srep = strchr(smat, ':'); /* replace string */
-    if (srep == NULL) {
-      srep = "";
-    } else {
+    if (srep != NULL) {
       *srep = '\0';
       srep++;
     }
     n = strlen(smat); /* match string length */
     if (strncmp(old, smat, n) == 0) {
-      strcpy(new, srep);
+      strcpy(new, srep ? srep : "");
       strcat(new, old + n);
       return;
     }
@@ -95,7 +92,7 @@ void __fort_gethostname(host) char *host;
 #ifndef _WIN64
   struct utsname un;
 #endif
-  char *p;
+  const char *p;
   int s;
 
   p = __fort_getopt("-curhost");

--- a/runtime/flang/dbug.c
+++ b/runtime/flang/dbug.c
@@ -169,15 +169,16 @@ void I8(__fort_show_section)(F90_Desc *d)
   fprintf(__io_stderr(), ")[%d]", F90_GSIZE_G(d));
 }
 
-static char *intentnames[4] = {"INOUT", "IN", "OUT", "??"};
+static const char *intentnames[4] = {"INOUT", "IN", "OUT", "??"};
 
-static char *specnames[4] = {"OMITTED", "PRESCRIPTIVE", "DESCRIPTIVE",
-                             "TRANSCRIPTIVE"};
+static const char *specnames[4] = {"OMITTED", "PRESCRIPTIVE", "DESCRIPTIVE",
+                                   "TRANSCRIPTIVE"};
 
-static char *dfmtnames[] = {"*",      "BLOCK",     "BLOCK",   "CYCLIC",
-                            "CYCLIC", "GEN_BLOCK", "INDIRECT"};
+static const char *dfmtnames[] = {"*",      "BLOCK",     "BLOCK",   "CYCLIC",
+                                  "CYCLIC", "GEN_BLOCK", "INDIRECT"};
 
-static char *dfmtabbrev[] = {"*", "BLK", "BLKK", "CYC", "CYCK", "GENB", "IND"};
+static const char *dfmtabbrev[] = {"*", "BLK", "BLKK", "CYC", "CYCK", "GENB",
+                                   "IND"};
 
 #if !defined(DESC_I8)
 

--- a/runtime/flang/entry.c
+++ b/runtime/flang/entry.c
@@ -30,10 +30,10 @@ extern __INT_T LINENO[];
 /* function stack entry */
 
 struct pent {
-  char *func; /* function name (no \0) */
-  __CLEN_T funcl;  /* length of above */
-  char *file; /* file name (no \0) */
-  __CLEN_T filel;  /* length of above */
+  const char *func; /* function name (no \0) */
+  __CLEN_T funcl;   /* length of above */
+  const char *file; /* file name (no \0) */
+  __CLEN_T filel;   /* length of above */
   int line;   /* line number of function entry */
   int lines;  /* number of lines in function */
   int cline;  /* calling function line number */
@@ -186,7 +186,7 @@ void ENTFTN(TRACEBACK, traceback)() { __fort_traceback(); }
 /* print message with one level call traceback */
 
 void
-__fort_tracecall(char *msg)
+__fort_tracecall(const char *msg)
 {
   struct pent *pe;
   char buf[512];

--- a/runtime/flang/eoshift.c
+++ b/runtime/flang/eoshift.c
@@ -351,7 +351,8 @@ void ENTFTN(EOSHIFTSZ, eoshiftsz)(char *rb,     /* result base */
 
   shift = *sb;
   dim = *db;
-  bb = (F90_KIND_G(rs) == __STR) ? " " : (char *)GET_DIST_ZED;
+  /* FIXME: bb is passed to many non-const parameters; just cast it for now. */
+  bb = (F90_KIND_G(rs) == __STR) ? (char *)" " : (char *)GET_DIST_ZED;
 
 #if defined(DEBUG)
   if (__fort_test & DEBUG_EOSH) {
@@ -600,7 +601,8 @@ void ENTFTN(EOSHIFTZ, eoshiftz)(char *rb,     /* result base */
   __INT_T dim;
 
   dim = *db;
-  bb = (F90_KIND_G(rs) == __STR) ? " " : (char *)GET_DIST_ZED;
+  /* FIXME: bb is passed to many non-const parameters; just cast it for now. */
+  bb = (F90_KIND_G(rs) == __STR) ? (char *)" " : (char *)GET_DIST_ZED;
   bs = (F90_Desc *)&F90_KIND_G(rs);
 
 #if defined(DEBUG)

--- a/runtime/flang/error.c
+++ b/runtime/flang/error.c
@@ -26,7 +26,7 @@ static src_info_struct src_info;
 static int current_unit;
 static INT *iostat_ptr;
 static int iobitv;
-static char *err_str = "?";
+static const char *err_str = "?";
 char *envar_fortranopt;
 
 static char *iomsg; /* pointer for optional IOMSG area */
@@ -42,7 +42,7 @@ typedef struct {
   bool newunit;
   INT *iostat_ptr;
   int iobitv;
-  char *err_str;
+  const char *err_str;
   char *envar_fortranopt;
   char *iomsg;
   __CLEN_T iomsgl;
@@ -225,7 +225,7 @@ save_fmtgbl()
 /* --------------------------------------------------------------- */
 
 extern void
-__fortio_errinit(__INT_T unit, __INT_T bitv, __INT_T *iostat, char *str)
+__fortio_errinit(__INT_T unit, __INT_T bitv, __INT_T *iostat, const char *str)
 {
   if (fioFcbTbls.fcbs == NULL)
     __fortio_init();
@@ -249,7 +249,7 @@ __fortio_errinit(__INT_T unit, __INT_T bitv, __INT_T *iostat, char *str)
 }
 
 extern void
-__fortio_errinit03(__INT_T unit, __INT_T bitv, __INT_T *iostat, char *str)
+__fortio_errinit03(__INT_T unit, __INT_T bitv, __INT_T *iostat, const char *str)
 {
   if (fioFcbTbls.fcbs == NULL)
     __fortio_init();
@@ -302,7 +302,7 @@ __fortio_fmtend(void)
 
 #define X(str) str,
 
-static char *errtxt[] = {
+static const char *errtxt[] = {
     X("xxx")                                           /* 200 */
     X("illegal value for specifier")                   /* ESPEC 201 */
     X("conflicting specifiers")                        /* ECOMPAT 202 */
@@ -378,7 +378,7 @@ int
 __fortio_error(int errval)
 {
   FIO_FCB *fdesc;
-  char *eoln, *txt;
+  const char *eoln, *txt;
   int one = 1;
   int retval;
 
@@ -451,10 +451,10 @@ __fortio_error(int errval)
 /* FIXME: this routine is a duplicate of
  *   runtime/lib/pgftn/error.h:__fio_errmsg
  */
-extern char *
+extern const char *
 __fortio_errmsg(int errval)
 {
-  char *txt;
+  const char *txt;
   static char buf[128];
   if (errval == 0) {
     buf[0] = ' ';
@@ -489,7 +489,7 @@ int
 __fortio_eoferr(int errval)
 {
   FIO_FCB *fdesc;
-  char *eoln, *txt, *tmp;
+  const char *eoln, *txt;
   int one = 1;
 
   assert(errval > FIO_ERROR_OFFSET);
@@ -539,7 +539,7 @@ int
 __fortio_eorerr(int errval)
 {
   FIO_FCB *fdesc;
-  char *eoln, *txt;
+  const char *eoln, *txt;
   int one = 1;
 
   assert(errval > FIO_ERROR_OFFSET);
@@ -580,7 +580,7 @@ __fortio_eorerr(int errval)
 static void
 ioerrinfo(FIO_FCB *fdesc)
 {
-  char *eoln;
+  const char *eoln;
   FILE *fp; /* stderr */
 
   fp = __io_stderr();
@@ -855,7 +855,7 @@ __fortio_init(void)
 
   f->fp = __io_stdin();
   f->unit = -5;
-  f->name = "stdin ";
+  f->name = strdup("stdin ");
   f->reclen = 0;
   f->wordlen = 1;
   f->nextrec = 1;
@@ -886,7 +886,7 @@ __fortio_init(void)
 
   f->fp = __io_stdout();
   f->unit = -6;
-  f->name = "stdout ";
+  f->name = strdup("stdout ");
   f->reclen = 0;
   f->wordlen = 1;
   f->nextrec = 1;
@@ -917,7 +917,7 @@ __fortio_init(void)
 
   f->fp = __io_stdin();
   f->unit = 5;
-  f->name = "stdin ";
+  f->name = strdup("stdin ");
   f->reclen = 0;
   f->wordlen = 1;
   f->nextrec = 1;
@@ -948,7 +948,7 @@ __fortio_init(void)
 
   f->fp = __io_stdout();
   f->unit = 6;
-  f->name = "stdout ";
+  f->name = strdup("stdout ");
   f->reclen = 0;
   f->wordlen = 1;
   f->nextrec = 1;
@@ -979,7 +979,7 @@ __fortio_init(void)
 
   f->fp = __io_stderr();
   f->unit = 0;
-  f->name = "stderr ";
+  f->name = strdup("stderr ");
   f->reclen = 0;
   f->wordlen = 1;
   f->nextrec = 1;

--- a/runtime/flang/error.h
+++ b/runtime/flang/error.h
@@ -11,13 +11,13 @@
 
 void set_gbl_newunit(bool newunit);
 bool get_gbl_newunit();
-void __fortio_errinit(__INT_T unit, __INT_T bitv, __INT_T *iostat, char *str);
-void __fortio_errinit03(__INT_T unit, __INT_T bitv, __INT_T *iostat, char *str);
+void __fortio_errinit(__INT_T unit, __INT_T bitv, __INT_T *iostat, const char *str);
+void __fortio_errinit03(__INT_T unit, __INT_T bitv, __INT_T *iostat, const char *str);
 void __fortio_errend03();
 void __fortio_fmtinit();
 void __fortio_fmtend(void);
 int __fortio_error(int errval);
-char * __fortio_errmsg(int errval);
+const char * __fortio_errmsg(int errval);
 int __fortio_eoferr(int errval);
 int __fortio_eorerr(int errval);
 int __fortio_check_format(void);

--- a/runtime/flang/fioMacros.h
+++ b/runtime/flang/fioMacros.h
@@ -296,7 +296,7 @@ extern void *__get_fort_mins(int);
 extern int __get_fort_shifts(int);
 extern int __get_fort_size_of(int);
 extern void *__get_fort_trues(int);
-extern char *__get_fort_typenames(int);
+extern const char *__get_fort_typenames(int);
 extern void *__get_fort_units(int);
 
 extern void __set_fort_maxs(int, void *);
@@ -304,7 +304,7 @@ extern void __set_fort_mins(int, void *);
 extern void __set_fort_shifts(int, int);
 extern void __set_fort_size_of(int, int);
 extern void __set_fort_trues(int, void *);
-extern void __set_fort_typenames(int, char *);
+extern void __set_fort_typenames(int, const char *);
 extern void __set_fort_units(int, void *);
 
 #define GET_DIST_MAXS(idx) __get_fort_maxs(idx)
@@ -341,7 +341,7 @@ extern int __get_fort_tcpus(void);
 extern int *__get_fort_tcpus_addr(void);
 extern int *__get_fort_tids(void);
 extern int __get_fort_tids_elem(int);
-extern char *__get_fort_transnam(void);
+extern const char *__get_fort_transnam(void);
 
 extern void __set_fort_debug(int);
 extern void __set_fort_debugn(int);
@@ -431,7 +431,7 @@ extern void *__fort_maxs[__NTYPES];
 extern void *__fort_mins[__NTYPES];
 extern int __fort_shifts[__NTYPES];
 extern void *__fort_trues[__NTYPES];
-extern char *__fort_typenames[__NTYPES];
+extern const char *__fort_typenames[__NTYPES];
 extern void *__fort_units[__NTYPES];
 
 #define GET_DIST_MAXS(idx) __fort_maxs[idx]
@@ -457,7 +457,7 @@ extern long long int __fort_zed[4];
 #define GET_DIST_ZED __fort_zed
 
 #include "fort_vars.h"
-extern char *__fort_transnam;
+extern const char *__fort_transnam;
 
 #define GET_DIST_HEAPZ 0
 #define GET_DIST_IOPROC 0
@@ -1438,9 +1438,9 @@ void __fort_show_scalar(void *adr, dtype kind);
 __INT_T
 I8(is_nonsequential_section)(F90_Desc *d, __INT_T dim);
 
-void *I8(__fort_create_conforming_mask_array)(char *what, char *ab, char *mb,
-                                             F90_Desc *as, F90_Desc *ms,
-                                             F90_Desc *new_ms);
+void *I8(__fort_create_conforming_mask_array)(const char *what, char *ab,
+                                              char *mb, F90_Desc *as,
+                                              F90_Desc *ms, F90_Desc *new_ms);
 
 void I8(__fort_reverse_array)(char *db, char *ab, F90_Desc *dd, F90_Desc *ad);
 
@@ -1546,9 +1546,9 @@ int I8(__fort_aligned)(F90_Desc *t, __INT_T *tmap, F90_Desc *u, __INT_T *umap);
 
 int I8(__fort_aligned_axes)(F90_Desc *t, int tx, F90_Desc *u, int ux);
 
-void __fort_abort(char *msg);
+void __fort_abort(const char *msg);
 
-void __fort_abortp(char *s);
+void __fort_abortp(const char *s);
 
 void __fort_bcopy(char *to, char *fr, size_t n);
 
@@ -1669,7 +1669,7 @@ void __fort_exit(int s);
 
 /* tracing functions -- entry.c */
 
-void __fort_tracecall(char *msg);
+void __fort_tracecall(const char *msg);
 
 /* utility functions -- util.c */
 
@@ -1697,14 +1697,18 @@ void __fort_ftnstrcpy(char *dst,  /*  destination string, blank-filled */
                      int len,    /*  length of destination space */
                      char *src); /*  null terminated source string  */
 
+const char *__fort_getopt(const char *opt);
+
+long __fort_getoptn(const char *opt, long def);
+
 int __fort_atol(char *p);
 
-long __fort_strtol(char *str, char **ptr, int base);
+long __fort_strtol(const char *str, char **ptr, int base);
 
-void __fort_initndx( int nd, int *cnts, int *ncnts, int *strs, int *nstrs,
+void __fort_initndx(int nd, int *cnts, int *ncnts, int *strs, int *nstrs,
                     int *mults);
 
-int __fort_findndx( int cpu, int nd, int low, int *nstrs, int *mults);
+int __fort_findndx(int cpu, int nd, int low, int *nstrs, int *mults);
 
 void __fort_barrier(void);
 

--- a/runtime/flang/fmtconv.c
+++ b/runtime/flang/fmtconv.c
@@ -31,7 +31,7 @@ static int dbgflag;
 
 static char *conv_int(__BIGINT_T, int *, int *);
 static char *conv_int8(DBLINT64, int *, int *);
-static void put_buf(int, char *, int, int);
+static void put_buf(int, const char *, int, int);
 
 static void conv_e(int, int, int, bool);
 static void conv_en(int, int, bool);
@@ -93,8 +93,9 @@ __fortio_default_convert(char *item, int type,
   switch (type) {
   default:
     assert(0);
-    *lenp = 1;
-    return " ";
+    width = 1;
+    strcpy(conv_bufp, " ");
+    break;
   case __INT1:
     width = 5;
     (void) __fortio_fmt_i((__BIGINT_T)PP_INT1(item), width, 1, plus_flag);
@@ -149,7 +150,9 @@ __fortio_default_convert(char *item, int type,
     break;
   case __WORD16:
     assert(0);
-    return "\0";
+    width = 0;
+    strcpy(conv_bufp, "");
+    break;
   case __CPLX8:
     p = cmplx_buf;
     *p++ = '(';
@@ -311,7 +314,8 @@ conv_int(__BIGINT_T val, int *lenp, int *negp)
     if (val == MAX_HX) {
       *lenp = 10;
       *negp = 1;
-      return MAX_STR;
+      strcpy(tmp, MAX_STR);
+      return tmp;
     }
     neg = 1;
     val = -val;
@@ -397,7 +401,8 @@ conv_int8(DBLINT64 val, int *lenp, int *negp)
     if (I64_MSH(value) == 0x80000000 && I64_LSH(value) == 0) {
       *lenp = 19;
       *negp = 1;
-      return "9223372036854775808";
+      strcpy(tmp, "9223372036854775808");
+      return tmp;
     }
     *negp = 1;
     /* now negate the value */
@@ -439,10 +444,10 @@ static struct {
   __BIGREAL_T zero; /* hide 0.0 from the optimizer here */
 } fpdat = {0, 0, 0, '.', 0, 0, 0, fpbuf, sizeof(fpbuf), 0.0};
 
-static void put_buf(int width,     /* where width (# bytes) */
-                    char *valp,    /* value in string form */
-                    int len,       /* length of value */
-                    int sign_char) /* '-', '+', or 0 (nothing to prepend) */
+static void put_buf(int width,        /* where width (# bytes) */
+                    const char *valp, /* value in string form */
+                    int len,          /* length of value */
+                    int sign_char)    /* '-', '+', or 0 (nothing to prepend) */
 {
   char *bufp;
   int cnt;
@@ -1083,7 +1088,6 @@ fp_canon(__BIGREAL_T val, int type, int round)
   }
   fpdat.ndigits = strlen(fpdat.cvtp);
   fpdat.curp = fpdat.buf;
-
 }
 
 /*

--- a/runtime/flang/fmtwrite.c
+++ b/runtime/flang/fmtwrite.c
@@ -85,7 +85,7 @@ static INT fw_get_val(G *);
 static int fw_writenum(int, char *, int);
 static int fw_OZwritenum(int, char *, int, int);
 static int fw_Bwritenum(char *, int, __CLEN_T);
-static int fw_write_item(char *, int);
+static int fw_write_item(const char *, int);
 static int fw_check_size(long);
 static int fw_write_record(void);
 /* ----------------------------------------------------------------------- */
@@ -2581,7 +2581,7 @@ fw_OZbyte(unsigned int c)
 
 /**  \return ERR_FLAG or 0 */
 static int
-fw_write_item(char *p, int len)
+fw_write_item(const char *p, int len)
 {
   G *g = gbl;
   char *q;

--- a/runtime/flang/fort_vars.h
+++ b/runtime/flang/fort_vars.h
@@ -24,7 +24,7 @@ typedef	struct	__fort_vars {
 	int64_t	heap_block;	/*  48: prcoessor heap size (not power of 2)  */
 	int32_t	*tids;		/*  56: tid for each processor                */
 	int32_t	dummy1[16];	/*  64:                                       */
-	char	*red_what;	/* 128: !! NOT THREAD-SAFE !!                 */
+	const char *red_what;	/* 128: !! NOT THREAD-SAFE !!                 */
 	int32_t	dummy2[30];	/* 136:                                       */
 } __fort_vars_t;
 

--- a/runtime/flang/fpcvt.c
+++ b/runtime/flang/fpcvt.c
@@ -46,7 +46,7 @@ typedef struct {
 
 static int ufpdnorm(UFP *, int);
 
-static void mtherr(char *, int);
+static void mtherr(const char *, int);
 static void fperror(int x);
 
 /* fperror error msg selectors */
@@ -2207,7 +2207,7 @@ struct etypdat_tag etypdat = {
     }};
 
 static void
-mtherr(char *s, int c)
+mtherr(const char *s, int c)
 {
   fperror(c);
 }

--- a/runtime/flang/ftnexit.c
+++ b/runtime/flang/ftnexit.c
@@ -15,8 +15,6 @@
 #include "fioMacros.h"
 #include "llcrit.h"
 
-extern char *__fort_getopt(char *opt);
-
 void ENTF90(EXIT, exit)(__INT_T *exit_status)
 {
   __fort_exit(ISPRESENT(exit_status) ? *exit_status : 0);

--- a/runtime/flang/ftnmiscsup.c
+++ b/runtime/flang/ftnmiscsup.c
@@ -39,8 +39,8 @@ Ftn_date(char *buf,     /* date buffer */
   INT idx1;
   time_t ltime;
   struct tm *lt;
-  static char *month[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+  static const char *month[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
   /* procedure */
 

--- a/runtime/flang/gerror3f.c
+++ b/runtime/flang/gerror3f.c
@@ -32,7 +32,7 @@ void ENT3F(GERROR, gerror)(DCHAR(str) DCLEN(str))
 
 void ENT3F(GET_IOSTAT_MSG, get_iostat_msg)(int *ios, DCHAR(str) DCLEN(str))
 {
-  char *p;
+  const char *p;
   p = Ftn_errmsg(*ios);
   __fcp_cstr(CADR(str), CLEN(str), p);
 }
@@ -40,7 +40,7 @@ void ENT3F(GET_IOSTAT_MSG, get_iostat_msg)(int *ios, DCHAR(str) DCLEN(str))
 /* for -Msecond_underscore */
 void ENT3F(GET_IOSTAT_MSG_, get_iostat_msg_)(int *ios, DCHAR(str) DCLEN(str))
 {
-  char *p;
+  const char *p;
   p = Ftn_errmsg(*ios);
   __fcp_cstr(CADR(str), CLEN(str), p);
 }

--- a/runtime/flang/global.h
+++ b/runtime/flang/global.h
@@ -349,16 +349,16 @@ WIN_MSVCRT_IMP double WIN_CDECL strtod(const char *, char **);
 /*****  error.c  *****/
 extern VOID set_gbl_newunit(bool newunit);
 extern bool get_gbl_newunit();
-extern VOID __fortio_errinit(__INT_T, __INT_T, __INT_T *, char *);
+extern VOID __fortio_errinit(__INT_T, __INT_T, __INT_T *, const char *);
 extern VOID __fortio_errinit03(__INT_T unit, __INT_T bitv, __INT_T *iostat,
-                               char *str);
+                               const char *str);
 extern VOID __fortio_errend(void);
 extern VOID __fortio_errend03(void);
 extern int f90_old_huge_rec_fmt(void);
 extern int __fortio_error(int);
 extern int __fortio_eoferr(int);
 extern int __fortio_eorerr(int);
-extern char *__fortio_errmsg(int);
+extern const char *__fortio_errmsg(int);
 extern int __fortio_check_format(void);
 extern int __fortio_eor_crlf(void);
 extern VOID __fortio_fmtinit(void);
@@ -386,14 +386,14 @@ extern VOID __fortio_cleanup_fcb(void);
 extern FIO_FCB *__fortio_rwinit(int, int, __INT_T *, int);
 extern FIO_FCB *__fortio_find_unit(int);
 extern int __fortio_zeropad(FILE *, long);
-extern bool __fortio_eq_str(char *, __CLEN_T, char *);
+extern bool __fortio_eq_str(char *, __CLEN_T, const char *);
 extern void *__fortio_fiofcb_asyptr(FIO_FCB *);
 extern bool __fortio_fiofcb_asy_rw(FIO_FCB *);
 extern void __fortio_set_asy_rw(FIO_FCB *, bool);
 extern bool __fortio_fiofcb_stdunit(FIO_FCB *);
 extern FILE *__fortio_fiofcb_fp(FIO_FCB *);
 extern short __fortio_fiofcb_form(FIO_FCB *);
-extern char *__fortio_fiofcb_name(FIO_FCB *);
+extern const char *__fortio_fiofcb_name(FIO_FCB *);
 extern void *__fortio_fiofcb_next(FIO_FCB *);
 
 extern bool __fio_eq_str(char *str, int len, char *pattern);

--- a/runtime/flang/hand.c
+++ b/runtime/flang/hand.c
@@ -14,13 +14,11 @@
 #define write _write
 #endif
 
-extern char *__fort_getopt(char *);
-
 /* signals handled and message strings */
 
 struct sigs {
-  int sig;   /* signal value */
-  char *str; /* message string */
+  int sig;          /* signal value */
+  const char *str;  /* message string */
 };
 
 static struct sigs sigs[] = {
@@ -98,7 +96,8 @@ static void sighand(s) int s;
 void
 __fort_sethand()
 {
-  char *p;
+  const char *p;
+  char *q;
   int n;
 
   p = __fort_getopt("-sigmsg");
@@ -112,12 +111,12 @@ __fort_sethand()
       signal(sigs[n].sig, sighand);
       n++;
     }
-  } else {
-    while (*p != '\0') {
-      n = __fort_strtol(p, &p, 0);
+  } else if (*p != '\0') {
+    do {
+      n = __fort_strtol(p, &q, 0);
       signal(n, sighand);
-      p = (*p == ',' ? p + 1 : p);
-    }
+      p = (*q == ',' ? q + 1 : q);
+    } while (*q != '\0');
   }
 }
 

--- a/runtime/flang/heapinit.c
+++ b/runtime/flang/heapinit.c
@@ -9,9 +9,6 @@
 #include "stdioInterf.h"
 #include "fioMacros.h"
 
-extern char *__fort_getopt();
-extern long __fort_getoptn();
-
 /* handler for bus error */
 
 static void sighand(s) int s;

--- a/runtime/flang/init.c
+++ b/runtime/flang/init.c
@@ -16,7 +16,7 @@
 
 static int tid = 0;
 
-char *__fort_transnam = "rpm1";
+const char *__fort_transnam = "rpm1";
 
 #ifdef WINNT
 

--- a/runtime/flang/initpar.c
+++ b/runtime/flang/initpar.c
@@ -45,7 +45,6 @@ WIN_MSVCRT_IMP char **environ;
 char *__fort_getgbuf(long);
 extern void __fort_init_consts();
 
-long __fort_strtol(char *str, char **ptr, int base); /* atol.c */
 void __fort_print_version();                         /* version.c */
 
 extern int __io_get_argc();
@@ -328,7 +327,7 @@ __fort_is_ioproc()
 /* abort with message */
 
 void
-__fort_abort(char *s)
+__fort_abort(const char *s)
 {
   char buf[256];
 
@@ -342,7 +341,7 @@ __fort_abort(char *s)
 /* abort with perror message */
 
 void
-__fort_abortp(char *s)
+__fort_abortp(const char *s)
 {
   fprintf(__io_stderr(), "%d: ", __fort_lcpu);
   perror(s);
@@ -450,11 +449,12 @@ __fort_initopt()
 }
 
 /* get option (command line -xx and environment */
-
-char *__fort_getopt(opt) char *opt;
+const char
+*__fort_getopt(const char *opt)
 {
   char env[64];
-  char *p, *q;
+  char *p;
+  const char *q;
   int n;
 
   if (arg == NULL)
@@ -464,7 +464,7 @@ char *__fort_getopt(opt) char *opt;
     if (strcmp(arg[n], opt) == 0) {
       p = arg[n + 1];
       if (p == NULL) {
-        p = "";
+        return "";
       }
       break;
     }
@@ -484,27 +484,29 @@ char *__fort_getopt(opt) char *opt;
       if (strcmp(opts[n], opt) == 0) {
         p = opts[n + 1];
         if (p == NULL) {
-          p = "";
+          return "";
         }
         break;
       }
     }
   }
   if ((strcmp(opt, "-g") == 0) && (p != NULL) && (*p == '-')) {
-    p = "";
+    return "";
   }
-  return (p);
+  return p;
 }
 
 /* abort because of problem with command/environment option */
 
 static void
-getopt_abort(char *problem, char *opt)
+getopt_abort(const char *problem, const char *opt)
 {
-  char buf[128], *p, *q;
+  char buf[128], *p;
+  const char *q;
 
   p = buf;
   q = opt;
+
   while (*++q != '\0')
     *p++ = toupper(*q);
   *p++ = '\0';
@@ -516,9 +518,10 @@ getopt_abort(char *problem, char *opt)
 /* get numeric option */
 
 long
-__fort_getoptn(char *opt, long def)
+__fort_getoptn(const char *opt, long def)
 {
-  char *p, *q;
+  const char *p;
+  char *q;
   long n;
 
   p = __fort_getopt(opt);
@@ -533,10 +536,10 @@ __fort_getoptn(char *opt, long def)
 /* get yes/no option */
 
 int
-__fort_getoptb(char *opt, int def)
+__fort_getoptb(const char *opt, int def)
 {
-  char *p;
-  int n;
+  const char *p;
+  int n = 0;
 
   p = __fort_getopt(opt);
   if (p == NULL)
@@ -555,7 +558,7 @@ __fort_getoptb(char *opt, int def)
 static void
 __fort_istat()
 {
-  char *p;
+  const char *p;
 
   p = __fort_getopt("-stat");
   if (p == NULL) {
@@ -603,7 +606,8 @@ __fort_istat()
 static void
 __fort_initcom()
 {
-  char *p, *q;
+  const char *p;
+  char *q;
   int n;
 
   /* -test [<n>] */

--- a/runtime/flang/inquire.c
+++ b/runtime/flang/inquire.c
@@ -22,9 +22,9 @@
 
 static FIO_FCB *f2; /* save fcb for inquire2 */
 
-static void copystr(char *dst, /*  destination string, blank-filled */
-                    int len,   /*  length of destination space */
-                    char *src) /*  null terminated source string  */
+static void copystr(char *dst,       /* destination string, blank-filled */
+                    int len,         /* length of destination space */
+                    const char *src) /* null terminated source string  */
 {
   char *end = dst + len;
   while (dst < end && *src != '\0')
@@ -56,7 +56,7 @@ inquire(__INT_T *unit, char *file_ptr, __INT_T *bitv, __INT_T *iostat,
 {
   FIO_FCB *f;
   __CLEN_T i;
-  char *cp;
+  const char *cp;
   __CLEN_T len, nleadb;
 
   __fortio_errinit03(*unit, *bitv, iostat, "INQUIRE");
@@ -1459,7 +1459,7 @@ ENTF90IO(INQUIRE2A, inquire2a)
      DCLEN64(stream))
 {
   FIO_FCB *f;
-  char *cp;
+  const char *cp;
 
   if (*istat)
     return *istat;

--- a/runtime/flang/ldwrite.c
+++ b/runtime/flang/ldwrite.c
@@ -72,7 +72,7 @@ static int gbl_size = GBL_SIZE;
 
 /* local functions */
 
-static int write_item(char *, int);
+static int write_item(const char *, int);
 static int write_record(void);
 
 static void
@@ -767,7 +767,7 @@ ENTCRF90IO(LDWA, ldwa) (type, length, stride, CADR(item), (__CLEN_T)CLEN(item));
 /* --------------------------------------------------------------------- */
 
 static int
-write_item(char *p, int len)
+write_item(const char *p, int len)
 {
   int newlen;
   int ret_err;

--- a/runtime/flang/map.c
+++ b/runtime/flang/map.c
@@ -13,8 +13,6 @@
 #include <sys/time.h>
 #endif
 
-extern char *__fort_getopt();
-
 /* tid comparison routine called by qsort */
 
 static int
@@ -58,7 +56,8 @@ static void
 __fort_getmap(int *processormap)
 {
   int j, k, m, n, tcpus, *usedmap;
-  char *argp, *endp;
+  const char *argp;
+  char *endp;
 
   /* -map <j>:<m>..<n>,... = map processors <m>..<n> to processors <l>..  */
 

--- a/runtime/flang/miscsup_com.c
+++ b/runtime/flang/miscsup_com.c
@@ -29,7 +29,6 @@ MP_SEMAPHORE(static, sem);
 #include "type.h"
 
 extern double __fort_second();
-extern long __fort_getoptn(char *, long);
 
 #define time(x) __fort_time(x)
 
@@ -442,8 +441,8 @@ fstrcpy(char *s1, char *s2, __CLEN_T len1, __CLEN_T len2)
   }
 }
 
-static char *month[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+static const char *month[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
 static int
 yr2(int yr)

--- a/runtime/flang/nmlread.c
+++ b/runtime/flang/nmlread.c
@@ -2227,7 +2227,7 @@ dtio_read_scalar(NML_DESC *descp, char *loc_addr)
   __INT_T tmp_iostat = 0;
   __INT_T *iostat;
   __INT_T *unit;
-  void (*dtio)(char *, INT *, char *, INT *, INT *, char *, F90_Desc *,
+  void (*dtio)(char *, INT *, const char *, INT *, INT *, char *, F90_Desc *,
                F90_Desc *, __CLEN_T, __CLEN_T);
   char *dtv;
   F90_Desc *dtv_sd;
@@ -2239,7 +2239,7 @@ dtio_read_scalar(NML_DESC *descp, char *loc_addr)
   __CLEN_T iomsglen = 250;
   static char iomsg[250];
   int k, num_consts, ret_err, j;
-  char *iotype = "NAMELIST";
+  const char *iotype = "NAMELIST";
   char *start_addr;
   char *mem_addr;
   __POINT_T *desc_dims, new_ndims;

--- a/runtime/flang/nmlwrite.c
+++ b/runtime/flang/nmlwrite.c
@@ -70,7 +70,7 @@ static int gbl_size = GBL_SIZE;
 
 static int emit_eol(void);
 static int write_nml_val(NML_DESC **, NML_DESC *, char *);
-static int write_item(char *, int);
+static int write_item(const char *, int);
 static int write_char(int);
 static int eval(int, char *, NML_DESC *, NML_DESC **);
 static int eval_dtio(int, char *, NML_DESC *, NML_DESC **);
@@ -490,7 +490,7 @@ write_nml_val(NML_DESC **NextDescp, NML_DESC *descp, char *loc_addr)
 }
 
 static int
-write_item(char *p, int len)
+write_item(const char *p, int len)
 {
   int newlen;
 
@@ -923,7 +923,7 @@ dtio_write_scalar(NML_DESC **NextDescp, NML_DESC *descp, char *loc_addr,
   __INT_T tmp_iostat = 0;
   __INT_T *iostat;
   __INT_T *unit;
-  void (*dtio)(char *, INT *, char *, INT *, INT *, char *, F90_Desc *,
+  void (*dtio)(char *, INT *, const char *, INT *, INT *, char *, F90_Desc *,
                F90_Desc *, __CLEN_T, __CLEN_T);
   char *dtv;
   F90_Desc *dtv_sd;
@@ -935,7 +935,7 @@ dtio_write_scalar(NML_DESC **NextDescp, NML_DESC *descp, char *loc_addr,
   __CLEN_T iomsglen = 250;
   static char iomsg[250];
   int k, num_consts, ret_err, j;
-  char *iotype = "NAMELIST";
+  const char *iotype = "NAMELIST";
   char *start_addr;
   char *mem_addr;
   __POINT_T *desc_dims, new_ndims;

--- a/runtime/flang/open.c
+++ b/runtime/flang/open.c
@@ -48,7 +48,7 @@ __fortio_open(int unit, int action_flag, int status_flag, int dispose_flag,
              __CLEN_T namelen)
 {
   char *q;
-  char *perms;
+  const char *perms;
   char bfilename[MAX_NAMELEN + 1];
   char *filename;
   int long_name;

--- a/runtime/flang/query.c
+++ b/runtime/flang/query.c
@@ -159,9 +159,9 @@ static void I8(store_vector_int)(void *ab, F90_Desc *as, int *vector,
   }
 }
 
-static void ftnstrcpy(char *dst, /*  destination string, blank-filled */
-                      size_t len,   /*  length of destination space */
-                      char *src) /*  null terminated source string  */
+static void ftnstrcpy(char *dst,       /* destination string, blank-filled */
+                      size_t len,      /* length of destination space */
+                      const char *src) /* null terminated source string  */
 {
   char *end = dst + len;
   while (dst < end && *src != '\0')
@@ -265,7 +265,7 @@ void ENTFTN(DIST_DISTRIBUTIONA, dist_distributiona)(
   proc *p;
   procdim *pd;
   __INT_T i, rank, vector[MAXDIMS];
-  char *src;
+  const char *src;
   __CLEN_T len;
 
   if (F90_TAG_G(distributee) == __DESC) {
@@ -397,7 +397,7 @@ void ENTFTN(DIST_TEMPLATEA,
   proc *p;
   __INT_T i, rank, n_alnd, ux;
   __INT_T alignee_axis[MAXDIMS], vector[MAXDIMS];
-  char *src;
+  const char *src;
   __CLEN_T len;
 
   if (F90_TAG_G(alignee) == __DESC) {
@@ -585,7 +585,7 @@ void ENTFTN(GLOBAL_DISTRIBUTIONA, global_distributiona)(
   proc *p;
   procdim *pd;
   __INT_T i, rank, vector[MAXDIMS];
-  char *src;
+  const char *src;
   __CLEN_T len;
 
   if (F90_TAG_G(array_s) == __DESC) {
@@ -722,7 +722,7 @@ void ENTFTN(GLOBAL_TEMPLATEA, global_templatea)(
   proc *p;
   __INT_T i, rank, n_alnd, ux;
   __INT_T alignee_axis[MAXDIMS], vector[MAXDIMS];
-  char *src;
+  const char *src;
   __CLEN_T len;
 
   if (F90_TAG_G(array_s) == __DESC) {

--- a/runtime/flang/rdst.c
+++ b/runtime/flang/rdst.c
@@ -28,7 +28,9 @@ ENTFTN(TEMPLATE, template)(F90_Desc *dd, __INT_T *p_rank,
 #endif
 static void store_int_kind(void *, __INT_T *, int);
 static void ftn_msgcpy(char*, const char*, int);
-static char *intents[] = {"INOUT", "IN", "OUT", "??"};
+#if defined(DEBUG)
+static const char *intents[] = {"INOUT", "IN", "OUT", "??"};
+#endif
 
 /** \brief Compare alignments and local storage sequences.  Return true if all
    elements of s1 are ultimately aligned to elements of s2 that reside
@@ -274,7 +276,7 @@ invalid_flags(int flags)
 #endif
 
 static void
-copy_in_abort(char *msg)
+copy_in_abort(const char *msg)
 {
   char str[120];
   sprintf(str, "COPY_IN: %s", msg);

--- a/runtime/flang/red.c
+++ b/runtime/flang/red.c
@@ -33,7 +33,7 @@ __fort_red_unimplemented()
 }
 
 void
-__fort_red_abort(char *msg)
+__fort_red_abort(const char *msg)
 {
   char str[80];
 
@@ -1292,9 +1292,9 @@ void ENTFTN(REDUCE_DESCRIPTOR,
   I8(__fort_finish_descriptor)(rd);
 }
 
-void *I8(__fort_create_conforming_mask_array)(char *what, char *ab, char *mb,
-                                             F90_Desc *as, F90_Desc *ms,
-                                             F90_Desc *new_ms)
+void *I8(__fort_create_conforming_mask_array)(const char *what, char *ab,
+                                              char *mb, F90_Desc *as,
+                                              F90_Desc *ms, F90_Desc *new_ms)
 {
 
   /* Create a conforming mask array. Returns a pointer to the

--- a/runtime/flang/red.h
+++ b/runtime/flang/red.h
@@ -66,7 +66,7 @@ typedef struct {
 
 void __fort_red_unimplemented();
 
-void __fort_red_abort(char *msg);
+void __fort_red_abort(const char *msg);
 
 void I8(__fort_red_scalar)(red_parm *z, char *rb, char *ab, char *mb,
                           F90_Desc *rs, F90_Desc *as, F90_Desc *ms, __INT_T *xb,
@@ -93,7 +93,7 @@ void I8(__fort_kred_arraylk)(red_parm *z, char *rb0, char *ab, char *mb,
                             F90_Desc *ds, red_enum op);
 
 void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
-                             F90_Desc *hd, char *what, void (*fn[__NTYPES])());
+                             F90_Desc *hd, const char *what, void (*fn[__NTYPES])());
 
 /* prototype local reduction function (name beginning with l_):
 

--- a/runtime/flang/reduct.c
+++ b/runtime/flang/reduct.c
@@ -92,7 +92,7 @@ static void
    template.  */
 
 static void
-global_reduce_abort(char *what, char *msg)
+global_reduce_abort(const char *what, const char *msg)
 {
   char str[120];
   sprintf(str, "GLOBAL_%s: %s", what, msg);
@@ -100,7 +100,7 @@ global_reduce_abort(char *what, char *msg)
 }
 
 void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
-                             F90_Desc *hd, char *what, void (*fn[__NTYPES])())
+                             F90_Desc *hd, const char *what, void (*fn[__NTYPES])())
 {
   DECL_HDR_PTRS(ht); /* align-target */
   DECL_DIM_PTRS(hdd);

--- a/runtime/flang/scatter.c
+++ b/runtime/flang/scatter.c
@@ -61,7 +61,7 @@ extern void local_scatter_WRAPPER();
 static __INT_T id_map[MAXDIMS] = {1, 2, 3, 4, 5, 6, 7};
 
 static void
-gathscat_abort(char *what, char *msg)
+gathscat_abort(const char *what, const char *msg)
 {
   char str[80];
   sprintf(str, "%s: %s", what, msg);
@@ -72,7 +72,7 @@ gathscat_abort(char *what, char *msg)
 
 typedef struct {
   sked sked;            /* schedule header */
-  char *what;           /* "GATHER"/"XXX_SCATTER" */
+  const char *what;     /* "GATHER"/"XXX_SCATTER" */
   void (*gathscatfn)(); /* local gather-scatter-reduction function */
   void (*scatterfn)();  /* local scatter-reduction function */
   chdr *repchn;         /* replication channel */
@@ -1170,8 +1170,9 @@ zero_lsize_ok_for_gen_block:
   return &sk->sked;
 }
 
-void *I8(__fort_adjust_index_array)(char *what, char *idx_array, char *src,
-                                   int dim, F90_Desc *is, F90_Desc *bs)
+void *I8(__fort_adjust_index_array)(const char *what, char *idx_array,
+                                    char *src, int dim, F90_Desc *is,
+                                    F90_Desc *bs)
 {
 
   /* Adjust Index array for scatter routines. This needs to be called
@@ -1250,9 +1251,9 @@ void *I8(__fort_adjust_index_array)(char *what, char *idx_array, char *src,
   return idx_array;
 }
 
-void *I8(__fort_create_conforming_index_array)(char *what, char *ab, void *ib,
-                                              F90_Desc *as, F90_Desc *is,
-                                              F90_Desc *new_is)
+void *I8(__fort_create_conforming_index_array)(const char *what, char *ab,
+                                               void *ib, F90_Desc *as,
+                                               F90_Desc *is, F90_Desc *new_is)
 {
 
   /* Create a conforming index array. Returns a pointer to the

--- a/runtime/flang/scatter.h
+++ b/runtime/flang/scatter.h
@@ -43,7 +43,7 @@ struct gathscat_dim {
 };
 
 struct gathscat_parm {
-  char *what; /* "GATHER"/"XXX_SCATTER" */
+  const char *what;           /* "GATHER"/"XXX_SCATTER" */
   void (*xfer_request)(struct chdr *, int, void *, long, long, int,
                        long); /* scatter: __fort_sendl; gather: __fort_recvl */
   void (*xfer_respond)(struct chdr *, int, void *, long, long, int,
@@ -101,9 +101,10 @@ void *ENTFTN(COMM_START, comm_start)();
 void ENTFTN(COMM_FINISH, comm_finish)();
 void ENTFTN(COMM_FREE, comm_free)();
 
-void *I8(__fort_adjust_index_array)(char *what, char *idx_array, char *src,
-                                   int dim, F90_Desc *is, F90_Desc *bs);
+void *I8(__fort_adjust_index_array)(const char *what, char *idx_array,
+                                    char *src, int dim, F90_Desc *is,
+                                    F90_Desc *bs);
 
-void *I8(__fort_create_conforming_index_array)(char *what, char *ab, void *ib,
-                                              F90_Desc *as, F90_Desc *is,
-                                              F90_Desc *new_is);
+void *I8(__fort_create_conforming_index_array)(const char *what, char *ab,
+                                               void *ib, F90_Desc *as,
+                                               F90_Desc *is, F90_Desc *new_is);

--- a/runtime/flang/stat.c
+++ b/runtime/flang/stat.c
@@ -17,7 +17,6 @@
 #define write _write
 #endif
 
-extern char *__fort_getopt();
 extern void __fort_gettb();
 
 static struct tb tb0 = {/* stats at beginning of program */
@@ -58,10 +57,10 @@ __fort_stat_init(void)
 
 /* scale byte quantity */
 
-static char *
+static const char *
 scale_bytes(double d, double *ds)
 {
-  char *s;
+  const char *s;
 
   s = "B";
   if (d >= 1024) {
@@ -86,10 +85,10 @@ scale_bytes(double d, double *ds)
 
 /* scale byte quantity, beginning with kilobytes */
 
-static char *
+static const char *
 scale_kbytes(double d, double *ds)
 {
-  char *s;
+  const char *s;
 
   d = (d + 1023) / 1024;
   s = "KB";
@@ -181,7 +180,7 @@ static void mem(tbp) struct tb *tbp;
   double tsbrk;   /* total heap used (local) */
   double tgsbrk;  /* total heap used (global) */
   int i, quiet, tcpus;
-  char *s_sbrk, *s_gsbrk;
+  const char *s_sbrk, *s_gsbrk;
   double d_sbrk, d_gsbrk;
   char buf[256];
 
@@ -233,7 +232,7 @@ static void msg(tbp) struct tb *tbp;
   int i, quiet, tcpus;
   double ds, dr, dc, dst, drt, dct;
   double mst, mrt, mct, ast, art, act;
-  char *ss, *sr, *sc, *as, *ar, *ac;
+  const char *ss, *sr, *sc, *as, *ar, *ac;
   double d;
   char buf[256];
 

--- a/runtime/flang/trace.c
+++ b/runtime/flang/trace.c
@@ -8,9 +8,6 @@
 #include "stdioInterf.h"
 #include "fioMacros.h"
 
-char *__fort_getopt(char *opt);
-long __fort_strtol(char *str, char **ptr, int base); /* atol.c */
-
 static int tracing = 0;
 static int call_level = 0;
 
@@ -18,7 +15,8 @@ static int call_level = 0;
 int
 __fort_trac_init(void)
 {
-  char *p, *q;
+  const char *p;
+  char *q;
   int n;
 
   p = __fort_getopt("-trace");

--- a/runtime/flang/usrio_smp.c
+++ b/runtime/flang/usrio_smp.c
@@ -38,12 +38,12 @@ static struct {
 /* open file */
 
 int
-__fort_par_open(char *fn, char *par)
+__fort_par_open(const char *fn, const char *par)
 {
   int nflags;
   int mode;
   int fd;
-  char *p;
+  const char *p;
 
   nflags = 0;
   mode = 0666;
@@ -65,8 +65,10 @@ __fort_par_open(char *fn, char *par)
       p += 5;
       nflags |= O_CREAT;
       if (*p == '=') {
+        char *q;
         p++;
-        mode = strtol(p, &p, 0);
+        mode = strtol(p, &q, 0);
+        p = q;
       }
     } else if (strncmp(p, "trunc", 5) == 0) {
       p += 5;

--- a/runtime/flang/utils.c
+++ b/runtime/flang/utils.c
@@ -73,7 +73,7 @@ __fortio_fiofcb_form(FIO_FCB *f)
   return f->form;
 }
 
-extern char *
+extern const char *
 __fortio_fiofcb_name(FIO_FCB *f)
 {
   return f->name;
@@ -465,11 +465,11 @@ __fortio_zeropad(FILE *fp, long len)
 
 /* --------------------------------------------------------------- */
 
+/* return TRUE if string 'str' of length 'len' is equal to 'pattern'. */
 extern bool __fortio_eq_str(
-    /* return TRUE if string 'str' of length 'len' is equal to 'pattern'. */
-
-    char *str, /* user specified string, not null terminated */
-    __CLEN_T len, char *pattern) /* upper case, null terminated string */
+    char *str,           /* user-specified string, not null terminated */
+    __CLEN_T len,        /* maximum number of characters to comprae */
+    const char *pattern) /* upper case, null terminated string */
 {
   char c1, c2;
 

--- a/runtime/flang/utils3f.h
+++ b/runtime/flang/utils3f.h
@@ -6,5 +6,5 @@
  */
 
 
-void __fcp_cstr(char *to, int to_len, char *from);
+void __fcp_cstr(char *to, int to_len, const char *from);
 

--- a/runtime/flang/version.c
+++ b/runtime/flang/version.c
@@ -16,12 +16,12 @@
 #endif
 
 static struct {
-  char *lib;  /* library */
-  char *host; /* host */
-  char *vsn;  /* version number */
-  char *bld;  /* build number */
-  char *dvsn; /* date-based version number */
-  char *copyright;
+  const char *lib;  /* library */
+  const char *host; /* host */
+  const char *vsn;  /* version number */
+  const char *bld;  /* build number */
+  const char *dvsn; /* date-based version number */
+  const char *copyright;
 } version = {
     LIBRARY, VHOST,
     VSN,     BLD,

--- a/runtime/flangrti/aarch64/dumpregs.c
+++ b/runtime/flangrti/aarch64/dumpregs.c
@@ -17,7 +17,7 @@
 
 typedef struct {
     size_t  ro;     // Register offset in to mcontext_t structure
-    char    *s;     // Symbolic name of register
+    const char *s;  // Symbolic name of register
 } xregs_t;
 
 

--- a/runtime/flangrti/trace.c
+++ b/runtime/flangrti/trace.c
@@ -62,7 +62,7 @@ dbg_stop_before_exit(void)
 #endif
 
 void
-__abort(int sv, char *msg)
+__abort(int sv, const char *msg)
 {
   char cmd[128];
   char *p;

--- a/runtime/include/stdioInterf.h
+++ b/runtime/include/stdioInterf.h
@@ -108,7 +108,7 @@ extern void *__aligned_malloc(size_t, size_t); /* pgmemalign.c */
 extern void __aligned_free(void *);
 extern int __fenv_fegetzerodenorm(void);
 
-void __abort(int sv, char *msg);
+void __abort(int sv, const char *msg);
 void __abort_trace(int skip);
 void __abort_sig_init(void);
 


### PR DESCRIPTION
This PR was part of #1087, and has been extracted to ease code reviews.

This patch fixes many `-Wincompatible-pointer-types-discards-qualifiers` and `-Wcast-qual` warnings that resulted from mixing `char *` variables with `const char *` values, especially string literals. Most of these can be trivially fixed by changing the types of the variables or functions in question to `const char *`. Some cases are handled by calling `strdup()` to put a literal in a non-const variable.

A couple of places in runtime/flang/eoshift.c cast string literals and `long long int *` values into `char *`. They are left as FIXMEs for now as the results of the casts are passed to many functions via `char *` parameters, and fixing all of those functions will not be trivial.