### PR TITLE
win: Fix the build on Windows

### DIFF
--- a/runtime/flang/global.h
+++ b/runtime/flang/global.h
@@ -16,6 +16,7 @@
 #include "fioMacros.h"
 #include "stdioInterf.h" /* stubbed version of stdio.h */
 #include "cnfg.h" /* declarations for configuration items */
+#include <stdint.h>
 
 #define GBL_SIZE_T_FORMAT "zu"
 
@@ -46,8 +47,8 @@ WIN_MSVCRT_IMP long WIN_CDECL strtol(const char *, char **, int);
 WIN_MSVCRT_IMP char *WIN_CDECL strerror(int);
 WIN_MSVCRT_IMP char *WIN_CDECL strstr(const char *, const char *);
 
-typedef __INT_T INT;       /* native integer at least 32 bits */
-typedef unsigned int UINT; /* unsigned 32 bit native integer */
+typedef int32_t INT;       /* native integer at least 32 bits */
+typedef uint32_t UINT; /* unsigned 32 bit native integer */
 #define ISDIGIT(c) ((c) >= '0' && (c) <= '9')
 
 /*


### PR DESCRIPTION
The build is broken with a redefinition error:

typedef redefinition with different types
      ('__INT_T' (aka 'long') vs 'int')
typedef __INT_T INT;       /* native integer at least 32 bits */

'INT' is already defined in winnt.h as 'int'.
The comment says it needs a 'native integer at least 32 bits',
'int' should be fine for it on all platform.