### PR TITLE
[DebugInfo] flang support for Assumed length string type

### DIFF
--- a/test/debug_info/assumed_len.f90
+++ b/test/debug_info/assumed_len.f90
@@ -1,0 +1,15 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!Verify the DebugInfo metadata contains DIStringType followed by DILocalVariable
+!CHECK: !DIStringType(name: "character(*)!2", stringLength: [[N:![0-9]+]]
+!CHECK: [[N]] = !DILocalVariable(
+
+program assumedLength
+  call sub('Hello')
+  contains
+  subroutine sub(string)
+    implicit none
+    character(len=*), intent(in) :: string
+    print *, string
+  end subroutine sub
+end program assumedLength

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -151,6 +151,11 @@ void cg_fetch_clen_parampos(SPTR *len, int *param, SPTR sptr);
 /**
    \brief ...
  */
+bool clen_parent_is_param(SPTR length);
+
+/**
+   \brief ...
+ */
 void cg_llvm_end(void);
 
 /**

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -2865,13 +2865,14 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
       type_mdnode = db->dtype_array[dtype];
   if (LL_MDREF_IS_NULL(type_mdnode)) {
     if (is_assumed_char(dtype)) {
-#if defined(FLANG_LLVM_EXTENSIONS)
-      if ((!skipDataDependentTypes) &&
-          ll_feature_has_diextensions(&db->module->ir)) {
+      /* For assumed length string type, emit !DIStringType metadata node
+       * if LLVM version is 11 and above. Here compiler created
+       * local variable holds the string length.
+       */
+      if (ll_feature_debug_info_ver11(&db->module->ir))
         type_mdnode =
             lldbg_create_assumed_len_string_type_mdnode(db, sptr, findex);
-      } else {
-#endif
+      else {
         type_mdnode =
             lldbg_emit_type(db, DT_CPTR, sptr, findex, false, false, false);
 #if defined(FLANG_LLVM_EXTENSIONS)
@@ -2880,8 +2881,8 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
           dtype_array_check_set(db, dtype, type_mdnode);
 #if defined(FLANG_LLVM_EXTENSIONS)
         }
-      }
 #endif
+      }
     } else
         if (DT_ISBASIC(dtype) && (DTY(dtype) != TY_PTR)) {
 


### PR DESCRIPTION
This fix handle support for Assumed length string type during debug info
generation. It emits !DIStringType metadata with stringLength field, which
points to compiler generated local variable(metadata !28 below) and holds
the length of assumed string. This fix has dependency on LLVM11 and above
to emit DW_AT_string_length attribute.

snippet from flang generated IR :
. . .
call void @llvm.dbg.declare (metadata i64* %.U0001.addr, metadata !28, metadata !29), !dbg !26
. . .
!28 = !DILocalVariable(scope: !25, arg: 2, file: !3, type: !27, flags: 64)
!29 = !DIExpression()
!30 = !DIStringType(name: "character(*)!2", size: 32, stringLength: !28, stringLengthExpression: !29)
. . .

Sample Dwarf info generated with flang fix:
. . .
0x0000009d:   DW_TAG_string_type [9]
                DW_AT_name [DW_FORM_strp]       ( .debug_str[0x0000007d] = "character(*)!2")
                DW_AT_string_length [DW_FORM_ref4]      (cu + 0x0071 => {0x00000071})

0x00000071:       DW_TAG_formal_parameter [5]
                    DW_AT_location [DW_FORM_block1]     (DW_OP_fbreg -8)
                    DW_AT_type [DW_FORM_ref4]   (cu + 0x008f => {0x0000008f} "integer*8")
                    DW_AT_artificial [DW_FORM_flag]     (0x01)
. . .

GDB session with fix:
. . .
Breakpoint 1, assumedlength::sub (string=...) at r.f90:8
8       print *, string
(gdb) p string
$1 = 'Hello'
. . .

test program:
program assumedLength
   call sub('Hello')
   call sub('Goodbye')
   contains
   subroutine sub(string)
           implicit none
           character(len=*), intent(in) :: string
           print *, string
   end subroutine sub
end program assumedLength