### PR TITLE
Disable checking SYM size on Windows

### DIFF
--- a/tools/flang1/flang1exe/interf.c
+++ b/tools/flang1/flang1exe/interf.c
@@ -70,7 +70,10 @@ static int modinclistsize = 0, modinclistavl = 0;
 void
 interf_init()
 {
-#if DEBUG
+/* Disable checking SYM size in Windows.
+ * https://github.com/flang-compiler/flang/issues/1043
+ */
+#if DEBUG && !defined(_WIN64)
   assert(sizeof(SYM) / sizeof(INT) == 44, "bad SYM size",
          sizeof(SYM) / sizeof(INT), 4);
   assert(sizeof(AST) / sizeof(int) == 19, "interf_init:inconsistent AST size",

--- a/tools/flang1/flang1exe/symacc.c
+++ b/tools/flang1/flang1exe/symacc.c
@@ -40,7 +40,12 @@ sym_init_first(void)
   int i;
 
   int sizeof_SYM = sizeof(SYM) / sizeof(INT);
+/* Disable checking SYM size on Windows
+ * https://github.com/flang-compiler/flang/issues/1043
+ */
+#ifndef _WIN64
   assert(sizeof_SYM == 44, "bad SYM size", sizeof_SYM, ERR_Fatal);
+#endif
 
   if (stb.stg_base == NULL) {
     STG_ALLOC(stb, 1000);

--- a/tools/flang2/flang2exe/symacc.cpp
+++ b/tools/flang2/flang2exe/symacc.cpp
@@ -40,6 +40,9 @@ sym_init_first(void)
   int i;
 
   int sizeof_SYM = sizeof(SYM) / sizeof(INT);
+/* Disable checking SYM size on Windows.
+ * https://github.com/flang-compiler/flang/issues/1043
+ */
 #ifndef _WIN64
   assert(sizeof_SYM == 36, "bad SYM size", sizeof_SYM, ERR_Fatal);
 #endif

--- a/tools/shared/utils/symacc.c
+++ b/tools/shared/utils/symacc.c
@@ -50,11 +50,17 @@ sym_init_first(void)
   int i;
 
   int sizeof_SYM = sizeof(SYM) / sizeof(INT);
+
+/* Disable checking sym size on Windows.
+ * https://github.com/flang-compiler/flang/issues/1043
+ */
+#if !defined(_WIN64)
 #if defined(PGHPF)
   assert(sizeof_SYM == 44, "bad SYM size", sizeof_SYM, ERR_Fatal);
 #else
   assert(sizeof_SYM == 36, "bad SYM size", sizeof_SYM, ERR_Fatal);
 #endif
+#endif // _WIN64
 
   if (stb.stg_base == NULL) {
 #ifdef UTILSYMTAB


### PR DESCRIPTION
Windows uses LLP64 data model where long is still 32bit as int.
The SYM structure consists of for example long type (ISZ_T)
and it is expected long is 'at least 64 bits', that's not true on Windows.

Workaround for #1043