### PR TITLE
Fix for the issue #1146 introduced by PR #949(issue #889).

### DIFF
--- a/test/f90_correct/inc/use01.mk
+++ b/test/f90_correct/inc/use01.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/inc/use02.mk
+++ b/test/f90_correct/inc/use02.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/inc/use03.mk
+++ b/test/f90_correct/inc/use03.mk
@@ -1,0 +1,18 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build: clean
+	@echo ------------------------------------ building test $(TEST)
+	-$(FC) -c $(FCFLAGS) $(SRC)/$(TEST).f90 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ test $(TEST) not expected to execute
+
+verify:
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f90 $(TEST).rslt $(FC)
+
+clean:
+	-@$(RM) $(TEST).rslt $(TEST).$(OBJX) *.mod $(TEST).$(EXE)
+

--- a/test/f90_correct/inc/use04.mk
+++ b/test/f90_correct/inc/use04.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/inc/use05.mk
+++ b/test/f90_correct/inc/use05.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/inc/use06.mk
+++ b/test/f90_correct/inc/use06.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/use01.sh
+++ b/test/f90_correct/lit/use01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/use02.sh
+++ b/test/f90_correct/lit/use02.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/use03.sh
+++ b/test/f90_correct/lit/use03.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/use04.sh
+++ b/test/f90_correct/lit/use04.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/use05.sh
+++ b/test/f90_correct/lit/use05.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/use06.sh
+++ b/test/f90_correct/lit/use06.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t 
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/use01.f90
+++ b/test/f90_correct/src/use01.f90
@@ -1,0 +1,36 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM
+! Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Code based on the reproducer from https://github.com/flang-compiler/flang/issues/1146
+
+module public1
+  integer, public :: var = 1
+  integer, public :: var1 = 11
+end module
+
+module public2
+  integer, public :: var = 2
+end module
+
+module use_public2
+  use public2, only : var
+  private
+end module
+
+program use_1_2
+  use public1, only : var1
+  use use_public2
+  integer :: ret = 0
+  ret = foo()
+  if (ret /= 1) STOP 1
+  print *, "PASS"
+contains
+  function foo() result(ret)
+    use public1, only : var
+    integer :: ret
+    ret = var
+  end function
+end program

--- a/test/f90_correct/src/use02.f90
+++ b/test/f90_correct/src/use02.f90
@@ -1,0 +1,41 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM
+! Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for USE statement when the local-name in subprogram has the same name
+! with a unaccessible entity in the module which appears in the USE statement
+! in host program.
+
+module m1
+  integer :: var1 = 1
+end module
+
+module m2
+  use m1, var2 => var1
+  private var2
+  integer :: var3 = 2
+end module
+
+module m3
+  integer :: var4 = 3
+end module
+
+program p
+  use m2
+  implicit none
+  call test1()
+  call test2()
+  print *, "PASS"
+contains
+  subroutine test1()
+    use m2, var2 => var3
+    if (var2 /= 2) STOP 1
+  end subroutine
+
+  subroutine test2()
+    use m3, var2 => var4
+    if (var2 /= 3) STOP 2
+  end subroutine
+end program

--- a/test/f90_correct/src/use03.f90
+++ b/test/f90_correct/src/use03.f90
@@ -1,0 +1,28 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM
+! Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for USE statement when redeclare local-name or only-use-name identifier
+! in subprogram.
+
+module m
+  integer :: var = 1
+end module
+
+program p
+  implicit none
+contains
+  subroutine test1()
+    use m, localvar => var
+    !{error "PGF90-S-0155-var is use associated and cannot be redeclared"}
+    integer :: localvar
+  end subroutine
+
+  subroutine test2()
+    use m, only: var
+    !{error "PGF90-S-0155-var is use associated and cannot be redeclared"}
+    integer :: var
+  end subroutine
+end program

--- a/test/f90_correct/src/use04.f90
+++ b/test/f90_correct/src/use04.f90
@@ -1,0 +1,28 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM
+! Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for rename of user-defined operator in USE statement.
+
+module m
+  implicit none
+  interface operator(.opr.)
+    module procedure :: foo
+  end interface
+  integer :: opr = 1
+contains
+  integer function foo(x, y)
+    integer, intent(in) :: x, y
+    foo = x + y
+  end function
+end module m
+
+program p
+  use m, operator(.localopr.) => operator(.opr.)
+  implicit none
+  if (opr /= 1) STOP 1
+  if ((1 .localopr. 2) /= 3) STOP 2
+  print *, "PASS"
+end program

--- a/test/f90_correct/src/use05.f90
+++ b/test/f90_correct/src/use05.f90
@@ -1,0 +1,35 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM
+! Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for USE statement when the local-name and use-name in rename of generic
+! interface have the same name.
+
+module m1
+  interface gnr
+    module procedure func
+  end interface
+contains
+  integer function func(x)
+    integer :: x
+    func = x
+  end function
+end module
+
+module m2
+end module
+
+program p
+  implicit none
+  call subr()
+  print *, "PASS"
+contains
+  subroutine subr()
+    use m1
+    use m1, only: gnr => gnr
+    use m2
+    if (gnr(100) /= 100) STOP 1
+  end subroutine
+end program

--- a/test/f90_correct/src/use06.f90
+++ b/test/f90_correct/src/use06.f90
@@ -1,0 +1,26 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM
+! Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for USE statement when there is rename of user-defined operator in the
+! ONLY option.
+
+module m
+  interface operator(.add.)
+    module procedure func
+  end interface
+contains
+  integer function func(x, y)
+    integer, intent(in) :: x, y
+    func = x + y
+  end function
+end module
+
+program p
+  use m, only: operator(.localadd.) => operator(.add.)
+  implicit none
+  if ((1 .localadd. 2) /= 3) STOP 1
+  print *, "PASS"
+end program

--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -266,7 +266,6 @@ SPTR
 add_use_rename(SPTR local, SPTR global, LOGICAL is_operator)
 {
   RENAME *pr;
-  int original_global = global;
 
   assert(module_id != NO_MODULE, "module_id must be set", 0, ERR_Fatal);
   assert(global > NOSYM, "global must be set", global, ERR_Fatal);
@@ -275,64 +274,11 @@ add_use_rename(SPTR local, SPTR global, LOGICAL is_operator)
   pr->is_operator = is_operator;
   pr->next = usedb.base[module_id].rename;
   usedb.base[module_id].rename = pr;
-  /*
-   * NOTE: MAY want to skip the ensuing 'if' when the rename is
-   * for an OPERATOR (is_operator is set) since an ST_OPERATOR is in
-   * its own overloading class!
-   */
-  if (!VALID_RENAME_SYM(global)) {
-    SPTR sptr;
-    for (sptr = first_hash(global); sptr; sptr = HASHLKG(sptr)) {
-      if (NMPTRG(sptr) == NMPTRG(global) && SCOPEG(sptr) == SCOPEG(global) &&
-          VALID_RENAME_SYM(sptr)) {
-        if (ST_ISVAR(sptr) && SYMLKG(sptr) &&
-            STYPEG(SYMLKG(sptr)) == ST_ALIAS &&
-            SCOPEG(SYMLKG(sptr)) == usedb.base[module_id].module) {
-          global = SYMLKG(sptr);
-        } else {
-          global = sptr;
-        }
-      }
-    }
-  }
-
-  if (local && STYPEG(local) == ST_ALIAS && PRIVATEG(local) &&
-      SCOPEG(local) != curr_scope()->sptr) {
-    /* local is a private rename from another module
-     * build and use a rename symbol in this scope.
-     */
-    int newlocal = insert_sym(local);
-    DTYPEP(newlocal, DTYPEG(global));
-    SCOPEP(newlocal, curr_scope()->sptr);
-    pr->local = newlocal;
-    HIDDENP(SYMLKG(local), 0);
-    pr->global = SYMLKG(local);
-    pr->lineno = gbl.lineno;
-    return pr->global;
-  }
-  if (STYPEG(global) == ST_ALIAS && PRIVATEG(global) &&
-      SCOPEG(global) != curr_scope()->sptr) {
-    /* global is an alias from another scope, generate an alias for the
-     * current scope */
-    SPTR newglobal = insert_sym(global);
-    pr->global = newglobal;
-    pr->local = local;
-    SCOPEP(newglobal, curr_scope()->sptr);
-    ENCLFUNCP(newglobal, SCOPEG(newglobal));
-    DTYPEP(newglobal, DTYPEG(global));
-    STYPEP(newglobal, ST_ALIAS);
-    SYMLKP(newglobal, SYMLKG(global));
-    HIDDENP(SYMLKG(newglobal), 0);
-    pr->lineno = gbl.lineno;
-    return pr->global;
-  }
-
-  if (!local && global != original_global && seen_contains &&
-      STYPEG(original_global) == ST_UNKNOWN) {
-    pr->local = original_global;
-  } else {
-    pr->local = local;
-  }
+ 
+  if (local && local == global)
+    /* treat "use m, only: global => global" as "use m, only: global"*/
+    local = SPTR_NULL;
+  pr->local = local;
   pr->global = global;
   pr->lineno = gbl.lineno;
 
@@ -495,7 +441,8 @@ apply_use_stmts(void)
 }
 
 static int
-find_def_in_most_recent_scope(int sptr, int save_sem_scope_level)
+find_def_in_most_recent_scope(int sptr, LOGICAL is_operator,
+                              int save_sem_scope_level)
 {
   int sptr1;
   SCOPESTACK *scope;
@@ -543,6 +490,9 @@ find_def_in_most_recent_scope(int sptr, int save_sem_scope_level)
              NMPTRG(SYMLKG(ng)) == NMPTRG(sptr)) {
         ng = SYMLKG(ng);
       }
+      if ((is_operator && STYPEG(ng) != ST_OPERATOR) ||
+          (!is_operator && STYPEG(ng) == ST_OPERATOR))
+        continue;
       /* is the symbol visible in this scope: i.e. not on except list or
           in private USE or a private module variable */
       if (!is_except_in_scope(scope, sptr1) &&
@@ -632,14 +582,13 @@ apply_use(MODULE_ID m_id)
       continue;
     }
 
-    newglobal = find_def_in_most_recent_scope(pr->global, save_sem_scope_level);
-   
+    newglobal = find_def_in_most_recent_scope(pr->global, pr->is_operator,
+                                              save_sem_scope_level);
+
     /* mark syms that are not accessible based on the USE ONLY list */
     /* step2: reverse NOT_IN_USEONLYP flag to 0 for syms on the USE ONLY list*/
-    for (sptr = stb.firstusym; sptr < stb.stg_avail; ++sptr) {
-      if (sptr == newglobal && SCOPEG(sptr) == used->module)
-        NOT_IN_USEONLYP(sptr, 0);
-    }
+    if (newglobal > NOSYM && SCOPEG(newglobal) == used->module)
+       NOT_IN_USEONLYP(newglobal, 0);
 
     if (newglobal > NOSYM) {
       /* look for generic with same name */

--- a/tools/flang1/flang1exe/semant.c
+++ b/tools/flang1/flang1exe/semant.c
@@ -10575,6 +10575,35 @@ procedure_stmt:
     } else
       error(34, 3, gbl.lineno, np, CNULL);
     break;
+  /*
+   *   <only> ::= <id name> ( <only operator> ) '=>' <id name> ( <only operator
+   *   > )
+   */
+  case ONLY5:
+    np = scn.id.name + SST_CVALG(RHS(1));
+    if (sem_strcmp(np, "operator") == 0) {
+      np = scn.id.name + SST_CVALG(RHS(6));
+      if (sem_strcmp(np, "operator")) {
+        error(34, 3, gbl.lineno, np, CNULL);
+        break;
+      }
+    } else {
+      error(34, 3, gbl.lineno, np, CNULL);
+      break;
+    }
+    sptr = SST_SYMG(RHS(3));
+    if (STYPEG(sptr) == ST_OPERATOR && INKINDG(sptr)) {
+      error(34, 3, gbl.lineno, SYMNAME(sptr), CNULL);
+      break;
+    }
+    sptr = SST_SYMG(RHS(8));
+    if (STYPEG(sptr) == ST_OPERATOR && INKINDG(sptr)) {
+      error(34, 3, gbl.lineno, SYMNAME(sptr), CNULL);
+      break;
+    }
+    /* local (RHS(3)) => global (RHS(8)) */
+    (void)add_use_rename(SST_SYMG(RHS(3)), SST_SYMG(RHS(8)), 1);
+    break;
 
   /* ------------------------------------------------------------------ */
   /*

--- a/tools/flang1/flang1exe/semsym.c
+++ b/tools/flang1/flang1exe/semsym.c
@@ -1044,12 +1044,6 @@ refsym_inscope(int first, OVCLASS oclass)
          */
         goto return0;
       }
-      if (gbl.internal > 1 && !INTERNALG(sptr)) {
-        /* This is a non-internal symbol in an internal subprogram. */
-        if (IS_INTRINSIC(STYPEG(sptr)))
-          goto returnit; // tentative intrinsic; may be overridden later
-        goto return0; // declare a new symbol
-      }
       if (ENCLFUNCG(sptr) && STYPEG(ENCLFUNCG(sptr)) == ST_MODULE &&
           ENCLFUNCG(sptr) != gbl.currmod) {
         /* see if the scope level makes this host associated */
@@ -1076,6 +1070,12 @@ refsym_inscope(int first, OVCLASS oclass)
         error(155, 3, gbl.lineno, SYMNAME(sptr),
               "is use associated and cannot be redeclared");
         goto return0;
+      }
+      if (gbl.internal > 1 && !INTERNALG(sptr)) {
+        /* This is a non-internal symbol in an internal subprogram. */
+        if (IS_INTRINSIC(STYPEG(sptr)))
+          goto returnit; // tentative intrinsic; may be overridden later
+        goto return0; // declare a new symbol
       }
       /*if ((int)SCOPEG(sptr) == stb.curr_scope)*/
       goto returnit;

--- a/tools/flang1/utils/prstab/gram.txt
+++ b/tools/flang1/utils/prstab/gram.txt
@@ -656,7 +656,8 @@
 <only> ::= <ident> |
 	   <ident> '=>' <ident> |
 	   <id name> ( <only operator> ) |
-	   <id name> ( = )
+	   <id name> ( = ) |
+	   <id name> ( <only operator> ) '=>' <id name> ( <only operator> )
 
 <only operator> ::= <intrinsic op> |
 	            . <ident> .    |


### PR DESCRIPTION
The reason of the problem is that the symbols with the same name
in different modules are linked in the hash list, and the local symbol is
inserted in front of the matching symbol instead of the head of hash list.
This commit adds an existence check of rename to fix the problem.