### PR TITLE
win: 'ffast-math' option is not recognized by clang-cl

### DIFF
--- a/runtime/flang/CMakeLists.txt
+++ b/runtime/flang/CMakeLists.txt
@@ -560,12 +560,21 @@ set_property(
  PG_PIC
  )
 
-set_source_files_properties(
-  ${I8_FILES_DIR}/red_norm2_stride1.c
-  red_norm2_stride1.c
-  PROPERTIES
-  COMPILE_FLAGS "-ffast-math"
-  )
+if (NOT MSVC  OR "${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "GNU")
+  set_source_files_properties(
+    ${I8_FILES_DIR}/red_norm2_stride1.c
+    red_norm2_stride1.c
+    PROPERTIES
+    COMPILE_FLAGS "-ffast-math"
+    )
+else()
+  set_source_files_properties(
+    ${I8_FILES_DIR}/red_norm2_stride1.c
+    red_norm2_stride1.c
+    PROPERTIES
+    COMPILE_FLAGS "/fp:fast"
+    )
+endif()
 
 ## CMake does not handle module dependencies between Fortran files,
 ## unless using the Ninja generator, we need to help it


### PR DESCRIPTION
Needs to use '/fp:fast' [1] compiler option instead.

[1]: https://docs.microsoft.com/en-us/cpp/build/reference/fp-specify-floating-point-behavior?view=msvc-160#fast