### PR TITLE
Remove Fortran entry symbol formats for Windows

### DIFF
--- a/runtime/include/FuncArgMacros.h
+++ b/runtime/include/FuncArgMacros.h
@@ -18,61 +18,6 @@
 #define _PGHPFENT_H_
 
 /* Alternate Fortran entry symbol formats */
-#if defined(WIN64)
-#if defined(DESC_I8)
-#define ENTF90IO(UC, LC) pgf90io_##LC##_i8
-#define ENTF90(UC, LC) pgf90_##LC##_i8
-#define ENTFTN(UC, LC) pghpf_##LC##_i8
-#define ENTRY(UC, LC) LC##_i8
-#define ENTCRF90IO(UC, LC) pgcrf90io_##LC##_i8
-#define ENTFTNIO(UC, LC) pghpfio_##LC##64
-#define ENTCRFTNIO(UC, LC) pgcrhpfio_##LC##_i8
-#define F90_MATMUL(s) pg_mm_##s##_i8_
-#define F90_NORM2(s) pg_norm2_##s##_i8_
-#else /* !defined(DESC_I8) */
-#define ENTF90IO(UC, LC) pgf90io_##LC
-#define ENTF90(UC, LC) pgf90_##LC
-#define ENTFTN(UC, LC) pghpf_##LC
-#define ENTRY(UC, LC) LC
-#define ENTCRF90IO(UC, LC) pgcrf90io_##LC
-#define ENTFTNIO(UC, LC) pghpfio_##LC
-#define ENTCRFTNIO(UC, LC) pgcrhpfio_##LC
-#define F90_MATMUL(s) pg_mm_##s##_
-#define F90_NORM2(s) pg_norm2_##s##_
-#endif /* defined(DESC_I8) */
-#define ENTF90COMN(UC, LC) pgf90_##LC
-#define ENTCRF90(UC, LC) pgcrf90_##LC
-#define ENTCRFTN(UC, LC) pgcrhpf_##LC
-#define ENTCOMN(UC, LC) pghpf_##LC##_
-
-#elif defined(WIN32)
-#define ENTF90(UC, LC) pgf90_##LC
-#define ENTF90IO(UC, LC) pgf90io_##LC
-#define ENTFTN(UC, LC) pghpf_##LC
-#define ENTFTNIO(UC, LC) pghpfio_##LC
-#define ENTRY(UC, LC) LC
-#define ENTCRF90IO(UC, LC) pgcrf90io_##LC
-#define ENTCRFTNIO(UC, LC) pgcrhpfio_##LC
-#define ENTCRF90(UC, LC) pgcrf90_##LC
-#define ENTCRFTN(UC, LC) pgcrhpf_##LC
-#define ENTCOMN(UC, LC) pghpf_##LC
-#define F90_MATMUL(s) pg_mm_##s##_
-#define F90_NORM2(s) pg_norm2_##s##_
-
-#elif defined(WINNT)
-#define ENTF90(UC, LC) pgf90_##LC
-#define ENTF90IO(UC, LC) pgf90io_##LC
-#define ENTFTN(UC, LC) pghpf_##LC
-#define ENTFTNIO(UC, LC) pghpfio_##LC
-#define ENTRY(UC, LC) LC
-#define ENTCRF90IO(UC, LC) pgcrf90io_##LC
-#define ENTCRFTNIO(UC, LC) pgcrhpfio_##LC
-#define ENTCRF90(UC, LC) pgcrf90_##LC
-#define ENTCRFTN(UC, LC) pgcrhpf_##LC
-#define ENTCOMN(UC, LC) pghpf_win_##LC
-#define F90_MATMUL(s) pg_mm_##s##_
-
-#else
 #if defined(DESC_I8)
 #define ENTF90IO(UC, LC) f90io_##LC##_i8
 #define ENTF90(UC, LC) f90_##LC##_i8
@@ -99,8 +44,6 @@
 #define ENTCRF90(UC, LC) crf90_##LC	/* FIXME: HPF, delete all with this prefix*/
 #define ENTCRFTN(UC, LC) crftn_##LC	/* FIXME: HPF, delete all with this prefix*/ 
 #define ENTCOMN(UC, LC) ftn_##LC##_	/* FIXME: common blocks */
-
-#endif
 
 #if defined(DESC_I8)
 #define I8(s) s##_i8


### PR DESCRIPTION
We can use standard symbol names, it seems it is not
necessary to keep different symbol names for Windows.