### PR TITLE
Flang test port for LLVM release_13x

### DIFF
--- a/test/directives/novector.f90
+++ b/test/directives/novector.f90
@@ -19,6 +19,4 @@ end subroutine
 ! CHECK: load <[[VF:[0-9]+]] x i32>
 ! CHECK: sub {{.*}} <[[VF]] x i32>
 ! CHECK: store <[[VF]] x i32>
-! NOVECTOR-NOT: load <[[VF:[0-9]+]] x i32>
-! NOVECTOR-NOT: sub {{.*}} <[[VF]] x i32>
-! NOVECTOR-NOT: store <[[VF]] x i32>
+! NOVECTOR-NOT: <{{[0-9]+}} x {{.+}}>

--- a/test/directives/omp_simd_clause.f90
+++ b/test/directives/omp_simd_clause.f90
@@ -13,9 +13,7 @@ subroutine sum(myarr1,myarr2,ub)
   end do
 end subroutine
 
-! CHECK-NOT:  {{.*}} add nsw <[[VF:[0-9]+]] x i32>{{.*}}
-! METADATA-NOT: load {{.*}}, !llvm.mem.parallel_loop_access ![[TAG1:[0-9]+]]
-! METADATA-NOT: store {{.*}}, !llvm.mem.parallel_loop_access ![[TAG1]]
-! METADATA-NOT: ![[TAG2:[0-9]+]] = !{!"llvm.loop.vectorize.enable", i1 true}
-! METADATA-NOT: ![[TAG1:[0-9]+]] = distinct !{![[TAG1]], ![[TAG2]]}
+! CHECK-NOT:  {{.*}} add nsw <{{[0-9]+}} x i32>{{.*}}
+! METADATA-NOT: llvm.mem.parallel_loop_access
+! METADATA-NOT: llvm.loop.vectorize.enable
 ! WARNING: F90-W-0604-Unsupported clause specified for the omp simd directive

--- a/test/directives/prefetch.f90
+++ b/test/directives/prefetch.f90
@@ -11,13 +11,13 @@ subroutine prefetch_dir(a1, a2)
   end do
 end subroutine prefetch_dir
 
-!! Ensure that the offset generated for the prefetch of a2(i + 256) is correct.
 ! CHECK-PREFETCH: [[a1:%[0-9]+]] = bitcast i64* %a1 to i8*
 ! CHECK-PREFETCH: [[a2:%[0-9]+]] = bitcast i64* %a2 to i8*
-! CHECK-PREFETCH: [[a2base:%[0-9]+]] = getelementptr i8, i8* [[a2]], i64 1020
 ! CHECK-PREFETCH: call void @llvm.prefetch{{.*}}(i8* [[a1]], i32 0, i32 3, i32 1)
 ! CHECK-PREFETCH: [[i:%[0-9]+]] = shl nuw nsw i64 %indvars.iv, 2
-! CHECK-PREFETCH: [[a2elem:%[0-9]+]] = getelementptr i8, i8* [[a2base]], i64 [[i]]
+!! Ensure that the offset generated for the prefetch of a2(i + 256) is correct.
+! CHECK-PREFETCH: [[a2offidx:%.*]] = add nuw nsw i64 [[i]], 1020
+! CHECK-PREFETCH: [[a2elem:%[0-9]+]] = getelementptr i8, i8* [[a2]], i64 [[a2offidx]]
 ! CHECK-PREFETCH: call void @llvm.prefetch{{.*}}(i8* [[a2elem]], i32 0, i32 3, i32 1)
 ! CHECK-PREFETCH: declare void @llvm.prefetch{{.*}}
 ! CHECK-NOPREFETCH-NOT: @llvm.prefetch

--- a/test/directives/unroll.f90
+++ b/test/directives/unroll.f90
@@ -34,7 +34,7 @@ subroutine func1(a, b)
   ! CHECK-O0-SAME:      !llvm.loop [[MD_LOOP1:![0-9]+]]
   ! CHECK-O1-COUNT-10:  store i32
   ! CHECK-O1-NOT:       store i32
-  ! CHECK-O1-NOT:       br i1 {{.*}}, label %[[BB1]]
+  ! CHECK-O1-NOT:       br i1 {{.*}}, label %{{L.LB[0-9]_[0-9]+}}
   ! CHECK-O1-NOT:       !llvm.loop !{{[0-9]+}}
   ! CHECK-O1:           ret void
   ! CHECK-DISABLED:     [[BB1:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB1]],

--- a/test/directives/vector.f90
+++ b/test/directives/vector.f90
@@ -17,5 +17,5 @@ end subroutine
 ! IGNORE-DIRECTIVES-NOT: !"llvm.loop.vectorize.enable", i1 true
 ! CHECK: load <[[VF:[0-9]+]] x i32>
 ! CHECK: store <[[VF]] x i32>
-! VECTOR-NOT: load <[[VF:[0-9]+]] x i32>
-! VECTOR-NOT: store <[[VF]] x i32>
+! VECTOR-NOT: <{{[0-9]+}} x
+


### PR DESCRIPTION
Minor changes to flang test in order to adapt them for LLVM release_13x.
Depends on https://github.com/flang-compiler/classic-flang-llvm-project/pull/62
