### PR TITLE
win: Fix the inconsistent usage of dllexport/dllimport

### DIFF
--- a/runtime/flang/descIntrins.c
+++ b/runtime/flang/descIntrins.c
@@ -18,10 +18,7 @@
 #include <string.h>
 #include "fioMacros.h"
 /* macros for entries */
-#if defined(WINNT) && !defined(WIN64) && !defined(UXOBJS) && !defined(CROBJS)
-#pragma global - x 121 0x20000
-#define ENTFTN_MS(UC) WIN_EXP __attribute__((stdcall)) UC
-#elif defined(WINNT) && defined(WIN64)
+#if defined(_WIN64)
 #define ENTFTN_MS I8
 #endif
 

--- a/runtime/flang/entry.c
+++ b/runtime/flang/entry.c
@@ -14,14 +14,7 @@
 #include "stdioInterf.h"
 #include "fioMacros.h"
 
-#if defined(WIN64) || defined(WIN32)
-WIN_IMP __INT_T LINENO[];
-#elif defined(C90) || defined(WINNT)
-__INT_T LINENO[1];
-char *__get_fort_lineno_addr(void);
-#else
-extern __INT_T LINENO[];
-#endif
+WIN_API __INT_T LINENO[];
 
 #if defined(WIN32) || defined(WIN64)
 #define write _write

--- a/runtime/flang/fioMacros.h
+++ b/runtime/flang/fioMacros.h
@@ -25,20 +25,9 @@
 
 /* special argument pointers */
 
-#if defined(TARGET_WIN) || defined(WIN64) || defined(WIN32)
-WIN_IMP __INT_T ENTCOMN(0, 0)[4];
-WIN_IMP __STR_T ENTCOMN(0C, 0c)[1];
-#elif defined(WINNT)
-__INT_T ENTCOMN(0, 0)[4];
-__STR_T ENTCOMN(0C, 0c)[1];
-char *__get_fort_01_addr(void);
-char *__get_fort_02_addr(void);
-char *__get_fort_03_addr(void);
-char *__get_fort_04_addr(void);
-char *__get_fort_0c_addr(void);
-char *__get_fort_me_addr(void);
-char *__get_fort_np_addr(void);
-
+#if defined(_WIN64)
+WIN_API __INT_T ENTCOMN(0, 0)[4];
+WIN_API __STR_T ENTCOMN(0C, 0c)[1];
 #else
 #if defined(DESC_I8)
 extern __INT4_T ENTCOMN(0, 0)[];
@@ -78,10 +67,8 @@ extern __STR_T ENTCOMN(0C, 0c)[];
 
 /* local mode flag declaration and test macro */
 
-#if defined(TARGET_WIN) || defined(WIN64) || defined(WIN32)
-WIN_IMP __INT_T ENTCOMN(LOCAL_MODE, local_mode)[1];
-#elif defined(WINNT) || defined(C90)
-__INT_T ENTCOMN(LOCAL_MODE, local_mode)[1];
+#if defined(_WIN64)
+WIN_API __INT_T ENTCOMN(LOCAL_MODE, local_mode)[1];
 #else
 #if defined(DESC_I8)
 extern __INT4_T ENTCOMN(LOCAL_MODE, local_mode)[];
@@ -540,10 +527,8 @@ extern int __fort_entry_mflag;
 #define __CORMEM_M1 0x58ad5e3
 #define __CORMEM_M2 0x61f072b
 
-#if   defined(TARGET_WIN) || defined(WIN64) || defined(WIN32)
-WIN_IMP __INT_T *CORMEM;
-#elif defined(WINNT)
-extern __INT_T *CORMEM;
+#if defined(_WIN64)
+WIN_API __INT_T *CORMEM;
 #else
 #if defined(DESC_I8)
 extern __INT4_T CORMEM[];

--- a/runtime/flang/initpar.c
+++ b/runtime/flang/initpar.c
@@ -66,16 +66,8 @@ static struct {
 /* common blocks containing values for inlined number_of_processors()
    and my_processor() functions */
 
-#if defined(WIN64) || defined(WIN32)
-WIN_IMP __INT_T ENTCOMN(NP, np)[];
-WIN_IMP __INT_T ENTCOMN(ME, me)[];
-#elif defined(C90) || defined(WINNT)
-__INT_T ENTCOMN(NP, np)[1];
-__INT_T ENTCOMN(ME, me)[1];
-#else
-extern __INT_T ENTCOMN(NP, np)[];
-extern __INT_T ENTCOMN(ME, me)[];
-#endif
+WIN_API __INT_T ENTCOMN(NP, np)[];
+WIN_API __INT_T ENTCOMN(ME, me)[];
 
 #if defined(WIN32) || defined(WIN64)
 #define write _write

--- a/runtime/include/FuncArgMacros.h
+++ b/runtime/include/FuncArgMacros.h
@@ -39,7 +39,6 @@
 #define F90_MATMUL(s) f90_mm_##s##_
 #define F90_NORM2(s) f90_norm2_##s##_
 #endif /* defined(DESC_I8) */
-
 #define ENTF90COMN(UC, LC) pgf90_##LC
 #define ENTCRF90(UC, LC) crf90_##LC	/* FIXME: HPF, delete all with this prefix*/
 #define ENTCRFTN(UC, LC) crftn_##LC	/* FIXME: HPF, delete all with this prefix*/ 
@@ -70,13 +69,10 @@
 #define CADR(ARG) (ARG##_adr)
 #define CLEN(ARG) (ARG##_len)
 
-/* #if defined(WIN64) || defined(WIN32) */
-#if defined(PGDLL) && defined(_DLL) &&                                         (defined(TARGET_WIN) || defined(WIN64) || defined(WIN32))
-#define WIN_EXP __declspec(dllexport)
-#define WIN_IMP extern __declspec(dllimport)
+#if defined(_WIN64) && defined(_DLL)
+   #define WIN_API extern __declspec(dllexport)
 #else
-#define WIN_EXP
-#define WIN_IMP extern
+  #define WIN_API extern
 #endif
 
 #define CORMEM ENTCOMN(0L, 0l)


### PR DESCRIPTION
Set the proper prefix for the delcarations.