### PR TITLE
 [DebugInfo] flang support for Deferred length string type

### DIFF
--- a/test/debug_info/deferred_len.f90
+++ b/test/debug_info/deferred_len.f90
@@ -1,0 +1,16 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: !DILocalVariable(name: "defl_string"{{.*}}, type: ![[DERIVEDSTRING:[0-9]+]]
+!CHECK: ![[DERIVEDSTRING]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[STRING:[0-9]+]]
+!CHECK: ![[STRING]] = !DIStringType(name: "character(*)", stringLength: !{{[0-9]+}}
+
+program deferredlength
+
+        character(len=100) :: buffer
+        character(len=:), allocatable :: defl_string
+
+        read(*,*) buffer
+        defl_string = trim(buffer)
+        print *,defl_string
+
+end program deferredlength

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -11395,8 +11395,9 @@ addDebugForLocalVar(SPTR sptr, LL_Type *type)
 {
   if (need_debug_info(sptr) || pointer_scalar_need_debug_info(sptr)) {
     /* Dummy sptrs are treated as local (see above) */
-    if (ll_feature_debug_info_ver90(&cpu_llvm_module->ir) &&
-        ftn_array_need_debug_info(sptr)) {
+    if ((ll_feature_debug_info_ver90(&cpu_llvm_module->ir) &&
+        ftn_array_need_debug_info(sptr)) &&
+        (DTYPEG(REVMIDLNKG(sptr)) != DT_DEFERCHAR)) {
       SPTR array_sptr = (SPTR)REVMIDLNKG(sptr);
       LL_MDRef array_md =
           lldbg_emit_local_variable(cpu_llvm_module->debug_info, array_sptr,


### PR DESCRIPTION
 This fix handle support for Deferred length string type during debug info
 generation. Here the length of the string is available during runtime only
 and its part of array descriptor ($sd), its 4th field as shown below where
 the length of the sample string taken is 6

 array_descriptor = (14, 140737341741098, 0, 6, 3, 140737354099760, 498, 140737341742316, 0, 140737323837350, 3, 22, 0, 140737341514576, 0, 140737354129776)

 This fix extracts the length field from array descriptor and creates a local
 variable to hold this length. Here DIExpression used will extract the length
 which is 24 bytes or 0x18 bytes away from the start of the array descriptor.
 DIStringType with stringLength attribute is generated. stringLength will point
 to this local variable which holds the length field. This fix has dependency
 on LLVM11 and above to emit DW_AT_string_length attribute.
 This is exactly the same behavior or representation when compared to gfortran. 
 Gfortran also uses stringLength attribute and pointer type representation.

 Test case:

 program deferredlength
 character(len=100) :: buffer
 character(len=:), allocatable :: cqe_defl_string
 read(*,*) buffer
 cqe_defl_string = trim(buffer)
 print *,cqe_defl_string
 end program deferredlength

 IR:
 . . .
 call void @llvm.dbg.declare (metadata [16 x i64]* %cqe_defl_string$sd_352, metadata !19, metadata !20), !dbg !15
 . . .

 !18 = !DIBasicType(tag: DW_TAG_base_type, name: "integer", size: 32, align: 32, encoding: DW_ATE_signed)
 !19 = distinct !DILocalVariable(scope: !14, file: !3, type: !18, flags: 64)
 !20 = !DIExpression(DW_OP_plus_uconst, 24)
 . . .
 !27 = !DIStringType(name: "character(*)", size: 32, stringLength: !19)
 !28 = !DIDerivedType(tag: DW_TAG_pointer_type, size: 64, align: 64, baseType: !27)
 !29 = !DILocalVariable(scope: !14, name: "cqe_defl_string", file: !3, type: !28)

 Dwarf dump:
 . . .
 0x00000054:   DW_TAG_variable [4]
                    DW_AT_location [DW_FORM_exprloc]      (DW_OP_fbreg -8)
                    DW_AT_name [DW_FORM_strp]     ( .debug_str[0x00000053] = "cqe_defl_string")
                    DW_AT_type [DW_FORM_ref4]     (cu + 0x00a1 => {0x000000a1} "character(*)*")

 0x000000a1:   DW_TAG_pointer_type [9]
                    DW_AT_type [DW_FORM_ref4]       (cu + 0x00a6 => {0x000000a6} "character(*)")

 0x000000a6:   DW_TAG_string_type [10]
                    DW_AT_name [DW_FORM_strp]       ( .debug_str[0x000000c6] = "character(*)")
                    DW_AT_string_length [DW_FORM_ref4]      (cu + 0x0049 => {0x00000049})

 0x00000049:   DW_TAG_variable [3]
                    DW_AT_location [DW_FORM_exprloc]      (DW_OP_fbreg -136, DW_OP_plus_uconst 0x18)
                    DW_AT_type [DW_FORM_ref4]     (cu + 0x009a => {0x0000009a} "integer")
                    DW_AT_artificial [DW_FORM_flag_present]       (true)
 . . .

GDB session :
. . .
(gdb) i local
cqe_defl_string = 0x220130
buffer = 'abcdef', ' ' <repeats 94 times>
(gdb) p *cqe_defl_string
$1 = 'abcdef'
(gdb) ptype cqe_defl_string
type = PTR TO -> ( character*(*) )
