### PR TITLE
Fix implicit declaration of function warnings reported by clang-cl

### DIFF
--- a/runtime/flang/close.c
+++ b/runtime/flang/close.c
@@ -19,6 +19,7 @@
 #include "stdioInterf.h"
 
 #if defined(_WIN64)
+#include <io.h> // for _access, _unlink
 #define unlink _unlink
 #define access _access
 #endif

--- a/runtime/flang/ent3f.h
+++ b/runtime/flang/ent3f.h
@@ -12,6 +12,11 @@
  * \brief ent3f.h macros for building RTE routine names and arg lists
  */
 
+#if defined(_WIN64)
+#include <io.h> // for _access, _chmod, _ulink
+#include <direct.h> // for _chdir
+#endif
+
 #undef DCHAR
 #undef DCLEN
 #undef CADR

--- a/runtime/flang/entry.c
+++ b/runtime/flang/entry.c
@@ -17,6 +17,7 @@
 WIN_API __INT_T LINENO[];
 
 #if defined(_WIN64)
+#include <io.h> // for _write
 #define write _write
 #endif
 

--- a/runtime/flang/stat.c
+++ b/runtime/flang/stat.c
@@ -14,6 +14,7 @@
 #include <memory.h>
 
 #if defined(_WIN64)
+#include <io.h> // for _write
 #define write _write
 #endif
 

--- a/runtime/flangrti/trace.c
+++ b/runtime/flangrti/trace.c
@@ -57,6 +57,7 @@ dbg_stop_before_exit(void)
  */
 
 #if defined(_WIN64)
+#include <process.h> // for _getpid, _exit
 #define getpid _getpid
 #define _Exit _exit
 #endif


### PR DESCRIPTION
It needs to include the proper header files to silence warnings for
access, chdir, chmod, ulink, write functions.