### PR TITLE
[flang2] Delete dead loop metadata code and fix build error on master branch; NFCI

### DIFF
--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -283,7 +283,6 @@ typedef enum LL_InstrListFlags {
   NOSIGNEDWRAP            = (1 << 11),
   NOUNSIGNEDWRAP          = (1 << 12),
   FUNC_RETURN_IS_FUNC_PTR = (1 << 13),
-  LDST_HAS_METADATA       = (1 << 13), /**< I_LOAD, I_STORE only */
   LDST_HAS_ACCESSGRP_METADATA = (1 << 14), /**< I_LOAD, I_STORE only, for llvm.loop.parallel_accesses */
 
   /* Information for atomic operations.


### PR DESCRIPTION
Commits 4c6964dabf06, 2838f5dbdc58, and 255fce7a3bf5 have re-written how loop metadata are generated for `NODEPCHK` and `VECTOR ALWAYS` directives. As a result, the `mark_rw_nodepchk` function from the original implementation is no longer called, which means the `rw_nodepchk` flag is never true, causing some code to never run. In particular, the unused `mark_rw_nodepchk` function causes `-Werror` to fail the build. This patch deletes all the dead code, merges `cons_no_depchk_metadata` into `cons_vec_always_metadata` (both are identical) and fixes up some incorrect comments.