### PR TITLE
[flang2] Make flang aware of LLVM Target features

### DIFF
--- a/test/llvm_ir_correct/attr.f90
+++ b/test/llvm_ir_correct/attr.f90
@@ -1,0 +1,13 @@
+!** Test checking attributes are set correctly
+! RUN: %flang -S -emit-llvm -march=armv8-a %s -o - | FileCheck %s -check-prefix=ATTRS1
+! RUN: %flang -S -emit-llvm -march=armv8-a+sve %s -o - | FileCheck %s -check-prefix=ATTRS2
+      program tz
+       integer :: i
+       integer ::acc(100)
+       do i=1,100
+            acc(i) = 5
+       end do
+      print *, acc(100)
+      end program
+! ATTRS1: attributes{{.*}}"target-features"="+neon"
+! ATTRS2: attributes{{.*}}"target-features"="+neon,+sve"

--- a/tools/flang2/flang2exe/aarch64/flgdf.h
+++ b/tools/flang2/flang2exe/aarch64/flgdf.h
@@ -29,6 +29,7 @@ FLG flg = {
     NULL,       /* idir == empty list */
     NULL,       /* linker_directives == empty list */
     NULL,       /* llvm_target_triple == empty ptr */
+    NULL,       /* target_features == empty ptr */
     false,      /* dlines = -nodlines */
     72,         /* extend_source = -noextend_source */
     true,       /* i4 = -i4 */

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -13366,6 +13366,11 @@ print_function_signature(int func_sptr, const char *fn_name, LL_ABI_Info *abi,
     /* Apply alwaysinline attribute if the pragma "forceinline" is given */
     print_token(" alwaysinline");
   }
+  if (flg.target_features) {
+    print_token(" \"target-features\"=\"");
+    print_token(flg.target_features);
+    print_token("\"");
+  }
 
   if (func_sptr > NOSYM) {
 /* print_function_signature() can be called with func_sptr=0 */

--- a/tools/flang2/flang2exe/main.cpp
+++ b/tools/flang2/flang2exe/main.cpp
@@ -644,6 +644,7 @@ init(int argc, char *argv[])
   register_boolean_arg(arg_parser, "recursive", &flg.recursive, false);
   register_integer_arg(arg_parser, "vect", &vect_val, 0);
   register_string_arg(arg_parser, "cmdline", &flg.cmdline, NULL);
+  register_string_arg(arg_parser, "target_features", &flg.target_features, NULL);
   register_boolean_arg(arg_parser, "debug", &flg.debug, false);
 
   flg.linker_directives = (char **)getitem(8, argc * sizeof(char *));

--- a/tools/flang2/flang2exe/ppc64le/flgdf.h
+++ b/tools/flang2/flang2exe/ppc64le/flgdf.h
@@ -29,6 +29,7 @@ FLG flg = {
     NULL,       /* idir == empty list */
     NULL,       /* linker_directives == empty list */
     NULL,       /* llvm_target_triple == empty ptr */
+    NULL,       /* target_features == empty ptr */
     false,      /* dlines = -nodlines */
     72,         /* extend_source = -noextend_source */
     true,       /* i4 = -i4 */

--- a/tools/flang2/flang2exe/x86_64/flgdf.h
+++ b/tools/flang2/flang2exe/x86_64/flgdf.h
@@ -31,6 +31,7 @@ FLG flg = {
     NULL,       /* idir == empty list */
     NULL,       /* linker_directives == empty list */
     NULL,       /* llvm_target_triple == empty ptr */
+    NULL,       /* target_features == empty ptr */
     false,      /* dlines = -nodlines */
     72,         /* extend_source = -noextend_source */
     true,       /* i4 = -i4 */

--- a/tools/shared/utils/global.h
+++ b/tools/shared/utils/global.h
@@ -175,6 +175,7 @@ typedef struct {
   char **idir;
   char **linker_directives;
   const char *llvm_target_triple;
+  const char *target_features; // TODO - not const char?
   bool dlines;
   int extend_source;
   bool i4;


### PR DESCRIPTION
Add a -target_features option to flang2 that takes a comma-separated list of
LLVM target features suitable for embedding in LLVM metadata.

Teach flang2 to output this as a "target-features" metadata.

This is needed for flang to produce llvm objects that can be used with LTO and
a combination of targets, for example Arm SVE targets.

Depends on https://github.com/flang-compiler/classic-flang-llvm-project/pull/66 on the classic-flang-llvm-project to tell the driver to pass through the options.