### PR TITLE
interface nested into subroutine causes symbol undefined, fix #1013

### DIFF
--- a/test/sema/interface_nested_into_subroutine.f90
+++ b/test/sema/interface_nested_into_subroutine.f90
@@ -1,0 +1,41 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK
+!
+! CHECK-LABEL: define void @MAIN_()
+module base
+  implicit none
+  integer, public :: a = 10
+end module
+
+module intermediate
+  use base, only: a
+  implicit none
+  private
+end module
+
+program x
+  use base
+  implicit none
+
+  interface
+    subroutine sub2
+      use intermediate
+      implicit none
+    end subroutine sub2
+  end interface
+
+  call sub
+
+contains
+
+subroutine sub
+  use intermediate
+  implicit none
+  print *, a
+end subroutine
+
+end program

--- a/tools/flang1/flang1exe/interf.c
+++ b/tools/flang1/flang1exe/interf.c
@@ -515,6 +515,21 @@ init_use_tree(void)
   use_tree = use_tree_end = 0;
 }
 
+void remove_from_use_tree(char *module)
+{
+  USES_LIST *prev = use_tree;
+  for (USES_LIST *n = use_tree; n; n = n->next) {
+    if (strcmp(n->use_module->modulename, module) == 0) {
+      if (n == use_tree) {
+        use_tree = use_tree->next;
+      } else {
+        prev->next = n->next;
+      }
+    }
+    prev = n;
+  }
+}
+
 static TOBE_IMPORTED_LIST *
 already_to_be_used(char *modulename, int public, int except)
 {

--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -67,6 +67,7 @@ typedef struct {
   LOGICAL submodule;    /* use of module by submodule */
   RENAME *rename;
   char *fullname; /* full path name of the module file */
+  unsigned int scope; /* scope of the module */
 } USED;
 
 struct {
@@ -371,7 +372,11 @@ apply_use_stmts(void)
   save_lineno = gbl.lineno;
 
   if (!gbl.currmod && gbl.internal <= 1) {
-    init_use_tree();
+    for (m_id = FIRST_USER_MODULE; m_id < usedb.avl; m_id++) {
+      if (usedb.base[m_id].scope > sem.scope_level) {
+        remove_from_use_tree(SYMNAME(usedb.base[m_id].module));
+      }
+    }
   }
   if (usedb.base[ISO_C_MOD].module) {
     if (usedb.base[ISO_C_MOD].module == ancestor_mod)
@@ -913,6 +918,7 @@ open_module(SPTR use)
   usedb.base[module_id].submodule = FALSE;
   usedb.base[module_id].rename = NULL;
   usedb.base[module_id].fullname = fullname;
+  usedb.base[module_id].scope = sem.scope_level;
 
   if (module_id == ISO_C_MOD) {
     int i;


### PR DESCRIPTION
It's my proposal for fix for ticket
https://trello.com/c/V7wB3kC6/30-hpcl3-1205-bigdft-surprising-interactions-within-the-code-interface-nested-into-subroutine-causes-imported-symbol-appear-undefin

related to
https://github.com/flang-compiler/flang/issues/1013


More experienced devs - please share discussion about pros and cons of such solution, because I can be wrong- this is only my idea and i can not investigate it deeper without any comments from you of such solution.
Please pay attention mostly because I am afraid that this fix will put regression- will let to successfully compile the programs which should not.