### PR TITLE
win: Fix the build on Windows on ARM

### DIFF
--- a/lib/scutil/host-fp-folding.c
+++ b/lib/scutil/host-fp-folding.c
@@ -24,7 +24,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(_M_ARM64)
 #include <mmintrin.h>
 #endif
 

--- a/runtime/flang/async.c
+++ b/runtime/flang/async.c
@@ -17,7 +17,7 @@
  * Fio_asy_close - called from close
  */
 
-#if !defined(TARGET_WIN_X8664)
+#if !defined(TARGET_WIN)
 #include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -42,7 +42,7 @@ struct asy_transaction_data {
   seekoffx_t off;
 };
 
-#if defined(TARGET_WIN_X8664)
+#if defined(TARGET_WIN)
 struct asy {
   FILE *fp;
   int fd;
@@ -82,7 +82,7 @@ static int slime;
 
 /* internal wait for asynch i/o */
 
-#if defined(TARGET_WIN_X8664)
+#if defined(TARGET_WIN)
 static int
 asy_wait(struct asy *asy)
 {
@@ -239,7 +239,7 @@ int
 Fio_asy_open(FILE *fp, struct asy **pasy)
 {
   struct asy *asy;
-#if defined(TARGET_WIN_X8664)
+#if defined(TARGET_WIN)
   HANDLE temp_handle;
 #endif
   asy = (struct asy *)calloc(sizeof(struct asy), 1);
@@ -249,7 +249,7 @@ Fio_asy_open(FILE *fp, struct asy **pasy)
   }
   asy->fp = fp;
   asy->fd = __io_getfd(fp);
-#if defined(TARGET_WIN_X8664)
+#if defined(TARGET_WIN)
   temp_handle = _get_osfhandle(asy->fd);
   asy->handle =
       ReOpenFile(temp_handle, GENERIC_READ | GENERIC_WRITE,
@@ -273,13 +273,13 @@ Fio_asy_read(struct asy *asy, void *adr, long len)
   int n;
   int tn;
 
-#if defined(TARGET_WIN_X8664)
+#if defined(TARGET_WIN)
   union Converter converter;
 #endif
   if (slime)
     printf("--Fio_asy_read %d %p %ld\n", asy->fd, adr, len);
 
-#if defined(TARGET_WIN_X8664)
+#if defined(TARGET_WIN)
   if (asy->flags & ASY_IOACT) { /* i/o active? */
     if (asy_wait(asy) == -1) {  /* ..yes, wait */
       return (-1);
@@ -326,14 +326,14 @@ Fio_asy_write(struct asy *asy, void *adr, long len)
 {
   int n;
   int tn;
-#if defined(TARGET_WIN_X8664)
+#if defined(TARGET_WIN)
   union Converter converter;
 #endif
 
   if (slime)
     printf("--Fio_asy_write %d %p %ld\n", asy->fd, adr, len);
 
-#if defined(TARGET_WIN_X8664)
+#if defined(TARGET_WIN)
   if (asy->flags & ASY_IOACT) { /* i/o active? */
     if (asy_wait(asy) == -1) {  /* ..yes, wait */
       return (-1);
@@ -394,7 +394,7 @@ Fio_asy_close(struct asy *asy)
   if (asy->flags & ASY_IOACT) { /* i/o active? */
     n = asy_wait(asy);
   }
-#if defined(TARGET_WIN_X8664)
+#if defined(TARGET_WIN)
   /* Close the Re-opened handle that we created. */
   CloseHandle(asy->handle);
 #endif

--- a/tools/flang2/flang2exe/upper.cpp
+++ b/tools/flang2/flang2exe/upper.cpp
@@ -1967,7 +1967,7 @@ gethexchar(FILE *file)
   return val;
 } /* gethexchar */
 
-#if defined(TARGET_WIN_X86) && defined(PGFTN)
+#if defined(TARGET_WIN) && defined(PGFTN)
 /*
  * convert to upper case
  */


### PR DESCRIPTION
* Avoid to build x86_64 intrinsics for ARM.
* Use general Windows macro instead of x86_64 specific.