### PR TITLE
Adding vscale_range feature to flang

### DIFF
--- a/test/llvm_ir_correct/attr.f90
+++ b/test/llvm_ir_correct/attr.f90
@@ -1,0 +1,13 @@
+!** Test checking attributes are set correctly
+! RUN: %flang -S -emit-llvm -march=armv8-a %s -o - | FileCheck %s -check-prefix=ATTRS1
+! RUN: %flang -S -emit-llvm -march=armv8-a+sve %s -o - | FileCheck %s -check-prefix=ATTRS2
+      program tz
+       integer :: i
+       integer ::acc(100)
+       do i=1,100
+            acc(i) = 5
+       end do
+      print *, acc(100)
+      end program
+! ATTRS1: attributes{{.*}}"target-features"="+neon"
+! ATTRS2: attributes{{.*}}"target-features"="+neon,+sve"

--- a/test/llvm_ir_correct/attr.f90
+++ b/test/llvm_ir_correct/attr.f90
@@ -1,6 +1,6 @@
 !** Test checking attributes are set correctly
-! RUN: %flang -S -emit-llvm -march=armv8-a %s -o - | FileCheck %s -check-prefix=ATTRS1
-! RUN: %flang -S -emit-llvm -march=armv8-a+sve %s -o - | FileCheck %s -check-prefix=ATTRS2
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a %s -o - | FileCheck %s -check-prefix=ATTRS1
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve %s -o - | FileCheck %s -check-prefix=ATTRS2
       program tz
        integer :: i
        integer ::acc(100)

--- a/test/llvm_ir_correct/vscale.f90
+++ b/test/llvm_ir_correct/vscale.f90
@@ -1,0 +1,25 @@
+!** Test checking attributes are set correctly
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a %s -o - | FileCheck %s -check-prefix=ATTRS1
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve %s -o - | FileCheck %s -check-prefix=ATTRS2
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve2 %s -o - | FileCheck %s -check-prefix=ATTRS3
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve2-sha3 %s -o - | FileCheck %s -check-prefix=ATTRS4
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve+nosve %s -o - | FileCheck %s -check-prefix=ATTRS5
+      program tz
+       integer :: i
+       integer ::acc(100)
+       do i=1,100
+            acc(i) = 5
+       end do
+      print *, acc(100)
+      end program
+! ATTRS1: attributes{{.*}}"target-features"="+neon"
+! ATTRS2: attributes{{.*}}
+! ATTRS2-DAG:"target-features"="+neon,+sve"
+! ATTRS2-DAG: "vscale-range"="1,16"
+! ATTRS3: attributes{{.*}}
+! ATTRS3-DAG:"target-features"="+neon,+sve2"
+! ATTRS3-DAG: "vscale-range"="1,16"
+! ATTRS4: attributes{{.*}}
+! ATTRS4-DAG:"target-features"="+neon,+sve2-sha3"
+! ATTRS4-DAG: "vscale-range"="1,16"
+! ATTRS5: attributes{{.*}}"target-features"="+neon,-sve"

--- a/tools/flang2/flang2exe/aarch64/flgdf.h
+++ b/tools/flang2/flang2exe/aarch64/flgdf.h
@@ -30,6 +30,8 @@ FLG flg = {
     NULL,       /* linker_directives == empty list */
     NULL,       /* llvm_target_triple == empty ptr */
     NULL,       /* target_features == empty ptr */
+    0,          /* min = 0 */
+    0,          /* max = 0 */
     false,      /* dlines = -nodlines */
     72,         /* extend_source = -noextend_source */
     true,       /* i4 = -i4 */

--- a/tools/flang2/flang2exe/aarch64/flgdf.h
+++ b/tools/flang2/flang2exe/aarch64/flgdf.h
@@ -29,6 +29,7 @@ FLG flg = {
     NULL,       /* idir == empty list */
     NULL,       /* linker_directives == empty list */
     NULL,       /* llvm_target_triple == empty ptr */
+    NULL,       /* target_features == empty ptr */
     false,      /* dlines = -nodlines */
     72,         /* extend_source = -noextend_source */
     true,       /* i4 = -i4 */

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -13563,6 +13563,11 @@ print_function_signature(int func_sptr, const char *fn_name, LL_ABI_Info *abi,
     /* Apply alwaysinline attribute if the pragma "forceinline" is given */
     print_token(" alwaysinline");
   }
+  if (flg.target_features) {
+    print_token(" \"target-features\"=\"");
+    print_token(flg.target_features);
+    print_token("\"");
+  }
 
   if (func_sptr > NOSYM) {
 /* print_function_signature() can be called with func_sptr=0 */

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -18,6 +18,16 @@
 #define FFAST_MATH_IS_PRESENT() XBIT(216, 1)
 #define QTMP_SIZE 4 /* tmp[] of union qtmp has 4 elements and 128 bits  */
 
+static const char *const CPU_VSCALE[]={
+  "+sve2-bitperm",
+  "+sve2-sha3",
+  "+sve2-aes",
+  "+sve2-sm4",
+  "+sve",
+  "+sve2",
+  "+sve+nosve+sve"
+};
+
 /**
    \brief ...
  */
@@ -289,6 +299,26 @@ void insert_llvm_dbg_declare(LL_MDRef mdnode, SPTR sptr, LL_Type *llTy,
 void insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode, SPTR sptr,
                            LL_Type *type);
 
+/**
+   \brief Extract the information coming from mArch into its features
+          Return true if finds the token , in the feature, if not
+          returns false 
+   \param arch_feat Input. architecture feature to be evaluated
+   \param mod     Output. value of features
+ */
+bool extract_arch_feat(const char *arch_feat, char *&mod);
+
+/**
+   \brief Check if the given command argument is valid for vscale
+          Output, return true if is valid vscale feature.
+   \param mod     Input. Type of model from the march
+ */
+bool is_vscale_feat(char *mod);
+
+/**
+   \brief Add the token for vscale_range(min, max) to the IR
+ */
+void add_vscale();
 
 int get_parnum(SPTR sptr);
 #endif

--- a/tools/flang2/flang2exe/main.cpp
+++ b/tools/flang2/flang2exe/main.cpp
@@ -647,6 +647,7 @@ init(int argc, char *argv[])
   register_boolean_arg(arg_parser, "recursive", &flg.recursive, false);
   register_integer_arg(arg_parser, "vect", &vect_val, 0);
   register_string_arg(arg_parser, "cmdline", &flg.cmdline, NULL);
+  register_string_arg(arg_parser, "target_features", &flg.target_features, NULL);
   register_boolean_arg(arg_parser, "debug", &flg.debug, false);
 
   flg.linker_directives = (char **)getitem(8, argc * sizeof(char *));

--- a/tools/flang2/flang2exe/ppc64le/flgdf.h
+++ b/tools/flang2/flang2exe/ppc64le/flgdf.h
@@ -30,6 +30,8 @@ FLG flg = {
     NULL,       /* linker_directives == empty list */
     NULL,       /* llvm_target_triple == empty ptr */
     NULL,       /* target_features == empty ptr */
+    0,          /* min = 0 */
+    0,          /* max = 0 */
     false,      /* dlines = -nodlines */
     72,         /* extend_source = -noextend_source */
     true,       /* i4 = -i4 */

--- a/tools/flang2/flang2exe/ppc64le/flgdf.h
+++ b/tools/flang2/flang2exe/ppc64le/flgdf.h
@@ -29,6 +29,7 @@ FLG flg = {
     NULL,       /* idir == empty list */
     NULL,       /* linker_directives == empty list */
     NULL,       /* llvm_target_triple == empty ptr */
+    NULL,       /* target_features == empty ptr */
     false,      /* dlines = -nodlines */
     72,         /* extend_source = -noextend_source */
     true,       /* i4 = -i4 */

--- a/tools/flang2/flang2exe/x86_64/flgdf.h
+++ b/tools/flang2/flang2exe/x86_64/flgdf.h
@@ -31,6 +31,7 @@ FLG flg = {
     NULL,       /* idir == empty list */
     NULL,       /* linker_directives == empty list */
     NULL,       /* llvm_target_triple == empty ptr */
+    NULL,       /* target_features == empty ptr */
     false,      /* dlines = -nodlines */
     72,         /* extend_source = -noextend_source */
     true,       /* i4 = -i4 */

--- a/tools/flang2/flang2exe/x86_64/flgdf.h
+++ b/tools/flang2/flang2exe/x86_64/flgdf.h
@@ -32,6 +32,8 @@ FLG flg = {
     NULL,       /* linker_directives == empty list */
     NULL,       /* llvm_target_triple == empty ptr */
     NULL,       /* target_features == empty ptr */
+    0,          /* min = 0 */
+    0,          /* max = 0 */
     false,      /* dlines = -nodlines */
     72,         /* extend_source = -noextend_source */
     true,       /* i4 = -i4 */

--- a/tools/shared/utils/global.h
+++ b/tools/shared/utils/global.h
@@ -184,6 +184,8 @@ typedef struct {
   char **linker_directives;
   const char *llvm_target_triple;
   const char *target_features; // TODO - not const char?
+  int min; /* minimum value for vscale_range(<min>[, <max>]) */
+  int max; /* maximum value for vscale_range(<min>[, <max>]) */
   bool dlines;
   int extend_source;
   bool i4;

--- a/tools/shared/utils/global.h
+++ b/tools/shared/utils/global.h
@@ -183,6 +183,7 @@ typedef struct {
   char **idir;
   char **linker_directives;
   const char *llvm_target_triple;
+  const char *target_features; // TODO - not const char?
   bool dlines;
   int extend_source;
   bool i4;


### PR DESCRIPTION
Depends on https://github.com/flang-compiler/classic-flang-llvm-project/pull/68

Similar to https://github.com/flang-compiler/flang/pull/1173 but I'm adding the check for target-feature and adding the default value of vscale_range(1,16) in case the target-feature is known as sve capable, to check this there is a 'table' of different acceptable models that can be given as an argument input, such 'table' can be expanded as needed.
This is the first part of a larger task, next part is to be able to check values for vscale_range(min,max) that will be passed as command argument
