### PR TITLE
[debuginfo] solve issues with DILocation nodes not being generated for the CP2K sources

### DIFF
--- a/test/llvm_ir_correct/fypp-dilocation.f90
+++ b/test/llvm_ir_correct/fypp-dilocation.f90
@@ -1,0 +1,33 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! RUN: %flang -cpp -g -S -emit-llvm %s -o - | FileCheck %s
+
+# 111 "fypp-dilocation.F"
+function fypp1()
+# 111 "fypp-dilocation.F"
+  implicit none
+# 111 "fypp-dilocation.F"
+  integer :: fypp1
+# 111 "fypp-dilocation.F"
+  fypp1 = 0
+# 111 "fypp-dilocation.F"
+end function fypp1
+# 111 "fypp-dilocation.F"
+function fypp2(data)
+# 111 "fypp-dilocation.F"
+  implicit none
+# 111 "fypp-dilocation.F"
+  integer :: fypp2
+# 111 "fypp-dilocation.F"
+  integer, dimension(2), intent(in) :: data
+! CHECK: br {{.*}}, !llvm.loop ![[LOOP:[0-9]+]]
+# 111 "fypp-dilocation.F"
+  fypp2 = sum(data)
+# 111 "fypp-dilocation.F"
+end function fypp2
+# 111 "fypp-dilocation.F"
+
+! CHECK-DAG: ![[DILOC:[0-9]+]] = !DILocation(line: 111, column: {{[0-9]+}}, scope: !{{[0-9]+}})
+! CHECK-DAG: !{![[LOOP]], ![[DILOC]], ![[DILOC]]}

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -2511,6 +2511,7 @@ void
 lldbg_emit_line(LL_DebugInfo *db, int lineno)
 {
   static int last_line = 0;
+  static LL_MDRef last_subprogram_mdnode = 0U;
   int idx = 0;
   int startline, endline;
   int i, j;
@@ -2523,7 +2524,9 @@ lldbg_emit_line(LL_DebugInfo *db, int lineno)
     db->cur_line_mdnode = ll_get_md_null();
     return;
   }
-  if (last_line != lineno) {
+  if ((last_line != lineno) ||
+      ((!LL_MDREF_IS_NULL(db->cur_subprogram_mdnode)) &&
+       (db->cur_subprogram_mdnode != last_subprogram_mdnode))) {
     j = db->blk_idx - 1;
     while (j >= 0) {
       if (db->blk_tab[j].keep) {
@@ -2567,6 +2570,7 @@ lldbg_emit_line(LL_DebugInfo *db, int lineno)
       db->cur_subprogram_line_mdnode = db->cur_line_mdnode;
 
     last_line = lineno;
+    last_subprogram_mdnode = db->cur_subprogram_mdnode;
   }
 }
 


### PR DESCRIPTION
CP2K uses fypp, a Fortran preprocessor based on Python expressions. It
can generate large code blocks spanning several functions from a
single line directive. This severely confuses flang's lldebug routines
making them unable to emit DILocation nodes (e.g. for the loops).

The consequences of this can vary, the most visible is an assertion
failure experienced while building CP2K with -g flag using
an assertion-enabled compiler.

The patch presented in this PR fixes the issue.