### PR TITLE
Use cmake built-in touch command instead of native one

### DIFF
--- a/runtime/libpgmath/lib/generic/math_tables/CMakeLists.txt
+++ b/runtime/libpgmath/lib/generic/math_tables/CMakeLists.txt
@@ -66,7 +66,7 @@ add_custom_command(OUTPUT ${TARGET_NAME}.i PRE_BUILD
 
 add_custom_command(OUTPUT ${TARGET_NAME}.check PRE_BUILD
   COMMAND "${SH_PROGRAM}" "${LIBPGMATH_TOOLS_DIR}/tmp-mth-check.sh" ${TARGET_NAME}.i
-  COMMAND touch ${TARGET_NAME}.check
+  COMMAND "${CMAKE_COMMAND}" -E touch ${TARGET_NAME}.check
   DEPENDS "${TARGET_NAME}.i")
 
 add_custom_command(OUTPUT ${TARGET_NAME}.h PRE_BUILD

--- a/runtime/libpgmath/lib/x86_64/math_tables/CMakeLists.txt
+++ b/runtime/libpgmath/lib/x86_64/math_tables/CMakeLists.txt
@@ -56,7 +56,7 @@ add_custom_command(OUTPUT ${TARGET_NAME}.i PRE_BUILD
 
 add_custom_command(OUTPUT ${TARGET_NAME}.check PRE_BUILD
   COMMAND "${SH_PROGRAM}" "${LIBPGMATH_TOOLS_DIR}/tmp-mth-check.sh" ${TARGET_NAME}.i
-  COMMAND touch ${TARGET_NAME}.check
+  COMMAND "${CMAKE_COMMAND}" -E touch ${TARGET_NAME}.check
   DEPENDS "${TARGET_NAME}.i")
 
 add_custom_command(OUTPUT ${TARGET_NAME}.h PRE_BUILD


### PR DESCRIPTION
Emulating touch command reduces the external build dependency,
especially on Windows where 'touch' is not available by default.