### PR TITLE
[DebugInfo] Debug support for assumed shape array at higher optimizations

### DIFF
--- a/test/debug_info/assumed_shape_non_contiguous.f90
+++ b/test/debug_info/assumed_shape_non_contiguous.f90
@@ -8,8 +8,8 @@
 !CHECK-SAME: type: [[TYPE:![0-9]+]])
 !CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: [[ARRAYDL]])
 !CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
-!CHECK: [[ELEM1]] = !DISubrange(lowerBound: 1, upperBound: {{![0-9]+}}, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
-!CHECK: [[ELEM2]] = !DISubrange(lowerBound: 1, upperBound: {{![0-9]+}}, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!CHECK: [[ELEM1]] = !DISubrange(count: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 88, DW_OP_deref), lowerBound: 1, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!CHECK: [[ELEM2]] = !DISubrange(count: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 136, DW_OP_deref), lowerBound: 1, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 
 subroutine show (message, array)
   character (len=*) :: message

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1447,8 +1447,9 @@ static const MDTemplate Tmpl_DISubrange_pre11[] = {
 };
 
 static const MDTemplate Tmpl_DISubrange[] = {
-  { "DISubrange", TF, 4 },
+  { "DISubrange", TF, 5 },
   { "tag",                      DWTagField,      FlgHidden },
+  { "count",                    SignedOrMDField, 0 },
   { "lowerBound",               SignedOrMDField, 0 },
   { "upperBound",               SignedOrMDField, 0 },
   { "stride",                   SignedOrMDField, 0 }


### PR DESCRIPTION
In existing debug info subscript is defined as lowerBound/upperBound/stride,
lowerBound is constant and upperBound is DIVariable and stride is taken from
descriptor. At higher optimizations DIVariable can be optimized out, we should
use count (from descriptor) in place of upperBound. Descriptor being paramter
gives better reliability at higher optimization levels.
Below program now shows better debugging with -O2
Inside fun, array1 can be seen.

```
subroutine fun (array1, array2)
  integer :: array1 (:, :)
  real    :: array2 (:, :, :)
  array1(:,:) = 5
  array1(1, 1) = 30
  array2(:,:,:) = 6
  array2(:,:,:) = 3
  array2(1,1,1) = 30
  array2(3,3,3) = 90
end subroutine
program vla_sub
  interface
    subroutine fun (array1, array2)
      integer :: array1 (:, :)
      real :: array2 (:, :, :)
    end subroutine
  end interface
  integer :: sub_arr1(42, 42)
  real    :: sub_arr2(42, 42, 42)
  sub_arr1(:,:) = 1
  sub_arr2(:,:,:) = 2
  call fun(sub_arr1, sub_arr2)
  call fun(sub_arr1(5:10, 5:10), sub_arr2(10:15,10:15,10:15))
end program vla_sub
```

Before fix

```
Reading symbols from vla-sub-short.O2...
(gdb) b fun
Breakpoint 1 at 0x201c4d: file vla-sub-short.f90, line 5.
(gdb) r
Starting program: vla-sub-short.O2.old
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Breakpoint 1, fun (array1=<error reading variable: failed to get range bounds>, array2=<error reading variable: failed to get range bounds>) at vla-sub-short.f90:5
5         array1(:,:) = 5
(gdb) p array1
failed to get range bounds
```

After fix

```
Breakpoint 2, fun (array1=..., array2=<error reading variable: value requires 296352 bytes, which is more than max-value-size>) at vla-sub-short.f90:5
5         array1(:,:) = 5
(gdb) p array1
$1 = ((1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...) ...)

```

Please note that https://github.com/flang-compiler/classic-flang-llvm-project/pull/75 and https://github.com/flang-compiler/classic-flang-llvm-project/pull/82 are dependency for it. 
