### PR TITLE
[DebugInfo] Use enhanced DIImportedEntity to generate better IR for renamed modules

### DIFF
--- a/test/debug_info/use_only_test.f90
+++ b/test/debug_info/use_only_test.f90
@@ -1,15 +1,16 @@
 !RUN: %flang -g -S -emit-llvm %s_mod.f90 %s
 !RUN: cat use_only_test.ll | FileCheck %s
 
-!CHECK: [[MOD_VAR:![0-9]+]] = distinct !DIGlobalVariable(name: "mod_var"
+!CHECK: [[MOD_VAR:![0-9]+]] = distinct !DIGlobalVariable(name: "mod_var1"
 !CHECK: distinct !DICompileUnit
 !CHECK-SAME: imports: [[IMPLIST:![0-9]+]]
 !CHECK: [[IMPLIST]] = !{[[IMPORT:![0-9]+]]
 !CHECK: [[IMPORT]] = !DIImportedEntity(tag: DW_TAG_imported_declaration
 !CHECK-SAME: entity: [[MOD_VAR]]
+!CHECK-NOT: !DIImportedEntity(tag: DW_TAG_imported_module
 
 program main
-  use use_only_mod, only: mod_var
+  use use_only_mod, only: mod_var1
   implicit none
-  print*, mod_var
+  print*, mod_var1
 end

--- a/test/debug_info/use_only_test.f90_mod.f90
+++ b/test/debug_info/use_only_test.f90_mod.f90
@@ -3,5 +3,6 @@
 !! testcase to exist in this directory.
 !RUN: true
 module use_only_mod
-  integer :: mod_var = 10
+  integer :: mod_var1 = 10
+  integer :: mod_var2
 end module use_only_mod

--- a/test/debug_info/usemodule.f90
+++ b/test/debug_info/usemodule.f90
@@ -11,10 +11,11 @@
 !CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: [[USE_RESTRICTED:![0-9]+]], entity: [[VAR1]]
 !CHECK: [[USE_RESTRICTED]] = distinct !DISubprogram(name: "use_restricted"
 
-!CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: [[USE_RENAMED:![0-9]+]], entity: [[VAR3]]
+!CHECK: !DIImportedEntity(tag: DW_TAG_imported_module, scope: [[USE_RENAMED:![0-9]+]], entity: [[MYMOD]]
+!CHECK-SAME: elements: [[RENAMES:![0-9]+]]
 !CHECK: [[USE_RENAMED]] = distinct !DISubprogram(name: "use_renamed"
-!CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: [[USE_RENAMED:![0-9]+]], entity: [[VAR2]]
-!CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4", scope: [[USE_RENAMED:![0-9]+]], entity: [[VAR1]]
+!CHECK: [[RENAMES]] = !{[[RENAME1:![0-9]+]]}
+!CHECK: [[RENAME1]] = !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4", scope: [[USE_RENAMED]], entity: [[VAR1]]
 
 !CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4", scope: [[USE_RESTRICTED_RENAMED:![0-9]+]], entity: [[VAR1]]
 !CHECK: [[USE_RESTRICTED_RENAMED]] = distinct !DISubprogram(name: "use_restricted_renamed"

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1488,7 +1488,7 @@ static const MDTemplate Tmpl_DIEnumerator[] = {
   { "value",                    SignedField, FlgMandatory }
 };
 
-static const MDTemplate Tmpl_DIImportedEntity[] = {
+static const MDTemplate Tmpl_DIImportedEntity_pre11[] = {
   { "DIImportedEntity", TF, 6 },
   { "tag",                      DWTagField,    0 },
   { "entity",                   NodeField,     0 },
@@ -1496,6 +1496,17 @@ static const MDTemplate Tmpl_DIImportedEntity[] = {
   { "file",                     NodeField,     0 },
   { "line",                     UnsignedField, 0 },
   { "name",                     StringField,   0 }
+};
+
+static const MDTemplate Tmpl_DIImportedEntity[] = {
+  { "DIImportedEntity", TF, 7 },
+  { "tag",                      DWTagField,    0 },
+  { "entity",                   NodeField,     0 },
+  { "scope",                    NodeField,     0 },
+  { "file",                     NodeField,     0 },
+  { "line",                     UnsignedField, 0 },
+  { "name",                     StringField,   0 },
+  { "elements",                 NodeField,     0 }
 };
 
 static const MDTemplate Tmpl_DICommonBlock[] = {
@@ -2212,7 +2223,12 @@ static void
 emitDIImportedEntity(FILE *out, LLVMModuleRef mod, const LL_MDNode *mdnode,
                      unsigned mdi)
 {
-  emitTmpl(out, mod, mdnode, mdi, Tmpl_DIImportedEntity);
+  if (ll_feature_debug_info_ver11(&mod->ir)) {
+    emitTmpl(out, mod, mdnode, mdi, Tmpl_DIImportedEntity);
+    return;
+  }
+
+  emitTmpl(out, mod, mdnode, mdi, Tmpl_DIImportedEntity_pre11);
 }
 
 static void

--- a/tools/flang2/flang2exe/lldebug.h
+++ b/tools/flang2/flang2exe/lldebug.h
@@ -171,6 +171,16 @@ LL_MDRef lldbg_emit_common_block_mdnode(LL_DebugInfo *db, SPTR sptr);
 void lldbg_create_cmblk_mem_mdnode_list(SPTR sptr, SPTR gblsym);
 
 /**
+   \brief Add symbol to the CHILD field of pending import entity.
+   \param db      the debug info object
+   \param entity  the symbol of module or variable to be imported
+   \param entity_type  0 indicates DECLARATION, 1 indicates MODULE, 
+   2 indicates UNIT.
+ */
+void lldbg_add_pending_import_entity_to_child(LL_DebugInfo *db, SPTR entity,
+                                             IMPORT_TYPE entity_type);
+
+/**
    \brief Add one symbol to the list of pending import entities.
    \param db      the debug info object
    \param entity  the symbol of module or variable to be imported


### PR DESCRIPTION
Consider the testcase below
```
module mymod
  integer :: var1 = 11
  integer :: var2 = 12
  integer :: var3 = 13
end module mymod
Program main
  call use_renamed()
  contains
    subroutine use_renamed()
      use mymod, var4 => var1
      print *, var4
    end subroutine use_renamed
end program main
```
Which currently produces IR as

```
!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
!1 = distinct !DIGlobalVariable(name: "var1", scope: !2, file: !3, line: 2, type: !9, isLocal: false, isDefinition: true)
!2 = !DIModule(scope: !4, name: "mymod", file: !3, line: 1)
!3 = !DIFile(filename: "usemodulealias.f90", directory: "/tmp")
!4 = distinct !DICompileUnit(language: DW_LANG_Fortran90, file: !3, producer: " F90 Flang - 1.5 2017-05-01", isOptimized: false, flags: "'+flang -g -S -emit-llvm usemodulealias.f90'", runtimeVersion: 0, emissionKind: FullDebug, enums: !5, retainedTypes: !5, globals: !6, **imports: !12**, nameTableKind: None)
!5 = !{}
!6 = !{!0, !7, !10}
!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression(DW_OP_plus_uconst, 4))
!8 = distinct !DIGlobalVariable(name: "var2", scope: !2, file: !3, line: 3, type: !9, isLocal: false, isDefinition: true)
!9 = !DIBasicType(name: "integer", size: 32, align: 32, encoding: DW_ATE_signed)
!10 = !DIGlobalVariableExpression(var: !11, expr: !DIExpression(DW_OP_plus_uconst, 8))
!11 = distinct !DIGlobalVariable(name: "var3", scope: !2, file: !3, line: 4, type: !9, isLocal: false, isDefinition: true)
**!12 = !{!13, !19, !20}**
**!13 = !DIImportedEntity(tag: DW_TAG_imported_declaration**, scope: !14, entity: !11, file: !3, line: 10)
!14 = distinct !DISubprogram(name: "use_renamed", scope: !15, file: !3, line: 10, type: !18, scopeLine: 10, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !4)
!15 = distinct !DISubprogram(name: "main", scope: !4, file: !3, line: 7, type: !16, scopeLine: 7, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: !4)
!16 = !DISubroutineType(cc: DW_CC_program, types: !17)
!17 = !{null}
!18 = !DISubroutineType(types: !17)
**!19 = !DIImportedEntity(tag: DW_TAG_imported_declaration**, scope: !14, entity: !8, file: !3, line: 10)
**!20 = !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4"**, scope: !14, entity: !1, file: !3, line: 10)
```
which can be optimize to
```
!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
!1 = distinct !DIGlobalVariable(name: "var1", scope: !2, file: !3, line: 2, type: !9, isLocal: false, isDefinition: true)
!2 = !DIModule(scope: !4, name: "mymod", file: !3, line: 1)
!3 = !DIFile(filename: "usemodulealias.f90", directory: "/tmp")
!4 = distinct !DICompileUnit(language: DW_LANG_Fortran90, file: !3, producer: " F90 Flang - 1.5 2017-05-01", isOptimized: false, flags: "'+flang usemodulealias.f90 -g -S -emit-llvm'", runtimeVersion: 0, emissionKind: FullDebug, enums: !5, retainedTypes: !5, globals: !6, **imports: !12**, nameTableKind: None)
!5 = !{}
!6 = !{!0, !7, !10}
!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression(DW_OP_plus_uconst, 4))
!8 = distinct !DIGlobalVariable(name: "var2", scope: !2, file: !3, line: 3, type: !9, isLocal: false, isDefinition: true)
!9 = !DIBasicType(name: "integer", size: 32, align: 32, encoding: DW_ATE_signed)
!10 = !DIGlobalVariableExpression(var: !11, expr: !DIExpression(DW_OP_plus_uconst, 8))
!11 = distinct !DIGlobalVariable(name: "var3", scope: !2, file: !3, line: 4, type: !9, isLocal: false, isDefinition: true)
**!12 = !{!13}**
**!13 = !DIImportedEntity(tag: DW_TAG_imported_module**, scope: !14, entity: !2, file: !3, line: 10, **elements: !19**)
!14 = distinct !DISubprogram(name: "use_renamed", scope: !15, file: !3, line: 10, type: !18, scopeLine: 10, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !4)
**!19 = !{!20}
!20 = !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4"**, scope: !14, entity: !1, file: !3, line: 10)
```
It is dependent on 
https://github.com/flang-compiler/classic-flang-llvm-project/pull/76
https://github.com/flang-compiler/classic-flang-llvm-project/pull/83