### PR TITLE
Fix lowering of move_alloc() subroutine

### DIFF
--- a/test/f90_correct/inc/move_alloc.mk
+++ b/test/f90_correct/inc/move_alloc.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+EXE=move_alloc.$(EXESUFFIX)
+
+build:  $(SRC)/move_alloc.f90
+	-$(RM) move_alloc.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	-$(RM) $(OBJ)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	@echo ------------------------------------ building test $@
+	$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/move_alloc.f90 check.$(OBJX) -o move_alloc.$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test move_alloc
+	move_alloc.$(EXESUFFIX)
+
+verify: ;
+
+move_alloc.run: run

--- a/test/f90_correct/lit/move_alloc.sh
+++ b/test/f90_correct/lit/move_alloc.sh
@@ -1,0 +1,10 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/move_alloc.f90
+++ b/test/f90_correct/src/move_alloc.f90
@@ -1,0 +1,89 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+program move_alloc_test
+  implicit none
+  type some
+    integer, allocatable :: a(:)
+  end type
+  type some_more
+    type(some) :: b
+  end type
+  type some_more_more
+    type(some_more) :: c
+  end type
+  integer, parameter :: num = 7
+  integer :: results(num)
+  integer, parameter :: expect(num) = &
+    (/.false., .false., .false., .false., .false., .true., .false./)
+  integer, allocatable :: a(:)
+  integer, allocatable :: b(:)
+  type(some) :: c
+  type(some_more) :: d
+  type(some_more_more) :: e
+
+  allocate(a(128))
+  call move_alloc(a, b)
+  deallocate(b)
+  allocate(c%a(128))
+  call move_alloc(c%a, b)
+  deallocate(b)
+  allocate(d%b%a(128))
+  call move_alloc(d%b%a, b)
+  deallocate(b)
+  allocate(e%c%b%a(128))
+  call move_alloc(e%c%b%a, b)
+  deallocate(b)
+  allocate(a(128))
+  call sub0(a)
+  allocate(c%a(128))
+  call sub1(c)
+  allocate(d%b%a(128))
+  call sub2(d)
+  results(1) = allocated(a)
+  results(2) = allocated(b)
+  results(3) = allocated(c%a)
+  results(4) = allocated(d%b%a)
+  results(5) = allocated(e%c%b%a)
+  if (all( expect .eq. results)) then
+    print *, "expect vs results match"
+  else
+    print *, "expect vs results mismatch"
+  endif
+  call check(results, expect, num)
+
+contains
+
+  subroutine sub0(a)
+    implicit none
+    integer, allocatable, intent(inout) :: a(:)
+    integer, allocatable :: b(:)
+
+    call move_alloc(a, b)
+    deallocate(b)
+  end subroutine
+
+  subroutine sub1(par)
+    implicit none
+    type(some), intent(inout) :: par
+    integer, allocatable :: b(:)
+
+    call move_alloc(par%a, b)
+    deallocate(b)
+  end subroutine
+
+  subroutine sub2(par)
+    implicit none
+    type(some_more), intent(inout) :: par
+    integer, allocatable :: b(:)
+
+    results(6) = allocated(par%b%a)
+    call move_alloc(par%b%a, b)
+    results(7) = allocated(par%b%a)
+    deallocate(b)
+  end subroutine
+
+end program

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -11916,6 +11916,16 @@ get_parm_ast(int parent, SPTR sptr, DTYPE dtype)
       return ast;
     }
   }
+  /* Field not found, so try again and take more recursive approach */
+  for (mem = DTY(dtype + 1); mem > NOSYM; mem = SYMLKG(mem)) {
+    /* Act only on the cases that were not considered before */
+    if ((!PARENTG(mem)) && strcmp(SYMNAME(sptr), SYMNAME(mem))) {
+      ast = mk_member(parent, mk_id(mem), dtype);
+      rslt = get_parm_ast(ast, sptr, DTYPEG(mem)); /* recurse here */
+      if (rslt)
+        return rslt;
+    }
+  }
   return 0;
 }
 


### PR DESCRIPTION
This is not the best solution for this problem. But it's the one that does not require a major rewrite of the code in this area.

The Fortran's internal move_alloc() subroutine failed to accept more complex field selection expressions used for the subroutine parameters. This patch solves the problem by adding more eager traversal through the member selection expression.
