### PR TITLE
[flang2] fix va_list being used before va_start() was called

### DIFF
--- a/tools/flang2/flang2exe/ll_structure.cpp
+++ b/tools/flang2/flang2exe/ll_structure.cpp
@@ -1435,7 +1435,9 @@ ll_create_named_struct_type(LLVMModuleRef module, int id, bool unique,
   LL_Value *struct_value;
 
   if (!unique) {
+    va_start(ap, format);
     struct_value = ll_named_struct_type_exists(module, id, format, ap);
+    va_end(ap);
     if (struct_value)
       return struct_value->type_struct;
     ll_remove_struct_type(module, id);


### PR DESCRIPTION
This patch fixes a very well hidden bug: va_list variable ap
was used before va_start() was called.

According to Robert Lipe, it is safe to call va_start()/va_end()
pair multiple times:

```
The standard doesn't appear to forbid it. In the non-normative text
of Plauger's "The Standard C Library" it says "Once ou execute va_end
you must not again execute va_arg unless you first execute va_start to
initiate a rescan."    This appears to give extra credence to the
restartability.
```

see https://gcc.gnu.org/legacy-ml/gcc/2001-08/msg00478.html