### PR TITLE
[runtime] Fix memory leak when freeing FIO_FCB

### DIFF
--- a/runtime/flang/close.c
+++ b/runtime/flang/close.c
@@ -65,8 +65,6 @@ __fortio_close(FIO_FCB *f, int flag)
     else if (f->status == FIO_SCRATCH)
       unlink(f->name);
 #endif
-
-    free(f->name);
   } else { /* stdin, stdout, stderr - just flush */
 #if defined(TARGET_OSX)
     if (f->unit != 5 && f->unit != -5)

--- a/runtime/flang/utils.c
+++ b/runtime/flang/utils.c
@@ -122,6 +122,11 @@ __fortio_alloc_fcb(void)
 extern void
 __fortio_free_fcb(FIO_FCB *p)
 {
+  if (p->name) {
+    free(p->name);
+    p->name = NULL;
+  }
+
   if (fioFcbTbls.fcbs == p) /* delete p from list */
     fioFcbTbls.fcbs = p->next;
   else {


### PR DESCRIPTION
Commit d3ee7f250c0331f7381d6bffe7b40037304f275e made the "name" field
in FIO_FCB objects a pointer to malloc'ed memory in all cases. When
freeing a FIO_FCB object, the name should be freed in all cases as well.