### PR TITLE
[runtime] Fix bug in iso_fortran_env.f90 (encountered in OpenMPI)

### DIFF
--- a/runtime/flang/iso_fortran_env.f90
+++ b/runtime/flang/iso_fortran_env.f90
@@ -59,14 +59,14 @@
 	integer REAL64
 	parameter (REAL64 = 8)
 	integer REAL128
-	parameter (REAL128 = -1)
+	parameter (REAL128 = 16)
 
         integer INTEGER_KINDS(4)
         parameter (INTEGER_KINDS = (/INT8, INT16, INT32, INT64/))
         integer LOGICAL_KINDS(4)
         parameter (LOGICAL_KINDS = (/LOGICAL8, LOGICAL16, LOGICAL32, LOGICAL64/))
-        integer REAL_KINDS(2)
-        parameter (REAL_KINDS = (/REAL32, REAL64/))
+        integer REAL_KINDS(3)
+        parameter (REAL_KINDS = (/REAL32, REAL64, REAL128/))
 
         end module  ISO_FORTRAN_ENV
 

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -9544,6 +9544,10 @@ eval_selected_real_kind(ACL *arg)
     r = 4;
   else if (con <= 15)
     r = 8;
+#ifdef TARGET_SUPPORTS_QUADFP
+  else if (con <= MAX_EXP_OF_QMANTISSA)
+    r = REAL_16;
+#endif
   else
     r = -1;
 
@@ -9556,6 +9560,11 @@ eval_selected_real_kind(ACL *arg)
     } else if (con <= 307) {
       if (r > 0 && r < 8)
         r = 8;
+#ifdef TARGET_SUPPORTS_QUADFP
+    } else if (con <= MAX_EXP_QVALUE) {
+      if (r > REAL_0 && r < REAL_16)
+        r = REAL_16;
+#endif
     } else {
       if (r > 0)
         r = 0;


### PR DESCRIPTION
After #1129 commited, a regression is generated when compiling OpenMPI. 
_Originally posted by @pawosm-arm in https://github.com/flang-compiler/flang/issues/1129#issuecomment-1030595159_

This PR fix this issue by correctly declaring REAL128 kind parameter.