### PR TITLE
Implement vectorize_width

### DIFF
--- a/include/flang/Error/errmsg-in.n
+++ b/include/flang/Error/errmsg-in.n
@@ -1334,8 +1334,9 @@ LAUNCH_BOUNDS is now allowed on ATTRIBUTES(DEVICE) or host subprograms.
 The LAUNCH_BOUNDS maximum number of threads and minimum grid size must
 be positive integer values.
 .MS W 602 "No clause specified for the vector directive. Note: Only the always clause is supported."
-.MS W 603 "Unsupported clause specified for the vector directive. Only the always clause is supported."
+.MS W 603 "Unsupported clause specified for the vector directive. Only the always and vectorlength clauses are supported."
 .MS W 604 "Unsupported clause specified for the omp simd directive. The directive will be ignored."
+.MS W 803 "Unsupported argument in the vectorlength clause; allowed values are one of: 'fixed', 'scalable', or a numeric literal"
 .MS S 901 "#elif after #else"
 A preprocessor #elif directive was found after a #else directive; only
 #endif is allowed in this context.

--- a/test/directives/vector_directive2.f90
+++ b/test/directives/vector_directive2.f90
@@ -11,4 +11,4 @@ subroutine add(arr1,arr2,arr3,N)
     arr3(i) = arr1(i) - arr2(i)
   end do
 end subroutine
-! CHECK-WRONG-CLAUSE: F90-W-0603-Unsupported clause specified for the vector directive. Only the always clause is supported.
+! CHECK-WRONG-CLAUSE: F90-W-0603-Unsupported clause specified for the vector directive. Only the always and vectorlength clauses are supported.

--- a/test/directives/vector_vectorlength_fixed.f90
+++ b/test/directives/vector_vectorlength_fixed.f90
@@ -1,0 +1,28 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! Check that the vector vectorlength(fixed) directive generates the correct metadata.
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s --check-prefixes=CHECK-00,CHECK-ALL
+
+! Check that "-Hx,59,2" disables vector directive.
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s --implicit-check-not "llvm.loop.vectorize" 
+subroutine func1(a, b, m)
+! CHECK-ALL: define void @func1
+  integer :: i, m, a(m), b(m)
+
+  !dir$ vector vectorlength(fixed)
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+! CHECK-00:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]]
+! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD:![0-9]+]]
+end subroutine func1
+
+! CHECK-00-NOT:  !"llvm.loop.vectorize.width"
+! CHECK-00:      [[VE_MD:![0-9]+]] = !{!"llvm.loop.vectorize.enable", i1 true}
+! CHECK-00:      [[VS_MD:![0-9]+]] = !{!"llvm.loop.vectorize.scalable.enable", i1 false}
+! CHECK-00:      [[LOOP_LATCH_MD]] = distinct !{
+! CHECK-00-SAME: [[VE_MD]]
+! CHECK-00-SAME: [[VS_MD]]
+! CHECK-00-SAME: }

--- a/test/directives/vector_vectorlength_integer.f90
+++ b/test/directives/vector_vectorlength_integer.f90
@@ -1,0 +1,45 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! Check that the vector vectorlength(int) directive generates the correct metadata.
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s --check-prefixes=CHECK-00,CHECK-ALL
+
+! Check that "-Hx,59,2" disables vector directive.
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s --implicit-check-not "llvm.loop.vectorize"
+
+subroutine func1(a, b, m)
+! CHECK-ALL: define void @func1
+  integer :: i, m, a(m), b(m)
+  !dir$ vector vectorlength(2)
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+! CHECK-00:      [[LOOP:L.LB1_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD:![0-9]+]]
+end subroutine func1
+
+subroutine func2(a, b, m)
+! CHECK-ALL: define void @func2
+  integer :: i, m, a(m), b(m)
+  !dir$ vector vectorlength(2,4,16)
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+! CHECK-00:      [[LOOP:L.LB2_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD2:![0-9]+]]
+end subroutine func2
+
+! CHECK-00:      [[VE_MD:![0-9]+]] = !{!"llvm.loop.vectorize.enable", i1 true}
+! CHECK-00:      [[VS_MD:![0-9]+]] = !{!"llvm.loop.vectorize.scalable.enable", i1 false}
+! CHECK-00:      [[VW_MD:![0-9]+]] = !{!"llvm.loop.vectorize.width", i32 2}
+! CHECK-00:      [[LOOP_LATCH_MD]] = distinct !{
+! CHECK-00-SAME: [[VE_MD]]
+! CHECK-00-SAME: [[VS_MD]]
+! CHECK-00-SAME: [[VW_MD]]
+! CHECK-00-SAME: }
+! CHECK-00:      [[LOOP_LATCH_MD2]] = distinct !{
+! CHECK-00-SAME: [[VE_MD]]
+! CHECK-00-SAME: [[VS_MD]]
+! CHECK-00-SAME: [[VW_MD]]
+! CHECK-00-SAME: }

--- a/test/directives/vector_vectorlength_not_supported.f90
+++ b/test/directives/vector_vectorlength_not_supported.f90
@@ -1,0 +1,36 @@
+! RUN: %flang -O0 -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-WRONG-CLAUSE --implicit-check-not "llvm.loop.vectorize"
+subroutine func1(a, b, m)
+  integer :: i, m, a(m), b(m)
+  !dir$ vector vectorlength(garbage)
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+end subroutine func1
+! CHECK-WRONG-CLAUSE: 90-W-0803-Unsupported argument in the vectorlength clause; allowed values are one of: 'fixed', 'scalable', or a numeric literal
+
+subroutine func2(a, b, m)
+  integer :: i, m, a(m), b(m)
+  !dir$ vector vectorlength(3,
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+end subroutine func2
+! CHECK-WRONG-CLAUSE: 90-W-0803-Unsupported argument in the vectorlength clause; allowed values are one of: 'fixed', 'scalable', or a numeric literal
+
+subroutine func3(a, b, m)
+  integer :: i, m, a(m), b(m)
+  !dir$ vector vectorlength(3 5 7
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+end subroutine func3
+! CHECK-WRONG-CLAUSE: 90-W-0803-Unsupported argument in the vectorlength clause; allowed values are one of: 'fixed', 'scalable', or a numeric literal
+
+subroutine func4(a, b, m)
+  integer :: i, m, a(m), b(m)
+  !dir$ vector vectorlengthX
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+end subroutine func4
+! CHECK-WRONG-CLAUSE: F90-W-0603-Unsupported clause specified for the vector directive. Only the always and vectorlength clauses are supported.

--- a/test/directives/vector_vectorlength_num_fixed.f90
+++ b/test/directives/vector_vectorlength_num_fixed.f90
@@ -1,0 +1,29 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! Check that the vector vectorlength(fixed) directive generates the correct metadata.
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s --check-prefixes=CHECK-00,CHECK-ALL
+
+! Check that "-Hx,59,2" disables vector directive.
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s --implicit-check-not "llvm.loop.vectorize" 
+
+subroutine func1(a, b, m)
+! CHECK-ALL: define void @func1
+  integer :: i, m, a(m), b(m)
+  !dir$ vector vectorlength(3,fixed)
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+! CHECK-00:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD:![0-9]+]]
+end subroutine func1
+
+! CHECK-00:      [[VE_MD:![0-9]+]] = !{!"llvm.loop.vectorize.enable", i1 true}
+! CHECK-00:      [[VS_MD:![0-9]+]] = !{!"llvm.loop.vectorize.scalable.enable", i1 false}
+! CHECK-00:      [[VW_MD:![0-9]+]] = !{!"llvm.loop.vectorize.width", i32 3}
+! CHECK-00:      [[LOOP_LATCH_MD]] = distinct !{
+! CHECK-00-SAME: [[VE_MD]]
+! CHECK-00-SAME: [[VS_MD]]
+! CHECK-00-SAME: [[VW_MD]]
+! CHECK-00-SAME: }

--- a/test/directives/vector_vectorlength_num_scalable.f90
+++ b/test/directives/vector_vectorlength_num_scalable.f90
@@ -1,0 +1,30 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! Check that the vector vectorlength(scalable) directive generates the correct metadata.
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s --check-prefixes=CHECK-00,CHECK-ALL
+
+! Check that "-Hx,59,2" disables vector directive.
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s --implicit-check-not "llvm.loop.vectorize"
+
+subroutine func1(a, b, m)
+! CHECK-ALL: define void @func1
+  integer :: i, m, a(m), b(m)
+  !dir$ vector vectorlength(2,scalable)
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+! CHECK-00:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD:![0-9]+]]
+end subroutine func1
+
+! CHECK-00-NOT:  !"llvm.loop.vectorize.width"
+! CHECK-00:      [[VE_MD:![0-9]+]] = !{!"llvm.loop.vectorize.enable", i1 true}
+! CHECK-00:      [[VS_MD:![0-9]+]] = !{!"llvm.loop.vectorize.scalable.enable", i1 true}
+! CHECK-00:      [[VW_MD:![0-9]+]] = !{!"llvm.loop.vectorize.width", i32 2}
+! CHECK-00:      [[LOOP_LATCH_MD]] = distinct !{
+! CHECK-00-SAME: [[VE_MD]]
+! CHECK-00-SAME: [[VS_MD]]
+! CHECK-00-SAME: [[VW_MD]]
+! CHECK-00-SAME: }

--- a/test/directives/vector_vectorlength_scalable.f90
+++ b/test/directives/vector_vectorlength_scalable.f90
@@ -1,0 +1,29 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! Check that the vector vectorlength(scalable) directive generates the correct metadata.
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s --check-prefixes=CHECK-00,CHECK-ALL
+
+! Check that "-Hx,59,2" disables vector directive.
+! RUN: %flang -Hx,59,2 -S -emit-llvm %s -o - | FileCheck %s --implicit-check-not "llvm.loop.vectorize"
+
+subroutine func1(a, b, m)
+! CHECK-ALL: define void @func1
+  integer :: i, m, a(m), b(m)
+
+  !dir$ vector vectorlength(scalable)
+  do i = 1, m
+    b(i) = a(i) + 1
+  end do
+! CHECK-00:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD:![0-9]+]]
+end subroutine func1
+
+! CHECK-00-NOT:  !"llvm.loop.vectorize.width"
+! CHECK-00:      [[VE_MD:![0-9]+]] = !{!"llvm.loop.vectorize.enable", i1 true}
+! CHECK-00:      [[VS_MD:![0-9]+]] = !{!"llvm.loop.vectorize.scalable.enable", i1 true}
+! CHECK-00:      [[LOOP_LATCH_MD]] = distinct !{
+! CHECK-00-SAME: [[VE_MD]]
+! CHECK-00-SAME: [[VS_MD]]
+! CHECK-00-SAME: }

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -5541,6 +5541,20 @@ Enable codegen for spmd kernel init.
 .XF "233:"
 reserved
 
+.XF "234:"
+vector vectorlength identifier
+.XB "0x01:"
+vector vectorlength(number)
+.XB "0x02:"
+vector vectorlength(fixed)
+.XB "0x04:"
+vector vectorlength(scalable)
+
+.XF "235:"
+Provides a parameter
+.i n
+for vector vectorlength(number)
+
 .XF "248:"
 OpenMP Threadprivate TLS/TPvector implementation control.
 

--- a/tools/flang2/flang2exe/bih.h
+++ b/tools/flang2/flang2exe/bih.h
@@ -119,6 +119,12 @@ typedef struct {
       unsigned unroll : 1;     /* bih is a loop to be fully unrolled */
       unsigned unroll_cnt : 1; /* bih has a user-specified unroll factor */
       unsigned nounroll : 1;   /* bih is a loop that must not be unrolled */
+      unsigned vectorlength_scalable : 1;  /* bih is a loop with vectorlength
+                                              set
+                                            */
+      unsigned vectorlength_enabled : 1;   /* bih is a loop that must be 
+                                              vectorized 
+                                            */
     } bits;
   } flags2;
   int lpcntFrom;  /* When a loop count temp is created, record the induction
@@ -236,6 +242,8 @@ typedef struct {
 #define BIH_UNROLL(i) bihb.stg_base[i].flags2.bits.unroll
 #define BIH_UNROLL_COUNT(i) bihb.stg_base[i].flags2.bits.unroll_cnt
 #define BIH_NOUNROLL(i) bihb.stg_base[i].flags2.bits.nounroll
+#define BIH_VECTORLENGTH_SCALABLE(i) bihb.stg_base[i].flags2.bits.vectorlength_scalable
+#define BIH_VECTORLENGTH_ENABLED(i) bihb.stg_base[i].flags2.bits.vectorlength_enabled
 
 #define EXEC_COUNT double
 #define UNKNOWN_EXEC_CNT -1.0


### PR DESCRIPTION
This PR is for "Implement vectorize_width" series of commits.
Its duplicate of recently closed PR :https://github.com/flang-compiler/flang/pull/1172
It implements !dir$ vector vectorlength(fixed|scalable|num) directive in flang and also contains tests for it.
Implementation was done in flang1 and flang2 and also is using flag 27 and 161 in xflag.n
@kiranchandramohan @RichBarton-Arm @bryanpkc @shivaramaarao @pawosm-arm @Chirag-Khandelwal please take a look on the patches

