### PR TITLE
Introduce the -dM option to print out the compiler-defined macros

### DIFF
--- a/test/preprocessor/dm_option.f90
+++ b/test/preprocessor/dm_option.f90
@@ -1,0 +1,82 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Just check some of the macros - if they are printed
+!
+! Check amd64-linux architecture
+! RUN: %flang -dM -E -target x86_64-unknown-linux-gnu %s | FileCheck %s \
+! RUN: --check-prefixes=CHECK-MACROS-AMD64,CHECK-MACROS-LINUX,CHECK-MACROS-COMMON-ACCPP
+!
+! Check amd64-linux architecture but from FPP module
+! RUN: %flang -Hx,123,0x4000000 -dM -E -target x86_64-unknown-linux-gnu %s | FileCheck %s \
+! RUN: --check-prefixes=CHECK-MACROS-AMD64,CHECK-MACROS-LINUX,CHECK-MACROS-COMMON-FPP
+!
+! Check aarch64-linux architecture
+! RUN: %flang -dM -E -target aarch64-unknown-linux-gnu %s | FileCheck %s \
+! RUN: --check-prefixes=CHECK-MACROS-AARCH64,CHECK-MACROS-LINUX,CHECK-MACROS-COMMON-ACCPP
+!
+! Check aarch64-linux architecture but from FPP module
+! RUN: %flang -Hx,123,0x4000000 -dM -E -target aarch64-unknown-linux-gnu %s | FileCheck %s \
+! RUN: --check-prefixes=CHECK-MACROS-AARCH64,CHECK-MACROS-LINUX,CHECK-MACROS-COMMON-FPP
+!
+! Check aarch64-windows architecture
+! RUN: %flang -dM -E -target aarch64-unknown-windows-gnu %s | FileCheck %s \
+! RUN: --check-prefixes=CHECK-MACROS-AARCH64,CHECK-MACROS-WINDOWS,CHECK-MACROS-COMMON-ACCPP
+!
+! Check aarch64-windows architecture but from FPP module
+! RUN: %flang -Hx,123,0x4000000 -dM -E -target aarch64-unknown-windows-gnu %s | FileCheck %s \
+! RUN: --check-prefixes=CHECK-MACROS-AARCH64,CHECK-MACROS-WINDOWS,CHECK-MACROS-COMMON-FPP
+!
+! Check amd64-windows architecture
+! RUN: %flang -dM -E -target x86_64-unknown-windows-gnu %s | FileCheck %s \
+! RUN: --check-prefixes=CHECK-MACROS-AMD64,CHECK-MACROS-WINDOWS,CHECK-MACROS-COMMON-ACCPP
+!
+! Check amd64-windows architecture but from FPP module
+! RUN: %flang -Hx,123,0x4000000 -dM -E -target x86_64-unknown-windows-gnu %s | FileCheck %s \
+! RUN: --check-prefixes=CHECK-MACROS-AMD64,CHECK-MACROS-WINDOWS,CHECK-MACROS-COMMON-FPP
+!
+! Check i386-windows architecture
+! RUN: %flang -dM -E -target i386-unknown-windows-gnu %s | FileCheck %s \
+! RUN: --check-prefixes=CHECK-MACROS-I386,CHECK-MACROS-WINDOWS,CHECK-MACROS-COMMON-ACCPP
+!
+! Check i386-windows architecture but from FPP module
+! RUN: %flang -Hx,123,0x4000000 -dM -E -target i386-unknown-windows-gnu %s | FileCheck %s \
+! RUN: --check-prefixes=CHECK-MACROS-I386,CHECK-MACROS-WINDOWS,CHECK-MACROS-COMMON-FPP
+!
+! CHECK-MACROS-AMD64: __amd64__
+! CHECK-MACROS-AMD64: __x86_64__
+
+! CHECK-MACROS-AARCH64: __AARCH64EL__ 
+! CHECK-MACROS-AARCH64: __aarch64__ 
+! CHECK-MACROS-AARCH64: __ARM_ARCH
+! CHECK-MACROS-AARCH64: __ARM_ARCH_PROFILE
+! CHECK-MACROS-AARCH64: __ARM_64BIT_STATE
+
+! CHECK-MACROS-I386: __i386__
+
+! CHECK-MACROS-LINUX: __linux
+! CHECK-MACROS-LINUX: __gnu_linux__
+
+! CHECK-MACROS-WINDOWS: _WIN32
+! CHECK-MACROS-WINDOWS: _MSVCRT__
+! CHECK-MACROS-WINDOWS: __declspec
+! CHECK-MACROS-WINDOWS: __stdcall
+! CHECK-MACROS-WINDOWS: __thiscall
+! CHECK-MACROS-WINDOWS: __pascal
+
+! CHECK-MACROS-COMMON-ACCPP: __FLANG
+! CHECK-MACROS-COMMON-ACCPP: __FLANG_MAJOR__ 
+! CHECK-MACROS-COMMON-ACCPP: __FLANG_MINOR__
+! CHECK-MACROS-COMMON-ACCPP: __FLANG_PATCHLEVEL__
+
+! CHECK-MACROS-COMMON-FPP: __PGIC__
+! CHECK-MACROS-COMMON-FPP: __PGIC_MINOR__ 
+! CHECK-MACROS-COMMON-FPP: __PGIF90__
+! CHECK-MACROS-COMMON-FPP: __PGIF90_MINOR__
+! CHECK-MACROS-COMMON-FPP: __PGIC_PATCHLEVEL__
+! CHECK-MACROS-COMMON-FPP: __PGIF90_PATCHLEVEL__
+
+program hello
+  print *, "hello world"
+end program hello

--- a/tools/flang1/flang1exe/accpp.c
+++ b/tools/flang1/flang1exe/accpp.c
@@ -701,6 +701,20 @@ print_and_check(FILE *ff, char *str, char end_c)
     fputc(end_c, ff);
 }
 
+static void acc_display_macros()
+{
+  unsigned int i;
+  for (i = 1U; i < next_hash; ++i) {
+    char *name = &deftab[hashrec[i].name];
+    char *value = &deftab[hashrec[i].value];
+    if ((strncmp(name, "__LINE__", 8) == 0) ||
+        (strncmp(name, "__DATE__", 8) == 0) ||
+        (strncmp(name, "__FILE__", 8) == 0) ||
+        (strncmp(name, "__TIME__", 8) == 0)) continue;
+    fprintf(gbl.outfil, "%s : %s\n", name, value);
+  }
+}
+
 void
 accpp(void)
 {
@@ -912,6 +926,23 @@ accpp(void)
       }
       delete(*cp); /* should check if IDENT */
     }
+  }
+
+  if (flg.list_macros) {
+    acc_display_macros();
+
+    FREE(deftab);
+    FREE(hashrec);
+    /* FREE(inclstack); Do not free this, gbl.curr_file points to it */
+    FREE(_ifs);
+    FREE(linebuf);
+
+    if (incllist != NULL) {
+      FREE(incllist);
+    }
+
+    flg.es = TRUE;
+    finish();
   }
 
   idir.b_avl = 0;

--- a/tools/flang1/flang1exe/flgdf.h
+++ b/tools/flang1/flang1exe/flgdf.h
@@ -72,4 +72,5 @@ FLG flg = {
     0,     /* accmp */
     "",    /* cmdline */
     FALSE, /* qp */
+    FALSE, /* list-macros */
 };

--- a/tools/flang1/flang1exe/fpp.c
+++ b/tools/flang1/flang1exe/fpp.c
@@ -376,6 +376,20 @@ skipbl(char *tokval, int flag)
   return toktyp;
 }
 
+static void fpp_display_macros()
+{
+  unsigned int i;
+  for (i = 1U; i < next_hash; ++i) {
+    char *name = &deftab[hashrec[i].name];
+    char *value = &deftab[hashrec[i].value];
+    if ((strncmp(name, "__LINE__", 8) == 0) ||
+        (strncmp(name, "__DATE__", 8) == 0) ||
+        (strncmp(name, "__FILE__", 8) == 0) ||
+        (strncmp(name, "__TIME__", 8) == 0)) continue;
+    fprintf(gbl.outfil, "%s : %s\n", name, value);
+  }
+}
+
 void
 fpp(void)
 {
@@ -532,6 +546,20 @@ fpp(void)
   for (cp = flg.undef; cp && *cp; ++cp) {
     /* undef it */
     delete (*cp); /* should check if IDENT */
+  }
+  
+  if (flg.list_macros) {
+    fpp_display_macros();
+
+    FREE(argbuf);
+    FREE(deftab);
+    FREE(hashrec);
+    if (incllist != NULL) {
+      FREE(incllist);
+    }
+
+    flg.es = TRUE;
+    finish();
   }
 
   idir.b_avl = 0;

--- a/tools/flang1/flang1exe/global.h
+++ b/tools/flang1/flang1exe/global.h
@@ -234,6 +234,7 @@ typedef struct {
   int accmp;
   const char *cmdline; /* command line used to invoke the compiler */
   LOGICAL qp; /* Enable quad-precision REAL and quad-precision COMPLEX. */
+  bool list_macros ; /* TRUE => flang -dM option was used to display macros */
 } FLG;
 
 extern FLG flg;

--- a/tools/flang1/flang1exe/main.c
+++ b/tools/flang1/flang1exe/main.c
@@ -760,6 +760,7 @@ init(int argc, char *argv[])
   register_string_arg(arg_parser, "cmdline", &(flg.cmdline), NULL);
   register_boolean_arg(arg_parser, "es", (bool *)&(flg.es), false);
   register_boolean_arg(arg_parser, "pp", (bool *)&(flg.p), false);
+  register_boolean_arg(arg_parser, "list-macros", &flg.list_macros, false);
 
   /* Set values form command line arguments */
   parse_arguments(arg_parser, argc, argv);


### PR DESCRIPTION
It was decided to add clang -dM option to flang.
It prints out all the macros defined - similarly as clang or gfortran does it.
It works only with llvm PR for this : https://github.com/flang-compiler/classic-flang-llvm-project/pull/90
