### PR TITLE
[DebugInfo] Artificial var debug info for common block should not be gererated

### DIFF
--- a/test/debug_info/common.f90
+++ b/test/debug_info/common.f90
@@ -1,0 +1,15 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: distinct !DIGlobalVariable(name: "cvar1", scope: [[CBLOCK:![0-9]+]]
+!CHECK: [[CBLOCK]] = distinct !DICommonBlock(scope: !3, declaration: null, name: "cname")
+!CHECK-NOT: distinct !DIGlobalVariable(name: "cname"
+!CHECK: distinct !DIGlobalVariable(name: "cvar2", scope: [[CBLOCK]]
+
+program main
+  integer :: cvar1, cvar2
+  common /cname/ cvar1, cvar2
+  cvar1 = 1
+  cvar2 = 2
+  print *, cvar1
+  print *, cvar2
+end program main


### PR DESCRIPTION
Currently a debug metadata of artificial global variable type for common block is generated (in addition to user visible common block members). With Flang extension of LLVM it has no name, otherwise it has name. Both the cases are problematic and redundant. which should be removed.

Please consider below test case.
```
program main
  integer :: cvar1, cvar2
  common /cname/ cvar1, cvar2
  cvar1 = 1
  cvar2 = 2
  print *, cvar1
  print *, cvar2
end program main
```
Generated IR.

```
!1 = distinct !DIGlobalVariable(name: "cvar1", scope: !2, file: !4, type: !16, isLocal: false, isDefinition: true)
!2 = distinct !DICommonBlock(scope: !3, declaration: !9, name: "cname")
!8 = !DIGlobalVariableExpression(var: !9, expr: !DIExpression())
!9 = distinct !DIGlobalVariable(scope: !2, type: !10, isLocal: false, isDefinition: true, flags: DIFlagArtificial)
!14 = !DIGlobalVariableExpression(var: !15, expr: !DIExpression(DW_OP_plus_uconst, 4))
!15 = distinct !DIGlobalVariable(name: "cvar2", scope: !2, file: !4, type: !16, isLocal: false, isDefinition: true)
```
!9 is artificial global variable, and when we allow the name, it is 
```
!9 = distinct !DIGlobalVariable(name: "cname", scope: !2, type: !10, isLocal: false, isDefinition: true)
```
It translates to debug info as 
```
0x00000040:     DW_TAG_common_block
                  DW_AT_name    ("cname")
                  DW_AT_location        (DW_OP_addr 0x0)

0x0000004f:       DW_TAG_variable
                    DW_AT_name  ("cname")
                    DW_AT_type  (0x000000a2 "byte[8]")
                    DW_AT_external      (true)
                    DW_AT_location      (DW_OP_addr 0x0)

0x00000062:       DW_TAG_variable
                    DW_AT_name  ("cvar1")
                    DW_AT_type  (0x000000bc "integer")
                    DW_AT_external      (true)
                    DW_AT_location      (DW_OP_addr 0x0)

0x00000075:       DW_TAG_variable
                    DW_AT_name  ("cvar2")
                    DW_AT_type  (0x000000bc "integer")
                    DW_AT_external      (true)
                    DW_AT_location      (DW_OP_addr 0x0, DW_OP_plus_uconst 0x4)

0x0000008a:       NULL
``` 
Please note the DIE (0x0000004f) is artificial global var.
when it has name, it fails gdb test case gdb.fortran/common-block.exp.
In case it has no name it is useless and results space penalty.
Only use of it is the address it has which is anyway already available at DIE tagged as DW_TAG_common_block.

So it is redundant and problematic and we should get rid of it.

