### PR TITLE
Fix issue #1227 about array constructor

### DIFF
--- a/test/f90_correct/inc/array_constructor01.mk
+++ b/test/f90_correct/inc/array_constructor01.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/array_constructor01.sh
+++ b/test/f90_correct/lit/array_constructor01.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/array_constructor01.f90
+++ b/test/f90_correct/src/array_constructor01.f90
@@ -1,0 +1,34 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for that the size of array section in array constructor is not constant and large.
+
+program p
+  implicit none
+  call non_constant_bound()
+  call large_array()
+  print *, "PASS"
+contains
+  subroutine non_constant_bound()
+    integer :: a(1, 100)
+    integer :: b(50)
+    integer :: m, n
+    a = 1
+    b = 2
+    m = 55
+    n = 10
+    b(1:n) = [a(1:1, m:m+n-1)]
+    if (any(b(1:n) /= 1)) STOP 1
+  end subroutine
+
+  subroutine large_array()
+    integer :: a(1, 100)
+    integer :: b(50)
+    a = 1
+    b = 2
+    b = [a(1:1, 21:70)]
+    if (any(b /= 1)) STOP 2
+  end subroutine
+end program

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -2577,6 +2577,7 @@ get_shape_arraydtype(int shape, int eltype)
 {
   int arrtype, i, n;
   int sz;
+  LOGICAL need_alloc = FALSE;
 
   n = sem.arrdim.ndim = SHD_NDIM(shape);
   sem.arrdim.ndefer = 0;
@@ -2596,13 +2597,15 @@ get_shape_arraydtype(int shape, int eltype)
       sem.bounds[i].uptype = S_EXPR;
       sem.bounds[i].upb = 0;
       sem.bounds[i].upast = sz;
-      sem.arrdim.ndefer++;
+      need_alloc = TRUE;
     }
   }
 
   if (is_deferlenchar_dtype(acs.arrtype))
-    sem.arrdim.ndefer = 1;
+    need_alloc = TRUE;
 
+  if (need_alloc)
+    sem.arrdim.ndefer = n;
   arrtype = mk_arrdsc();
   DTY(arrtype + 1) = eltype;
   return arrtype;


### PR DESCRIPTION
When the size of any dimension of array section in array constructor is a variable or
a constant whose value is greater than the macro THRESHHOLD, all dimensions should be treated as deferred dimensions.