### PR TITLE
[DebugInfo] Display common block variable in sub-routines

### DIFF
--- a/test/debug_info/allocated_nodup.f90
+++ b/test/debug_info/allocated_nodup.f90
@@ -1,16 +1,13 @@
 !RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
 
-!CHECK: distinct !DIGlobalVariable(name: "arr",
-!CHECK-SAME: type: [[TYPE:![0-9]+]]
-!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: [[DTYPE:![0-9]+]]
-!CHECK: [[DTYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "dtype"
-!CHECK-SAME: elements: [[MEMBERS:![0-9]+]]
-!CHECK: [[MEMBERS]] = !{[[MEM1:![0-9]+]]
-!CHECK: [[MEM1]] = !DIDerivedType(tag: DW_TAG_member, name: "memfunptr",
-!CHECK-SAME: baseType: [[FUNPTRTYPE:![0-9]+]]
-!CHECK: [[FUNPTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[FUNTYPE:![0-9]+]]
-!CHECK: [[FUNTYPE]] = !DISubroutineType(types: [[FUNSIGNATURE:![0-9]+]])
-!CHECK: [[FUNSIGNATURE]] = !{[[DTYPE]]
+!CHECK-DAG: distinct !DIGlobalVariable(name: "arr",{{.*}}type: [[TYPE:![0-9]+]]
+!CHECK-DAG: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: [[DTYPE:![0-9]+]]
+!CHECK-DAG: [[DTYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "dtype"{{.*}}elements: [[MEMBERS:![0-9]+]]
+!CHECK-DAG: [[MEMBERS]] = !{[[MEM1:![0-9]+]]
+!CHECK-DAG: [[MEM1]] = !DIDerivedType(tag: DW_TAG_member, name: "memfunptr",{{.*}}baseType: [[FUNPTRTYPE:![0-9]+]]
+!CHECK-DAG: [[FUNPTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[FUNTYPE:![0-9]+]]
+!CHECK-DAG: [[FUNTYPE]] = !DISubroutineType(types: [[FUNSIGNATURE:![0-9]+]])
+!CHECK-DAG: [[FUNSIGNATURE]] = !{[[DTYPE]]
 
 module pdt
   type dtype

--- a/test/debug_info/cmn_blk_dbg_info.f90
+++ b/test/debug_info/cmn_blk_dbg_info.f90
@@ -1,0 +1,45 @@
+!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK-DAG: ![[B3i1:[0-9]+]] = distinct !DIGlobalVariable(name: "b3i", scope: ![[BLK:[0-9]+]]
+!CHECK-DAG: ![[B3j1:[0-9]+]] = distinct !DIGlobalVariable(name: "b3j", scope: ![[BLK]]
+!CHECK-DAG: ![[BLK]] = distinct !DICommonBlock(scope: ![[SCOPE1:[0-9]+]]
+!CHECK-DAG: ![[SCOPE1]] = distinct !DISubprogram(name: "bdata"
+
+!CHECK-DAG: ![[B3i2:[0-9]+]] = distinct !DIGlobalVariable(name: "b3i", scope: ![[MOD:[0-9]+]]
+!CHECK-DAG: ![[B3j2:[0-9]+]] = distinct !DIGlobalVariable(name: "b3j", scope: ![[MOD]]
+!CHECK-DAG: ![[MOD]] = !DIModule({{.*}}, name: ".blockdata."
+
+!CHECK-DAG: ![[B3i3:[0-9]+]] = distinct !DIGlobalVariable(name: "b3i", scope: ![[SUB:[0-9]+]]
+!CHECK-DAG: ![[B3j3:[0-9]+]] = distinct !DIGlobalVariable(name: "b3j", scope: ![[SUB]]
+!CHECK-DAG: ![[SUB]] = distinct !DICommonBlock(scope: ![[SCOPE2:[0-9]+]]
+!CHECK-DAG: ![[SCOPE2]] = distinct !DISubprogram(name: "sub_block_data"
+
+!CHECK-DAG: ![[REF1:[0-9]+]] = !DIGlobalVariableExpression(var: ![[B3i1]]
+!CHECK-DAG: ![[REF2:[0-9]+]] = !DIGlobalVariableExpression(var: ![[B3j1]]
+!CHECK-DAG: ![[REF3:[0-9]+]] = !DIGlobalVariableExpression(var: ![[B3i2]]
+!CHECK-DAG: ![[REF4:[0-9]+]] = !DIGlobalVariableExpression(var: ![[B3j2]]
+!CHECK-DAG: ![[REF5:[0-9]+]] = !DIGlobalVariableExpression(var: ![[B3i3]]
+!CHECK-DAG: ![[REF6:[0-9]+]] = !DIGlobalVariableExpression(var: ![[B3j3]]
+!CHECK-DAG: @blk_ = global{{.*}}![[REF1]]{{.*}}![[REF2]]{{.*}}![[REF3]]{{.*}}![[REF4]]{{.*}}![[REF5]]{{.*}}![[REF6]]
+
+PROGRAM bdata
+   integer b3i, b3j, adr
+   COMMON/BLK/b3i, b3j
+   b3i = 111
+   b3j = 222
+   CALL sub_block_data      ! BP_BEFORE_SUB
+   print *,"End of program"
+END
+! BLOCK DATA
+BLOCK DATA
+integer b3i, b3j
+COMMON/BLK/b3i, b3j
+DATA b3i, b3j/11, 22/
+END
+! SUBROUTINE
+SUBROUTINE sub_block_data
+   integer b3i, b3j
+   COMMON/BLK/b3i, b3j
+   b3i = 1111; ! BP_SUB
+   b3j = 2222; ! BP_SUB
+END

--- a/test/debug_info/debug_module_import.f90
+++ b/test/debug_info/debug_module_import.f90
@@ -24,12 +24,12 @@ print *, var1
 print *, var2
 end program hello
 
-! CHECK: ![[DBG_MOD1:[0-9]+]] = !DIModule({{.*}}, name: "first"
-! CHECK: ![[DBG_DIC:[0-9]+]] = distinct !DICompileUnit({{.*}}, imports: ![[DBG_IMPORTS:[0-9]+]], nameTableKind: None
-! CHECK: ![[DBG_MOD2:[0-9]+]] = !DIModule({{.*}}, name: "second"
-! CHECK: ![[DBG_IMPORTS]] = !{![[DBG_IE1:[0-9]+]], ![[DBG_IE2:[0-9]+]], ![[DBG_IE3:[0-9]+]]}
-! CHECK: ![[DBG_IE1]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP1:[0-9]+]], entity: ![[DBG_MOD1]],
-! CHECK: ![[DBG_SP1]] = distinct !DISubprogram(name: "init", scope: ![[DBG_MOD2]]
-! CHECK: ![[DBG_IE2]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP2:[0-9]+]], entity: ![[DBG_MOD1]],
-! CHECK: ![[DBG_SP2]] = distinct !DISubprogram(name: "hello", scope: ![[DBG_DIC]]
-! CHECK: ![[DBG_IE3]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP2]], entity: ![[DBG_MOD2]],
+! CHECK-DAG: ![[DBG_MOD1:[0-9]+]] = !DIModule({{.*}}, name: "first"
+! CHECK-DAG: ![[DBG_DIC:[0-9]+]] = distinct !DICompileUnit({{.*}}, imports: ![[DBG_IMPORTS:[0-9]+]], nameTableKind: None
+! CHECK-DAG: ![[DBG_MOD2:[0-9]+]] = !DIModule({{.*}}, name: "second"
+! CHECK-DAG: ![[DBG_IMPORTS]] = !{![[DBG_IE1:[0-9]+]], ![[DBG_IE2:[0-9]+]], ![[DBG_IE3:[0-9]+]]}
+! CHECK-DAG: ![[DBG_IE1]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP1:[0-9]+]], entity: ![[DBG_MOD1]],
+! CHECK-DAG: ![[DBG_SP1]] = distinct !DISubprogram(name: "init", scope: ![[DBG_MOD2]]
+! CHECK-DAG: ![[DBG_IE2]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP2:[0-9]+]], entity: ![[DBG_MOD1]],
+! CHECK-DAG: ![[DBG_SP2]] = distinct !DISubprogram(name: "hello", scope: ![[DBG_DIC]]
+! CHECK-DAG: ![[DBG_IE3]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP2]], entity: ![[DBG_MOD2]],

--- a/tools/flang2/flang2exe/llassem.h
+++ b/tools/flang2/flang2exe/llassem.h
@@ -116,6 +116,7 @@ ISZ_T put_skip(ISZ_T old, ISZ_T New, bool is_char);
 #define AG_ARGDTLIST_LENGTH(s) agb.s_base[s].n_argdtlist
 #define AG_ARGDTLIST_IS_VALID(s) agb.s_base[s].argdtlist_is_set
 #define AG_OBJTODBGLIST(s) agb.s_base[s].cmblk_mem_mdnode_list
+#define AG_CMBLKINITDATA(s) agb.s_base[s].cmblk_init_data
 
 #define FPTR_HASHLK(s) fptr_local.s_base[s].hashlk
 #define FPTR_IFACENMPTR(s) fptr_local.s_base[s].ifacenmptr
@@ -154,6 +155,7 @@ typedef struct {
   LL_Type *ret_lltype;   /**< If this is a func this is the return type */
   DTLIST *argdtlist;     /**< linked listed of argument lltype */
   LL_ObjToDbgList *cmblk_mem_mdnode_list; ///< linked listed of cmem mdnode
+  char* cmblk_init_data; /**< llvm reference of common block initialization data*/
   int uplevel_avl;
   int uplevel_sz;
   UPLEVEL_PAIR *uplist; /**< uplevel list for internal procecure */


### PR DESCRIPTION
Issue: Common block variables are shown as “optimized out” in subroutines. (Due to missing metadata references).
Fix: In the  “write_comm” function, instead of emitting the global variable with defn to IR, we capture the same into a member “cmblk_init_data” of variable agb.  At the end of processing a source file, in the function “assemble_end”, we will generate the same with all the debug info metadata references.

Note: This is same as #1169. Review comments are addressed here.