### PR TITLE
Support debug info for deferred array in module.

### DIFF
--- a/test/debug_info/deferred_len.f90
+++ b/test/debug_info/deferred_len.f90
@@ -2,7 +2,7 @@
 
 !CHECK: !DILocalVariable(name: "defl_string"{{.*}}, type: ![[DERIVEDSTRING:[0-9]+]]
 !CHECK: ![[DERIVEDSTRING]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[STRING:[0-9]+]]
-!CHECK: ![[STRING]] = !DIStringType(name: "character(*)", stringLength: !{{[0-9]+}}
+!CHECK: ![[STRING]] = distinct !DIStringType(name: "character(*)", stringLength: !{{[0-9]+}}
 
 program deferredlength
 

--- a/test/debug_info/deferred_len_in_module.f90
+++ b/test/debug_info/deferred_len_in_module.f90
@@ -1,0 +1,19 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK-DAG: distinct !DIGlobalVariable(name: "def_arr"{{.*}}, type: ![[DERIVEDSTRING:[0-9]+]]
+!CHECK-DAG: ![[DERIVEDSTRING]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[STRING:[0-9]+]]
+!CHECK-DAG: ![[STRING]] = distinct !DIStringType(name: "character(*)", stringLength: ![[STRING_LEN:[0-9]+]]
+!CHECK-DAG: ![[STRING_LEN]] = distinct !DIGlobalVariable(scope: ![[MODULE:[0-9]+]]
+!CHECK-DAG: ![[MODULE]] = !DIModule{{.*}}, name: "samp"
+
+
+module samp
+    CHARACTER(len=:), ALLOCATABLE :: def_arr
+    CHARACTER(len=:), ALLOCATABLE :: def_arr2
+end module samp


### PR DESCRIPTION
This patch extends support to deferred array in global
scope (i,e inside modules).
Follow the same design as local deferred length arrays and
create a new global variable mdnode to capture the length of
the array.
Module deferred array variable considered as string type will
refer above mdnode to find the string length (length of array).