### PR TITLE
[directives] Make VECTOR test cases compatible with LLVM 14

### DIFF
--- a/test/directives/vector.f90
+++ b/test/directives/vector.f90
@@ -15,6 +15,5 @@ subroutine add(arr1,arr2,arr3,N)
 end subroutine
 ! METADATA: !"llvm.loop.vectorize.enable", i1 true
 ! IGNORE-DIRECTIVES-NOT: !"llvm.loop.vectorize.enable", i1 true
-! CHECK: load <[[VF:[0-9]+]] x i32>
-! CHECK: store <[[VF]] x i32>
+! CHECK: store <[[VF:[0-9]+]] x i32>
 ! VECTOR-NOT: <{{[0-9]+}} x

--- a/test/directives/vector_directive3.f90
+++ b/test/directives/vector_directive3.f90
@@ -1,14 +1,13 @@
 !! check for pragma support for !dir$ vector always
 !RUN: %flang -S -O2 -emit-llvm %s -o - | FileCheck %s
 !CHECK: define void @sumsimd_{{.*$}}
-!CHECK: {{.*}}!llvm.access.group ![[ACCGRP:[0-9]+]]
-!CHECK: vector.ph:{{.*}}
-!CHECK: vector.body:{{.*}}
-!CHECK: {{.*}}shufflevector{{.*}}
-!CHECK: {{.*}}add <2 x i64>{{.*}}
-!CHECK: {{.*}}"llvm.loop.parallel_accesses", ![[ACCGRP]]}
-!CHECK: {{.*}}"llvm.loop.isvectorized", i32 1{{.*}}
-!CHECK: {{.*}}"llvm.loop.unroll.runtime.disable"{{.*}}
+!CHECK: !llvm.access.group ![[ACCGRP:[0-9]+]]
+!CHECK: vector.ph:
+!CHECK: vector.body:
+!CHECK: add nsw <2 x i32>
+!CHECK: "llvm.loop.parallel_accesses", ![[ACCGRP]]}
+!CHECK: "llvm.loop.isvectorized", i32 1
+!CHECK: "llvm.loop.unroll.runtime.disable"
 
 SUBROUTINE sumsimd(myarr1,myarr2,ub)
   INTEGER, POINTER :: myarr1(:)


### PR DESCRIPTION
With the `!DIR$ VECTOR ALWAYS` directive, LLVM 14 vectorizes the test case
`test/directives/vector.f90`, but the chosen VPlan replicates the `i32` load
instead of widening it; the `i32` store at the end of the loop is still
widened. This patch changes the FileCheck patterns in the test case to
match only the widened store.

For `test/directives/vector_directive3.f90`, LLVM 14 also replicates the `i32`
load instead of widening it. Furthermore, the test case originally matched
`add <2 x i64>` which referred to the vectorized add of section descriptor
values (rather than actual array elements). This patch changes the FileCheck
patterns in the test case to match the vectorized add of the `i32` array
elements.

The release_13x branch of classic-flang-llvm-project still passes the
updated tests.