### PR TITLE
Fix the im30.f test case

### DIFF
--- a/test/f90_correct/src/im30.f
+++ b/test/f90_correct/src/im30.f
@@ -23,10 +23,11 @@ c  --- check the results:
 	common /fast/ a(100)
 	real*8 a
 	real*8 x1wxyz
-	integer istuff
+	integer istuff, stuff
 	locf(x1wxyz) = ishft(%loc(x1wxyz),-3)
 	istuff = locf(a(1))
-	if (istuff .ne. ishft(%loc(a(1)),-3)) then
+	stuff = ishft(%loc(a(1)),-3)
+	if (istuff .ne. stuff) then
 	    if1 = 99
 	else
 	    if1 = 1


### PR DESCRIPTION
LLVM15+ brings a new default for creation of the PIE binaries on Linux
systems. In effect, position independed executables are always
assumed.

With the recent change in the default for creation of PIE binaries,
some of the fragile test cases could start to fail.

In the im30 test case, the result of the first use of %loc() function
was truncated (due to the way the variable holding the result is
created), while the second use of %loc() was properly used (in the
comparison expression) as a 64-bit value. Up until recently it wasn't
hurting as the most significant bits were always 0. Sadly, it has
changed with the introduction of the PIE binaries.

Due to the way the `locf` array is created, we have no ability to
change its assumed type. In order to keep this test objectives intact,
the result of the second %loc() call is now kept in a 32-bit integer
variable, so the values used in the comparison are both of the same
type.