### PR TITLE
[test] Adapt AArch64 target-features attribute tests for LLVM 14

### DIFF
--- a/test/llvm_ir_correct/attr.f90
+++ b/test/llvm_ir_correct/attr.f90
@@ -16,5 +16,5 @@
        end do
        print *, acc(100)
       end program
-! ATTRS-NOSVE: attributes{{.*}}"target-features"="+neon"
-! ATTRS-SVE: attributes{{.*}}"target-features"="+neon,+sve"
+! ATTRS-NOSVE: attributes{{.*}}"target-features"="+neon{{(,\+v8a)*}}"
+! ATTRS-SVE: attributes{{.*}}"target-features"="+neon{{(,\+v8a)*}},+sve"

--- a/test/llvm_ir_correct/vscale-mbits.f90
+++ b/test/llvm_ir_correct/vscale-mbits.f90
@@ -20,17 +20,17 @@
        print *, acc(100)
       end program
 ! ATTRS-SVE-128: attributes #{{[0-9]+}}
-! ATTRS-SVE-128-DAG: "target-features"="+neon,+sve"
+! ATTRS-SVE-128-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
 ! ATTRS-SVE-128-DAG: vscale_range(1,1)
 ! ATTRS-SVE-256: attributes #{{[0-9]+}}
-! ATTRS-SVE-256-DAG: "target-features"="+neon,+sve"
+! ATTRS-SVE-256-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
 ! ATTRS-SVE-256-DAG: vscale_range(2,2)
 ! ATTRS-SVE2-512: attributes #{{[0-9]+}}
-! ATTRS-SVE2-512-DAG: "target-features"="+neon,+sve2,+sve"
+! ATTRS-SVE2-512-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve"
 ! ATTRS-SVE2-512-DAG: vscale_range(4,4)
 ! ATTRS-SVE2SHA3-2048: attributes #{{[0-9]+}}
-! ATTRS-SVE2SHA3-2048-DAG: "target-features"="+neon,+sve2-sha3,+sve,+sve2"
+! ATTRS-SVE2SHA3-2048-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2-sha3,+sve,+sve2"
 ! ATTRS-SVE2SHA3-2048-DAG: vscale_range(16,16)
 ! ATTRS-SVE2-SCALABLE: attributes #{{[0-9]+}}
-! ATTRS-SVE2-SCALABLE-DAG: "target-features"="+neon,+sve2,+sve"
+! ATTRS-SVE2-SCALABLE-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve"
 ! ATTRS-SVE2-SCALABLE-DAG: vscale_range(1,16)

--- a/test/llvm_ir_correct/vscale.f90
+++ b/test/llvm_ir_correct/vscale.f90
@@ -23,23 +23,23 @@
        print *, acc(100)
       end program
 ! ATTRS-NEON-NOT: vscale_range
-! ATTRS-NEON: attributes{{.*}}"target-features"="+neon"
+! ATTRS-NEON: attributes{{.*}}"target-features"="+neon{{(,\+v8a)*}}"
 ! ATTRS-SVE: attributes #{{[0-9]+}}
-! ATTRS-SVE-DAG: "target-features"="+neon,+sve"
+! ATTRS-SVE-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
 ! ATTRS-SVE-DAG: vscale_range(1,16)
 ! ATTRS-SVE2: attributes #{{[0-9]+}}
-! ATTRS-SVE2-DAG: "target-features"="+neon,+sve2,+sve"
+! ATTRS-SVE2-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve"
 ! ATTRS-SVE2-DAG: vscale_range(1,16)
 ! ATTRS-SVE2SHA3: attributes #{{[0-9]+}}
-! ATTRS-SVE2SHA3-DAG: "target-features"="+neon,+sve2-sha3,+sve,+sve2"
+! ATTRS-SVE2SHA3-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2-sha3,+sve,+sve2"
 ! ATTRS-SVE2SHA3-DAG: vscale_range(1,16)
 ! ATTRS-SVE-NOSVE-NOT: vscale_range
-! ATTRS-SVE-NOSVE: attributes{{.*}}"target-features"="+neon,-sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
+! ATTRS-SVE-NOSVE: attributes{{.*}}"target-features"="+neon{{(,\+v8a)*}},-sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
 ! ATTRS-SVE2-NOSVE2SHA3: attributes #{{[0-9]+}}
-! ATTRS-SVE2-NOSVE2SHA3-DAG: "target-features"="+neon,+sve2,+sve,-sve2-sha3"
+! ATTRS-SVE2-NOSVE2SHA3-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve,-sve2-sha3"
 ! ATTRS-SVE2-NOSVE2SHA3-DAG: vscale_range(1,16)
 ! ATTRS-SVE2SHA3-NOSVE2: attributes #{{[0-9]+}}
-! ATTRS-SVE2SHA3-NOSVE2-DAG: "target-features"="+neon,+sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
+! ATTRS-SVE2SHA3-NOSVE2-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
 ! ATTRS-SVE2SHA3-NOSVE2-DAG: vscale_range(1,16)
 ! ATTRS-SVE2SHA3-NOSVE-NOT: vscale_range
-! ATTRS-SVE2SHA3-NOSVE: attributes{{.*}}"target-features"="+neon,-sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
+! ATTRS-SVE2SHA3-NOSVE: attributes{{.*}}"target-features"="+neon{{(,\+v8a)*}},-sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"


### PR DESCRIPTION
In LLVM 14, the `-march=armv8-a` option adds `+v8a` to the `target-features`
attribute. This patch updates Flang test cases that match the attribute,
so that they will work with both LLVM 13 and LLVM 14.