### PR TITLE
[flang2] Fix generation of upperilm.h

### DIFF
--- a/tools/flang2/utils/upper/CMakeLists.txt
+++ b/tools/flang2/utils/upper/CMakeLists.txt
@@ -30,7 +30,7 @@ if(cpp_result EQUAL 0)
   # Skip all lines which starts with '#'
   list(FILTER UPPERILM_H_CONTENTS EXCLUDE REGEX "^#")
   list(JOIN UPPERILM_H_CONTENTS "\n" UPPERILM_H_CONTENTS_SORTED)
-  file(WRITE ${UTILS_UPPER_BIN_DIR}/upperilm.sort "${UPPERILM_H_CONTENTS_SORTED}")
+  file(WRITE ${UTILS_UPPER_BIN_DIR}/upperilm.sort "${UPPERILM_H_CONTENTS_SORTED}\n")
 else()
   message(FATAL_ERROR "Preprocessing of upperilm.in failed; aborting.")
 endif()


### PR DESCRIPTION
The CMake recipe for running `upperl` to generate `upperilm.h` from `upperilm.in` incorrectly leaves out a terminating newline character, without which the parser inside `upperl` will not print the last opcode (`IM_KXOR`, a.k.a. `XOR8`) in its output. This patch adds back the missing newline and fixes the `XOR8` opcode.