### PR TITLE
Add a test case exposing potential issues with implied do

### DIFF
--- a/test/f90_correct/inc/implied_do10.mk
+++ b/test/f90_correct/inc/implied_do10.mk
@@ -1,0 +1,18 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 $(SRC)/$(TEST).c $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/implied_do10.sh
+++ b/test/f90_correct/lit/implied_do10.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/implied_do10.c
+++ b/test/f90_correct/src/implied_do10.c
@@ -1,0 +1,21 @@
+/*
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+_Noreturn void f90_alloc04a_i8 (size_t *nelem, void *kind, size_t *len,
+                                void *stat, void *pointer, void *offset,
+                                void *firsttime, void *align, void *errmsg_adr,
+                                size_t *errmsg_len)
+{
+  printf("nelem: %lu\n", *nelem);
+  if ((!(*nelem)) || (2UL < *nelem))
+    abort();
+  printf(" PASSED\n");
+  exit(0);
+}

--- a/test/f90_correct/src/implied_do10.f90
+++ b/test/f90_correct/src/implied_do10.f90
@@ -1,0 +1,22 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+program implied_do10
+  implicit none
+  real :: x(2) = 0
+  integer :: i
+
+  x = (/ (f(1), i = 1, 2) /)
+  print *, x
+contains
+  function f(n)
+    implicit none
+    integer :: n
+    real f(n)
+
+    f = x(1) + 4
+  end function
+end


### PR DESCRIPTION
The purpose of this test is to demonstrate symptoms described
in the issue #1253

Note that this test case intercepts a call to the flang runtime
(the f90_alloc04a_i8() function) in order to verify that the
number of temporarily allocated elements do not exceed the
array size.