### PR TITLE
Make those two tests safe to run in parallel

### DIFF
--- a/test/llvm_ir_correct/invalid_ambiguous_generic_proc.f90
+++ b/test/llvm_ir_correct/invalid_ambiguous_generic_proc.f90
@@ -4,40 +4,40 @@
 
 ! RUN: %flang -S -emit-llvm %s
 
-MODULE dbcsr_operations
+MODULE dbcsr_ambiguous_operations
   IMPLICIT NONE
-  PUBLIC :: dbcsr_add
+  PUBLIC :: dbcsr_ambiguous_add
   PRIVATE
-  INTERFACE dbcsr_add
-    MODULE PROCEDURE dbcsr_add_d
+  INTERFACE dbcsr_ambiguous_add
+    MODULE PROCEDURE dbcsr_ambiguous_add_d
   END INTERFACE
 CONTAINS
-  SUBROUTINE dbcsr_add_d()
+  SUBROUTINE dbcsr_ambiguous_add_d()
     print *, "add_d and anytype."
-  END SUBROUTINE dbcsr_add_d
-END MODULE dbcsr_operations
+  END SUBROUTINE dbcsr_ambiguous_add_d
+END MODULE dbcsr_ambiguous_operations
 
-MODULE dbcsr_api
-  USE dbcsr_operations,ONLY: &
-    dbcsr_add_prv=>dbcsr_add
+MODULE dbcsr_ambiguous_api
+  USE dbcsr_ambiguous_operations,ONLY: &
+    dbcsr_ambiguous_add_prv=>dbcsr_ambiguous_add
   IMPLICIT NONE
-  PUBLIC :: dbcsr_add
+  PUBLIC :: dbcsr_ambiguous_add
   PRIVATE
-  INTERFACE dbcsr_add
-    MODULE PROCEDURE dbcsr_add_dd
+  INTERFACE dbcsr_ambiguous_add
+    MODULE PROCEDURE dbcsr_ambiguous_add_dd
   END INTERFACE
   CONTAINS
-    SUBROUTINE dbcsr_add_dd()
+    SUBROUTINE dbcsr_ambiguous_add_dd()
       print *, "add_dd in API."
     END SUBROUTINE
-END MODULE dbcsr_api
+END MODULE dbcsr_ambiguous_api
 
-PROGRAM dbcsr_test_csr_conversions
-USE dbcsr_api,ONLY:  dbcsr_add
+PROGRAM dbcsr_ambiguous_test_csr_conversions
+USE dbcsr_ambiguous_api,ONLY:  dbcsr_ambiguous_add
 IMPLICIT NONE
   CONTAINS
   SUBROUTINE csr_conversion_test()
-    CALL dbcsr_add()
+    CALL dbcsr_ambiguous_add()
   END SUBROUTINE csr_conversion_test
-END PROGRAM dbcsr_test_csr_conversions
+END PROGRAM dbcsr_ambiguous_test_csr_conversions
 

--- a/test/llvm_ir_correct/invalid_public_entity_error.f90
+++ b/test/llvm_ir_correct/invalid_public_entity_error.f90
@@ -4,30 +4,30 @@
 
 ! RUN: %flang -S -emit-llvm %s
 
-MODULE dbcsr_operations
- PUBLIC :: dbcsr_norm
- INTERFACE dbcsr_norm
-  MODULE PROCEDURE dbcsr_norm_anytype
+MODULE dbcsr_public_operations
+ PUBLIC :: dbcsr_public_norm
+ INTERFACE dbcsr_public_norm
+  MODULE PROCEDURE dbcsr_public_norm_anytype
  END INTERFACE
  CONTAINS
- SUBROUTINE dbcsr_norm_anytype
+ SUBROUTINE dbcsr_public_norm_anytype
    print *, "hello world"
  END SUBROUTINE
-END MODULE dbcsr_operations
+END MODULE dbcsr_public_operations
 
-MODULE dbcsr_api
-use dbcsr_operations
- use dbcsr_operations, only: &
- dbcsr_norm_prv => dbcsr_norm
- public::dbcsr_norm
+MODULE dbcsr_public_api
+use dbcsr_public_operations
+ use dbcsr_public_operations, only: &
+ dbcsr_public_norm_prv => dbcsr_public_norm
+ public::dbcsr_public_norm
 private
  CONTAINS
- SUBROUTINE dbcsr_norm()
-  print *, "hellow world from dbcsr_api "
+ SUBROUTINE dbcsr_public_norm()
+  print *, "hellow world from dbcsr_public_api "
  end subroutine
 end module
 
 program main
-use dbcsr_api, only : dbcsr_norm
- call dbcsr_norm();
+use dbcsr_public_api, only : dbcsr_public_norm
+ call dbcsr_public_norm();
 end program


### PR DESCRIPTION
Initially, I could not replicate this error outside the testing
environment. Then I figured out that both these tests share the
same names of the exported modules. In effect, two flangs running
in parallel are overwritting the same .mod files.

This patch renames the modules so they are different for each test.
