### PR TITLE
[flang1] Fix final subroutine attribute

### DIFF
--- a/test/llvm_ir_correct/final-subroutine.f90
+++ b/test/llvm_ir_correct/final-subroutine.f90
@@ -1,0 +1,23 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! RUN: %flang -S -emit-llvm %s -o - 2>&1 | FileCheck %s
+
+! CHECK: define void @m_sub_
+! CHECK-NOT: define internal void @m_sub_
+
+module m
+  private
+  type my_type
+    integer :: x
+   contains
+    final :: sub
+  end type
+contains
+  subroutine sub(t)
+    type(my_type) :: t
+  end
+end

--- a/tools/flang1/flang1exe/semtbp.c
+++ b/tools/flang1/flang1exe/semtbp.c
@@ -305,6 +305,8 @@ initFinalSub(tbpTask task, TBP *curr)
       STYPEP(curr->impSptr, ST_ENTRY);
       SCOPEP(curr->impSptr, stb.curr_scope);
     }
+    /* FINAL subroutine is always public. See Fortran 2018 7.5.6.1 NOTE 1. */
+    PRIVATEP(curr->impSptr, 0);
     if (task == TBP_COMPLETE_ENDMODULE || task == TBP_COMPLETE_FIN) {
       proc_arginfo(curr->impSptr, &paramct, &dpdsc, &sym);
       if (task == TBP_COMPLETE_FIN && (!sym || !dpdsc || !paramct ||


### PR DESCRIPTION
As Fortran 2018 7.5.6.1 NOTE 1, final subroutines are effectively always
"accessible". So, the final subroutine can never be private.