### PR TITLE
NFCI: improve consistency by explicitly initializing cached_access_group_metadata

### DIFF
--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -211,7 +211,7 @@ static LL_MDRef cached_vectorize_enable_metadata = ll_get_md_null();
 static LL_MDRef cached_vectorize_disable_metadata = ll_get_md_null();
 static LL_MDRef cached_unroll_enable_metadata = ll_get_md_null();
 static LL_MDRef cached_unroll_disable_metadata = ll_get_md_null();
-static LL_MDRef cached_access_group_metadata;
+static LL_MDRef cached_access_group_metadata = ll_get_md_null();
 
 static bool CG_cpu_compile = false;
 


### PR DESCRIPTION
The goal is to have all of those `LL_MDRef` objects being initialized the same way.

This is to prevent `cached_access_grop_metadata` being used uninitialized in the functions like `cons_loop_parallel_accesses_metadata()`.
