### PR TITLE
AArch64 consistency: define FLANG_GEN_LLVM_ATOMIC_INTRINSICS for ARM64 targets

### DIFF
--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -53,6 +53,9 @@
 
 #include "upper.h"
 
+#ifdef TARGET_LLVM_ARM64
+#define FLANG_GEN_LLVM_ATOMIC_INTRINSICS 1
+#endif
 
 typedef enum SincosOptimizationFlags {
   /* used only for sincos() optimization */


### PR DESCRIPTION
This is for ensuring consistency.
