### PR TITLE
runtime, NFCI: fix inconsistency in defining 64-bit ARM architecture

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -29,6 +29,7 @@ elseif( ${TARGET_ARCHITECTURE} STREQUAL "aarch64" )
   add_definitions(
    -DTARGET_LLVM_ARM64
    -DTARGET_${OS}_ARM
+   -DTARGET_${OS}_ARM64
   )
 elseif( ${TARGET_ARCHITECTURE} STREQUAL "ppc64le" )
   add_definitions(


### PR DESCRIPTION
E.g. TARGET_LINUX_ARM64 is being used, so it is worth to make sure it is explicitly defined.