### PR TITLE
[flang1] Fix the issue which introduced form PR#1212

### DIFF
--- a/test/f90_correct/inc/implied_do10.mk
+++ b/test/f90_correct/inc/implied_do10.mk
@@ -1,0 +1,18 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 $(SRC)/$(TEST).c $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/implied_do11.mk
+++ b/test/f90_correct/inc/implied_do11.mk
@@ -1,0 +1,18 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/implied_do10.sh
+++ b/test/f90_correct/lit/implied_do10.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/implied_do11.sh
+++ b/test/f90_correct/lit/implied_do11.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/implied_do10.c
+++ b/test/f90_correct/src/implied_do10.c
@@ -1,0 +1,21 @@
+/*
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+_Noreturn void f90_alloc04a_i8 (size_t *nelem, void *kind, size_t *len,
+                                void *stat, void *pointer, void *offset,
+                                void *firsttime, void *align, void *errmsg_adr,
+                                size_t *errmsg_len)
+{
+  printf("nelem: %lu\n", *nelem);
+  if (2UL < *nelem)
+    abort();
+  printf(" PASSED\n");
+  exit(0);
+}

--- a/test/f90_correct/src/implied_do10.f90
+++ b/test/f90_correct/src/implied_do10.f90
@@ -1,0 +1,22 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+program implied_do10
+  implicit none
+  real :: x(2) = 0
+  integer :: i
+
+  x = (/ (f(1), i = 1, 2) /)
+  print *, x
+contains
+  function f(n)
+    implicit none
+    integer :: n
+    real f(n)
+
+    f = x(1) + 4
+  end function
+end

--- a/test/f90_correct/src/implied_do11.f90
+++ b/test/f90_correct/src/implied_do11.f90
@@ -1,0 +1,44 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+program implied_do11
+  implicit none
+  real :: x(2) = 0
+  real :: y(3) = 0
+  real :: z(10) = 0
+  integer :: i
+
+  x = (/ (f1(1), i = 1, 2) /)
+  if (any(x /= 4.0)) STOP 1
+  y = (/ (f1(i), i = 1, 2) /)
+  if (any(y /= (/4.0, 8.0, 8.0/))) STOP 2
+  z = (/ (f1(5), i = 1, 2) /)
+  if (any(z /= 20.0)) STOP 3
+  x = (/ (f2(1), i = 1, 2) /)
+  if (any(x /= 10.0)) STOP 4
+  y = (/ (f2(i), i = 1, 2) /)
+  if (any(y /= (/10.0, 20.0, 20.0/))) STOP 5
+  z = (/ (f2(5), i = 1, 2) /)
+  if (any(z /= 50.0)) STOP 6
+  print *, 'PASS'
+contains
+  function f1(n)
+    implicit none
+    integer :: n
+    real :: f1(n)
+
+    f1 = n * 4.0
+  end function
+  function f2(n)
+    implicit none
+    integer :: n
+    real, pointer :: f2(:)
+    allocate(f2(n))
+
+    f2 = n * 10.0
+  end function
+
+end program

--- a/test/sema/implied_do.f90
+++ b/test/sema/implied_do.f90
@@ -1,0 +1,49 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! RUN: %flang1 %s | FileCheck %s
+! CHECK: procedure:Program
+! CHECK-DAG: s:[[FUNC:[0-9]+]] {{.*}}:func
+! CHECK-DAG: s:[[REALLOC:[0-9]+]] {{.*}}:f90_realloc_arr_in_impiled_do
+! CHECK-DAG: s:[[DEALLOC:[0-9]+]] {{.*}}:f90_dealloc03a
+! CHECK-COM: begin of implied-do loop
+! CHECK: DOBEG
+! CHECK-NOT: DOEND
+! CHECK-COM: call func() in the loop and realloc temp array before copying
+! CHECK: UCALL n{{[0-9]+}} s[[FUNC]]
+! CHECK: UCALL n6 s[[REALLOC]]
+! CHECK-COM: loop for copying from return variable
+! CHECK: DOBEG
+! CHECK: DOEND
+! CHECK-COM: dealloc return variable in the implied-do loop
+! CHECK: CALL n4 s[[DEALLOC]]
+! CHECK-COM: end of implied-do loop
+! CHECK: DOEND
+! CHECK-COM: loop for assignment to x
+! CHECK: DOBEG
+! CHECK: DOEND
+! CHECK-COM: dealloc temp array outside the implied-do loop
+! CHECK: CALL n4 s[[DEALLOC]]
+! CHECK-NOT: CALL n4 s[[DEALLOC]]
+! CHECK: procedure:Subroutine
+
+program main
+  implicit none
+  integer :: x(2) = 0
+  integer :: i
+
+  x = (/ (func(1), i = 1, 2) /)
+  call check()
+contains
+  function func(n)
+    integer :: n
+    integer :: func(n)
+    func = n
+  end function
+  subroutine check()
+    if (any(x /= (/1, 1/))) STOP 1
+  end subroutine
+end program


### PR DESCRIPTION
After PR#1212 commited, @paulwalker-arm found a test case failed and filed a issue https://github.com/flang-compiler/flang/issues/1253, this PR is used to fix this regression.

In https://github.com/flang-compiler/flang/pull/1102, [qiaozhang-hnc](https://github.com/qiaozhang-hnc) introduced a zero-size array to handle a function which return an array in impiled-do statement, and then call `realloc` to get the right size of array.

In #1212, I called `move_range_after()` to change the order of stmts . However, it is not well coordinated with #1102, resulting in the problem of undefined use. 