### PR TITLE
flang1, flang2: larger buffers, to hold longer filenames

### DIFF
--- a/tools/flang1/flang1exe/astout.c
+++ b/tools/flang1/flang1exe/astout.c
@@ -39,10 +39,10 @@ static int continuations = 0; /* number of continuation lines */
 
 static int indent; /* number of indentation levels */
 
-#define CARDB_SIZE 300 /* make it large enough */
+#define CARDB_SIZE 2100 /* make it large enough */
 static char lbuff[CARDB_SIZE];
 
-#define MAX_FNAME_LEN 258
+#define MAX_FNAME_LEN 2050
 static LOGICAL ast_is_comment = FALSE;
 static LOGICAL op_space = TRUE;
 

--- a/tools/flang1/flang1exe/exterf.c
+++ b/tools/flang1/flang1exe/exterf.c
@@ -89,7 +89,7 @@ static LOGICAL for_contained = FALSE;
 static LOGICAL exporting_module = FALSE;
 static lzhandle *outlz;
 static int exportmode = 0;
-#define MAX_FNAME_LEN 258
+#define MAX_FNAME_LEN 2050
 
 static int out_platform = MOD_ANY;
 

--- a/tools/flang1/flang1exe/fpp.c
+++ b/tools/flang1/flang1exe/fpp.c
@@ -186,7 +186,7 @@ static char ctable[256] = {
 #define FORMALMAX 31
 #define ARGST 0xFE
 /* * * * * MAX_FNAME_LEN MUST be less than scan.c:CARDB_SIZE * * * * */
-#define MAX_FNAME_LEN 258
+#define MAX_FNAME_LEN 2050
 #define MAXINC 20
 #define MACSTK_MAX 100
 

--- a/tools/flang1/flang1exe/gbldefs.h
+++ b/tools/flang1/flang1exe/gbldefs.h
@@ -62,7 +62,7 @@
 #define MAXIDLEN 163
 
 /*  should replace local MAX_FNAME_LENs with: */
-#define MAX_FILENAME_LEN 256
+#define MAX_FILENAME_LEN 2048
 
 /* maximum number of array subscripts */
 #define MAXSUBS 7

--- a/tools/flang1/flang1exe/inliner.c
+++ b/tools/flang1/flang1exe/inliner.c
@@ -58,7 +58,7 @@
 #define INLINER_VERSION 14
 
 #define MAX_INLINE_NAME 42
-#define MAX_FNAME_LEN 256
+#define MAX_FNAME_LEN 2048
 #define TOC_HEADER_FMT "Inliner TOC V.%d"
 #define TOC_ENTRY_FMT "%s %s %s %s"
 #define MODNAME_FMT "i%d.e"

--- a/tools/flang1/flang1exe/interf.c
+++ b/tools/flang1/flang1exe/interf.c
@@ -61,7 +61,7 @@ static int HOST_OLDSCOPE = 0, HOST_NEWSCOPE = 0;
 static char **modinclist = NULL;
 static int modinclistsize = 0, modinclistavl = 0;
 
-#define MAX_FNAME_LEN 258
+#define MAX_FNAME_LEN 2050
 #define MOD_SUFFIX ".mod"
 
 /** \brief 'interface' initialization, called once per compilation

--- a/tools/flang1/flang1exe/module.c
+++ b/tools/flang1/flang1exe/module.c
@@ -882,7 +882,7 @@ open_module(SPTR use)
     if (strcmp(SYMNAME(usedb.base[module_id].module), name) == 0)
       return;
 
-#define MAX_FNAME_LEN 258
+#define MAX_FNAME_LEN 2050
 
   fullname = getitem(8, MAX_FNAME_LEN + 1);
   modu_file_name = getitem(8, strlen(name) + strlen(MOD_SUFFIX) + 1);

--- a/tools/flang2/flang2exe/gbldefs.h
+++ b/tools/flang2/flang2exe/gbldefs.h
@@ -53,7 +53,7 @@
 #define MAXIDLEN 163
 
 /*  should replace local MAX_FNAME_LENs with: */
-#define MAX_FILENAME_LEN 256
+#define MAX_FILENAME_LEN 2048
 
 /* Max function/variable name length, 
  * Function/variable name in C++ can be really long 


### PR DESCRIPTION
Despite the changes introduced by commit

c9c3f0d0479744c336c45daaa635f33284c93ca8

...we're still experiencing issues while compiling Fortran codes deep
in the directory tree.
