### PR TITLE
Set dwarf version to 4 in debug_info tests

### DIFF
--- a/test/debug_info/nametable.f90
+++ b/test/debug_info/nametable.f90
@@ -2,7 +2,7 @@
 !RUN: %flang %s -g -c -o - | llvm-readelf -S - | FileCheck %s --check-prefix=NOPUBNAMESECTION
 
 !RUN: %flang %s -gdwarf-5 -gpubnames -c -o - | llvm-readelf -S - | FileCheck %s --check-prefix=NAMESECTION
-!RUN: %flang %s -g -gpubnames -c -o - | llvm-readelf -S - | FileCheck %s --check-prefix=PUBNAMESECTION
+!RUN: %flang %s -gdwarf-4 -gpubnames -c -o - | llvm-readelf -S - | FileCheck %s --check-prefix=PUBNAMESECTION
 
 !Ensure that `.debug_names` or `.debug_pubnames` are NOT present by default.
 !NONAMESECTION-NOT: .debug_names

--- a/test/debug_info/producer.f90
+++ b/test/debug_info/producer.f90
@@ -1,7 +1,7 @@
 !RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
 
 !CHECK: !DICompileUnit(language: DW_LANG_Fortran90
-!CHECK-SAME: flags: "'+flang -gdwarf-4 -S -emit-llvm 
+!CHECK-SAME: flang -gdwarf-4 -S -emit-llvm
 
 program main
 end program main

--- a/test/debug_info/redundant_inst.f90
+++ b/test/debug_info/redundant_inst.f90
@@ -1,5 +1,5 @@
 !RUN: %flang %s -g -S -emit-llvm -o - | FileCheck %s --check-prefix=STORE
-!RUN: %flang %s -g -S -emit-llvm -o - | llc -O0 -fast-isel=true -filetype=obj -o %t
+!RUN: %flang %s -g -gdwarf-4 -S -emit-llvm -o - | llc -O0 -fast-isel=true -filetype=obj -o %t
 !RUN: llvm-dwarfdump --debug-line %t | FileCheck %s --check-prefix=LINETABLE
 
 !Check that `store` instruction is getting emitted for the second assignment.


### PR DESCRIPTION
This PR is a series of the 3 small commits.

The LLVM14 uses dwarf version 5 by default, but those tests are only compatible with the older dwarf version.
