### PR TITLE
Fix flang testing with newer gcc versions

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -15,6 +15,17 @@ import tempfile
 
 import lit.formats
 import lit.util
+import lit.llvm
+
+# When clang and flang are built using a non system compiler
+# (for example loaded by conan) we need to make sure that the linker is using
+# the same libgcc.a library, as used to build clang/flang and libraries.
+# The system one may be not compatible with newer versions.
+# From gcc 10.1 -moutline-atomics is the default, so older versions
+# of libgcc.a won't be compatible as will not have defined required
+# symbols.
+lit.llvm.initialize(lit_config, config)
+lit.llvm.llvm_config.with_system_environment("COMPILER_PATH")
 
 if platform.system() == 'Windows':
     lit_config.note('We do not support Windows, but hey, congratulations on porting to Windows!')


### PR DESCRIPTION
When flang is being built with compiler version newer than
the one installed on the system, we need to make sure that
COMPILER_PATH variable is set for lit testing,
otherwise there might be compatibillity problems with the libgcc.a library.
Flang tests are building and executing programs, so some symbols
could be missing when those programs are linked with older libgcc.a
than the one used to build compiler.