### PR TITLE
Add attributes to IR instructions

### DIFF
--- a/test/llvm_ir_correct/fp_reduce.f90
+++ b/test/llvm_ir_correct/fp_reduce.f90
@@ -1,0 +1,26 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! RUN: %flang                                 -S -emit-llvm %s -o - | FileCheck %s  --check-prefixes=CHECK
+! RUN: %flang -Ofast                          -S -emit-llvm %s -o - | FileCheck %s  --check-prefixes=FAST
+! RUN: %flang -Mx,216,0x8                     -S -emit-llvm %s -o - | FileCheck %s  --check-prefixes=NSZ
+! RUN: %flang -Mx,216,0x10                    -S -emit-llvm %s -o - | FileCheck %s  --check-prefixes=REASSOC
+! RUN: %flang -Mx,216,0x8 -Mx,216,0x10        -S -emit-llvm %s -o - | FileCheck %s  --check-prefixes=NSZ_REASSOC
+! RUN: %flang -Ofast -Mx,216,0x8 -Mx,216,0x10 -S -emit-llvm %s -o - | FileCheck %s  --check-prefixes=FAST
+
+real function acc(arr,N)
+  real arr
+  integer N
+  do i=1, N
+    acc = acc + arr(i)
+! CHECK-NOT: fadd fast
+! FAST: fadd fast
+! FAST-NOT: fadd nsz
+! FAST-NOT: fadd reassoc
+! NSZ: fadd nsz
+! REASSOC: fadd reassoc
+! NSZ_REASSOC: fadd reassoc nsz
+! NSZ_REASSOC-NOT: fadd fast
+  end do
+end function

--- a/test/llvm_ir_correct/fp_reduce_intrinsic.f90
+++ b/test/llvm_ir_correct/fp_reduce_intrinsic.f90
@@ -1,0 +1,29 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! RUN: %flang -O3                             -emit-flang-llvm %s -o - | FileCheck %s  --check-prefixes=CHECK
+! RUN: %flang -Ofast                          -emit-flang-llvm %s -o - | FileCheck %s  --check-prefixes=FAST
+! RUN: %flang -O3 -Mx,216,0x8                 -emit-flang-llvm %s -o - | FileCheck %s  --check-prefixes=NSZ
+! RUN: %flang -O3 -Mx,216,0x10                -emit-flang-llvm %s -o - | FileCheck %s  --check-prefixes=REASSOC
+! RUN: %flang -O3 -Mx,216,0x8 -Mx,216,0x10    -emit-flang-llvm %s -o - | FileCheck %s  --check-prefixes=NSZ_REASSOC
+! RUN: %flang -Ofast -Mx,216,0x8 -Mx,216,0x10 -emit-flang-llvm %s -o - | FileCheck %s  --check-prefixes=FAST
+
+real function acc(arr1,arr2)
+  real :: arr1(:)
+  real :: arr2(:)
+  acc = SUM(arr1 * arr2)
+! CHECK-NOT: call fast float @llvm.fmuladd.f32
+! CHECK-NOT: call nsz float @llvm.fmuladd.f32
+! CHECK-NOT: call nsz reassoc float @llvm.fmuladd.f32
+! FAST-NOT: call nsz float @llvm.fmuladd.f32
+! FAST-NOT: call reassoc float @llvm.fmuladd.f32
+! NSZ: call nsz float @llvm.fmuladd.f32
+! NSZ-NOT: call fast float @llvm.fmuladd.f32
+! NSZ-NOT: call reassoc {{.*}}float @llvm.fmuladd.f32
+! REASSOC-NOT: call fast float @llvm.fmuladd.f32
+! REASSOC-NOT: call nsz {{.*}}float @llvm.fmuladd.f32
+! REASSOC: call reassoc float @llvm.fmuladd.f32
+! NSZ_REASSOC: call nsz reassoc float @llvm.fmuladd.f32
+! NSZ_REASSOC-NOT: call fast float @llvm.fmuladd.f32
+end function

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -5505,6 +5505,10 @@ The -ffast-math command-line option is present.
 Disable fast math attribute on floating-point addition.
 .XB 0x04:
 Disable fast math attribute on floating-point division.
+.XB 0x08:
+Add nsz attribute to LLVM arithmetic operations.
+.XB 0x10:
+Add reassoc attribute to LLVM arithmetic operations.
 .XB 0x1000:
 The -ffp-contract=[fast|on] command-line option is present.
 

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -2558,6 +2558,12 @@ write_I_CALL(INSTR_LIST *curr_instr, bool emit_func_signature_for_call)
 
   if ((!flg.ieee || XBIT(216, 1)) && (curr_instr->flags & FAST_MATH_FLAG))
     print_token("fast ");
+  if (!XBIT(216, 1)) {
+    if (curr_instr->flags & NSZ_MATH_FLAG)
+      print_token("nsz ");
+    if (curr_instr->flags & REASSOC_MATH_FLAG)
+      print_token("reassoc ");
+  }
 
   /* Print calling conventions */
   if (curr_instr->flags & CALLCONV_MASK) {
@@ -3017,6 +3023,21 @@ write_instructions(LL_Module *module)
         case I_FMUL:
         case I_FREM:
           print_token(" fast");
+          break;
+        default:
+          break;
+        }
+      if (!XBIT(216, 1))
+        switch (i_name) {
+        case I_FADD:
+        case I_FDIV:
+        case I_FSUB:
+        case I_FMUL:
+        case I_FREM:
+          if (XBIT(216, 0x8))
+            print_token(" nsz");
+          if (XBIT(216, 0x10))
+            print_token(" reassoc");
           break;
         default:
           break;
@@ -4722,7 +4743,10 @@ gen_call_llvm_non_fm_math_intrinsic(const char *fname, OPERAND *params,
                            LL_InstrName i_name)
 {
   LL_InstrListFlags MathFlag = InstrListFlagsNull;
-
+  if (XBIT(216, 0x8))
+    MathFlag |= NSZ_MATH_FLAG;
+  if (XBIT(216, 0x10))
+    MathFlag |= REASSOC_MATH_FLAG;
   return gen_call_llvm_intrinsic_impl(fname, params, return_ll_type,
                                       Call_Instr, i_name, MathFlag);
 }

--- a/tools/flang2/flang2exe/llutil.h
+++ b/tools/flang2/flang2exe/llutil.h
@@ -269,12 +269,9 @@ typedef enum LL_InstrListFlags {
   FAST_MATH_FLAG      = (1 << 4), /**< I_CALL only */
   VOLATILE_FLAG       = (1 << 4), /**< I_LOAD, I_STORE, I_ATOMICRMW,
                                        I_CMPXCHG only */
+  NSZ_MATH_FLAG       = (1 << 5),
+  REASSOC_MATH_FLAG   = (1 << 6),
 
-  /* Call instruction flags.
-     These call-only flags overlap the load/store-only alignment bits.
-     See LDST_LOGALIGN_MASK */
-          CALL_FUNC_CAST_FLAG     = (1 << 5),
-  CALL_FUNC_INDIRECT_CAST = (1 << 6),
   FAST_CALL               = (1 << 7),
 
   ARM_AAPCS               = (1 << 8),


### PR DESCRIPTION
This patch adds the nsz, reassoc attributes to arithmetic instructions.
These attributes helps with vectorisation of loops containing
reductions.

Also included are testcases.

This commit requires corresponding change to be submitted on the classic-flang-llvm-project repository in order to have all of the test cases passing!