### PR TITLE
portability: on Mac systems __WORDSIZE is defined in stdint.h

### DIFF
--- a/runtime/include/komp.h
+++ b/runtime/include/komp.h
@@ -7,6 +7,9 @@
 
 #ifndef _PGOMP_H
 #define _PGOMP_H
+
+#include <stdint.h>
+
 /* simple lock */
 
 /* lock API functions */


### PR DESCRIPTION
Apparently, stdint.h must be included explicitly.

This is emergency fix as the previous commit might have broken builds for some.
