### PR TITLE
portability: `__WORDSIZE` isn't defined in MinGW

### DIFF
--- a/runtime/include/komp.h
+++ b/runtime/include/komp.h
@@ -176,7 +176,7 @@ public:
 typedef void ident_t;
 
 #ifndef __WORDSIZE
-#ifdef _MSC_VER
+#ifdef _WIN32
 #ifdef _WIN64
 #define __WORDSIZE 64
 #else


### PR DESCRIPTION
Afaict, `__WORDSIZE` is only defined on glibc (and XCode?) platforms.
This change should fix compilation for MinGW.