### PR TITLE
portability: Fix alignment and size for LLP64

### DIFF
--- a/runtime/include/komp.h
+++ b/runtime/include/komp.h
@@ -190,9 +190,9 @@ typedef void ident_t;
 typedef int kmp_int32;
 typedef long long kmp_int64;
 #if __WORDSIZE == 32
-typedef int kmp_critical_name[8];  /* must be 32 bytes */
+typedef kmp_int32 kmp_critical_name[8];  /* must be 32 bytes */
 #else
-typedef long kmp_critical_name[4]; /* must be 32 bytes and  8-byte aligned */
+typedef kmp_int64 kmp_critical_name[4];  /* must be 32 bytes and 8-byte aligned */
 #endif
 
 extern kmp_int32 __kmpc_global_thread_num(ident_t *);


### PR DESCRIPTION
On platforms with LLP64 data model (e.g. Windows 64-bit), `long` has 4 bytes. Use `kmp_int64` (a typedef for `long long`) to fix alignment and size of `kmp_critical_name` on such platforms (to match the comments).