### PR TITLE
[build] Update workflows to build release_13x and release_14x

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -20,7 +20,7 @@ jobs:
         target: [X86]
         cc: [clang, gcc]
         version: [10, 11]
-        llvm_branch: [release_12x, release_13x]
+        llvm_branch: [release_13x, release_14x]
         include:
           - target: X86
             cc: gcc
@@ -84,7 +84,9 @@ jobs:
         run: sudo apt install gcc-11 g++-11
 
       - name: Build and install flang & libpgmath
-        run: ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n $(nproc) -c -s
+        run: |
+          ${{ env.install_prefix }}/bin/clang --version
+          ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n $(nproc) -c -s
 
       - name: Copy llvm-lit
         run: |

--- a/.github/workflows/build_flang_arm64.yml
+++ b/.github/workflows/build_flang_arm64.yml
@@ -26,7 +26,7 @@ jobs:
         cc: [gcc]
         cpp: [g++]
         version: [10]
-        llvm_branch: [release_11x, release_12x]
+        llvm_branch: [release_13x, release_14x]
 
     steps:
       - name: Check tools
@@ -34,6 +34,7 @@ jobs:
           git --version
           cmake --version
           make --version
+          ${{ env.install_prefix }}/bin/clang --version
 
       - name: Manual checkout to build in user's home dir (push)
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
The GitHub workflow should stop building with the release_11x branch. This will unblock PRs that require newer versions of LLVM.