### PR TITLE
runtime: fix building of alarm3f.c on Linux systems with modern glibc

### DIFF
--- a/runtime/flang/alarm3f.c
+++ b/runtime/flang/alarm3f.c
@@ -11,12 +11,13 @@
 
 #ifndef WINNT
 #include <signal.h>
+#include <unistd.h>
 #include "ent3f.h"
 
 /*
 extern void (*signal(int, void (*)(int)))(int);
-*/
 extern int alarm();
+*/
 
 int ENT3F(ALARM, alarm)(int *time, void (*proc)())
 {


### PR DESCRIPTION
Popular UNIX systems (e.g. Linux, MacOS) have alarm() function
declared in unistd.h, there is no need to provide a separate forward
declaration, which could go easily out of date and create a conflict
at compile time.
