### PR TITLE
tests: The IEEE mode is now being used by default

### DIFF
--- a/test/driver/ieee_mode.f90
+++ b/test/driver/ieee_mode.f90
@@ -4,7 +4,10 @@
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
 
+! RUN: %flang -c -Knoieee %s -v 2>&1 | grep flang1 | grep "-ieee 0"
+! RUN: %flang -c -Kieee %s -v 2>&1 | grep flang1 | grep "-ieee 1"
+! RUN: %flang -c %s -v 2>&1 | grep flang1 | grep "-ieee 1"
+
 ! RUN: %flang -c -Knoieee %s -v 2>&1 | grep flang2 | grep "-ieee 0"
 ! RUN: %flang -c -Kieee %s -v 2>&1 | grep flang2 | grep "-ieee 1"
-! RUN: %flang -c %s -v 2>&1 | grep flang2 | grep "-ieee 0"
-
+! RUN: %flang -c %s -v 2>&1 | grep flang2 | grep "-ieee 1"


### PR DESCRIPTION
To make this pass, https://github.com/flang-compiler/classic-flang-llvm-project/pull/122 (and similar for other LLVM release branches) needs to be merged first.
