### PR TITLE
Fix for regression introduced by PR #1101.

### DIFF
--- a/test/f90_correct/inc/empty_type_02.mk
+++ b/test/f90_correct/inc/empty_type_02.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/empty_type_02.sh
+++ b/test/f90_correct/lit/empty_type_02.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/empty_type_02.f90
+++ b/test/f90_correct/src/empty_type_02.f90
@@ -1,0 +1,20 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test the fix for regression introduced by PR!1101.
+
+module m
+  implicit none
+  type empty
+  end type empty
+  type(empty) :: x = empty()
+  type(empty), parameter :: y = empty()
+end module m
+
+program test
+  use m
+  implicit none
+  print *, "PASS"
+end program

--- a/test/sema/sconst_with_null_subc.f90
+++ b/test/sema/sconst_with_null_subc.f90
@@ -1,0 +1,27 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! Reproducer for a flang1 crash in getict.
+! Ensure that flang1 generates a flag for empty derived type to mark null subc
+! when exporting typedef initialization to MOD file.
+
+! RUN: %flang1 %s
+! RUN: FileCheck %s --input-file=./sconst_with_null_subc.mod
+! RUN: rm -f ./sconst_with_null_subc.mod
+module sconst_with_null_subc
+  implicit none
+  type empty
+  end type
+  type(empty), parameter :: x = empty()
+end module sconst_with_null_subc
+
+!CHECK: {{^}}S [[PARAM_ALIAS:[0-9]+]] {{.*}} x$ac{{$}}
+!CHECK: {{^}}A [[AST:[0-9]+]] {{.*}} [[PARAM_ALIAS]]
+!CHECK: {{^}}Z
+!CHECK: {{^}}J [[# @LINE - 6]] 1 1
+!CHECK: {{^}}V [[AST]]
+!CHECK-NEXT: {{^}}S {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} 1
+!CHECK: {{^}}Z

--- a/tools/flang1/flang1exe/exterf.c
+++ b/tools/flang1/flang1exe/exterf.c
@@ -1174,9 +1174,11 @@ static void
 export_ict(ACL *ict)
 {
   for (; ict != NULL; ict = ict->next) {
-    int more = 0;
+    int more = 0, nosubc = 0;
     if (ict->next)
       more = 1;
+    if (ict->subc == NULL)
+      nosubc = 1;
     switch (ict->id) {
     case AC_IDENT:
       lzprintf(outlz, "I %d %d %d %d %d %d\n", ict->sptr, ict->dtype,
@@ -1197,8 +1199,8 @@ export_ict(ACL *ict)
       export_ict(ict->subc);
       break;
     case AC_SCONST:
-      lzprintf(outlz, "S %d %d %d %d %d\n", ict->sptr, ict->dtype,
-               ict->ptrdtype, ict->repeatc, more);
+      lzprintf(outlz, "S %d %d %d %d %d %d\n", ict->sptr, ict->dtype,
+               ict->ptrdtype, ict->repeatc, more, nosubc);
       export_ict(ict->subc);
       break;
     case AC_IDO:

--- a/tools/flang1/flang1exe/interf.c
+++ b/tools/flang1/flang1exe/interf.c
@@ -3587,7 +3587,7 @@ getict(lzhandle *fdlz, const char *file_name, int ipa)
   do {
     int op;
     int init_ast, limit_ast, step_ast;
-    int sptr, dtype, ptrdtype, repeatc, is_const, ast;
+    int sptr, dtype, ptrdtype, repeatc, is_const, ast, nosubc;
     ACL *subone;
     READ_LZLINE;
     if (p == NULL) {
@@ -3749,7 +3749,8 @@ getict(lzhandle *fdlz, const char *file_name, int ipa)
       ptrdtype = get_num(10);
       repeatc = get_num(10);
       more = get_num(10);
-      subone = getict(fdlz, file_name, ipa);
+      nosubc = get_num(10);
+      subone = nosubc ? NULL : getict(fdlz, file_name, ipa);
       thisone = GET_ACL(PERM_AREA);
       memset(thisone, 0, sizeof(ACL));
       thisone->id = AC_SCONST;

--- a/tools/flang1/flang1exe/interf.h
+++ b/tools/flang1/flang1exe/interf.h
@@ -105,7 +105,7 @@ void ipa_export_close(void);                 /* exterf.c */
 #define MOD_PG  0x40 /* compilers' own module files */
 
 #undef IVSN
-#define IVSN 34
+#define IVSN 35
 #undef IVSN_24
 #define IVSN_24 24
 #undef IVSN_27
@@ -139,6 +139,7 @@ void ipa_export_close(void);                 /* exterf.c */
  *          It is set if it is compiler module file.
  *     33 - Add MP_TASKLOOP[REG] for taskloop
  *     34 - half precision and half-complex datatypes
+ *     35 - Add flag for null subc in typedef initializer
  */
 
 /*


### PR DESCRIPTION
The root cause is that when an empty derived type parameter is declared in module,
an ACL structure for that parameter is generated, but its subc node is empty and
exported to the MOD file. But when importing the MOD file, flang cannot get the
information of this empty subc node.

This commit adds a flag to the MOD file to indicate whether the ACL structure
for the derived type parameter has a subc node.