### PR TITLE
[NFC] Add -fopenmp to test cases which use openmp runtime routines

### DIFF
--- a/test/f90_correct/inc/rio2.mk
+++ b/test/f90_correct/inc/rio2.mk
@@ -5,7 +5,7 @@
 #
 
 build: $(SRC)/rio2.f90
-	-$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/rio2.f90 -o rio2
+	-$(FC) $(FFLAGS) $(LDFLAGS) -fopenmp $(SRC)/rio2.f90 -o rio2
 run:
 	-./rio2 
 verify: ;

--- a/test/f90_correct/inc/rio3.mk
+++ b/test/f90_correct/inc/rio3.mk
@@ -5,7 +5,7 @@
 #
 
 build: $(SRC)/rio3.f90
-	-$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/rio3.f90 -o rio3
+	-$(FC) $(FFLAGS) $(LDFLAGS) -fopenmp $(SRC)/rio3.f90 -o rio3
 run:
 	-./rio3 
 verify: ;


### PR DESCRIPTION
Previously, classic flang provides ompstub for cases using openmp
runtime routines, but not adding the option "-fopenmp". gfortran/ifort
report errors of "undefined reference to ...".

This adds the option "-fopenmp" for the two test cases, which is
prepared for removing the "-lompstub" in the driver. After that, the two
test cases compiled without the option "-fopenmp" will report the error.