### PR TITLE
win: use long double instead of __float128 on Windows platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,8 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unused-but-set-variable")
      endif()
   endif ()
+elseif(MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -mlong-double-128")
 endif ()
 
 if (APPLE)

--- a/runtime/include/float128.h
+++ b/runtime/include/float128.h
@@ -8,7 +8,7 @@
 #ifndef _FLOAT128_H_
 #define _FLOAT128_H_
 
-#if defined(TARGET_POWER) || defined(TARGET_X8664)
+#if defined(TARGET_POWER) || (defined(TARGET_X8664) && !defined(TARGET_WIN))
 typedef __float128 float128_t;
 #else
 /* __float128 is not available on AArch64 or other generic targets;

--- a/runtime/libpgmath/lib/common/float128.h
+++ b/runtime/libpgmath/lib/common/float128.h
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 
-#if defined(TARGET_LINUX_POWER) || defined(LINUX8664) || defined(TARGET_X8664)
+#if defined(TARGET_LINUX_POWER) || defined(LINUX8664) || (defined(TARGET_X8664) && !defined(TARGET_WIN))
 typedef __float128 float128_t;
 #else
 /* __float128 is not available on AArch64 or other generic targets;


### PR DESCRIPTION
128 bit float is not supported on Windows platform and it causes build error.