### PR TITLE
[LLVM 15][runtime] Define overloaded function types and improve type checking

### DIFF
--- a/runtime/flang/comm.c
+++ b/runtime/flang/comm.c
@@ -61,12 +61,11 @@ sked *I8(__fort_comm_sked)(chdr *ch, char *rb, char *sb, dtype kind, int len)
   return &sk->sked;
 }
 
-void *ENTFTN(COMM_START, comm_start)(sked **skp, void *rb, F90_Desc *rd,
+void *ENTFTN(COMM_START, comm_start)(void **skp, void *rb, F90_Desc *rd,
                                      void *sb, F90_Desc *sd)
 {
-  sked *sk;
+  sked *sk = (sked *)*skp;
 
-  sk = *skp;
   if (sk != NULL) {
 #if defined(DEBUG)
     if (sk->tag != __SKED)

--- a/runtime/flang/desc.c
+++ b/runtime/flang/desc.c
@@ -10,12 +10,11 @@
 /* desc.c - Fortran90 descriptor IO */
 
 #include "global.h"
+#include "descRW.h"
 #include "feddesc.h"
 #include "format.h"
 #include "unf.h"
 #include "list_io.h"
-
-extern int I8(__fortio_main)(char *, F90_Desc *, int, int (*)());
 
 __INT_T
 ENTFTNIO(FMT_READ, fmt_read)

--- a/runtime/flang/descRW.c
+++ b/runtime/flang/descRW.c
@@ -88,10 +88,10 @@ static void I8(__io_write)(fio_parm *z)
                           F90_LEN_G(ac));
 }
 
-int I8(__fortio_main)(char *ab,          /* base address */
-                     F90_Desc *ac,      /* array descriptor */
-                     int rw,            /* 0 => read, 1 => write */
-                     int (*f90io_rw)()) /* f90io function */
+int I8(__fortio_main)(char *ab,             /* base address */
+                      F90_Desc *ac,         /* array descriptor */
+                      int rw,               /* 0 => read, 1 => write */
+                      f90io_rw_fn f90io_rw) /* f90io function */
 {
   int ioproc, size_of_kind;
   fio_parm z;

--- a/runtime/flang/descRW.h
+++ b/runtime/flang/descRW.h
@@ -5,13 +5,14 @@
  *
  */
 
+typedef int (*f90io_rw_fn)(int, long, int, char *, __CLEN_T);
+
 typedef struct fio_parm fio_parm;
 struct fio_parm {
   char *ab;          /* array base address */
   DECL_HDR_PTRS(ac); /* array descriptor */
 
-  int (*f90io_rw)(int kind, int cnt, int str, char *adr,
-                  __CLEN_T len); /* f90io read/write function ptr */
+  f90io_rw_fn f90io_rw; /* f90io read/write function ptr */
 
   int (*pario_rw)(int fd, char *adr, int cnt, int str, int typ, int ilen,
                   int own); /* pario read/write function ptr */
@@ -28,5 +29,10 @@ struct fio_parm {
   repl_t repl; /* replication descriptor */
 };
 
+int I8(__fortio_main)(char *ab,              /* base address */
+                      F90_Desc *ac,          /* array descriptor */
+                      int rw,                /* 0 => read, 1 => write */
+                      f90io_rw_fn f90io_rw); /* f90io function */
+
 void I8(__fortio_loop)(fio_parm *z, /* parameter struct */
-                      int dim);      /* loop dimension */
+                       int dim);    /* loop dimension */

--- a/runtime/flang/fioMacros.h
+++ b/runtime/flang/fioMacros.h
@@ -1272,14 +1272,20 @@ struct repl_t {
   int gstr[MAXDIMS]; /* replication group index strides */
 };
 
+/* overloaded schedule start/free function types */
+
+typedef void (*sked_start_fn)(void *schedule, char *rb, char *sb, F90_Desc *rd,
+                              F90_Desc *sd);
+typedef void (*sked_free_fn)(void *schedule);
+
 /* communication schedule */
 
 typedef struct sked sked;
 struct sked {
-  dtype tag;       /* structure type tag == __SKED */
-  void *arg;       /* unspecified pointer argument */
-  void (*start)(); /* function called by ENTFTN(comm_start) */
-  void (*free)();  /* function called by ENTFTN(comm_free) */
+  dtype tag;           /* structure type tag == __SKED */
+  void *arg;           /* unspecified pointer argument */
+  sked_start_fn start; /* function called by ENTFTN(comm_start) */
+  sked_free_fn free;   /* function called by ENTFTN(comm_free) */
 };
 
 

--- a/runtime/flang/fioMacros.h
+++ b/runtime/flang/fioMacros.h
@@ -1288,6 +1288,17 @@ struct sked {
   sked_free_fn free;   /* function called by ENTFTN(comm_free) */
 };
 
+/* overloaded reduction function types; keep in sync with red.h */
+
+typedef void (*local_reduc_fn)(void *, __INT_T, void *, __INT_T, __LOG_T *,
+                               __INT_T, __INT_T *, __INT_T, __INT_T, __INT_T);
+
+typedef void (*local_reduc_back_fn)(void *, __INT_T, void *, __INT_T, __LOG_T *,
+                                    __INT_T, __INT_T *, __INT_T, __INT_T,
+                                    __INT_T, __LOG_T);
+
+typedef void (*global_reduc_fn)(__INT_T, void *, void *, void *, void *, __INT_T);
+
 
 #if defined(DEBUG)
 /***** The following are internal to the HPF runtime library *****/
@@ -1558,8 +1569,8 @@ int __fort_exchange_counts(int *counts);
 void I8(__fort_get_scalar)(void *temp, void *b, F90_Desc *d, __INT_T *gidx);
 
 void I8(__fort_reduce_section)(void *vec1, dtype typ1, int siz1, void *vec2,
-                              dtype typ2, int siz2, int cnt, void (*fn_g)(),
-                              int dim, F90_Desc *d);
+                               dtype typ2, int siz2, int cnt,
+                               global_reduc_fn fn_g, int dim, F90_Desc *d);
 
 void I8(__fort_replicate_result)(void *vec1, dtype typ1, int siz1, void *vec2,
                                 dtype typ2, int siz2, int cnt, F90_Desc *d);

--- a/runtime/flang/gather.c
+++ b/runtime/flang/gather.c
@@ -7,122 +7,151 @@
 
 #include "stdioInterf.h"
 #include "fioMacros.h"
+#include "scatter.h"
 
 /* local gather functions */
 
 static void
-local_gather_INT1(int n, __INT1_T *dst, __INT1_T *src, int *gv)
+local_gather_INT1(int n, void *dstp, void *srcp, int *gv)
 {
+  __INT1_T *dst = (__INT1_T *)dstp;
+  __INT1_T *src = (__INT1_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_INT2(int n, __INT2_T *dst, __INT2_T *src, int *gv)
+local_gather_INT2(int n, void *dstp, void *srcp, int *gv)
 {
+  __INT2_T *dst = (__INT2_T *)dstp;
+  __INT2_T *src = (__INT2_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_INT4(int n, __INT4_T *dst, __INT4_T *src, int *gv)
+local_gather_INT4(int n, void *dstp, void *srcp, int *gv)
 {
+  __INT4_T *dst = (__INT4_T *)dstp;
+  __INT4_T *src = (__INT4_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_INT8(int n, __INT8_T *dst, __INT8_T *src, int *gv)
+local_gather_INT8(int n, void *dstp, void *srcp, int *gv)
 {
+  __INT8_T *dst = (__INT8_T *)dstp;
+  __INT8_T *src = (__INT8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_LOG1(int n, __LOG1_T *dst, __LOG1_T *src, int *gv)
+local_gather_LOG1(int n, void *dstp, void *srcp, int *gv)
 {
+  __LOG1_T *dst = (__LOG1_T *)dstp;
+  __LOG1_T *src = (__LOG1_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_LOG2(int n, __LOG2_T *dst, __LOG2_T *src, int *gv)
+local_gather_LOG2(int n, void *dstp, void *srcp, int *gv)
 {
+  __LOG2_T *dst = (__LOG2_T *)dstp;
+  __LOG2_T *src = (__LOG2_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_LOG4(int n, __LOG4_T *dst, __LOG4_T *src, int *gv)
+local_gather_LOG4(int n, void *dstp, void *srcp, int *gv)
 {
+  __LOG4_T *dst = (__LOG4_T *)dstp;
+  __LOG4_T *src = (__LOG4_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_LOG8(int n, __LOG8_T *dst, __LOG8_T *src, int *gv)
+local_gather_LOG8(int n, void *dstp, void *srcp, int *gv)
 {
+  __LOG8_T *dst = (__LOG8_T *)dstp;
+  __LOG8_T *src = (__LOG8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_REAL4(int n, __REAL4_T *dst, __REAL4_T *src, int *gv)
+local_gather_REAL4(int n, void *dstp, void *srcp, int *gv)
 {
+  __REAL4_T *dst = (__REAL4_T *)dstp;
+  __REAL4_T *src = (__REAL4_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_REAL8(int n, __REAL8_T *dst, __REAL8_T *src, int *gv)
+local_gather_REAL8(int n, void *dstp, void *srcp, int *gv)
 {
+  __REAL8_T *dst = (__REAL8_T *)dstp;
+  __REAL8_T *src = (__REAL8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_REAL16(int n, __REAL16_T *dst, __REAL16_T *src, int *gv)
+local_gather_REAL16(int n, void *dstp, void *srcp, int *gv)
 {
+  __REAL16_T *dst = (__REAL16_T *)dstp;
+  __REAL16_T *src = (__REAL16_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_CPLX8(int n, __CPLX8_T *dst, __CPLX8_T *src, int *gv)
+local_gather_CPLX8(int n, void *dstp, void *srcp, int *gv)
 {
+  __CPLX8_T *dst = (__CPLX8_T *)dstp;
+  __CPLX8_T *src = (__CPLX8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_CPLX16(int n, __CPLX16_T *dst, __CPLX16_T *src, int *gv)
+local_gather_CPLX16(int n, void *dstp, void *srcp, int *gv)
 {
+  __CPLX16_T *dst = (__CPLX16_T *)dstp;
+  __CPLX16_T *src = (__CPLX16_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
 static void
-local_gather_CPLX32(int n, __CPLX32_T *dst, __CPLX32_T *src, int *gv)
+local_gather_CPLX32(int n, void *dstp, void *srcp, int *gv)
 {
+  __CPLX32_T *dst = (__CPLX32_T *)dstp;
+  __CPLX32_T *src = (__CPLX32_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[i] = src[gv[i]];
 }
 
-void (*__fort_local_gather[__NTYPES])() = {
+static gatherfn_t __fort_local_gather[__NTYPES] = {
     NULL,                /*     no type (absent optional argument) */
     NULL,                /* C   signed short */
     NULL,                /* C   unsigned short */
@@ -158,3 +187,9 @@ void (*__fort_local_gather[__NTYPES])() = {
     local_gather_INT1,   /*   F integer*1 */
     NULL                 /*   F derived type */
 };
+
+void
+local_gather_WRAPPER(int n, void *dst, void *src, int *gv, __INT_T kind)
+{
+  __fort_local_gather[kind](n, dst, src, gv);
+}

--- a/runtime/flang/gathscat.c
+++ b/runtime/flang/gathscat.c
@@ -7,132 +7,151 @@
 
 #include "stdioInterf.h"
 #include "fioMacros.h"
-
-extern void (*__fort_local_scatter[__NTYPES])();
-extern void (*__fort_local_gathscat[__NTYPES])();
+#include "scatter.h"
 
 /* local scatter functions */
 
-void
-local_scatter_WRAPPER(int n, void *dst, int *sv, void *src, __INT_T kind)
-{
-
-  __fort_local_scatter[kind](n, dst, sv, src);
-}
-
 static void
-local_scatter_INT1(int n, __INT1_T *dst, int *sv, __INT1_T *src)
+local_scatter_INT1(int n, void *dstp, int *sv, void *srcp)
 {
+  __INT1_T *dst = (__INT1_T *)dstp;
+  __INT1_T *src = (__INT1_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_INT2(int n, __INT2_T *dst, int *sv, __INT2_T *src)
+local_scatter_INT2(int n, void *dstp, int *sv, void *srcp)
 {
+  __INT2_T *dst = (__INT2_T *)dstp;
+  __INT2_T *src = (__INT2_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_INT4(int n, __INT4_T *dst, int *sv, __INT4_T *src)
+local_scatter_INT4(int n, void *dstp, int *sv, void *srcp)
 {
+  __INT4_T *dst = (__INT4_T *)dstp;
+  __INT4_T *src = (__INT4_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_INT8(int n, __INT8_T *dst, int *sv, __INT8_T *src)
+local_scatter_INT8(int n, void *dstp, int *sv, void *srcp)
 {
+  __INT8_T *dst = (__INT8_T *)dstp;
+  __INT8_T *src = (__INT8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_LOG1(int n, __LOG1_T *dst, int *sv, __LOG1_T *src)
+local_scatter_LOG1(int n, void *dstp, int *sv, void *srcp)
 {
+  __LOG1_T *dst = (__LOG1_T *)dstp;
+  __LOG1_T *src = (__LOG1_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_LOG2(int n, __LOG2_T *dst, int *sv, __LOG2_T *src)
+local_scatter_LOG2(int n, void *dstp, int *sv, void *srcp)
 {
+  __LOG2_T *dst = (__LOG2_T *)dstp;
+  __LOG2_T *src = (__LOG2_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_LOG4(int n, __LOG4_T *dst, int *sv, __LOG4_T *src)
+local_scatter_LOG4(int n, void *dstp, int *sv, void *srcp)
 {
+  __LOG4_T *dst = (__LOG4_T *)dstp;
+  __LOG4_T *src = (__LOG4_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_LOG8(int n, __LOG8_T *dst, int *sv, __LOG8_T *src)
+local_scatter_LOG8(int n, void *dstp, int *sv, void *srcp)
 {
+  __LOG8_T *dst = (__LOG8_T *)dstp;
+  __LOG8_T *src = (__LOG8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_REAL4(int n, __REAL4_T *dst, int *sv, __REAL4_T *src)
+local_scatter_REAL4(int n, void *dstp, int *sv, void *srcp)
 {
+  __REAL4_T *dst = (__REAL4_T *)dstp;
+  __REAL4_T *src = (__REAL4_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_REAL8(int n, __REAL8_T *dst, int *sv, __REAL8_T *src)
+local_scatter_REAL8(int n, void *dstp, int *sv, void *srcp)
 {
+  __REAL8_T *dst = (__REAL8_T *)dstp;
+  __REAL8_T *src = (__REAL8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_REAL16(int n, __REAL16_T *dst, int *sv, __REAL16_T *src)
+local_scatter_REAL16(int n, void *dstp, int *sv, void *srcp)
 {
+  __REAL16_T *dst = (__REAL16_T *)dstp;
+  __REAL16_T *src = (__REAL16_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_CPLX8(int n, __CPLX8_T *dst, int *sv, __CPLX8_T *src)
+local_scatter_CPLX8(int n, void *dstp, int *sv, void *srcp)
 {
+  __CPLX8_T *dst = (__CPLX8_T *)dstp;
+  __CPLX8_T *src = (__CPLX8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_CPLX16(int n, __CPLX16_T *dst, int *sv, __CPLX16_T *src)
+local_scatter_CPLX16(int n, void *dstp, int *sv, void *srcp)
 {
+  __CPLX16_T *dst = (__CPLX16_T *)dstp;
+  __CPLX16_T *src = (__CPLX16_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
 static void
-local_scatter_CPLX32(int n, __CPLX32_T *dst, int *sv, __CPLX32_T *src)
+local_scatter_CPLX32(int n, void *dstp, int *sv, void *srcp)
 {
+  __CPLX32_T *dst = (__CPLX32_T *)dstp;
+  __CPLX32_T *src = (__CPLX32_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[i];
 }
 
-void (*__fort_local_scatter[__NTYPES])() = {
+static scatterfn_t __fort_local_scatter[__NTYPES] = {
     NULL,                 /*     no type (absent optional argument) */
     NULL,                 /* C   signed short */
     NULL,                 /* C   unsigned short */
@@ -169,129 +188,155 @@ void (*__fort_local_scatter[__NTYPES])() = {
     NULL                  /*   F derived type */
 };
 
+void
+local_scatter_WRAPPER(int n, void *dst, int *sv, void *src, __INT_T kind)
+{
+  __fort_local_scatter[kind](n, dst, sv, src);
+}
+
 /* local gather-scatter functions */
 
-void
-local_gathscat_WRAPPER(int n, void *dst, int *sv, void *src, int *gv,
-                       __INT_T kind)
-{
-
-  __fort_local_gathscat[kind](n, dst, sv, src, gv);
-}
-
 static void
-local_gathscat_INT1(int n, __INT1_T *dst, int *sv, __INT1_T *src, int *gv)
+local_gathscat_INT1(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __INT1_T *dst = (__INT1_T *)dstp;
+  __INT1_T *src = (__INT1_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_INT2(int n, __INT2_T *dst, int *sv, __INT2_T *src, int *gv)
+local_gathscat_INT2(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __INT2_T *dst = (__INT2_T *)dstp;
+  __INT2_T *src = (__INT2_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_INT4(int n, __INT4_T *dst, int *sv, __INT4_T *src, int *gv)
+local_gathscat_INT4(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __INT4_T *dst = (__INT4_T *)dstp;
+  __INT4_T *src = (__INT4_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_INT8(int n, __INT8_T *dst, int *sv, __INT8_T *src, int *gv)
+local_gathscat_INT8(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __INT8_T *dst = (__INT8_T *)dstp;
+  __INT8_T *src = (__INT8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_LOG1(int n, __LOG1_T *dst, int *sv, __LOG1_T *src, int *gv)
+local_gathscat_LOG1(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __LOG1_T *dst = (__LOG1_T *)dstp;
+  __LOG1_T *src = (__LOG1_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_LOG2(int n, __LOG2_T *dst, int *sv, __LOG2_T *src, int *gv)
+local_gathscat_LOG2(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __LOG2_T *dst = (__LOG2_T *)dstp;
+  __LOG2_T *src = (__LOG2_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_LOG4(int n, __LOG4_T *dst, int *sv, __LOG4_T *src, int *gv)
+local_gathscat_LOG4(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __LOG4_T *dst = (__LOG4_T *)dstp;
+  __LOG4_T *src = (__LOG4_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_LOG8(int n, __LOG8_T *dst, int *sv, __LOG8_T *src, int *gv)
+local_gathscat_LOG8(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __LOG8_T *dst = (__LOG8_T *)dstp;
+  __LOG8_T *src = (__LOG8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_REAL4(int n, __REAL4_T *dst, int *sv, __REAL4_T *src, int *gv)
+local_gathscat_REAL4(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __REAL4_T *dst = (__REAL4_T *)dstp;
+  __REAL4_T *src = (__REAL4_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_REAL8(int n, __REAL8_T *dst, int *sv, __REAL8_T *src, int *gv)
+local_gathscat_REAL8(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __REAL8_T *dst = (__REAL8_T *)dstp;
+  __REAL8_T *src = (__REAL8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_REAL16(int n, __REAL16_T *dst, int *sv, __REAL16_T *src, int *gv)
+local_gathscat_REAL16(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __REAL16_T *dst = (__REAL16_T *)dstp;
+  __REAL16_T *src = (__REAL16_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_CPLX8(int n, __CPLX8_T *dst, int *sv, __CPLX8_T *src, int *gv)
+local_gathscat_CPLX8(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __CPLX8_T *dst = (__CPLX8_T *)dstp;
+  __CPLX8_T *src = (__CPLX8_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_CPLX16(int n, __CPLX16_T *dst, int *sv, __CPLX16_T *src, int *gv)
+local_gathscat_CPLX16(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __CPLX16_T *dst = (__CPLX16_T *)dstp;
+  __CPLX16_T *src = (__CPLX16_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
 static void
-local_gathscat_CPLX32(int n, __CPLX32_T *dst, int *sv, __CPLX32_T *src, int *gv)
+local_gathscat_CPLX32(int n, void *dstp, int *sv, void *srcp, int *gv)
 {
+  __CPLX32_T *dst = (__CPLX32_T *)dstp;
+  __CPLX32_T *src = (__CPLX32_T *)srcp;
   int i;
   for (i = 0; i < n; ++i)
     dst[sv[i]] = src[gv[i]];
 }
 
-void (*__fort_local_gathscat[__NTYPES])() = {
+static gathscatfn_t __fort_local_gathscat[__NTYPES] = {
     NULL,                  /*     no type (absent optional argument) */
     NULL,                  /* C   signed short */
     NULL,                  /* C   unsigned short */
@@ -327,3 +372,10 @@ void (*__fort_local_gathscat[__NTYPES])() = {
     local_gathscat_INT1,   /*   F integer*1 */
     NULL                   /*   F derived type */
 };
+
+void
+local_gathscat_WRAPPER(int n, void *dst, int *sv, void *src, int *gv,
+                       __INT_T kind)
+{
+  __fort_local_gathscat[kind](n, dst, sv, src, gv);
+}

--- a/runtime/flang/mmul.c
+++ b/runtime/flang/mmul.c
@@ -9,12 +9,15 @@
 
 /* mmul.c -- DOT_PRODUCT and MATMUL intrinsics */
 
+#include <memory.h>
 #include "stdioInterf.h"
 #include "fioMacros.h"
-#include <memory.h>
-
-
 #include "fort_vars.h"
+
+/* Declare pointer-type parameters in overloaded function pointer types
+   as void *, then cast the function pointers during function selection. */
+typedef void (*mmul_fn)(void *, int, void *, int, int, void *, int, int);
+
 extern void (*I8(__fort_g_sum)[__NTYPES])();
 extern void (*__fort_scalar_copy[__NTYPES])(void *rp, void *sp, int len);
 
@@ -222,7 +225,7 @@ void ENTFTN(DOTPR, dotpr)(char *cb, char *ab0, char *bb0, F90_Desc *cs,
   DECL_DIM_PTRS(ajd);
   DECL_DIM_PTRS(bjd);
   __INT_T flags, kind, len;
-  void (*dotp)();
+  mmul_fn dotp;
   __INT_T al, alof, an, aoff, astr, au, bl, blof, bn, boff, bstr, bu, acl, bcl,
       cn;
   int copy_required;
@@ -271,40 +274,40 @@ void ENTFTN(DOTPR, dotpr)(char *cb, char *ab0, char *bb0, F90_Desc *cs,
 
   switch (kind) {
   case __REAL4:
-    dotp = dotp_real4;
+    dotp = (mmul_fn)dotp_real4;
     break;
   case __REAL8:
-    dotp = dotp_real8;
+    dotp = (mmul_fn)dotp_real8;
     break;
   case __CPLX8:
-    dotp = dotp_cplx8;
+    dotp = (mmul_fn)dotp_cplx8;
     break;
   case __CPLX16:
-    dotp = dotp_cplx16;
+    dotp = (mmul_fn)dotp_cplx16;
     break;
   case __INT1:
-    dotp = dotp_int1;
+    dotp = (mmul_fn)dotp_int1;
     break;
   case __INT2:
-    dotp = dotp_int2;
+    dotp = (mmul_fn)dotp_int2;
     break;
   case __INT4:
-    dotp = dotp_int4;
+    dotp = (mmul_fn)dotp_int4;
     break;
   case __LOG1:
-    dotp = dotp_log1;
+    dotp = (mmul_fn)dotp_log1;
     break;
   case __LOG2:
-    dotp = dotp_log2;
+    dotp = (mmul_fn)dotp_log2;
     break;
   case __LOG4:
-    dotp = dotp_log4;
+    dotp = (mmul_fn)dotp_log4;
     break;
   case __INT8:
-    dotp = dotp_int8;
+    dotp = (mmul_fn)dotp_int8;
     break;
   case __LOG8:
-    dotp = dotp_log8;
+    dotp = (mmul_fn)dotp_log8;
     break;
   default:
     __fort_abort("DOT_PRODUCT: unimplemented for data type");
@@ -393,7 +396,7 @@ static void I8(mmul_mxm)(char *cb0, char *ab0, char *bb0, F90_Desc *cs0,
   DECL_DIM_PTRS(cid);
   DECL_DIM_PTRS(ckd);
   __INT_T flags, kind, len;
-  void (*mmul)();
+  mmul_fn mmul;
   __INT_T a0, ai, ais, ajs, b0, bjs, bk, bks, c0, cik, cis, ck, cks, icl, icn,
       il, ilof, in, iu, kcl, kcn, kl, klof, kn, ku, jn;
   int copy_required;
@@ -452,40 +455,40 @@ static void I8(mmul_mxm)(char *cb0, char *ab0, char *bb0, F90_Desc *cs0,
 
   switch (kind) {
   case __REAL4:
-    mmul = dotp_real4;
+    mmul = (mmul_fn)dotp_real4;
     break;
   case __REAL8:
-    mmul = dotp_real8;
+    mmul = (mmul_fn)dotp_real8;
     break;
   case __CPLX8:
-    mmul = mmul_cplx8;
+    mmul = (mmul_fn)mmul_cplx8;
     break;
   case __CPLX16:
-    mmul = mmul_cplx16;
+    mmul = (mmul_fn)mmul_cplx16;
     break;
   case __INT1:
-    mmul = dotp_int1;
+    mmul = (mmul_fn)dotp_int1;
     break;
   case __INT2:
-    mmul = dotp_int2;
+    mmul = (mmul_fn)dotp_int2;
     break;
   case __INT4:
-    mmul = dotp_int4;
+    mmul = (mmul_fn)dotp_int4;
     break;
   case __LOG1:
-    mmul = dotp_log1;
+    mmul = (mmul_fn)dotp_log1;
     break;
   case __LOG2:
-    mmul = dotp_log2;
+    mmul = (mmul_fn)dotp_log2;
     break;
   case __LOG4:
-    mmul = dotp_log4;
+    mmul = (mmul_fn)dotp_log4;
     break;
   case __INT8:
-    mmul = dotp_int8;
+    mmul = (mmul_fn)dotp_int8;
     break;
   case __LOG8:
-    mmul = dotp_log8;
+    mmul = (mmul_fn)dotp_log8;
     break;
   default:
     __fort_abort("MATMUL: unimplemented for data type");
@@ -619,7 +622,7 @@ static void I8(mmul_vxm)(char *cb0, char *ab0, char *bb0, F90_Desc *cs0,
   DECL_DIM_PTRS(bkd);
   DECL_DIM_PTRS(ckd);
   __INT_T flags, kind, len;
-  void (*mmul)();
+  mmul_fn mmul;
   __INT_T a0, aj, ajcl, ajclof, ajclos, ajcn, ajcs, ajcu, ajl, ajn, ajs, aju,
       b0, bj, bjcl, bjclof, bjcn, bjk, bjl, bjn, bjs, bju, bkcl, bkclof, bkcn,
       bkl, bkn, bks, bku, c0, ck, ckcl, ckclof, ckclos, ckcn, ckcs, ckcu, ckl,
@@ -676,40 +679,40 @@ static void I8(mmul_vxm)(char *cb0, char *ab0, char *bb0, F90_Desc *cs0,
 
   switch (kind) {
   case __REAL4:
-    mmul = dotp_real4;
+    mmul = (mmul_fn)dotp_real4;
     break;
   case __REAL8:
-    mmul = dotp_real8;
+    mmul = (mmul_fn)dotp_real8;
     break;
   case __CPLX8:
-    mmul = mmul_cplx8;
+    mmul = (mmul_fn)mmul_cplx8;
     break;
   case __CPLX16:
-    mmul = mmul_cplx16;
+    mmul = (mmul_fn)mmul_cplx16;
     break;
   case __INT1:
-    mmul = dotp_int1;
+    mmul = (mmul_fn)dotp_int1;
     break;
   case __INT2:
-    mmul = dotp_int2;
+    mmul = (mmul_fn)dotp_int2;
     break;
   case __INT4:
-    mmul = dotp_int4;
+    mmul = (mmul_fn)dotp_int4;
     break;
   case __LOG1:
-    mmul = dotp_log1;
+    mmul = (mmul_fn)dotp_log1;
     break;
   case __LOG2:
-    mmul = dotp_log2;
+    mmul = (mmul_fn)dotp_log2;
     break;
   case __LOG4:
-    mmul = dotp_log4;
+    mmul = (mmul_fn)dotp_log4;
     break;
   case __INT8:
-    mmul = dotp_int8;
+    mmul = (mmul_fn)dotp_int8;
     break;
   case __LOG8:
-    mmul = dotp_log8;
+    mmul = (mmul_fn)dotp_log8;
     break;
   default:
     __fort_abort("MATMUL: unimplemented for data type");
@@ -855,7 +858,7 @@ static void I8(mmul_mxv)(char *cb0, char *ab0, char *bb0, F90_Desc *cs0,
   DECL_DIM_PTRS(bjd);
   DECL_DIM_PTRS(cid);
   __INT_T flags, kind, len;
-  void (*mmul)();
+  mmul_fn mmul;
   __INT_T a0, aicl, aicn, aij, ail, aiclof, ain, ais, aiu, aj, ajcl, ajcn, ajl,
       ajclof, ajn, ajs, aju, b0, bj, bjcl, bjclof, bjclos, bjcn, bjcs, bjcu,
       bjl, bjn, bjs, bju, c0, ci, cicl, ciclof, ciclos, cicn, cics, cicu, cil,
@@ -924,40 +927,40 @@ static void I8(mmul_mxv)(char *cb0, char *ab0, char *bb0, F90_Desc *cs0,
 
   switch (kind) {
   case __REAL4:
-    mmul = dotp_real4;
+    mmul = (mmul_fn)dotp_real4;
     break;
   case __REAL8:
-    mmul = dotp_real8;
+    mmul = (mmul_fn)dotp_real8;
     break;
   case __CPLX8:
-    mmul = mmul_cplx8;
+    mmul = (mmul_fn)mmul_cplx8;
     break;
   case __CPLX16:
-    mmul = mmul_cplx16;
+    mmul = (mmul_fn)mmul_cplx16;
     break;
   case __INT1:
-    mmul = dotp_int1;
+    mmul = (mmul_fn)dotp_int1;
     break;
   case __INT2:
-    mmul = dotp_int2;
+    mmul = (mmul_fn)dotp_int2;
     break;
   case __INT4:
-    mmul = dotp_int4;
+    mmul = (mmul_fn)dotp_int4;
     break;
   case __LOG1:
-    mmul = dotp_log1;
+    mmul = (mmul_fn)dotp_log1;
     break;
   case __LOG2:
-    mmul = dotp_log2;
+    mmul = (mmul_fn)dotp_log2;
     break;
   case __LOG4:
-    mmul = dotp_log4;
+    mmul = (mmul_fn)dotp_log4;
     break;
   case __INT8:
-    mmul = dotp_int8;
+    mmul = (mmul_fn)dotp_int8;
     break;
   case __LOG8:
-    mmul = dotp_log8;
+    mmul = (mmul_fn)dotp_log8;
     break;
   default:
     __fort_abort("MATMUL: unimplemented for data type");

--- a/runtime/flang/olap.c
+++ b/runtime/flang/olap.c
@@ -43,9 +43,10 @@ typedef struct {
 
 /* ENTFTN(comm_start) function: adjust base addresses and call doit */
 
-static void I8(olap_start)(olap_sked *o, char *rb, char *sb, F90_Desc *rs,
+static void I8(olap_start)(void *op, char *rb, char *sb, F90_Desc *rs,
                            F90_Desc *ss)
 {
+  olap_sked *o = (olap_sked *)op;
   __INT_T i;
 
 #if defined(DEBUG)
@@ -72,8 +73,9 @@ static void I8(olap_start)(olap_sked *o, char *rb, char *sb, F90_Desc *rs,
 /* olap_free function: free channels and schedule structure */
 
 static void
-olap_free(olap_sked *o)
+olap_free(void *op)
 {
+  olap_sked *o = (olap_sked *)op;
   int i;
 
   for (i = 0; i < o->rank; ++i) {

--- a/runtime/flang/red.h
+++ b/runtime/flang/red.h
@@ -33,13 +33,9 @@ typedef enum {
 /* parameter struct for intrinsic reductions */
 
 typedef struct {
-  void (*l_fn)(void *, __INT_T, void *, __INT_T, __LOG_T *, __INT_T, __INT_T *,
-               __INT_T, __INT_T, __INT_T); /* local reduction function */
-  void (*l_fn_b)(void *, __INT_T, void *, __INT_T, __LOG_T *, __INT_T,
-                 __INT_T *, __INT_T, __INT_T, __INT_T, __LOG_T);
-  /* local reduction function with "back" arg */
-  void (*g_fn)(__INT_T, void *, void *, void *, void *, __INT_T);
-  /* global reduction function */
+  local_reduc_fn      l_fn;   /* local reduction function */
+  local_reduc_back_fn l_fn_b; /* local reduction function with "back" arg */
+  global_reduc_fn     g_fn;   /* global reduction function */
   char *rb, *ab; /* result, array base addresses */
   void *zb;      /* null value */
   __LOG_T *mb;   /* mask base address */
@@ -97,8 +93,8 @@ void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
 
 /* prototype local reduction function (name beginning with l_):
 
-   void l_NAME(void *r, __INT_T n, void *v, __INT_T vs,
-               __LOG_T *m, __INT_T ms, __INT_T *loc, __INT_T li, __INT_T ls);
+   void l_NAME(void *r, __INT_T n, void *v, __INT_T vs, __LOG_T *m,
+               __INT_T ms, __INT_T *loc, __INT_T li, __INT_T ls, __INT_T len);
    where
       r   = result address (scalar)
       n   = vector length
@@ -150,8 +146,9 @@ void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
     *r = x;                                                                    \
   }
 
-#define ARITHFNG(OP, NAME, RTYP, ATYP)                                        \
-  static void g_##NAME(__INT_T n, RTYP *lr, RTYP *rr, void *lv, void *rv)      \
+#define ARITHFNG(OP, NAME, RTYP, ATYP)                                         \
+  static void g_##NAME(__INT_T n, RTYP *lr, RTYP *rr, void *lv, void *rv,      \
+                       __INT_T len)                                            \
   {                                                                            \
     __INT_T i;                                                                 \
     for (i = 0; i < n; i++) {                                                  \

--- a/runtime/flang/reduct.c
+++ b/runtime/flang/reduct.c
@@ -100,7 +100,8 @@ global_reduce_abort(const char *what, const char *msg)
 }
 
 void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
-                             F90_Desc *hd, const char *what, void (*fn[__NTYPES])())
+                              F90_Desc *hd, const char *what,
+                              global_reduc_fn fn[__NTYPES])
 {
   DECL_HDR_PTRS(ht); /* align-target */
   DECL_DIM_PTRS(hdd);
@@ -197,7 +198,7 @@ void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
         if (it < np) {
           cpu = I8(map_to_processor)(it, pl, pr, pe, ps);
           __fort_rrecvl(cpu, tmp, cnt, 1, kind, len);
-          fn[kind](cnt, rb, tmp);
+          fn[kind](cnt, rb, tmp, /* optional args */ NULL, NULL, 0);
         }
       }
       bit >>= 1;
@@ -337,8 +338,8 @@ void I8(__fort_global_reduce)(char *rb, char *hb, int dims, F90_Desc *rd,
    from all other processors to produce the final result. */
 
 void I8(__fort_reduce_section)(void *vec1, dtype typ1, int len1, void *vec2,
-                              dtype typ2, int len2, int cnt, void (*fn_g)(),
-                              int dim, F90_Desc *a)
+                               dtype typ2, int len2, int cnt,
+                               global_reduc_fn fn_g, int dim, F90_Desc *a)
 {
   DECL_DIM_PTRS(ad);
   char *tmp1, *tmp2; /* temporary buffer pointers */
@@ -421,7 +422,7 @@ void I8(__fort_reduce_section)(void *vec1, dtype typ1, int len1, void *vec2,
         __fort_rrecvl(cpu, tmp1, cnt, 1, typ1, len1);
         if (tmp2 != NULL)
           __fort_rrecvl(cpu, tmp2, cnt, 1, typ2, len2);
-        fn_g(cnt, vec1, tmp1, vec2, tmp2);
+        fn_g(cnt, vec1, tmp1, vec2, tmp2, /* optional arg */ 0);
       }
     }
     bit >>= 1;

--- a/runtime/flang/scatter.c
+++ b/runtime/flang/scatter.c
@@ -87,9 +87,10 @@ typedef struct {
 
 /* ENTFTN(comm_start) function: gather, transfer, scatter */
 
-static void I8(gathscat_start)(gathscat_sked *sk, char *rb, char *sb,
-                               F90_Desc *rd, F90_Desc *sd)
+static void I8(gathscat_start)(void *skp, char *rb, char *sb, F90_Desc *rd,
+                               F90_Desc *sd)
 {
+  gathscat_sked *sk = (gathscat_sked *)skp;
   char *rp, *sp, *bufr, *bufs;
   int cpu, j, k, lcpu, m, nr, ns, tcpus;
 
@@ -200,8 +201,9 @@ static void I8(gathscat_start)(gathscat_sked *sk, char *rb, char *sb,
 /* ENTFTN(comm_free) function: free channels, vectors, schedule structures */
 
 static void
-gathscat_free(gathscat_sked *sk)
+gathscat_free(void *skp)
 {
+  gathscat_sked *sk = (gathscat_sked *)skp;
   if (sk->repchn)
     __fort_frechn(sk->repchn);
   if (sk->countbuf)

--- a/runtime/flang/scatter.h
+++ b/runtime/flang/scatter.h
@@ -97,9 +97,9 @@ void __fort_gathscat_abort(char *what, char *msg);
 
 sked *I8(__fort_gathscat)(gathscat_parm *z);
 
-void *ENTFTN(COMM_START, comm_start)();
-void ENTFTN(COMM_FINISH, comm_finish)();
-void ENTFTN(COMM_FREE, comm_free)();
+void *ENTFTN(COMM_START, comm_start)(sked **, void *, F90_Desc *, void *, F90_Desc *);
+void ENTFTN(COMM_FINISH, comm_finish)(void *);
+void ENTFTN(COMM_FREE, comm_free)(__INT_T *ns, ...);
 
 void *I8(__fort_adjust_index_array)(const char *what, char *idx_array,
                                     char *src, int dim, F90_Desc *is,

--- a/runtime/flang/scatter.h
+++ b/runtime/flang/scatter.h
@@ -42,15 +42,19 @@ struct gathscat_dim {
   __INT_T *xmap;     /* map index axis -> unvectored axis */
 };
 
+typedef void (*gatherfn_t)(int, void *, void *, int *);
+typedef void (*gathscatfn_t)(int, void *, int *, void *, int *);
+typedef void (*scatterfn_t)(int, void *, int *, void *);
+
 struct gathscat_parm {
   const char *what;           /* "GATHER"/"XXX_SCATTER" */
   void (*xfer_request)(struct chdr *, int, void *, long, long, int,
                        long); /* scatter: __fort_sendl; gather: __fort_recvl */
   void (*xfer_respond)(struct chdr *, int, void *, long, long, int,
                        long); /* scatter: __fort_recvl; gather: __fort_sendl */
-  void (*gathscatfn)();       /* local gather-scatter-reduction function */
-  void (*scatterfn)();        /* local scatter-reduction function */
-  char *rb, *ab, *mb;         /* base addresses */
+  gathscatfn_t gathscatfn; /* local gather-scatter-reduction function */
+  scatterfn_t scatterfn;   /* local scatter-reduction function */
+  char *rb, *ab, *mb;      /* base addresses */
   char *ub, *vb;
   DECL_HDR_PTRS(rd);
   DECL_HDR_PTRS(ad);
@@ -108,3 +112,9 @@ void *I8(__fort_adjust_index_array)(const char *what, char *idx_array,
 void *I8(__fort_create_conforming_index_array)(const char *what, char *ab,
                                                void *ib, F90_Desc *as,
                                                F90_Desc *is, F90_Desc *new_is);
+
+void local_gathscat_WRAPPER(int n, void *dst, int *sv, void *src, int *gv, __INT_T kind);
+
+void local_gather_WRAPPER(int n, void *dst, void *src, int *gv, __INT_T kind);
+
+void local_scatter_WRAPPER(int n, void *dst, int *sv, void *src, __INT_T kind);


### PR DESCRIPTION
Classic Flang code uses tables of functions (with different argument types) to achieve polymorphism. Previously, such a function was declared as `void (*p)()`, to allow any function to be assigned to the function pointer variable `p`. But when a call to such a function pointer is attempted, Clang 15 now emits warnings like these:
```
.../flang/runtime/flang/comm.c:97:14: error: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
    sk->start(sk->arg, rb, sb, rd, sd);
             ^
.../flang/runtime/flang/comm.c:117:13: error: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
    sk->free(sk->arg);
            ^
```
To work around these issues, this PR replaces polymorphic pointer parameters in such functions with `void *` parameters, and casts the `void` pointers in the function body to the intended types of the respective arguments. By creating `typedef`s of the fully prototyped function pointers, some degree of type checking is possible without too much overhead. Relaxing the parameter type to `void *` also eliminates `-Wincompatible-function-pointer-types` warnings when assigning functions to function pointers.

The changes are organized into multiple relatively independent commits for easier review. If necessary, I can break this up into multiple pull requests.