### PR TITLE
[LLVM 15][runtime] Stop using K&R function declarations

### DIFF
--- a/runtime/flang/backspace.c
+++ b/runtime/flang/backspace.c
@@ -127,9 +127,7 @@ _f90io_backspace(__INT_T *unit, __INT_T *bitv, __INT_T *iostat, int swap_bytes)
 }
 
 __INT_T
-ENTF90IO(BACKSPACE, backspace)(unit, bitv, iostat) __INT_T *unit;
-__INT_T *bitv;
-__INT_T *iostat;
+ENTF90IO(BACKSPACE, backspace)(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
 {
   int s = 0;
 
@@ -141,9 +139,7 @@ __INT_T *iostat;
 }
 
 __INT_T
-ENTCRF90IO(BACKSPACE, backspace)(unit, bitv, iostat) __INT_T *unit;
-__INT_T *bitv;
-__INT_T *iostat;
+ENTCRF90IO(BACKSPACE, backspace)(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
 {
   int s = 0;
   s = _f90io_backspace(unit, bitv, iostat, 0);
@@ -152,9 +148,7 @@ __INT_T *iostat;
 }
 
 __INT_T
-ENTF90IO(SWBACKSPACE, swbackspace)(unit, bitv, iostat) __INT_T *unit;
-__INT_T *bitv;
-__INT_T *iostat;
+ENTF90IO(SWBACKSPACE, swbackspace)(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
 {
   int s = 0;
 
@@ -166,9 +160,7 @@ __INT_T *iostat;
 }
 
 __INT_T
-ENTCRF90IO(SWBACKSPACE, swbackspace)(unit, bitv, iostat) __INT_T *unit;
-__INT_T *bitv;
-__INT_T *iostat;
+ENTCRF90IO(SWBACKSPACE, swbackspace)(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
 {
   int s = _f90io_backspace(unit, bitv, iostat, 1);
   __fortio_errend03();

--- a/runtime/flang/buffer.c
+++ b/runtime/flang/buffer.c
@@ -84,8 +84,7 @@ __fort_zopen(char *path)
 
 /* write */
 
-void __fort_zwrite(adr, len) char *adr;
-int len;
+void __fort_zwrite(char *adr, int len)
 {
   int ioproc;
   int s;

--- a/runtime/flang/chn1t1.c
+++ b/runtime/flang/chn1t1.c
@@ -12,17 +12,15 @@
 
 /* allocate 1 to 1 channel structure */
 
-struct chdr *
-    __fort_chn_1to1(cp, dnd, dlow, dcnts, dstrs, snd, slow, scnts,
-                   sstrs) struct chdr *cp; /* previous structure in list */
-int dnd;                                   /* source cpu DImenSIons */
-int dlow;                                  /* source lowest numbered cpu */
-int *dcnts;                                /* source number of cpus */
-int *dstrs;                                /* source cpu stride */
-int snd;                                   /* destination cpu DImenSIons */
-int slow;                                  /* destination lowest numbered cpu */
-int *scnts;                                /* destination number of cpus */
-int *sstrs;                                /* destination cpu stride */
+struct chdr *__fort_chn_1to1(struct chdr *cp, /* previous structure in list */
+                             int dnd,         /* source cpu DImenSIons */
+                             int dlow,        /* source lowest numbered cpu */
+                             int *dcnts,      /* source number of cpus */
+                             int *dstrs,      /* source cpu stride */
+                             int snd,         /* destination cpu DImenSIons */
+                             int slow,   /* destination lowest numbered cpu */
+                             int *scnts, /* destination number of cpus */
+                             int *sstrs) /* destination cpu stride */
 {
   int snstrs[MAXDIMS];
   int sncnts[MAXDIMS];

--- a/runtime/flang/chn1tn.c
+++ b/runtime/flang/chn1tn.c
@@ -12,17 +12,15 @@
 
 /* 1toN */
 
-struct chdr *
-    __fort_chn_1toN(cp, dnd, dlow, dcnts, dstrs, snd, slow, scnts,
-                   sstrs) struct chdr *cp; /* previous structure in list */
-int dnd;                                   /* destination cpu dimensions */
-int dlow;                                  /* destination lowest numbered cpu */
-int *dcnts;                                /* destination number of cpus */
-int *dstrs;                                /* destination cpu stride */
-int snd;                                   /* source cpu dimensions */
-int slow;                                  /* source lowest numbered cpu */
-int *scnts;                                /* source number of cpus */
-int *sstrs;                                /* source cpu stride */
+struct chdr *__fort_chn_1toN(struct chdr *cp, /* previous structure in list */
+                             int dnd,         /* destination cpu dimensions */
+                             int dlow,   /* destination lowest numbered cpu */
+                             int *dcnts, /* destination number of cpus */
+                             int *dstrs, /* destination cpu stride */
+                             int snd,    /* source cpu dimensions */
+                             int slow,   /* source lowest numbered cpu */
+                             int *scnts, /* source number of cpus */
+                             int *sstrs) /* source cpu stride */
 {
   int dnstrs[MAXDIMS];
   int dncnts[MAXDIMS];

--- a/runtime/flang/commitqq3f.c
+++ b/runtime/flang/commitqq3f.c
@@ -14,7 +14,7 @@
 #include "ent3f.h"
 #include "utils3f.h"
 
-int ENT3F(COMMITQQ, commitqq)(lu) int *lu;
+int ENT3F(COMMITQQ, commitqq)(int *lu)
 {
   FILE *f;
   int i;

--- a/runtime/flang/curdir.c
+++ b/runtime/flang/curdir.c
@@ -26,8 +26,7 @@ WIN_MSVCRT_IMP char *WIN_CDECL getenv(const char *);
 
 /* fix pathname for "funny" NFS mount points */
 
-void __fort_fixmnt(new, old) char *new;
-char *old;
+void __fort_fixmnt(char *new, char *old)
 {
   const char *q;
   char s[MAXPATHLEN]; /* substitute patterns */
@@ -67,7 +66,7 @@ char *old;
 
 /* get current working directory */
 
-void __fort_getdir(curdir) char *curdir;
+void __fort_getdir(char *curdir)
 {
   char path[MAXPATHLEN];
   char *p;
@@ -85,7 +84,7 @@ void __fort_getdir(curdir) char *curdir;
 
 /* get current hostname */
 
-void __fort_gethostname(host) char *host;
+void __fort_gethostname(char *host)
 {
 #ifndef _WIN64
   struct utsname un;

--- a/runtime/flang/descFioUtil.c
+++ b/runtime/flang/descFioUtil.c
@@ -56,8 +56,7 @@ static __INT_T *fio_iostat;
 
 /* init bitv and iostat */
 
-void __fort_status_init(bitv, iostat) __INT_T *bitv;
-__INT_T *iostat;
+void __fort_status_init(__INT_T *bitv, __INT_T *iostat)
 {
   fio_bitv = *bitv;
   fio_iostat = iostat;
@@ -67,7 +66,7 @@ __INT_T *iostat;
 
 #undef DIST_STATUS_BCST
 __INT_T
-__fort_status_bcst(s) __INT_T s;
+__fort_status_bcst(__INT_T s)
 {
   __INT_T msg[2];
   int ioproc, lcpu;

--- a/runtime/flang/encodefmt.c
+++ b/runtime/flang/encodefmt.c
@@ -686,8 +686,7 @@ static bool ef_getnum(
 
 /* ---------------------------------------------------------------- */
 
-static int ef_nextchar(p, len) char *p;
-int *len;
+static int ef_nextchar(char *p, int *len)
 {
   char *begin = p, c;
 
@@ -706,10 +705,8 @@ int *len;
 /* ---------------------------------------------------------------- */
 
 #ifdef FLANG_ENCODEFMT_UNUSED
-static int ef_nextdtchar(p, len)
-    /* call after encounter DT */
-    char *p;
-int *len;
+/* call after encounter DT */
+static int ef_nextdtchar(char *p, int *len)
 {
   char *begin = p, c;
 

--- a/runtime/flang/endfile.c
+++ b/runtime/flang/endfile.c
@@ -35,9 +35,7 @@ _f90io_endfile(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
 }
 
 __INT_T
-ENTF90IO(ENDFILE, endfile)(unit, bitv, iostat) __INT_T *unit;
-__INT_T *bitv;
-__INT_T *iostat;
+ENTF90IO(ENDFILE, endfile)(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
 {
   int s = 0;
 
@@ -49,9 +47,7 @@ __INT_T *iostat;
 }
 
 __INT_T
-ENTCRF90IO(ENDFILE, endfile)(unit, bitv, iostat) __INT_T *unit;
-__INT_T *bitv;
-__INT_T *iostat;
+ENTCRF90IO(ENDFILE, endfile)(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
 {
   int s = 0;
   s = _f90io_endfile(unit, bitv, iostat);

--- a/runtime/flang/flush.c
+++ b/runtime/flang/flush.c
@@ -14,9 +14,7 @@
 #include "global.h"
 #include "async.h"
 
-int ENTF90IO(FLUSH, flush)(unit, bitv, iostat) __INT_T *unit;
-__INT_T *bitv;
-__INT_T *iostat;
+int ENTF90IO(FLUSH, flush)(__INT_T *unit, __INT_T *bitv, __INT_T *iostat)
 {
   FIO_FCB *f;
   int s = 0;

--- a/runtime/flang/flush3f.c
+++ b/runtime/flang/flush3f.c
@@ -16,7 +16,7 @@
 #include "utils3f.h"
 #include "stdioInterf.h"
 
-void ENT3F(FLUSH, flush)(lu) int *lu;
+void ENT3F(FLUSH, flush)(int *lu)
 {
   FILE *f;
 

--- a/runtime/flang/fseek3f.c
+++ b/runtime/flang/fseek3f.c
@@ -15,9 +15,7 @@
 #include "ent3f.h"
 #include "utils3f.h"
 
-int ENT3F(FSEEK, fseek)(lu, offset, from) int *lu;
-int *offset;
-int *from;
+int ENT3F(FSEEK, fseek)(int *lu, int *offset, int *from)
 {
   FILE *f;
 

--- a/runtime/flang/fseek643f.c
+++ b/runtime/flang/fseek643f.c
@@ -15,9 +15,7 @@
 #include "ent3f.h"
 #include "utils3f.h"
 
-int ENT3F(FSEEK64, fseek64)(lu, offset, from) int *lu;
-long long *offset;
-int *from;
+int ENT3F(FSEEK64, fseek64)(int *lu, long long *offset, int *from)
 {
   FILE *f;
 

--- a/runtime/flang/fsync3f.c
+++ b/runtime/flang/fsync3f.c
@@ -13,7 +13,7 @@
 #include "utils3f.h"
 #include "stdioInterf.h"
 
-void ENT3F(FSYNC, fsync)(lu) int *lu;
+void ENT3F(FSYNC, fsync)(int *lu)
 {
   FILE *f;
 

--- a/runtime/flang/ftell3f.c
+++ b/runtime/flang/ftell3f.c
@@ -15,7 +15,7 @@
 #include "ent3f.h"
 #include "utils3f.h"
 
-int ENT3F(FTELL, ftell)(lu) int *lu;
+int ENT3F(FTELL, ftell)(int *lu)
 {
   FILE *f;
 

--- a/runtime/flang/ftell643f.c
+++ b/runtime/flang/ftell643f.c
@@ -15,7 +15,7 @@
 #include "ent3f.h"
 #include "utils3f.h"
 
-long long ENT3F(FTELL64, ftell64)(lu) int *lu;
+long long ENT3F(FTELL64, ftell64)(int *lu)
 {
   FILE *f;
 

--- a/runtime/flang/ftni64bitsup.c
+++ b/runtime/flang/ftni64bitsup.c
@@ -24,10 +24,9 @@ static void ushf64();
 /*************************************************************************/
 
 __I8RET_T
-ftn_i_kishftc(op, sc,
-              rc) _LONGLONG_T op; /* value containing field to be shifted */
-int sc;                           /* shift count and direction */
-int rc;                           /* # of rightmost val bits to be shifted */
+ftn_i_kishftc(_LONGLONG_T op, /* value containing field to be shifted */
+              int sc,         /* shift count and direction */
+              int rc)         /* # of rightmost val bits to be shifted */
 {
   DBLUINT64 i8neg1, mask, field, tmp1, tmp2, val;
   int norm;
@@ -121,11 +120,11 @@ int rc;                           /* # of rightmost val bits to be shifted */
  * moves len bits from pos in src to posd in dest
  */
 /*************************************************************************/
-void Ftn_kmvbits(src, pos, len, dest, posd) int *src; /* source field */
-int pos;   /* start position in source field */
-int len;   /* number of bits to move */
-int *dest; /* destination field */
-int posd;  /* start position in dest field */
+void Ftn_kmvbits(int *src,  /* source field */
+                 int pos,   /* start position in source field */
+                 int len,   /* number of bits to move */
+                 int *dest, /* destination field */
+                 int posd)  /* start position in dest field */
 {
   int mask;
   int tmp;
@@ -212,8 +211,8 @@ int posd;  /* start position in dest field */
  */
 /*************************************************************************/
 __I8RET_T
-ftn_i_kibclr(arg1, arg2, bit) int arg1, arg2; /* value to be cleared */
-int bit;                                      /* bit to clear        */
+ftn_i_kibclr(int arg1, int arg2, /* value to be cleared */
+             int bit)            /* bit to clear        */
 {
   DBLINT64 result;
   DBLUINT64 i81, tmp;
@@ -235,10 +234,9 @@ int bit;                                      /* bit to clear        */
  */
 /*************************************************************************/
 __I8RET_T
-ftn_i_kibits(arg1, arg2, bitpos, numbits) int arg1,
-    arg2;    /* value to be extracted from    */
-int bitpos;  /* position of bit to start from */
-int numbits; /* number of bits to extract     */
+ftn_i_kibits(int arg1, int arg2, /* value to be extracted from    */
+             int bitpos,         /* position of bit to start from */
+             int numbits)        /* number of bits to extract     */
 {
   DBLINT64 result;
   DBLUINT64 i8neg1, tmp, maski8, u_arg;
@@ -267,8 +265,8 @@ int numbits; /* number of bits to extract     */
  */
 /*************************************************************************/
 __I8RET_T
-ftn_i_kibset(arg1, arg2, bit) int arg1, arg2; /* value to be set   */
-int bit;                                      /* bit to set        */
+ftn_i_kibset(int arg1, int arg2, /* value to be set   */
+             int bit)            /* bit to set        */
 {
   DBLINT64 i8one, result;
   DBLUINT64 tmp;
@@ -291,8 +289,8 @@ int bit;                                      /* bit to set        */
  */
 /*************************************************************************/
 __I8RET_T
-ftn_i_bktest(arg1, arg2, bit) int arg1, arg2; /* value to be tested  */
-int bit;                                      /* bit to test         */
+ftn_i_bktest(int arg1, int arg2, /* value to be tested  */
+             int bit)            /* bit to test         */
 {
   DBLINT64 i8one, result;
   DBLUINT64 tmp;
@@ -329,9 +327,7 @@ int bit;                                      /* bit to test         */
  *	Return value:
  *	    none.
  */
-static void shf64(arg, count, result) DBLINT64 arg;
-int count;
-DBLINT64 result;
+static void shf64(DBLINT64 arg, int count, DBLINT64 result)
 {
   DBLUINT64 u_arg; /* 'copy-in' unsigned value of arg */
 
@@ -378,9 +374,7 @@ DBLINT64 result;
  *	Return value:
  *	    none.
  */
-static void ushf64(arg, count, result) DBLUINT64 arg;
-int count;
-DBLUINT64 result;
+static void ushf64(DBLUINT64 arg, int count, DBLUINT64 result)
 {
   DBLUINT64 u_arg; /* 'copy-in' value of arg */
 

--- a/runtime/flang/ftni64misc.c
+++ b/runtime/flang/ftni64misc.c
@@ -26,11 +26,10 @@
  */
 /*************************************************************************/
 _LONGLONG_T
-ftn_str_kindex(a1, a2, a1_len,
-               a2_len) char *a1; /* pointer to string being searched */
-char *a2;                        /* pointer to string being searched for */
-int a1_len;                      /* length of a1 */
-int a2_len;                      /* length of a2 */
+ftn_str_kindex(char *a1,   /* pointer to string being searched */
+               char *a2,   /* pointer to string being searched for */
+               int a1_len, /* length of a1 */
+               int a2_len) /* length of a2 */
 {
   int idx1, idx2, match;
   for (idx1 = 0; idx1 < a1_len; idx1++) {
@@ -62,11 +61,10 @@ int a2_len;                      /* length of a2 */
  * padded with blanks.
  */
 /*************************************************************************/
-int Ftn_kstrcmp(a1, a2, a1_len,
-                a2_len) char *a1; /* first string to be compared */
-char *a2;                         /* second string to be compared */
-int a1_len;                       /* length of a1 */
-int a2_len;                       /* length of a2 */
+int Ftn_kstrcmp(char *a1,   /* first string to be compared */
+                char *a2,   /* second string to be compared */
+                int a1_len, /* length of a1 */
+                int a2_len) /* length of a2 */
 {
   int ret_val, idx1;
   if (a1_len == a2_len) {
@@ -136,11 +134,10 @@ int a2_len;                       /* length of a2 */
  */
 /*************************************************************************/
 _LONGLONG_T
-ftn_str_kindex_klen(a1, a2, a1_len,
-                   a2_len) char *a1; /* pointer to string being searched */
-char *a2;                            /* pointer to string being searched for */
-_LONGLONG_T a1_len;                      /* length of a1 */
-_LONGLONG_T a2_len;                      /* length of a2 */
+ftn_str_kindex_klen(char *a1, /* pointer to string being searched */
+                    char *a2, /* pointer to string being searched for */
+                    _LONGLONG_T a1_len, /* length of a1 */
+                    _LONGLONG_T a2_len) /* length of a2 */
 {
   _LONGLONG_T idx1, idx2;
   int match;
@@ -173,11 +170,10 @@ _LONGLONG_T a2_len;                      /* length of a2 */
  * padded with blanks.
  */
 /*************************************************************************/
-int Ftn_kstrcmp_klen(a1, a2, a1_len,
-                     a2_len) char *a1; /* first string to be compared */
-char *a2;                              /* second string to be compared */
-_LONGLONG_T a1_len;                       /* length of a1 */
-_LONGLONG_T a2_len;                       /* length of a2 */
+int Ftn_kstrcmp_klen(char *a1,           /* first string to be compared */
+                     char *a2,           /* second string to be compared */
+                     _LONGLONG_T a1_len, /* length of a1 */
+                     _LONGLONG_T a2_len) /* length of a2 */
 {
   _LONGLONG_T idx1;
   int ret_val;

--- a/runtime/flang/ftnncharsup.c
+++ b/runtime/flang/ftnncharsup.c
@@ -70,11 +70,10 @@ exit_return:
  * value according to the INDEX intrinsic.
  */
 /* ***********************************************************************/
-int Ftn_nstr_index(a1, a2, a1_len,
-                   a2_len) WCHAR *a1; /* pointer to string being searched */
-WCHAR *a2;                            /* pointer to string being searched for */
-int a1_len;                           /* length of a1 */
-int a2_len;                           /* length of a2 */
+int Ftn_nstr_index(WCHAR *a1,  /* pointer to string being searched */
+                   WCHAR *a2,  /* pointer to string being searched for */
+                   int a1_len, /* length of a1 */
+                   int a2_len) /* length of a2 */
 {
   int i, j, match;
 
@@ -105,11 +104,10 @@ int a2_len;                           /* length of a2 */
  * padded with blanks.
  */
 /* ***********************************************************************/
-int Ftn_nstrcmp(a1, a2, a1_len,
-                a2_len) WCHAR *a1; /* first string to be compared */
-WCHAR *a2;                         /* second string to be compared */
-int a1_len;                        /* length of a1 */
-int a2_len;                        /* length of a2 */
+int Ftn_nstrcmp(WCHAR *a1,  /* first string to be compared */
+                WCHAR *a2,  /* second string to be compared */
+                int a1_len, /* length of a1 */
+                int a2_len) /* length of a2 */
 {
   int i, k;
 
@@ -207,11 +205,11 @@ exit_return:
  * value according to the INDEX intrinsic.
  */
 /* **********************************************************************/
-_LONGLONG_T Ftn_nstr_index_klen(a1, a2, a1_len,
-                   a2_len) WCHAR *a1; /* pointer to string being searched */
-WCHAR *a2;                            /* pointer to string being searched for */
-_LONGLONG_T a1_len;                           /* length of a1 */
-_LONGLONG_T a2_len;                           /* length of a2 */
+_LONGLONG_T
+Ftn_nstr_index_klen(WCHAR *a1, /* pointer to string being searched */
+                    WCHAR *a2, /* pointer to string being searched for */
+                    _LONGLONG_T a1_len, /* length of a1 */
+                    _LONGLONG_T a2_len) /* length of a2 */
 {
   _LONGLONG_T i, j;
   int match;
@@ -243,11 +241,10 @@ _LONGLONG_T a2_len;                           /* length of a2 */
  * padded with blanks.
  */
 /* ***********************************************************************/
-int Ftn_nstrcmp_klen(a1, a2, a1_len,
-                a2_len) WCHAR *a1; /* first string to be compared */
-WCHAR *a2;                         /* second string to be compared */
-_LONGLONG_T a1_len;                        /* length of a1 */
-_LONGLONG_T a2_len;                        /* length of a2 */
+int Ftn_nstrcmp_klen(WCHAR *a1,          /* first string to be compared */
+                     WCHAR *a2,          /* second string to be compared */
+                     _LONGLONG_T a1_len, /* length of a1 */
+                     _LONGLONG_T a2_len) /* length of a2 */
 {
   _LONGLONG_T i, k;
 
@@ -285,4 +282,3 @@ _LONGLONG_T a2_len;                        /* length of a2 */
 
   return 0;
 }
-

--- a/runtime/flang/genlist.c
+++ b/runtime/flang/genlist.c
@@ -77,11 +77,10 @@ int __fort_findndx( int cpu, /* cpu whose index is wanted */
 
 /* generate list of cpu numbers */
 
-struct cgrp *__fort_genlist(nd, low, cnts,
-                           strs) int nd; /* number of dimensions */
-int low;                                 /* lowest cpu number */
-int cnts[];                              /* counts per dimension */
-int strs[];                              /* strides per dimension */
+struct cgrp *__fort_genlist(int nd,     /* number of dimensions */
+                            int low,    /* lowest cpu number */
+                            int cnts[], /* counts per dimension */
+                            int strs[]) /* strides per dimension */
 {
 
   int dim;

--- a/runtime/flang/getfd3f.c
+++ b/runtime/flang/getfd3f.c
@@ -18,7 +18,7 @@
 #include "utils3f.h"
 
 int
-ENT3F(GETFD, getfd)(lu) int *lu;
+ENT3F(GETFD, getfd)(int *lu)
 {
   FILE *f;
 

--- a/runtime/flang/hand.c
+++ b/runtime/flang/hand.c
@@ -58,8 +58,7 @@ static struct sigs sigs[] = {
 
 /* print signal message */
 
-void __fort_psignal(lcpu, s) int lcpu;
-int s;
+void __fort_psignal(int lcpu, int s)
 {
   char buf[256];
   int n;
@@ -79,7 +78,7 @@ int s;
 
 /* handler for signals */
 
-static void sighand(s) int s;
+static void sighand(int s)
 {
   int lcpu;
 

--- a/runtime/flang/heapinit.c
+++ b/runtime/flang/heapinit.c
@@ -11,7 +11,7 @@
 
 /* handler for bus error */
 
-static void sighand(s) int s;
+static void sighand(int s)
 {
   int lcpu;
 
@@ -23,9 +23,7 @@ static void sighand(s) int s;
 
 /* init global heap (maybe) */
 
-void __fort_heapinit(beg, end, val) char *beg;
-char *end;
-int val;
+void __fort_heapinit(char *beg, char *end, int val)
 {
   void (*save)();
   int *pi;

--- a/runtime/flang/kill3f.c
+++ b/runtime/flang/kill3f.c
@@ -19,8 +19,7 @@
 #include "io3f.h"
 #include "ent3f.h"
 
-int ENT3F(KILL, kill)(pid, sig) int *pid;
-int *sig;
+int ENT3F(KILL, kill)(int *pid, int *sig)
 {
   int i;
 

--- a/runtime/flang/mvbits3f.c
+++ b/runtime/flang/mvbits3f.c
@@ -13,12 +13,11 @@
 #include "enames.h"
 #include "ftnbitsup.h"
 
-void ENT3F(MVBITS, mvbits)(src, pos, len, dest,
-                           posd) int *src; /* source field */
-int *pos;                                  /* start position in source field */
-int *len;                                  /* number of bits to move */
-int *dest;                                 /* destination field */
-int *posd;                                 /* start position in dest field */
+void ENT3F(MVBITS, mvbits)(int *src,  /* source field */
+                           int *pos,  /* start position in source field */
+                           int *len,  /* number of bits to move */
+                           int *dest, /* destination field */
+                           int *posd) /* start position in dest field */
 {
   Ftn_jmvbits(*src, *pos, *len, dest, *posd);
 }

--- a/runtime/flang/pxffileno3f.c
+++ b/runtime/flang/pxffileno3f.c
@@ -15,9 +15,7 @@
 #include "utils3f.h"
 #include "stdioInterf.h"
 
-void ENT3F(PXFFILENO, pxffileno)(lu, fd, err) int *lu;
-int *fd;
-int *err;
+void ENT3F(PXFFILENO, pxffileno)(int *lu, int *fd, int *err)
 {
   FILE *f;
 

--- a/runtime/flang/sleep3f.c
+++ b/runtime/flang/sleep3f.c
@@ -18,12 +18,12 @@
 
 #include <windows.h>
 
-void ENT3F(SLEEP, sleep)(t) unsigned int *t;
+void ENT3F(SLEEP, sleep)(unsigned int *t)
 {
   Sleep(1000 * (*t)); /* MS Sleep() is in terms of milliseconds */
 }
 #else
-void ENT3F(SLEEP, sleep)(t) unsigned int *t;
+void ENT3F(SLEEP, sleep)(unsigned int *t)
 {
   sleep(*t);
 }

--- a/runtime/flang/sleepqq3f.c
+++ b/runtime/flang/sleepqq3f.c
@@ -18,12 +18,12 @@
 
 #include <windows.h>
 
-void ENT3F(SLEEPQQ, sleepqq)(t) unsigned int *t;
+void ENT3F(SLEEPQQ, sleepqq)(unsigned int *t)
 {
   Sleep(*t); /* MS Sleep() is in terms of milliseconds */
 }
 #else
-void ENT3F(SLEEPQQ, sleepqq)(t) unsigned int *t;
+void ENT3F(SLEEPQQ, sleepqq)(unsigned int *t)
 {
   sleep((*t) / 1000);
 }

--- a/runtime/flang/stat.c
+++ b/runtime/flang/stat.c
@@ -111,7 +111,7 @@ scale_kbytes(double d, double *ds)
 
 /* print cpu info */
 
-static void cpu(tbp) struct tb *tbp;
+static void cpu(struct tb *tbp)
 {
   int i, quiet, tcpus;
   struct tb n, a, x, e;
@@ -171,7 +171,7 @@ static void cpu(tbp) struct tb *tbp;
 
 /* print memory info */
 
-static void mem(tbp) struct tb *tbp;
+static void mem(struct tb *tbp)
 {
   double tmaxrss; /* total max set size */
   double tminflt; /* total minor fault */
@@ -228,7 +228,7 @@ static void mem(tbp) struct tb *tbp;
 
 /* print message info */
 
-static void msg(tbp) struct tb *tbp;
+static void msg(struct tb *tbp)
 {
   int i, quiet, tcpus;
   double ds, dr, dc, dst, drt, dct;

--- a/runtime/flang/stat_linux.c
+++ b/runtime/flang/stat_linux.c
@@ -35,7 +35,7 @@ __fort_setarg(void)
 }
 
 // TODO: Implement functions for WIN32
-static void nodename(s) char *s;
+static void nodename(char *s)
 {
 #ifndef _WIN64
   struct utsname u0;
@@ -45,7 +45,7 @@ static void nodename(s) char *s;
 #endif
 }
 
-void __fort_gettb(t) struct tb *t;
+void __fort_gettb(struct tb *t)
 {
 #ifndef _WIN64
   struct timeval tv0;

--- a/runtime/flang/utils3f.c
+++ b/runtime/flang/utils3f.c
@@ -56,7 +56,7 @@ __fcp_cstr(char *to, int to_len, char *from)
 
 /* --------------------------------------------------------------- */
 
-extern bool __isatty3f(unit) int unit;
+bool __isatty3f(int unit)
 {
   void *p;
   int fd;
@@ -83,7 +83,7 @@ extern bool __isatty3f(unit) int unit;
 
 /* --------------------------------------------------------------- */
 
-extern FILE *__getfile3f(unit) int unit;
+FILE *__getfile3f(int unit)
 {
   void *p;
 

--- a/runtime/flang/utilsi64.c
+++ b/runtime/flang/utilsi64.c
@@ -846,8 +846,6 @@ static void uneg64(DBLUINT64 arg, DBLUINT64 result)
 }
 
 static void ushf64(DBLUINT64 arg, int count, DBLINT64 result)
-int count;
-DBLINT64 result;
 {
   DBLUINT64 u_arg; /* 'copy-in' unsigned value of arg */
 

--- a/runtime/flang/wait.c
+++ b/runtime/flang/wait.c
@@ -21,10 +21,7 @@
 /* ------------------------------------------------------------------ */
 
 __INT_T
-ENTF90IO(WAIT, wait)(unit, bitv, iostat, id) __INT_T *unit; /* unit number */
-__INT_T *bitv;
-__INT_T *iostat;
-__INT_T *id;
+ENTF90IO(WAIT, wait)(__INT_T *unit, __INT_T *bitv, __INT_T *iostat, __INT_T *id)
 {
   FIO_FCB *f;
   int s = 0;

--- a/runtime/flang/xfer_rpm1.c
+++ b/runtime/flang/xfer_rpm1.c
@@ -12,24 +12,21 @@ int __fort_minxfer = 0;
 
 /* receive data items */
 
-void __fort_erecv(cpu, e) int cpu;
-struct ents *e;
+void __fort_erecv(int cpu, struct ents *e)
 {
   __fort_abort("__fort_erecv: not implemented");
 }
 
 /* send data items */
 
-void __fort_esend(cpu, e) int cpu;
-struct ents *e;
+void __fort_esend(int cpu, struct ents *e)
 {
   __fort_abort("__fort_esend: not implemented");
 }
 
 /* bcopy data items */
 
-void __fort_ebcopys(ed, es) struct ents *ed;
-struct ents *es;
+void __fort_ebcopys(struct ents *ed, struct ents *es)
 {
   struct ent *p;
   struct ent *q;
@@ -57,7 +54,7 @@ struct ents *es;
 
 /* execute structure */
 
-void __fort_doit(c) struct chdr *c;
+void __fort_doit(struct chdr *c)
 {
   struct ccpu *cp;
   int n;

--- a/runtime/libpgmath/lib/common/fpcvt.c
+++ b/runtime/libpgmath/lib/common/fpcvt.c
@@ -51,10 +51,7 @@ typedef struct {
 
 #define IEEE64_SUBNORMAL(a) (a.v.e == 0 && (a.v.hm != 0L || a.v.lm != 0L))
 
-static void ui64toa(m, s, n, decpl) INT m[2];
-char *s;
-int n;
-int decpl;
+static void ui64toa(INT m[2], char *s, int n, int decpl)
 {
   int i, j;
   INT lo, hi;
@@ -87,8 +84,7 @@ int decpl;
   s[j] = '\0';
 }
 
-static void manshftr(m, n) INT m[4];
-int n;
+static void manshftr(INT m[4], int n)
 {
   int i;
   int j;
@@ -109,8 +105,7 @@ int n;
   }
 }
 
-static void manshftl(m, n) register INT m[4];
-int n;
+static void manshftl(register INT m[4], int n)
 {
   register int i;
   register int j;
@@ -131,8 +126,7 @@ int n;
   }
 }
 
-static void manadd(m1, m2) register INT m1[4];
-register INT m2[4];
+static void manadd(register INT m1[4], register INT m2[4])
 {
   INT t1, t2, carry;
   INT lo, hi;
@@ -153,8 +147,7 @@ register INT m2[4];
   }
 }
 
-static void manrnd(m, bits) INT m[4];
-int bits;
+static void manrnd(INT m[4], int bits)
 {
   int rndwrd, rndbit;
   int oddwrd, oddbit;
@@ -183,7 +176,7 @@ int bits;
   manshftl(m, 128 - bits);
 }
 
-static void manneg(m) register INT m[4];
+static void manneg(register INT m[4])
 {
   void manadd();
   static INT one[4] = {0L, 0L, 0L, 1L};
@@ -193,8 +186,7 @@ static void manneg(m) register INT m[4];
   manadd(m, one);
 }
 
-static void manmul(m1, m2) register INT m1[4];
-register INT m2[4];
+static void manmul(register INT m1[4], register INT m2[4])
 {
   register INT carry;
   register int i, j, k;
@@ -224,7 +216,7 @@ register INT m2[4];
     m1[i] = (p[j] << 16) | p[j + 1];
 }
 
-static void ufpnorm(u) register UFP *u;
+static void ufpnorm(register UFP *u)
 {
   if (u->fman[0] == 0 && u->fman[1] == 0 && u->fman[2] == 0 && u->fman[3] == 0)
     return;
@@ -240,8 +232,7 @@ static void ufpnorm(u) register UFP *u;
   }
 }
 
-static int ufpdnorm(u, bias) UFP *u;
-int bias;
+static int ufpdnorm(UFP *u, int bias)
 {
   /*  adjust the denormalized number, unset the implicit bit, and
       report true underflow condition */
@@ -262,14 +253,14 @@ int bias;
   return 1;
 }
 
-static void ufprnd(u, bits) UFP *u;
-int bits;
+static void ufprnd(UFP *u, int bits)
 {
   void ufpnorm();
   ufpnorm(u);
   manrnd(u->fman, bits + 12);
   ufpnorm(u);
 }
+
 static INT ftab1[29][3] = {
     {0xA05C0DD7, 0x0F6E1619, -1162}, {0xA5CED43B, 0x7E3E9188, -1079},
     {0xAB70FE17, 0xC79AC6CA, -996},  {0xB1442798, 0xF49FFB4A, -913},
@@ -287,6 +278,7 @@ static INT ftab1[29][3] = {
     {0xBF21E440, 0x03ACDD2C, 997},   {0xC5A05277, 0x621BE293, 1080},
     {0xCC573C2A, 0x0ECCDAA6, 1163},
 };
+
 static INT ftab2[25][3] = {
     {0x80000000, 0x00000000, 1},  {0xA0000000, 0x00000000, 4},
     {0xC8000000, 0x00000000, 7},  {0xFA000000, 0x00000000, 10},
@@ -302,8 +294,8 @@ static INT ftab2[25][3] = {
     {0x87867832, 0x6EAC9000, 74}, {0xA968163F, 0x0A57B400, 77},
     {0xD3C21BCE, 0xCCEDA100, 80},
 };
-static void ufpxten(u, exp) UFP *u;
-int exp;
+
+static void ufpxten(UFP *u, int exp)
 {
   int i, j;
   if (exp < -350) {
@@ -324,11 +316,7 @@ int exp;
   u->fexp += ftab1[i][2] + ftab2[j][2];
 }
 
-static void ufptosci(u, s, dp, decpt, sign) UFP *u;
-char *s;
-int dp;
-int *decpt;
-int *sign;
+static void ufptosci(UFP *u, char *s, int dp, int *decpt, int *sign)
 {
   INT man[2];
   int exp10, exp2;
@@ -369,8 +357,7 @@ again:
   *decpt = exp10;
 }
 
-static void dtoufp(d, u) IEEE64 d;
-register UFP *u;
+static void dtoufp(IEEE64 d, register UFP *u)
 {
   union ieee v;
 
@@ -402,8 +389,7 @@ register UFP *u;
     u->fman[0] |= 0x00100000L;
 }
 
-static void ufptod(u, r) register UFP *u;
-IEEE64 *r;
+static void ufptod(register UFP *u, IEEE64 *r)
 {
   union ieee v;
   int bias = 1023;
@@ -458,10 +444,7 @@ IEEE64 *r;
   *r = v.d;
 }
 
-static int atoxi(s, i, n, base) register char *s;
-INT *i;
-int n;
-int base;
+static int atoxi(register char *s, INT *i, int n, int base)
 {
   register char *end;
   register INT value;
@@ -550,10 +533,7 @@ ovflo:
   return -2;
 }
 
-static void atoui64(s, m, n, exp) char *s;
-INT m[2];
-int n;
-INT *exp;
+static void atoui64(char *s, INT m[2], int n, INT *exp)
 {
   char *end;
   int dp;
@@ -602,9 +582,7 @@ INT *exp;
   *exp -= dp;
 }
 
-static void atoxufp(s, u, p) char *s;
-UFP *u;
-char **p;
+static void atoxufp(char *s, UFP *u, char **p)
 {
   void atoui64();
   INT exp;
@@ -686,7 +664,7 @@ ret:
 }
 
 #if defined(PGI_FPCVT)
-double atof(s) char *s;
+double atof(char *s)
 {
   double strtod();
   int save_errno;
@@ -698,15 +676,7 @@ double atof(s) char *s;
   return d;
 }
 
-double strtod(s, p)
-{
-  double __strtod();
-
-  return __strtod(s, p);
-}
-
-double __strtod(s, p) char *s;
-char **p;
+double __strtod(char *s, char **p)
 {
   IEEE64 d;
   void atoxufp();
@@ -724,6 +694,11 @@ char **p;
   ufptod(&u, &d);
   return d;
 }
+
+double strtod(char *s, char **p)
+{
+  return __strtod(s, p);
+}
 #endif
 
 /*
@@ -733,8 +708,7 @@ char **p;
 #define NDIG 25
 
 #if defined(PGI_FPCVT) || defined(INTERIX86)
-char *ecvt(value, ndigit, decpt, sign) double value;
-int ndigit, *decpt, *sign;
+char *ecvt(double value, int ndigit, int *decpt, int *sign)
 {
   char *__ecvt();
 
@@ -828,8 +802,7 @@ ret0:
 }
 #endif
 
-char *__ecvt(value, ndigit, decpt, sign) double value;
-int ndigit, *decpt, *sign;
+char *__ecvt(double value, int ndigit, int *decpt, int *sign)
 {
   static char buf[64];
   char *s;
@@ -925,8 +898,7 @@ int ndigit, *decpt, *sign;
 }
 
 #if defined(PGI_FPCVT)
-char *fcvt(value, ndigit, decpt, sign) double value;
-int ndigit, *decpt, *sign;
+char *fcvt(double value, int ndigit, int *decpt, int *sign)
 {
   char *__fcvt();
 
@@ -934,9 +906,7 @@ int ndigit, *decpt, *sign;
 }
 #endif
 
-char *__fcvt(v, prec, decpt, sign) double v;
-int prec;
-int *decpt, *sign;
+char *__fcvt(double v, int prec, int *decpt, int *sign)
 {
   char *__ecvt();
   static char tmp[512];

--- a/tools/flang1/utils/prstab/prodstr.c
+++ b/tools/flang1/utils/prstab/prodstr.c
@@ -25,7 +25,7 @@ static void readln();
 static void header();
 static void footer();
 static int scan();
-static void error();
+static void error(char *);
 static void init();
 static void output();
 
@@ -190,7 +190,7 @@ scan()
   return token;
 }
 
-static void error(p) char *p;
+static void error(char *p)
 {
   printf("%s, line %d\n", p, lineno);
   return;


### PR DESCRIPTION
Legacy Classic Flang code uses K&R C function declarations, which differ from ANSI C function declarations in that the parameters are not part of the function prototype, which means that the functions can have unknown numbers of parameters, of unknown types. With Clang 15, they will now cause a warning message, e.g.
```
.../flang/runtime/flang/curdir.c:31:6: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
void __fort_fixmnt(new, old)
     ^
```
This commit rewrites all function declarations in modern C.