### PR TITLE
[LLVM 15][runtime] Remove extern function declarations

### DIFF
--- a/runtime/flang/access3f.c
+++ b/runtime/flang/access3f.c
@@ -16,9 +16,7 @@
 
 #include "io3f.h"
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(ACCESS, access)(DCHAR(fil), DCHAR(mode) DCLEN(fil) DCLEN(mode))
 {

--- a/runtime/flang/allo.c
+++ b/runtime/flang/allo.c
@@ -18,7 +18,6 @@
 #include "type.h"
 #define DEBUG 1
 #include "llcrit.h"
-#include "mpalloc.h"
 #include "f90alloc.h"
 
 MP_SEMAPHORE(static, sem);

--- a/runtime/flang/chdir3f.c
+++ b/runtime/flang/chdir3f.c
@@ -17,13 +17,11 @@
 #endif
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 
 #ifdef _WIN64
 #define chdir _chdir
 #endif
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
 
 int ENT3F(CHDIR, chdir)(DCHAR(path) DCLEN(path))
 {

--- a/runtime/flang/chmod3f.c
+++ b/runtime/flang/chmod3f.c
@@ -16,13 +16,11 @@
 
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 
 #ifdef _WIN64
 #define chmod _chmod
 #endif
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
 
 int ENT3F(CHMOD, chmod)(DCHAR(nam), int *mode DCLEN(nam))
 {

--- a/runtime/flang/chn1t1.c
+++ b/runtime/flang/chn1t1.c
@@ -7,9 +7,8 @@
 
 #include "stdioInterf.h"
 #include "fioMacros.h"
-
-extern struct cgrp *__fort_genlist();
-extern struct chdr *__fort_allchn();
+#include "genlist.h"
+#include "xfer.h"
 
 /* allocate 1 to 1 channel structure */
 

--- a/runtime/flang/chn1tn.c
+++ b/runtime/flang/chn1tn.c
@@ -7,9 +7,8 @@
 
 #include "stdioInterf.h"
 #include "fioMacros.h"
-
-extern struct cgrp *__fort_genlist();
-extern struct chdr *__fort_allchn();
+#include "genlist.h"
+#include "xfer.h"
 
 /* 1toN */
 

--- a/runtime/flang/chnmerge.c
+++ b/runtime/flang/chnmerge.c
@@ -7,8 +7,7 @@
 
 #include "stdioInterf.h"
 #include "fioMacros.h"
-
-extern struct chdr *__fort_allchn();
+#include "xfer.h"
 
 /* merge ent structures */
 

--- a/runtime/flang/cnfg.c
+++ b/runtime/flang/cnfg.c
@@ -13,9 +13,6 @@
 #include <stdlib.h>
 #include "stdioInterf.h"
 
-
-extern char *__fort_getenv();
-
 /* WARNING: cnfg.c generates two objects, cnfg.o and pgfcnfg.o
  * define global variable which contains the configurable items:
  *
@@ -74,7 +71,6 @@ void
 __fortio_scratch_name(char *filename, int unit)
 /* generate the name of an unnamed scracth file */
 {
-  extern char *__io_tempnam();
   char *nm;
 
 #if defined(WINNT)

--- a/runtime/flang/commitqq3f.c
+++ b/runtime/flang/commitqq3f.c
@@ -12,8 +12,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int ENT3F(COMMITQQ, commitqq)(lu) int *lu;
 {

--- a/runtime/flang/curdir.c
+++ b/runtime/flang/curdir.c
@@ -22,8 +22,6 @@
 #define getcwd _getcwd
 #endif
 
-extern char *getcwd();
-
 WIN_MSVCRT_IMP char *WIN_CDECL getenv(const char *);
 
 /* fix pathname for "funny" NFS mount points */

--- a/runtime/flang/delfilesqq3f.c
+++ b/runtime/flang/delfilesqq3f.c
@@ -16,9 +16,9 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 
 #if defined(WIN64) || defined(WIN32)
-extern char *__fstr2cstr();
 int ENT3F(DELFILESQQ, delfilesqq)(DCHAR(ffiles) DCLEN(ffiles))
 {
   char *files;

--- a/runtime/flang/drandm3f.c
+++ b/runtime/flang/drandm3f.c
@@ -9,12 +9,11 @@
 
 /*	drandm3f.c - Implements LIB3F drandm subprogram.  */
 
+#include <stdlib.h>
 #include "ent3f.h"
 
 /* drand48, srand48 are not currently available on win64 */
 #if defined(WIN64) || defined(WIN32)
-
-#include <stdlib.h>
 
 double ENT3F(DRANDM, drandm)(int *flag)
 {
@@ -34,9 +33,6 @@ double ENT3F(DRAND, drand)(int *flag)
 }
 
 #else
-
-extern double drand48();
-extern void srand48();
 
 double ENT3F(DRANDM, drandm)(int *flag)
 {

--- a/runtime/flang/fgetc3f.c
+++ b/runtime/flang/fgetc3f.c
@@ -13,8 +13,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int ENT3F(FGETC, fgetc)(int *lu, DCHAR(ch) DCLEN(ch))
 {

--- a/runtime/flang/findfileqq3f.c
+++ b/runtime/flang/findfileqq3f.c
@@ -15,10 +15,10 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 
 #if defined(WIN64) || defined(WIN32)
 
-extern char *__fstr2cstr();
 int ENT3F(FINDFILEQQ, findfileqq)(DCHAR(fname), DCHAR(fvarname),
                                   DCHAR(fpath) DCLEN(fname) DCLEN(fvarname)
                                       DCLEN(fpath))

--- a/runtime/flang/flush3f.c
+++ b/runtime/flang/flush3f.c
@@ -13,9 +13,8 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 #include "stdioInterf.h"
-
-extern FILE *__getfile3f();
 
 void ENT3F(FLUSH, flush)(lu) int *lu;
 {

--- a/runtime/flang/fpcvt.c
+++ b/runtime/flang/fpcvt.c
@@ -258,7 +258,6 @@ ufpnorm(UFP *u)
 static void
 ufprnd(UFP *u, int bits)
 {
-  void ufpnorm();
   ufpnorm(u);
   manrnd(u->fman, bits + 12);
   ufpnorm(u);
@@ -643,7 +642,6 @@ atoui64(char *s, INT *m, /* m[2] */
 static void
 atoxufp(char *s, UFP *u, char **p)
 {
-  void atoui64();
   INT exp;
   int sign;
   int err;
@@ -727,8 +725,6 @@ double
 __fortio_strtod(char *s, char **p)
 {
   IEEE64 d;
-  void atoxufp();
-  void ufpxten();
   UFP u;
   int exp;
   char *q;
@@ -800,7 +796,6 @@ char *
 __fortio_ecvt(__BIGREAL_T lvalue, int width, int ndigit, int *decpt, int *sign,
               int round, int is_quad)
 {
-  void ufptosci();
   int i, j;
 
   union ieee ieee_v;

--- a/runtime/flang/fputc3f.c
+++ b/runtime/flang/fputc3f.c
@@ -13,8 +13,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int ENT3F(FPUTC, fputc)(int *lu, DCHAR(ch) DCLEN(ch))
 {

--- a/runtime/flang/fseek3f.c
+++ b/runtime/flang/fseek3f.c
@@ -13,8 +13,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int ENT3F(FSEEK, fseek)(lu, offset, from) int *lu;
 int *offset;

--- a/runtime/flang/fseek643f.c
+++ b/runtime/flang/fseek643f.c
@@ -13,8 +13,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int ENT3F(FSEEK64, fseek64)(lu, offset, from) int *lu;
 long long *offset;

--- a/runtime/flang/fsync3f.c
+++ b/runtime/flang/fsync3f.c
@@ -10,9 +10,8 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 #include "stdioInterf.h"
-
-extern FILE *__getfile3f();
 
 void ENT3F(FSYNC, fsync)(lu) int *lu;
 {

--- a/runtime/flang/ftell3f.c
+++ b/runtime/flang/ftell3f.c
@@ -13,8 +13,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int ENT3F(FTELL, ftell)(lu) int *lu;
 {

--- a/runtime/flang/ftell643f.c
+++ b/runtime/flang/ftell643f.c
@@ -13,8 +13,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 long long ENT3F(FTELL64, ftell64)(lu) int *lu;
 {

--- a/runtime/flang/fullpathqq3f.c
+++ b/runtime/flang/fullpathqq3f.c
@@ -14,10 +14,10 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 
 #if defined(WIN64) || defined(WIN32)
 
-extern char *__fstr2cstr();
 int ENT3F(FULLPATHQQ, fullpathqq)(DCHAR(fname),
                                   DCHAR(fpath) DCLEN(fname) DCLEN(fpath))
 {

--- a/runtime/flang/genlist.h
+++ b/runtime/flang/genlist.h
@@ -1,0 +1,17 @@
+/*
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#ifndef RUNTIME_FLANG_GENLIST_H
+#define RUNTIME_FLANG_GENLIST_H
+
+/* generate list of cpu numbers */
+struct cgrp *__fort_genlist(int nd,      /* number of dimensions */
+                            int low,     /* lowest cpu number */
+                            int cnts[],  /* counts per dimension */
+                            int strs[]); /* strides per dimension */
+
+#endif /* RUNTIME_FLANG_GENLIST_H */

--- a/runtime/flang/gerror3f.c
+++ b/runtime/flang/gerror3f.c
@@ -9,6 +9,7 @@
 
 /*	gerror3f.c - Implements LIB3F gerror subprogram.  */
 
+#include <string.h>
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
@@ -16,10 +17,6 @@
 #include "error.h"
 
 #define Ftn_errmsg __fortio_errmsg
-
-#if !defined(WIN64) && !defined(WIN32)
-extern char *strerror(); /* SVR4 only ? */
-#endif
 
 void ENT3F(GERROR, gerror)(DCHAR(str) DCLEN(str))
 {

--- a/runtime/flang/getarg.c
+++ b/runtime/flang/getarg.c
@@ -15,11 +15,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include "fioMacros.h"
-#include "mpalloc.h"
+#include "utils3f.h"
 
 extern int __io_get_argc();
 extern char **__io_get_argv();
-extern char *__fstr2cstr();
 
 static void store_int_kind(void *, __INT_T *, int);
 

--- a/runtime/flang/getc3f.c
+++ b/runtime/flang/getc3f.c
@@ -14,8 +14,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int
 ENT3F(GETC, getc)(DCHAR(ch) DCLEN(ch))

--- a/runtime/flang/getcwd3f.c
+++ b/runtime/flang/getcwd3f.c
@@ -21,8 +21,6 @@
 #define GETCWDM getcwd
 #endif
 
-extern char *GETCWDM();
-
 int ENT3F(GETCWD, getcwd)(DCHAR(dir) DCLEN(dir))
 {
   char *p;

--- a/runtime/flang/getdrivedirqq3f.c
+++ b/runtime/flang/getdrivedirqq3f.c
@@ -22,9 +22,6 @@
 #define GETCWDM getcwd
 #endif
 
-extern char *GETCWDM();
-extern char *__fstr2cstr();
-
 int ENT3F(GETDRIVEDIRQQ, getdrivedirqq)(DCHAR(dir) DCLEN(dir))
 {
   char *p, *q;

--- a/runtime/flang/getenv3f.c
+++ b/runtime/flang/getenv3f.c
@@ -12,11 +12,6 @@
 #include "ent3f.h"
 #include "utils3f.h"
 
-
-extern char *getenv();
-extern char *__fstr2cstr();
-extern void __cstr_free();
-
 void ENT3F(GETENV, getenv)(DCHAR(en), DCHAR(ev) DCLEN(en) DCLEN(ev))
 {
   char *p, *q;

--- a/runtime/flang/getenvqq3f.c
+++ b/runtime/flang/getenvqq3f.c
@@ -13,10 +13,6 @@
 #include "ent3f.h"
 #include "utils3f.h"
 
-extern char *getenv();
-extern char *__fstr2cstr();
-extern void __cstr_free();
-
 int ENT3F(GETENVQQ, getenvqq)(DCHAR(en), DCHAR(ev) DCLEN(en) DCLEN(ev))
 {
   char *p, *q;

--- a/runtime/flang/getfd3f.c
+++ b/runtime/flang/getfd3f.c
@@ -15,8 +15,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int
 ENT3F(GETFD, getfd)(lu) int *lu;

--- a/runtime/flang/getfileinfoqq3f.c
+++ b/runtime/flang/getfileinfoqq3f.c
@@ -16,9 +16,9 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 
 #if defined(WIN64) || defined(WIN32)
-extern char *__fstr2cstr();
 extern void __GetTimeToSecondsSince1970(ULARGE_INTEGER *fileTime,
                                         unsigned int *out);
 extern int __GETFILEINFOQQ(DCHAR(ffiles), char *buffer,

--- a/runtime/flang/getfileinfoqqi83f.c
+++ b/runtime/flang/getfileinfoqqi83f.c
@@ -16,13 +16,13 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 
 #define FILE$FIRST -1
 #define FILE$LAST -2
 #define FILE$ERROR -3
 
 #if defined(WIN64) || defined(WIN32)
-extern char *__fstr2cstr();
 extern void __GetTimeToSecondsSince1970(ULARGE_INTEGER *fileTime,
                                         unsigned int *out);
 int ENT3F(GETFILEINFOQQI8, getfileinfoqqi8)(DCHAR(ffiles), char *buffer,

--- a/runtime/flang/hostnm3f.c
+++ b/runtime/flang/hostnm3f.c
@@ -11,11 +11,10 @@
 
 #ifndef WINNT
 
+#include <unistd.h>
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern int gethostname();
 
 int ENT3F(HOSTNM, hostnm)(DCHAR(nm) DCLEN(nm))
 {

--- a/runtime/flang/ioinit3f.c
+++ b/runtime/flang/ioinit3f.c
@@ -12,9 +12,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 #define IS_TRUE(x) ((x)&0x1)
 

--- a/runtime/flang/irandm3f.c
+++ b/runtime/flang/irandm3f.c
@@ -9,6 +9,7 @@
 
 /*	irandm3f.c - Implements LIB3F irandm subprogram.  */
 
+#include <stdlib.h>
 #include "ent3f.h"
 
 #ifdef WINNT
@@ -21,9 +22,6 @@ int ENT3F(IRANDM, irandm)(int *flag)
 }
 
 #else
-
-extern int lrand48();
-extern void srand48();
 
 int ENT3F(IRANDM, irandm)(int *flag)
 {

--- a/runtime/flang/isatty3f.c
+++ b/runtime/flang/isatty3f.c
@@ -10,8 +10,7 @@
 /*	isatty3f.c - Implements LIB3F isatty subprogram.  */
 
 #include "ent3f.h"
-
-extern int __isatty3f();
+#include "utils3f.h"
 
 int ENT3F(ISATTY, isatty)(int *lu)
 {

--- a/runtime/flang/link3f.c
+++ b/runtime/flang/link3f.c
@@ -14,9 +14,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(LINK, link)(DCHAR(n1), DCHAR(n2) DCLEN(n1) DCLEN(n2))
 {

--- a/runtime/flang/lstat3f.c
+++ b/runtime/flang/lstat3f.c
@@ -15,9 +15,7 @@
 #include <sys/stat.h>
 #include "io3f.h"
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(LSTAT, lstat)(DCHAR(nm), int *statb DCLEN(nm))
 {

--- a/runtime/flang/lstat643f.c
+++ b/runtime/flang/lstat643f.c
@@ -15,9 +15,7 @@
 #include <sys/stat.h>
 #include "io3f.h"
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(LSTAT64, lstat64)(DCHAR(nm), long long *statb DCLEN(nm))
 {

--- a/runtime/flang/miscsup_com.c
+++ b/runtime/flang/miscsup_com.c
@@ -3910,8 +3910,6 @@ ENTF90(AMIN1, amin1)(__REAL_T *a, __REAL_T *b) { return (*a < *b) ? *a : *b; }
 __DBLE_T
 ENTF90(DMIN1, dmin1)(__DBLE_T *a, __DBLE_T *b) { return (*a < *b) ? *a : *b; }
 
-double fmod();
-
 __REAL_T
 ENTF90(AMOD, amod)(__REAL_T *a, __REAL_T *b) { return fmod(*a, *b); }
 

--- a/runtime/flang/mpalloc.h
+++ b/runtime/flang/mpalloc.h
@@ -16,5 +16,3 @@ extern void * _mp_calloc(size_t n, size_t);
 extern void * _mp_realloc(void *p, size_t n);
 extern void * _mp_realloc(void *p, size_t n);
 extern void _mp_free(void *p);
-
-void __cstr_free(char *from);

--- a/runtime/flang/nmlread.c
+++ b/runtime/flang/nmlread.c
@@ -579,7 +579,7 @@ ENTF90IO(NML_READ, nml_read)( __INT_T *unit,
  *  \param iostat same as for ENTF90IO(open)
  *  \param nmldesc) namelist group descr
  */
-extern int
+int
 ENTCRF90IO(NML_READ, nml_read)(__INT_T *unit, 
                                __INT_T *bitv, 
                                __INT_T *iostat, 
@@ -967,7 +967,6 @@ get_token(void)
       goto do_numeric_token;
 
     if (c == '*') { /* REPEAT COUNT */
-      extern long atol();
       long k = atol(token_buff);
       if (recur)
         return __fortio_error(FIO_ELEX); /* unknown token */

--- a/runtime/flang/outstr3f.c
+++ b/runtime/flang/outstr3f.c
@@ -14,8 +14,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int ENT3F(OUTSTR, outstr)(DCHAR(ch) DCLEN(ch))
 {

--- a/runtime/flang/packtimeqq3f.c
+++ b/runtime/flang/packtimeqq3f.c
@@ -18,7 +18,6 @@
 #include "ent3f.h"
 
 #if defined(WIN64) || defined(WIN32)
-extern char *__fstr2cstr();
 extern void __GetTimeToSecondsSince1970(ULARGE_INTEGER *fileTime,
                                         unsigned int *out);
 

--- a/runtime/flang/perror3f.c
+++ b/runtime/flang/perror3f.c
@@ -9,14 +9,11 @@
 
 /*	perror3f.c - Implements LIB3F perror subprogram.  */
 
+#include <string.h>
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-#if !defined(WIN64) && !defined(WIN32)
-extern char *strerror(); /* SVR4 only ? */
-#endif
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 void ENT3F(PERROR, perror)(DCHAR(str) DCLEN(str))
 {

--- a/runtime/flang/putc3f.c
+++ b/runtime/flang/putc3f.c
@@ -14,8 +14,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int ENT3F(PUTC, putc)(DCHAR(ch) DCLEN(ch))
 {

--- a/runtime/flang/putenv3f.c
+++ b/runtime/flang/putenv3f.c
@@ -9,12 +9,9 @@
 
 /*	putenv3f.c - Implements LIB3F putenv subprogram.  */
 
+#include <stdlib.h>
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
-
-extern int putenv();
+#include "utils3f.h"
 
 int ENT3F(PUTENV, putenv)(DCHAR(str) DCLEN(str))
 {

--- a/runtime/flang/pxffileno3f.c
+++ b/runtime/flang/pxffileno3f.c
@@ -12,9 +12,8 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 #include "stdioInterf.h"
-
-extern FILE *__getfile3f();
 
 void ENT3F(PXFFILENO, pxffileno)(lu, fd, err) int *lu;
 int *fd;

--- a/runtime/flang/random3f.c
+++ b/runtime/flang/random3f.c
@@ -9,12 +9,11 @@
 
 /*	random3f.c - Implements LIB3F random subprogram.  */
 
+#include <stdlib.h>
 #include "ent3f.h"
 
 /* drand48, srand48 are not currently available on win64 */
 #if defined(WIN64) || defined(WIN32)
-
-#include <stdlib.h>
 
 float ENT3F(RANDOM, random)(int *flag)
 {
@@ -29,9 +28,6 @@ float ENT3F(RANDOM, random)(int *flag)
 }
 
 #else
-
-extern double drand48();
-extern void srand48();
 
 float ENT3F(RANDOM, random)(int *flag)
 {

--- a/runtime/flang/rdst.c
+++ b/runtime/flang/rdst.c
@@ -13,9 +13,7 @@
 
 #include "stdioInterf.h"
 #include "fioMacros.h"
-#include "mpalloc.h" /* for __cstr_free */
-
-extern char *__fstr2cstr();
+#include "utils3f.h" /* for __cstr_free */
 
 void
 ENTFTN(TEMPLATE, template)(F90_Desc *dd, __INT_T *p_rank,

--- a/runtime/flang/rename3f.c
+++ b/runtime/flang/rename3f.c
@@ -12,10 +12,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern int rename();
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(RENAME, rename)(DCHAR(from), DCHAR(to) DCLEN(from) DCLEN(to))
 {

--- a/runtime/flang/renamefileqq3f.c
+++ b/runtime/flang/renamefileqq3f.c
@@ -12,10 +12,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern int rename();
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(RENAMEFILEQQ, renamefileqq)(DCHAR(from),
                                       DCHAR(to) DCLEN(from) DCLEN(to))

--- a/runtime/flang/runqq3f.c
+++ b/runtime/flang/runqq3f.c
@@ -12,10 +12,7 @@
 #include <string.h>
 #include "ent3f.h"
 #include "mpalloc.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
-extern void *_mp_malloc();
+#include "utils3f.h"
 
 short ENT3F(RUNQQ, runqq)(DCHAR(fname), DCHAR(cline) DCLEN(fname) DCLEN(cline))
 {

--- a/runtime/flang/setenvqq3f.c
+++ b/runtime/flang/setenvqq3f.c
@@ -9,12 +9,9 @@
 
 /*	setenvqq3f.c - Implements DFLIB setenvqq subprogram.  */
 
+#include <stdlib.h>
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
-
-extern int putenv();
+#include "utils3f.h"
 
 int ENT3F(SETENVQQ, setenvqq)(DCHAR(str) DCLEN(str))
 {

--- a/runtime/flang/setfileaccessqq3f.c
+++ b/runtime/flang/setfileaccessqq3f.c
@@ -16,6 +16,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 
 #define FILE$FIRST -1
 #define FILE$LAST -2
@@ -23,8 +24,6 @@
 #define FILE$CURTIME -1
 
 #if defined(WIN64) || defined(WIN32)
-extern char *__fstr2cstr();
-
 int ENT3F(SETFILEACCESSQQ, setfileaccessqq)(DCHAR(ffile),
                                             int *access DCLEN(ffile))
 {

--- a/runtime/flang/setfiletimeqq3f.c
+++ b/runtime/flang/setfiletimeqq3f.c
@@ -16,6 +16,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 
 #define FILE$FIRST -1
 #define FILE$LAST -2
@@ -23,7 +24,6 @@
 #define FILE$CURTIME -1
 
 #if defined(WIN64) || defined(WIN32)
-extern char *__fstr2cstr();
 extern void __UnpackTime(unsigned int secsSince1970, ULARGE_INTEGER *fileTime);
 extern int __GETFILEINFOQQ(DCHAR(ffiles), char *buffer,
                            int *handle DCLEN(ffiles));

--- a/runtime/flang/setvbuf3f.c
+++ b/runtime/flang/setvbuf3f.c
@@ -20,8 +20,7 @@
 
 #include <stdio.h>
 #include "ent3f.h"
-
-extern FILE *__getfile3f();
+#include "utils3f.h"
 
 int ENT3F(SETVBUF3F, setvbuf3f)(int *lu, int *type, int *size)
 {

--- a/runtime/flang/splitpathqq3f.c
+++ b/runtime/flang/splitpathqq3f.c
@@ -14,10 +14,10 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
+#include "utils3f.h"
 
 #if defined(WIN64) || defined(WIN32)
 
-extern char *__fstr2cstr();
 int ENT3F(SPLITPATHQQ, splitpathqq)(DCHAR(fpath), DCHAR(fdrive), DCHAR(fdir),
                                     DCHAR(fname),
                                     DCHAR(fext) DCLEN(fpath) DCLEN(fdrive)

--- a/runtime/flang/stat.c
+++ b/runtime/flang/stat.c
@@ -17,7 +17,8 @@
 #define write _write
 #endif
 
-extern void __fort_gettb();
+/* defined in stat_linux.c */
+void __fort_gettb(struct tb *);
 
 static struct tb tb0 = {/* stats at beginning of program */
                         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,

--- a/runtime/flang/stat3f.c
+++ b/runtime/flang/stat3f.c
@@ -13,9 +13,7 @@
 #include <sys/stat.h>
 #include "io3f.h"
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(STAT, stat)(DCHAR(nm), int *statb DCLEN(nm))
 {

--- a/runtime/flang/stat643f.c
+++ b/runtime/flang/stat643f.c
@@ -13,9 +13,7 @@
 #include <sys/stat.h>
 #include "io3f.h"
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(STAT64, stat64)(DCHAR(nm), long long *statb DCLEN(nm))
 {

--- a/runtime/flang/stat_linux.c
+++ b/runtime/flang/stat_linux.c
@@ -24,7 +24,8 @@ union ieee {
   int i[2];
 };
 
-extern void *__fort_sbrk(int);
+/* defined in xfer_heap_dum.c */
+void *__fort_sbrk(int);
 
 /* these little routines had to go somewhere, so here they are. */
 

--- a/runtime/flang/symlnk3f.c
+++ b/runtime/flang/symlnk3f.c
@@ -13,9 +13,7 @@
 
 #include "io3f.h"
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(SYMLNK, symlnk)(DCHAR(n1), DCHAR(n2) DCLEN(n1) DCLEN(n2))
 {

--- a/runtime/flang/system3f.c
+++ b/runtime/flang/system3f.c
@@ -11,9 +11,7 @@
 
 #include <stdlib.h>
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(SYSTEM, system)(DCHAR(str) DCLEN(str))
 {

--- a/runtime/flang/systemqq3f.c
+++ b/runtime/flang/systemqq3f.c
@@ -11,9 +11,7 @@
 
 #include <stdlib.h>
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(SYSTEMQQ, systemqq)(DCHAR(str) DCLEN(str))
 {

--- a/runtime/flang/ttynam3f.c
+++ b/runtime/flang/ttynam3f.c
@@ -11,12 +11,11 @@
 
 #ifndef WINNT
 
+#include <unistd.h>
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
 #include "utils3f.h"
-
-extern char *ttyname();
 
 /* ttynam is a character function */
 void ENT3F(TTYNAM, ttynam)(DCHAR(nm) DCLEN(nm), int *lu)

--- a/runtime/flang/unlink3f.c
+++ b/runtime/flang/unlink3f.c
@@ -12,9 +12,7 @@
 /* must include ent3f.h AFTER io3f.h */
 #include "io3f.h"
 #include "ent3f.h"
-
-extern char *__fstr2cstr();
-extern void __cstr_free();
+#include "utils3f.h"
 
 int ENT3F(UNLINK, unlink)(DCHAR(fil) DCLEN(fil))
 {

--- a/runtime/flang/unpacktimeqq3f.c
+++ b/runtime/flang/unpacktimeqq3f.c
@@ -19,7 +19,6 @@
 #include "ent3f.h"
 
 #if defined(WIN64) || defined(WIN32)
-extern char *__fstr2cstr();
 extern void __UnpackTime(unsigned int secsSince1970, ULARGE_INTEGER *fileTime);
 
 void ENT3F(UNPACKTIMEQQ, unpacktimeqq)(unsigned int *timedate, int *year,

--- a/runtime/flang/utils3f.h
+++ b/runtime/flang/utils3f.h
@@ -5,6 +5,19 @@
  *
  */
 
+#ifndef FLANG_RUNTIME_UTILS3F_H
+#define FLANG_RUNTIME_UTILS3F_H
 
+#include <stdio.h>
+#include "global.h"
+
+/* String conversion/copy between Fortran and C */
+char *__fstr2cstr(char *from, int from_len);
+void __cstr_free(char *from);
 void __fcp_cstr(char *to, int to_len, const char *from);
 
+/* IO-related routines needed to support 3f routines */
+bool __isatty3f(int unit);
+FILE *__getfile3f(int unit);
+
+#endif /* FLANG_RUNTIME_UTILS3F_H */

--- a/runtime/flang/xfer.h
+++ b/runtime/flang/xfer.h
@@ -1,0 +1,14 @@
+/*
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#ifndef RUNTIME_FLANG_XFER_H
+#define RUNTIME_FLANG_XFER_H
+
+/* allocate channel structure */
+struct chdr *__fort_allchn(struct chdr *cp, int dents, int sents, int cpus);
+
+#endif /* RUNTIME_FLANG_XFER_H */

--- a/runtime/flang/xfer_rpm1.c
+++ b/runtime/flang/xfer_rpm1.c
@@ -8,8 +8,6 @@
 #include "stdioInterf.h"
 #include "fioMacros.h"
 
-extern void *__fort_malloc();
-
 int __fort_minxfer = 0;
 
 /* receive data items */


### PR DESCRIPTION
`extern` function declarations have been replaced by headers (standard headers if possible), except for single unique uses. This not only reduces code duplication, but also fixes `-Wdeprecated-non-prototype` warnings, e.g.
```
.../flang/runtime/flang/curdir.c:25:14: error: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a previous declaration [-Werror,-Wdeprecated-non-prototype]
extern char *getcwd();
             ^
/usr/include/unistd.h:514:14: note: conflicting prototype is here extern char *getcwd (char *__buf, size_t __size) __THROW __wur;
             ^
```
Some other dead code is also removed.