### PR TITLE
[LLVM 15][runtime] Add C prototypes for external Fortran matmul functions

### DIFF
--- a/runtime/flang/mmcmplx16.c
+++ b/runtime/flang/mmcmplx16.c
@@ -16,6 +16,36 @@
 #define SMALL_ROWSB 10
 #define SMALL_COLSB 10
 
+/* C prototypes for external Fortran functions */
+void ftn_mvmul_cmplx16_(int *, int *, __POINT_T *, __POINT_T *,
+                        DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *,
+                        __POINT_T *, DOUBLE_COMPLEX_TYPE *,
+                        DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *);
+void ftn_vmmul_cmplx16_(int *, int *, __POINT_T *, __POINT_T *,
+                        DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *,
+                        DOUBLE_COMPLEX_TYPE *, __POINT_T *,
+                        DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *);
+void ftn_mnaxnb_cmplx16_(__POINT_T *, __POINT_T *, __POINT_T *,
+                         DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *,
+                         __POINT_T *, DOUBLE_COMPLEX_TYPE *, __POINT_T *,
+                         DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *,
+                         __POINT_T *);
+void ftn_mnaxtb_cmplx16_(__POINT_T *, __POINT_T *, __POINT_T *,
+                         DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *,
+                         __POINT_T *, DOUBLE_COMPLEX_TYPE *, __POINT_T *,
+                         DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *,
+                         __POINT_T *);
+void ftn_mtaxnb_cmplx16_(__POINT_T *, __POINT_T *, __POINT_T *,
+                         DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *,
+                         __POINT_T *, DOUBLE_COMPLEX_TYPE *, __POINT_T *,
+                         DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *,
+                         __POINT_T *);
+void ftn_mtaxtb_cmplx16_(__POINT_T *, __POINT_T *, __POINT_T *,
+                         DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *,
+                         __POINT_T *, DOUBLE_COMPLEX_TYPE *, __POINT_T *,
+                         DOUBLE_COMPLEX_TYPE *, DOUBLE_COMPLEX_TYPE *,
+                         __POINT_T *);
+
 void ENTF90(MMUL_CMPLX16,
             mmul_cmplx16)(int ta, int tb, __POINT_T mra, __POINT_T ncb,
                           __POINT_T kab, DOUBLE_COMPLEX_TYPE *alpha,
@@ -55,9 +85,6 @@ void ENTF90(MMUL_CMPLX16,
   DOUBLE_COMPLEX_TYPE buffera[SMALL_ROWSA * SMALL_ROWSB];
   DOUBLE_COMPLEX_TYPE bufferb[SMALL_COLSB * SMALL_ROWSB];
   DOUBLE_COMPLEX_TYPE temp;
-  void ftn_mvmul_cmplx16_(), ftn_vmmul_cmplx16_();
-  void ftn_mnaxnb_cmplx16_(), ftn_mnaxtb_cmplx16_();
-  void ftn_mtaxnb_cmplx16_(), ftn_mtaxtb_cmplx16_();
   DOUBLE_COMPLEX_TYPE calpha, cbeta;
   /*
    * Small matrix multiply variables

--- a/runtime/flang/mmcmplx8.c
+++ b/runtime/flang/mmcmplx8.c
@@ -16,6 +16,36 @@
 #define SMALL_ROWSB 10
 #define SMALL_COLSB 10
 
+/* C prototypes for external Fortran functions */
+void ftn_mvmul_cmplx8_(int *, int *, __POINT_T *, __POINT_T *,
+                       FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *,
+                       __POINT_T *, FLOAT_COMPLEX_TYPE *,
+                       FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *);
+void ftn_vmmul_cmplx8_(int *, int *, __POINT_T *, __POINT_T *,
+                       FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *,
+                       FLOAT_COMPLEX_TYPE *, __POINT_T *,
+                       FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *);
+void ftn_mnaxnb_cmplx8_(__POINT_T *, __POINT_T *, __POINT_T *,
+                        FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *,
+                        __POINT_T *, FLOAT_COMPLEX_TYPE *, __POINT_T *,
+                        FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *,
+                        __POINT_T *);
+void ftn_mnaxtb_cmplx8_(__POINT_T *, __POINT_T *, __POINT_T *,
+                        FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *,
+                        __POINT_T *, FLOAT_COMPLEX_TYPE *, __POINT_T *,
+                        FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *,
+                        __POINT_T *);
+void ftn_mtaxnb_cmplx8_(__POINT_T *, __POINT_T *, __POINT_T *,
+                        FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *,
+                        __POINT_T *, FLOAT_COMPLEX_TYPE *, __POINT_T *,
+                        FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *,
+                        __POINT_T *);
+void ftn_mtaxtb_cmplx8_(__POINT_T *, __POINT_T *, __POINT_T *,
+                        FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *,
+                        __POINT_T *, FLOAT_COMPLEX_TYPE *, __POINT_T *,
+                        FLOAT_COMPLEX_TYPE *, FLOAT_COMPLEX_TYPE *,
+                        __POINT_T *);
+
 void ENTF90(MMUL_CMPLX8,
             mmul_cmplx8)(int ta, int tb, __POINT_T mra, __POINT_T ncb,
                          __POINT_T kab, FLOAT_COMPLEX_TYPE *alpha, FLOAT_COMPLEX_TYPE a[],
@@ -54,9 +84,6 @@ void ENTF90(MMUL_CMPLX8,
   FLOAT_COMPLEX_TYPE buffera[SMALL_ROWSA * SMALL_ROWSB];
   FLOAT_COMPLEX_TYPE bufferb[SMALL_COLSB * SMALL_ROWSB];
   FLOAT_COMPLEX_TYPE temp;
-  void ftn_mvmul_cmplx8_(), ftn_vmmul_cmplx8_();
-  void ftn_mnaxnb_cmplx8_(), ftn_mnaxtb_cmplx8_();
-  void ftn_mtaxnb_cmplx8_(), ftn_mtaxtb_cmplx8_();
   FLOAT_COMPLEX_TYPE calpha, cbeta;
   /*
    * Small matrix multiply variables

--- a/runtime/flang/mmreal4.c
+++ b/runtime/flang/mmreal4.c
@@ -16,6 +16,24 @@
 #define SMALL_ROWSB 10
 #define SMALL_COLSB 10
 
+/* C prototypes for external Fortran functions */
+void ftn_mvmul_real4_(int *, __POINT_T *, __POINT_T *, float *, float *,
+                      __POINT_T *, float *, float *, float *);
+void ftn_vmmul_real4_(int *, __POINT_T *, __POINT_T *, float *, float *,
+                      float *, __POINT_T *, float *, float *);
+void ftn_mnaxnb_real4_(__POINT_T *, __POINT_T *, __POINT_T *, float *, float *,
+                       __POINT_T *, float *, __POINT_T *, float *, float *,
+                       __POINT_T *);
+void ftn_mnaxtb_real4_(__POINT_T *, __POINT_T *, __POINT_T *, float *, float *,
+                       __POINT_T *, float *, __POINT_T *, float *, float *,
+                       __POINT_T *);
+void ftn_mtaxnb_real4_(__POINT_T *, __POINT_T *, __POINT_T *, float *, float *,
+                       __POINT_T *, float *, __POINT_T *, float *, float *,
+                       __POINT_T *);
+void ftn_mtaxtb_real4_(__POINT_T *, __POINT_T *, __POINT_T *, float *, float *,
+                       __POINT_T *, float *, __POINT_T *, float *, float *,
+                       __POINT_T *);
+
 void ENTF90(MMUL_REAL4, mmul_real4)(int ta, int tb, __POINT_T mra,
                                     __POINT_T ncb, __POINT_T kab, float *alpha,
                                     float a[], __POINT_T lda, float b[],
@@ -55,9 +73,6 @@ void ENTF90(MMUL_REAL4, mmul_real4)(int ta, int tb, __POINT_T mra,
   float buffera[SMALL_ROWSA * SMALL_ROWSB];
   float bufferb[SMALL_COLSB * SMALL_ROWSB];
   float temp;
-  void ftn_mvmul_real4_(), ftn_vmmul_real4_();
-  void ftn_mnaxnb_real4_(), ftn_mnaxtb_real4_();
-  void ftn_mtaxnb_real4_(), ftn_mtaxtb_real4_();
   float calpha, cbeta;
   /*
    * Small matrix multiply variables

--- a/runtime/flang/mmreal8.c
+++ b/runtime/flang/mmreal8.c
@@ -16,6 +16,24 @@
 #define SMALL_ROWSB 10
 #define SMALL_COLSB 10
 
+/* C prototypes for external Fortran functions */
+void ftn_mvmul_real8_(int *, __POINT_T *, __POINT_T *, double *, double *,
+                      __POINT_T *, double *, double *, double *);
+void ftn_vmmul_real8_(int *, __POINT_T *, __POINT_T *, double *, double *,
+                      double *, __POINT_T *, double *, double *);
+void ftn_mnaxnb_real8_(__POINT_T *, __POINT_T *, __POINT_T *, double *,
+                       double *, __POINT_T *, double *, __POINT_T *,
+                       double *, double *, __POINT_T *);
+void ftn_mnaxtb_real8_(__POINT_T *, __POINT_T *, __POINT_T *, double *,
+                       double *, __POINT_T *, double *, __POINT_T *,
+                       double *, double *, __POINT_T *);
+void ftn_mtaxnb_real8_(__POINT_T *, __POINT_T *, __POINT_T *, double *,
+                       double *, __POINT_T *, double *, __POINT_T *,
+                       double *, double *, __POINT_T *);
+void ftn_mtaxtb_real8_(__POINT_T *, __POINT_T *, __POINT_T *, double *,
+                       double *, __POINT_T *, double *, __POINT_T *,
+                       double *, double *, __POINT_T *);
+
 void ENTF90(MMUL_REAL8, mmul_real8)(int ta, int tb, __POINT_T mra,
                                     __POINT_T ncb, __POINT_T kab, double *alpha,
                                     double a[], __POINT_T lda, double b[],
@@ -55,9 +73,6 @@ void ENTF90(MMUL_REAL8, mmul_real8)(int ta, int tb, __POINT_T mra,
   double buffera[SMALL_ROWSA * SMALL_ROWSB];
   double bufferb[SMALL_COLSB * SMALL_ROWSB];
   double temp;
-  void ftn_mvmul_real8_(), ftn_vmmul_real8_();
-  void ftn_mnaxnb_real8_(), ftn_mnaxtb_real8_();
-  void ftn_mtaxnb_real8_(), ftn_mtaxtb_real8_();
   double calpha, cbeta;
   /*
    * Small matrix multiply variables


### PR DESCRIPTION
This fixes errors such as:
```
.../flang/runtime/flang/mmreal8.c:99:21: error: passing arguments to 'ftn_mvmul_real8_' without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
    ftn_mvmul_real8_(&ta, &mra, &kab, alpha, a, &lda, b, beta, c);
                    ^
```