### PR TITLE
[LLVM 15][libpgmath] Decouple from libflangrti by using errno directly; NFCI

### DIFF
--- a/runtime/libpgmath/lib/common/fpcvt.c
+++ b/runtime/libpgmath/lib/common/fpcvt.c
@@ -418,18 +418,18 @@ IEEE64 *r;
     u->fexp = 1024;
     u->fman[0] = ~0L;
     u->fman[1] = ~0L;
-    __io_set_errno(ERANGE);
+    errno = ERANGE;
   }
   if (u->fval == INFIN || u->fval == BIG || u->fval == DIVZ) {
     u->fexp = 1024;
     u->fman[0] = 0L;
     u->fman[1] = 0L;
-    __io_set_errno(ERANGE);
+    errno = ERANGE;
   }
   if (u->fval == NORMAL && u->fexp <= -1023) {
     if (ufpdnorm(u, 1022) < 0) {
       u->fval = NIL;
-      __io_set_errno(ERANGE);
+      errno = ERANGE;
     } else
       u->fval = SUBNORMAL;
   } else if (u->fval == SUBNORMAL)
@@ -692,9 +692,9 @@ double atof(s) char *s;
   int save_errno;
   double d;
 
-  save_errno = __io_errno();
+  save_errno = errno;
   d = strtod(s, (char **)0);
-  __io_set_errno(save_errno);
+  errno = save_errno;
   return d;
 }
 


### PR DESCRIPTION
libpgmath should be able to use `errno` directly, without having to go through `libflangrti`. Decoupling the libraries not only allows libpgmath to be used independently, but also fixes compiler warnings about undeclared functions.