### PR TITLE
[test] Slight aesthetic improvement for previous commit; NFC

### DIFF
--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -19,10 +19,7 @@ config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
 config.flang_obj_root = "@FLANG_BINARY_DIR@"
 config.flang_tools_dir = "@FLANG_TOOLS_DIR@"
 config.host_triple = "@LLVM_HOST_TRIPLE@"
-if "@LLVM_TARGET_TRIPLE@":
-    config.target_triple = "@LLVM_TARGET_TRIPLE@"
-else:
-    config.target_triple = "@TARGET_TRIPLE@"
+config.target_triple = "@LLVM_TARGET_TRIPLE@" or "@TARGET_TRIPLE@"
 config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
 config.have_zlib = "@HAVE_LIBZ@"
 config.enable_shared = @ENABLE_SHARED@


### PR DESCRIPTION
The previous change to `lit.site.cfg.in` would generate an explicit `if` statement in the output file, e.g.
```python
if "x86_64-unknown-linux-gnu":
    config.target_triple = "x86_64-unknown-linux-gnu"
else:
    config.target_triple = ""
```
...which looks a bit ridiculous.