### PR TITLE
[LLVM 15][runtime] Avoid -Wdeprecated-non-prototype warnings; NFC

### DIFF
--- a/runtime/flangrti/memalign.c
+++ b/runtime/flangrti/memalign.c
@@ -9,10 +9,8 @@
 #include <stdlib.h>
 
 #if (defined(WIN32) || defined(WIN64))
-extern void *_aligned_malloc();
-extern void _aligned_free();
-#else
-extern int posix_memalign();
+extern void *_aligned_malloc(size_t, size_t);
+extern void _aligned_free(void *);
 #endif
 
 void *

--- a/tools/flang1/flang1exe/accpp.c
+++ b/tools/flang1/flang1exe/accpp.c
@@ -19,10 +19,6 @@
   fprintf(stderr, "%d: toktyp=%c(%d);  tokval=%s; line=%d\n", __LINE__, \
           toktyp, toktyp, tokval, cur_line);
 
-/*  external functions referenced by this module:  */
-
-extern void list_line();
-
 /* structures and data local to this module : */
 
 /* char classification macros */

--- a/tools/flang1/flang1exe/fpp.c
+++ b/tools/flang1/flang1exe/fpp.c
@@ -15,10 +15,6 @@
 #include "machar.h"
 #include "version.h"
 
-/*  external functions referenced by this module:  */
-
-extern void list_line();
-
 /* structures and data local to this module : */
 
 /* char classification macros */

--- a/tools/flang1/flang1exe/induc.c
+++ b/tools/flang1/flang1exe/induc.c
@@ -434,7 +434,6 @@ find_bivs(void)
      */
     PSI_P pred;
     Q_ITEM *p;
-    extern LOGICAL bv_mem();
     int rdef;
 
     for (ind = 1; ind < induc.indb.stg_avail; ind++) {
@@ -514,7 +513,6 @@ def_in_out(int fgx, int def)
   int ret;
   int tempfgx;
   PSI_P pred;
-  extern LOGICAL bv_mem();
 
   if (FG_OUT(fgx) != NULL) {
     return bv_mem(FG_OUT(fgx), def);

--- a/tools/flang1/flang1exe/parser.c
+++ b/tools/flang1/flang1exe/parser.c
@@ -174,7 +174,7 @@ parser(void)
 static void
 _parser(void)
 {
-  int tkntyp, newtop, rednum, get_token(), endflg;
+  int tkntyp, newtop, rednum, endflg;
   int t;
   int start, end, nstate;
   int jstart, jend, ptr, i;

--- a/tools/flang1/utils/ast/ast.in.h
+++ b/tools/flang1/utils/ast/ast.in.h
@@ -326,10 +326,10 @@ extern ASTB  astb;
 extern int   intast_sym[];
 
 /** \brief Type of function passed to ast_traverse() and ast_traverse_all() */
-typedef LOGICAL (*ast_preorder_fn) ();
+typedef LOGICAL (*ast_preorder_fn) (int, int *);
 
 /** \brief Type of function passed to ast_visit(), ast_traverse() and ast_traverse_all() */
-typedef void (*ast_visit_fn) ();
+typedef void (*ast_visit_fn) (int, int *);
 
 /*   declare external functions from ast.c:  */
 


### PR DESCRIPTION
Delete extern function declarations that already have conflicting prototypes declared earlier/elsewhere. This avoids errors such as:
```
.../flang/tools/flang1/flang1exe/induc.c:517:18: error: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a previous declaration [-Werror,-Wdeprecated-non-prototype]
  extern LOGICAL bv_mem();
                 ^
.../flang/tools/flang1/flang1exe/optimize.h:749:9: note: conflicting prototype is here
LOGICAL bv_mem(int *, int);
```
In some cases, the function declaration is modified to complete the prototype.