### PR TITLE
[LLVM 15][flang1] Clean up duplicate declarations of MAXDIMS; fix is_ordered prototype

### DIFF
--- a/tools/flang1/flang1exe/comm.c
+++ b/tools/flang1/flang1exe/comm.c
@@ -1759,7 +1759,7 @@ emit_copy_section(int a, int std)
   int nd;
   int sptr;
   int allocast;
-  int order2[7];
+  int order2[MAXDIMS];
   int no;
   int header;
   int lhssec;
@@ -1912,7 +1912,7 @@ emit_permute_section(int a, int std)
   int list;
   int lhs;
   LOGICAL use_lhs;
-  int order2[7];
+  int order2[MAXDIMS];
   int no;
   int func;
   int new_a;

--- a/tools/flang1/flang1exe/commopt.c
+++ b/tools/flang1/flang1exe/commopt.c
@@ -530,7 +530,7 @@ same_forall_bnds(int lp1, int lp2, int nested)
   int i, k;
   int asd1, asd2;
   int ndim1, ndim2;
-  int order2[7];
+  int order2[MAXDIMS];
   int no;
   int lhs1, lhs2, newlhs2, l, l2;
   int sptr1, sptr2;

--- a/tools/flang1/flang1exe/extern.h
+++ b/tools/flang1/flang1exe/extern.h
@@ -78,7 +78,7 @@ void rt_outvalue(void);
 int mk_ftb(void);
 void init_ftb(void);
 void init_bnd(void);
-LOGICAL is_ordered(int, int, int, int[7], int *);
+LOGICAL is_ordered(int, int, int, int[MAXDIMS], int *);
 LOGICAL is_duplicate(int, int);
 int delete_astli(int list, int);
 void forall_lhs_indirection(int);

--- a/tools/flang1/flang1exe/gbldefs.h
+++ b/tools/flang1/flang1exe/gbldefs.h
@@ -66,6 +66,7 @@
 
 /* maximum number of array subscripts */
 #define MAXSUBS 7
+#define MAXDIMS 7
 
 typedef int8_t INT8;
 typedef int16_t INT16;

--- a/tools/flang1/flang1exe/semant.c
+++ b/tools/flang1/flang1exe/semant.c
@@ -132,7 +132,6 @@ static struct {
 #define _LEN_ZERO 3
 #define _LEN_ADJ 4
 #define _LEN_DEFER 5
-#define MAXDIMS 7
 
 /** \brief Subprogram prefix struct defintions for RECURESIVE, PURE,
            IMPURE, ELEMENTAL, and MODULE. 

--- a/tools/flang1/flang1exe/semant.h
+++ b/tools/flang1/flang1exe/semant.h
@@ -886,7 +886,6 @@ void mod_end_subprogram_two(void);
 /* semantio.c */
 int get_nml_array(int);
 
-#define MAXDIMS 7
 typedef struct {
   struct _sem_bounds {
     int lowtype;

--- a/tools/flang1/flang1exe/vsub.c
+++ b/tools/flang1/flang1exe/vsub.c
@@ -709,7 +709,7 @@ is_vector_subscript(int a, int list)
 /* order2: used for pghpf_permute_section */
 /* no: number of elements returned in order2 */
 LOGICAL
-is_ordered(int lhs, int rhs, int list, int order2[], int *no)
+is_ordered(int lhs, int rhs, int list, int order2[MAXDIMS], int *no)
 {
   int asd, ndim;
   int i, j, r, l;


### PR DESCRIPTION
tools/flang1/flang1exe/vsub.c and tools/flang1/flang1exe/extern.h have different prototypes for the function `vsub`. This patch makes them consistent to avoid the following compiler warning:
```
error: argument 'order2' of type 'int[]' with mismatched bound [-Werror,-Warray-parameter]
```