### PR TITLE
[flang1] Skip deep deallocation for allocatable temporary variable

### DIFF
--- a/test/f90_correct/inc/allocatable_function_10.mk
+++ b/test/f90_correct/inc/allocatable_function_10.mk
@@ -1,0 +1,21 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f08
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f08 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/remove_deep_deallocatable.mk
+++ b/test/f90_correct/inc/remove_deep_deallocatable.mk
@@ -1,0 +1,21 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f08
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f08 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/allocatable_function_10.sh
+++ b/test/f90_correct/lit/allocatable_function_10.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/remove_deep_deallocatable.sh
+++ b/test/f90_correct/lit/remove_deep_deallocatable.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/allocatable_function_10.f08
+++ b/test/f90_correct/src/allocatable_function_10.f08
@@ -1,0 +1,44 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for allocatable arraies inside functions.
+
+module m
+  implicit none
+
+  type t
+     integer, allocatable, dimension(:) :: r
+  end type t
+
+contains
+
+  function tt(a,b)
+    implicit none
+    type(t), allocatable, dimension(:) :: tt
+    type(t), intent(in), dimension(:) :: a,b
+    allocate(tt, source = [a,b])
+  end function tt
+
+  function ts(arg)
+    implicit none
+    type(t), allocatable, dimension(:) :: ts
+    integer, intent(in) :: arg(:)
+    allocate(ts(1))
+    allocate(ts(1)%r, source = arg)
+    return
+  end function ts
+
+end module m
+
+program test
+  use m
+  implicit none
+  type(t), dimension(2) :: c, d
+  c=tt(ts([99,199,1999]),ts([42,142]))
+  d=tt(ts([1,2,3]),ts([4,5]))
+  call check(c(1)%r, [99,199,1999], 3)
+  call check(d(1)%r, [1,2,3], 3)
+  call check(c(2)%r, [42,142], 2)
+  call check(d(2)%r, [4,5], 2)
+end program test

--- a/test/f90_correct/src/remove_deep_deallocatable.f08
+++ b/test/f90_correct/src/remove_deep_deallocatable.f08
@@ -1,0 +1,26 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! test for removing deep dealloction of temp variables.
+program test
+  implicit none
+
+  type t
+      integer, allocatable, dimension(:) :: r
+  end type t
+
+  type(t), allocatable, dimension(:) :: arg1, arg2
+  type(t), dimension(2) :: d
+
+  allocate(arg1(1))
+  allocate(arg1(1)%r, source=[99,199,1999])
+  allocate(arg2(1))
+  allocate(arg2(1)%r, source=[42,142])
+  d = [arg1, arg2]
+  deallocate(arg1)
+  deallocate(arg2)
+
+  call check(d(1)%r, [99,199,1999], 3)
+  call check(d(2)%r, [42,142], 2)
+end program test


### PR DESCRIPTION
Flang skips deep allocation for a compiler-generated temporary variable,
but does not check this condition for its deallocation counterpart.
This fix adds a condition check to address this problem.