### PR TITLE
[LLVM 15] Make check-all invoke check-flang again

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build and install flang & libpgmath
         run: |
           ${{ env.install_prefix }}/bin/clang --version
-          ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n $(nproc) -c -s
+          ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n $(nproc) -c -s -v
 
       - name: Copy llvm-lit
         run: |

--- a/.github/workflows/build_flang_arm64.yml
+++ b/.github/workflows/build_flang_arm64.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build and install flang & libpgmath
         run: |
           cd ${{ env.build_path }}/flang
-          ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n `nproc --ignore=1`
+          ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n `nproc --ignore=1` -v
 
       # Copy llvm-lit
       - name: Copy llvm-lit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,7 +408,11 @@ if (FLANG_OPENMP_GPU_NVIDIA)
   add_definitions("-DOMP_OFFLOAD_LLVM")
 endif()
 
-if( FLANG_INCLUDE_TESTS )
+if(FLANG_INCLUDE_TESTS)
+  if(COMMAND umbrella_lit_testsuite_begin)
+    umbrella_lit_testsuite_begin(check-all)
+  endif()
+
 #  if(EXISTS ${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include/gtest/gtest.h)
 #    add_subdirectory(unittests)
 #    list(APPEND FLANG_TEST_DEPS FlangUnitTests)
@@ -419,19 +423,23 @@ if( FLANG_INCLUDE_TESTS )
   add_subdirectory(test)
 
   if(FLANG_BUILT_STANDALONE)
-    # Add a global check rule now that all subdirectories have been traversed
-    # and we know the total set of lit testsuites.
-    get_property(LLVM_LIT_TESTSUITES GLOBAL PROPERTY LLVM_LIT_TESTSUITES)
-    get_property(LLVM_LIT_PARAMS GLOBAL PROPERTY LLVM_LIT_PARAMS)
-    get_property(LLVM_LIT_DEPENDS GLOBAL PROPERTY LLVM_LIT_DEPENDS)
-    get_property(LLVM_LIT_EXTRA_ARGS GLOBAL PROPERTY LLVM_LIT_EXTRA_ARGS)
-    add_lit_target(check-all
-      "Running all regression tests"
-      ${LLVM_LIT_TESTSUITES}
-      PARAMS ${LLVM_LIT_PARAMS}
-      DEPENDS ${LLVM_LIT_DEPENDS}
-      ARGS ${LLVM_LIT_EXTRA_ARGS}
+    if(COMMAND umbrella_lit_testsuite_end)
+      umbrella_lit_testsuite_end(check-all)
+    else()
+      # Add a global check rule now that all subdirectories have been traversed
+      # and we know the total set of lit testsuites.
+      get_property(LLVM_LIT_TESTSUITES GLOBAL PROPERTY LLVM_LIT_TESTSUITES)
+      get_property(LLVM_LIT_PARAMS GLOBAL PROPERTY LLVM_LIT_PARAMS)
+      get_property(LLVM_LIT_DEPENDS GLOBAL PROPERTY LLVM_LIT_DEPENDS)
+      get_property(LLVM_LIT_EXTRA_ARGS GLOBAL PROPERTY LLVM_LIT_EXTRA_ARGS)
+      add_lit_target(check-all
+        "Running all regression tests"
+        ${LLVM_LIT_TESTSUITES}
+        PARAMS ${LLVM_LIT_PARAMS}
+        DEPENDS ${LLVM_LIT_DEPENDS}
+        ARGS ${LLVM_LIT_EXTRA_ARGS}
       )
+    endif()
   endif()
 #  add_subdirectory(utils/perf-training)
 endif()


### PR DESCRIPTION
D121838 introduced a new macro for adding lit test suites to an umbrella test suite (e.g. "check-all"). It updated clang/CMakeLists.txt to change how "check-clang" is added to "check-all". This patch applies a similar transformation to Classic Flang's CMakeLists.txt, but retains the original code path so that the code still works for release_14x and older branches. Without this patch, when building Classic Flang with LLVM 15, running "make check-all" would have no effect (it does not invoke "make check-flang").