### PR TITLE
Add test for pgmath veclib assertion failure with sincos.

### DIFF
--- a/test/f90_correct/src/sincos.f90
+++ b/test/f90_correct/src/sincos.f90
@@ -1,0 +1,12 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+program foo
+      real(kind=8) :: val, res1, res2
+      read *, val
+      res1 = sin(val)
+      res2 = cos(val)
+      print *, res1, res2
+end program foo


### PR DESCRIPTION
As requested on https://github.com/flang-compiler/classic-flang-llvm-project/pull/136. This fails locally for me, and was initially reported in https://github.com/flang-compiler/classic-flang-llvm-project/issues/11. It needs at least O1 to fail for me.