### PR TITLE
[workflows] Build and test master branch with release_15x only

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -20,18 +20,7 @@ jobs:
         target: [X86]
         cc: [clang, gcc]
         version: [10, 11]
-        llvm_branch: [release_13x, release_14x]
-        include:
-          - target: X86
-            cc: gcc
-            cpp: g++
-            version: 10
-            llvm_branch: release_12x
-          - target: X86
-            cc: gcc
-            cpp: g++
-            version: 10
-            llvm_branch: release_13x
+        llvm_branch: [release_15x]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it

--- a/.github/workflows/build_flang_arm64.yml
+++ b/.github/workflows/build_flang_arm64.yml
@@ -23,10 +23,7 @@ jobs:
     strategy:
       matrix:
         target: [AArch64]
-        cc: [gcc]
-        cpp: [g++]
-        version: [10]
-        llvm_branch: [release_13x, release_14x]
+        llvm_branch: [release_15x]
 
     steps:
       - name: Check tools
@@ -56,7 +53,6 @@ jobs:
           cd ${{ env.build_path }}/flang
           ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n `nproc --ignore=1` -v
 
-      # Copy llvm-lit
       - name: Copy llvm-lit
         run: |
           cd ${{ env.build_path }}/flang

--- a/.github/workflows/build_flang_arm64.yml
+++ b/.github/workflows/build_flang_arm64.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build_flang:
+    if: github.repository_owner == 'flang-compiler'
     runs-on: self-hosted
     env:
       build_path: /home/github


### PR DESCRIPTION
As discussed at the 2022/11/02 call, going forward the `master` branch will only
support opaque pointer IR, while the `legacy` branch will continue to support
legacy IR with older classic-flang-llvm-project release branches.