### PR TITLE
[workflows] Add build script options to allow customization

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -90,17 +90,17 @@ jobs:
 
       - name: Copy llvm-lit
         run: |
-          cp ../../classic-flang-llvm-project/build/bin/llvm-lit build/bin/.
+          cp ../../classic-flang-llvm-project/build/bin/llvm-lit build/flang/bin/.
 
       - name: Test flang
         run: |
-          cd build
+          cd build/flang
           make check-all
 
       # Archive documentation just once, for the fastest job.
       - if: matrix.cc == 'clang' && matrix.version == '11'
         run: |
-          cd build/docs/web
+          cd build/flang/docs/web
           cp -r html/ ../../.. # copy to a place where Upload can find it.
 
       # Upload docs just once, for the fastest job.

--- a/.github/workflows/build_flang_arm64.yml
+++ b/.github/workflows/build_flang_arm64.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Copy llvm-lit
         run: |
           cd ${{ env.build_path }}/flang
-          cp /home/root/classic-flang-llvm-project/build/bin/llvm-lit build/bin/.
+          cp /home/root/classic-flang-llvm-project/build/bin/llvm-lit build/flang/bin/.
 
       - name: Test flang
         run: |
-          cd ${{ env.build_path }}/flang/build
+          cd ${{ env.build_path }}/flang/build/flang
           make check-all


### PR DESCRIPTION
This patch adds the `-b` option to `build-flang.sh` which lets the user specify an alternate location for the build directories of libpgmath and flang (both will be placed under the same build prefix), and the `-x` option which lets the user specify additional CMake options when configuring flang.