### PR TITLE
[feature][flang2] Initial support for opaque pointers

### DIFF
--- a/test/debug_info/allocatable_arr_param.f90
+++ b/test/debug_info/allocatable_arr_param.f90
@@ -1,9 +1,9 @@
 !RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
 
 !CHECK-LABEL: define void @callee_
-!CHECK: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[DLOC:![0-9]+]]
-!CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[ALLOCATED:![0-9]+]]
-!CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata ptr %"array$p", metadata [[DLOC:![0-9]+]]
+!CHECK-NEXT: call void @llvm.dbg.declare(metadata ptr %"array$p", metadata [[ALLOCATED:![0-9]+]]
+!CHECK-NEXT: call void @llvm.dbg.declare(metadata ptr %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
 !CHECK: [[ARRAY]] = !DILocalVariable(name: "array",
 !CHECK-SAME: arg: 2,
 !CHECK-SAME: type: [[TYPE:![0-9]+]]

--- a/test/debug_info/assumed_rank.f90
+++ b/test/debug_info/assumed_rank.f90
@@ -3,7 +3,7 @@
 !RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=DWARF4
 !RUN: %flang -gdwarf-5 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=DWARF5
 
-!DWARF4: call void @llvm.dbg.value(metadata i64* %ararray, metadata [[DLOC:![0-9]+]], metadata !DIExpression())
+!DWARF4: call void @llvm.dbg.value(metadata ptr %ararray, metadata [[DLOC:![0-9]+]], metadata !DIExpression())
 !DWARF4: !DILocalVariable(name: "ararray"
 !DWARF4-SAME: arg: 2
 !DWARF4-SAME: type: [[ARTYPE:![0-9]+]])
@@ -18,7 +18,7 @@
 !DWARF4: [[ELEM7]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 368, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 408, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 400, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 
 
-!DWARF5: call void @llvm.dbg.value(metadata i64* %ararray, metadata [[DLOC:![0-9]+]], metadata !DIExpression())
+!DWARF5: call void @llvm.dbg.value(metadata ptr %ararray, metadata [[DLOC:![0-9]+]], metadata !DIExpression())
 !DWARF5: !DILocalVariable(name: "ararray"
 !DWARF5-SAME: arg: 2
 !DWARF5-SAME: type: [[ARTYPE:![0-9]+]])

--- a/test/debug_info/assumed_shape.f90
+++ b/test/debug_info/assumed_shape.f90
@@ -1,6 +1,6 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
-!CHECK: call void @llvm.dbg.declare(metadata i64* %assume, metadata [[ASSUME:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata ptr %assume, metadata [[ASSUME:![0-9]+]], metadata !DIExpression())
 !CHECK: [[TYPE:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEMS:![0-9]+]])
 !CHECK: [[ELEMS]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]], [[ELEM3:![0-9]+]], [[ELEM4:![0-9]+]]
 !CHECK: [[ELEM1]] = !DISubrange(lowerBound: 1, upperBound: 5)

--- a/test/debug_info/assumed_shape_non_contiguous.f90
+++ b/test/debug_info/assumed_shape_non_contiguous.f90
@@ -1,7 +1,7 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
-!CHECK: call void @llvm.dbg.value(metadata i64* %array, metadata [[ARRAYDL:![0-9]+]], metadata !DIExpression())
-!CHECK: call void @llvm.dbg.declare(metadata i64* %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.value(metadata ptr %array, metadata [[ARRAYDL:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata ptr %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
 !CHECK-LABEL: distinct !DICompileUnit(language: DW_LANG_Fortran90,
 !CHECK: [[ARRAY]] = !DILocalVariable(name: "array"
 !CHECK-SAME: arg: 3

--- a/test/debug_info/assumed_size_array.f90
+++ b/test/debug_info/assumed_size_array.f90
@@ -1,7 +1,7 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
-!CHECK: call void @llvm.dbg.declare(metadata i64* %array1, metadata [[ARRAY1:![0-9]+]], metadata !DIExpression())
-!CHECK: call void @llvm.dbg.declare(metadata i64* %array2, metadata [[ARRAY2:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata ptr %array1, metadata [[ARRAY1:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata ptr %array2, metadata [[ARRAY2:![0-9]+]], metadata !DIExpression())
 !CHECK: [[TYPE1:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, align: 32, elements: [[ELEMS1:![0-9]+]])
 !CHECK: [[ELEMS1]] = !{[[ELEM11:![0-9]+]]}
 !CHECK: [[ELEM11]] = !DISubrange(lowerBound: 1)

--- a/test/debug_info/byval-name.f90
+++ b/test/debug_info/byval-name.f90
@@ -4,8 +4,8 @@
 ! operation using them are well formed.
 !CHECK: sub_(i32 [[PREFIXED_ARG_NAME:%_V_arg_abc.arg]])
 !CHECK: [[PREFIXED_LOCAL_NAME:%_V_arg_abc.addr]] = alloca i32, align 4
-!CHECK: call void @llvm.dbg.declare(metadata i32* [[PREFIXED_LOCAL_NAME]]
-!CHECK: store i32 [[PREFIXED_ARG_NAME]], i32* [[PREFIXED_LOCAL_NAME]], align 4
+!CHECK: call void @llvm.dbg.declare(metadata ptr [[PREFIXED_LOCAL_NAME]]
+!CHECK: store i32 [[PREFIXED_ARG_NAME]], ptr [[PREFIXED_LOCAL_NAME]], align 4
 
 !Verify the DebugInfo metadata contains prefix _V_ truncated names.
 !CHECK: DILocalVariable(name: "arg_abc"

--- a/test/debug_info/cray_ptr_param.f90
+++ b/test/debug_info/cray_ptr_param.f90
@@ -1,7 +1,7 @@
 !RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
 
 !CHECK-LABEL: define internal void @main_callee
-!CHECK: call void @llvm.dbg.declare(metadata i64* %callee_ptr, metadata [[CALLEE_PTR:![0-9]+]]
+!CHECK: call void @llvm.dbg.declare(metadata ptr %callee_ptr, metadata [[CALLEE_PTR:![0-9]+]]
 !CHECK: [[CALLEE_PTR]] = !DILocalVariable(name: "callee_ptr"
 !CHECK-SAME: arg: 1
 

--- a/test/debug_info/pointer_arr_param.f90
+++ b/test/debug_info/pointer_arr_param.f90
@@ -1,9 +1,9 @@
 !RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
 
 !CHECK-LABEL: define void @callee_
-!CHECK: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[DLOC:![0-9]+]]
-!CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$p", metadata [[ASSOCIATED:![0-9]+]]
-!CHECK-NEXT: call void @llvm.dbg.declare(metadata i64* %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata ptr %"array$p", metadata [[DLOC:![0-9]+]]
+!CHECK-NEXT: call void @llvm.dbg.declare(metadata ptr %"array$p", metadata [[ASSOCIATED:![0-9]+]]
+!CHECK-NEXT: call void @llvm.dbg.declare(metadata ptr %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
 !CHECK: [[ARRAY]] = !DILocalVariable(name: "array"
 !CHECK-SAME: arg: 2
 !CHECK-SAME: type: [[TYPE:![0-9]+]]

--- a/test/debug_info/pointer_array_openmp.f90
+++ b/test/debug_info/pointer_array_openmp.f90
@@ -2,9 +2,9 @@
 
 !CHECK: define internal void @main_sub
 !CHECK: define internal void @__nv_main_sub_
-!CHECK:  call void @llvm.dbg.declare(metadata double** %"res$p
-!CHECK-NEXT:  call void @llvm.dbg.declare(metadata double** %"res$p
-!CHECK-NEXT:  call void @llvm.dbg.declare(metadata [16 x i64]* %"res$sd
+!CHECK:  call void @llvm.dbg.declare(metadata ptr %"res$p
+!CHECK-NEXT:  call void @llvm.dbg.declare(metadata ptr %"res$p
+!CHECK-NEXT:  call void @llvm.dbg.declare(metadata ptr %"res$sd
 
 program main
   type :: dtype

--- a/test/debug_info/prolog.f90
+++ b/test/debug_info/prolog.f90
@@ -4,8 +4,8 @@
 !CHECK: define void @show_
 !CHECK: call void @llvm.dbg.declare
 !CHECK-SAME: , !dbg {{![0-9]+}}
-!CHECK-NOT: bitcast i64* %"array$sd" to i8*, !dbg
-!CHECK: store i64 {{%[0-9]+}}, i64* %z_b_3_{{[0-9]+}}, align 8
+!CHECK-NOT: bitcast ptr %"array$sd" to ptr, !dbg
+!CHECK: store i64 {{%[0-9]+}}, ptr %z_b_3_{{[0-9]+}}, align 8
 !CHECK: br label
 !CHECK: ret void, !dbg {{![0-9]+}}
 subroutine show (message, array)
@@ -18,7 +18,7 @@ subroutine show (message, array)
 end subroutine show
 
 !CHECK: define void @MAIN_
-!CHECK-NOT: bitcast void (...)* @fort_init to void (i8*, ...)*, !dbg {{![0-9]+}}
+!CHECK-NOT: bitcast ptr @fort_init to ptr, !dbg {{![0-9]+}}
 !CHECK: call void @llvm.dbg.declare
 !CHECK-SAME: , !dbg {{![0-9]+}}
 !CHECK: ret void, !dbg

--- a/test/debug_info/redundant_inst.f90
+++ b/test/debug_info/redundant_inst.f90
@@ -3,9 +3,9 @@
 !RUN: llvm-dwarfdump --debug-line %t | FileCheck %s --check-prefix=LINETABLE
 
 !Check that `store` instruction is getting emitted for the second assignment.
-!STORE: store i32 4, i32* %[[VAR_A:.*]], align 4
-!STORE: %[[TEMP:.*]] = load i32, i32* %[[VAR_A]], align 4, !dbg ![[LOCATION:.*]]
-!STORE: store i32 %[[TEMP]], i32* %[[VAR_A]], align 4, !dbg ![[LOCATION]]
+!STORE: store i32 4, ptr %[[VAR_A:.*]], align 4
+!STORE: %[[TEMP:.*]] = load i32, ptr %[[VAR_A]], align 4, !dbg ![[LOCATION:.*]]
+!STORE: store i32 %[[TEMP]], ptr %[[VAR_A]], align 4, !dbg ![[LOCATION]]
 !STORE: ![[LOCATION]] = !DILocation(line: 19, column: 1, scope: !{{.*}})
 
 !Check the line table entry of the second assignment.

--- a/test/debug_info/result_var.f90
+++ b/test/debug_info/result_var.f90
@@ -1,6 +1,6 @@
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
-!CHECK: call void @llvm.dbg.declare(metadata i32* %rvar_{{[0-9]+}}, metadata [[RESULT:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata ptr %rvar_{{[0-9]+}}, metadata [[RESULT:![0-9]+]], metadata !DIExpression())
 !CHECK: [[RESULT]] = !DILocalVariable(name: "rvar"
 
 function func(arg) result(rvar)

--- a/test/debug_info/retained-nodes.f90
+++ b/test/debug_info/retained-nodes.f90
@@ -10,15 +10,15 @@
 
 subroutine addf(a, b, c, d, e, f, g, h, i)
   integer :: a, b, c, d, e, f, g, h, i
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata i64* %a, metadata [[A:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata i64* %b, metadata [[B:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata i64* %c, metadata [[C:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata i64* %d, metadata [[D:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata i64* %e, metadata [[E:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata i64* %f, metadata [[F:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata i64* %g, metadata [[G:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata i64* %h, metadata [[H:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata i64* %i, metadata [[I:![0-9]+]]
+! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %a, metadata [[A:![0-9]+]]
+! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %b, metadata [[B:![0-9]+]]
+! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %c, metadata [[C:![0-9]+]]
+! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %d, metadata [[D:![0-9]+]]
+! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %e, metadata [[E:![0-9]+]]
+! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %f, metadata [[F:![0-9]+]]
+! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %g, metadata [[G:![0-9]+]]
+! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %h, metadata [[H:![0-9]+]]
+! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %i, metadata [[I:![0-9]+]]
 end subroutine
 
 ! CHECK-DAG: [[NODES:![0-9]+]] = !{{{.*}}[[A]], [[B]], [[C]], [[D]], [[E]], [[F]], [[G]], [[H]], [[I]]{{.*}}}

--- a/test/debug_info/scalar_allocatable.f90
+++ b/test/debug_info/scalar_allocatable.f90
@@ -2,7 +2,7 @@
 
 !Ensure that for an allocatable variable, we're taking the type of
 !allocatable variable as DW_TAG_pointer_type.
-!CHECK: call void @llvm.dbg.declare(metadata double** %{{.*}}, metadata ![[DILocalVariable:[0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata ptr %{{.*}}, metadata ![[DILocalVariable:[0-9]+]], metadata !DIExpression())
 !CHECK: ![[DILocalVariable]] = !DILocalVariable(name: "alcvar"
 !CHECK-SAME: type: ![[PTRTYPE:[0-9]+]]
 !CHECK: ![[PTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[TYPE:[0-9]+]]

--- a/test/directives/getarg.f90
+++ b/test/directives/getarg.f90
@@ -8,5 +8,5 @@ subroutine test()
 
   call getarg(pos, arg)
 end subroutine
-! CHECK: bitcast void ({{.*}})* @f90_getarga to void (i8*, i8*, i8*, i64{{.*}})*,
-! CHECK-NOT: bitcast void ({{.*}})* @getarg_ to void (i8, i8, i64{{.*}})*,
+! CHECK: bitcast ptr @f90_getarga to ptr,
+! CHECK-NOT: bitcast ptr @getarg_ to ptr,

--- a/test/directives/prefetch.f90
+++ b/test/directives/prefetch.f90
@@ -12,13 +12,13 @@ subroutine prefetch_dir(a1, a2)
 end subroutine prefetch_dir
 
 !! Ensure that the offset generated for the prefetch of a2(i + 256) is correct.
-! CHECK-PREFETCH: [[a1:%[0-9]+]] = bitcast i64* %a1 to i8*
-! CHECK-PREFETCH: [[a2:%[0-9]+]] = bitcast i64* %a2 to i8*
-! CHECK-PREFETCH: [[a2base:%[0-9]+]] = getelementptr i8, i8* [[a2]], i64 1020
+! CHECK-PREFETCH: [[a1:%[0-9]+]] = bitcast ptr %a1 to ptr
+! CHECK-PREFETCH: [[a2:%[0-9]+]] = bitcast ptr %a2 to ptr
+! CHECK-PREFETCH: [[a2base:%[0-9]+]] = getelementptr i8, ptr [[a2]], i64 1020
 ! CHECK-PREFETCH: [[i:%[0-9]+]] = load i32
 ! CHECK-PREFETCH: [[TMP1:%[0-9]+]] = sext i32 [[i]] to i64
 ! CHECK-PREFETCH: [[TMP2:%[0-9]+]] = mul nsw i64 [[TMP1]], 4
-! CHECK-PREFETCH: [[a2elem:%[0-9]+]] = getelementptr i8, i8* [[a2base]], i64 [[TMP2]]
-! CHECK-PREFETCH: call void @llvm.prefetch{{.*}}(i8* [[a2elem]], i32 0, i32 3, i32 1)
+! CHECK-PREFETCH: [[a2elem:%[0-9]+]] = getelementptr i8, ptr [[a2base]], i64 [[TMP2]]
+! CHECK-PREFETCH: call void @llvm.prefetch{{.*}}(ptr [[a2elem]], i32 0, i32 3, i32 1)
 ! CHECK-PREFETCH: declare void @llvm.prefetch{{.*}}
 ! CHECK-NOPREFETCH-NOT: @llvm.prefetch

--- a/test/llvm_ir_correct/assign_cray_pointer_in_data.f
+++ b/test/llvm_ir_correct/assign_cray_pointer_in_data.f
@@ -3,7 +3,7 @@
       IMPLICIT NONE
       REAL OLD(1)
       POINTER(IOLD, OLD)
-       ! CHECK: %struct.STATICS1 = type <{ i8*  }>
+       ! CHECK: %struct.STATICS1 = type <{ ptr  }>
       DATA IOLD/-1/
-       ! CHECK: @.STATICS1 = internal global %struct.STATICS1 <{ i8* inttoptr (i64 -1 to i8*) }>
+       ! CHECK: @.STATICS1 = internal global %struct.STATICS1 <{ ptr inttoptr (i64 -1 to ptr) }>
       END PROGRAM MINIMAL

--- a/test/llvm_ir_correct/daz.f90
+++ b/test/llvm_ir_correct/daz.f90
@@ -6,7 +6,7 @@
 
 ! RUN: %flang -target x86_64-unknown-unknown -Mdaz %s -S -emit-llvm -o - | FileCheck %s
 ! REQUIRES: x86_64-host
-! CHECK: @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 65535, void ()* @__daz, i8* null }]
+! CHECK: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__daz, ptr null }]
 
 program daz
 end program

--- a/test/llvm_ir_correct/len_intrinsic.f90
+++ b/test/llvm_ir_correct/len_intrinsic.f90
@@ -17,14 +17,14 @@ subroutine s1(x)
   print *, s1_test_len
 end subroutine
 ! CONVERT: define void @s1_
-! CONVERT: %[[LOAD_IGNORE:[0-9]+]] = load i64, i64* %"s1_str$len
-! CONVERT: %[[LOAD:[0-9]+]] = load i64, i64* %"s1_str$len
+! CONVERT: %[[LOAD_IGNORE:[0-9]+]] = load i64, ptr %"s1_str$len
+! CONVERT: %[[LOAD:[0-9]+]] = load i64, ptr %"s1_str$len
 ! CONVERT: %[[TRUNC:[0-9]+]] = trunc i64 %[[LOAD]] to i32
-! CONVERT: store i32 %[[TRUNC]], i32* %s1_test_len
+! CONVERT: store i32 %[[TRUNC]], ptr %s1_test_len
 ! CONVERT_I8: define void @s1_
-! CONVERT_I8: %[[LOAD_IGNORE:[0-9]+]] = load i64, i64* %"s1_str$len
-! CONVERT_I8: %[[LOAD:[0-9]+]] = load i64, i64* %"s1_str$len
-! CONVERT_I8: store i64 %[[LOAD]], i64* %s1_test_len
+! CONVERT_I8: %[[LOAD_IGNORE:[0-9]+]] = load i64, ptr %"s1_str$len
+! CONVERT_I8: %[[LOAD:[0-9]+]] = load i64, ptr %"s1_str$len
+! CONVERT_I8: store i64 %[[LOAD]], ptr %s1_test_len
 
 subroutine s2()
   character(len=100) :: s2_str
@@ -33,6 +33,6 @@ subroutine s2()
   print *, s2_test_len
 end subroutine
 ! NO_CONVERT: define void @s2_
-! NO_CONVERT: store i32 100, i32* %s2_test_len
+! NO_CONVERT: store i32 100, ptr %s2_test_len
 ! NO_CONVERT_I8: define void @s2_
-! NO_CONVERT_I8: store i64 100, i64* %s2_test_len
+! NO_CONVERT_I8: store i64 100, ptr %s2_test_len

--- a/test/llvm_ir_correct/omp_atomic_load_logical.f90
+++ b/test/llvm_ir_correct/omp_atomic_load_logical.f90
@@ -24,7 +24,7 @@ subroutine sub8
   do
 !$OMP ATOMIC READ
     v = l8
-! //CHECK: load atomic i8, i8*
+! //CHECK: load atomic i8, ptr
     if (v) exit
   end do
 end subroutine
@@ -37,7 +37,7 @@ subroutine sub16
   do
 !$OMP ATOMIC READ
     v = l16
-! //CHECK: load atomic i16, i16*
+! //CHECK: load atomic i16, ptr
     if (v) exit
   end do
 end subroutine
@@ -50,7 +50,7 @@ subroutine sub32
   do
 !$OMP ATOMIC READ
     v = l32
-! //CHECK: load atomic i32, i32*
+! //CHECK: load atomic i32, ptr
     if (v) exit
   end do
 end subroutine
@@ -63,7 +63,7 @@ subroutine sub64
   do
 !$OMP ATOMIC READ
     v = l64
-! //CHECK: load atomic i64, i64*
+! //CHECK: load atomic i64, ptr
     if (v) exit
   end do
 end subroutine

--- a/test/llvm_ir_correct/save.f90
+++ b/test/llvm_ir_correct/save.f90
@@ -14,9 +14,9 @@ program msave
   implicit none
 ! NOSAVE: alloca i32
   integer :: x
-! NOSAVE: store i32 5, i32* %x
-! SAVE: bitcast %struct.BSS1* @.BSS1 to i32*
-! SAVE: store i32 5, i32*
+! NOSAVE: store i32 5, ptr %x
+! SAVE: bitcast ptr @.BSS1 to ptr
+! SAVE: store i32 5, ptr
   x = 5
 end program
 

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -795,7 +795,7 @@ void
 print_personality(void)
 {
   print_token(
-      " personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*)");
+      " personality ptr @__gxx_personality_v0");
 }
 
 /**
@@ -1196,7 +1196,7 @@ add_profile_decl(const char *key, char *gname)
 INLINE static void
 write_profile_call(const char *profFn)
 {
-  fprintf(ASMFIL, "\tcall void @%s(i8* %%prof.thisfn, i8* %%prof.callsite)\n",
+  fprintf(ASMFIL, "\tcall void @%s(ptr %%prof.thisfn, ptr %%prof.callsite)\n",
           profFn);
 }
 
@@ -1221,15 +1221,15 @@ write_profile_enter(SPTR sptr, LL_Type *currFnTy)
   static bool protos_defined = false;
   const char *currFn = get_llvm_name(sptr);
   fprintf(ASMFIL,
-          "\t%%prof.thisfn = bitcast %s* @%s to i8*\n"
-          "\t%%prof.callsite = call i8*(i32) @" PROF_CALLSITE "(i32 0)\n",
-          currFnTy->str, currFn);
+          "\t%%prof.thisfn = ptr @%s\n"
+          "\t%%prof.callsite = call ptr @" PROF_CALLSITE "(i32 0)\n",
+          currFn);
   write_profile_call(PROF_ENTER);
   if (!protos_defined) {
     /* add the declarations for output */
-    const char retAddr[] = "declare i8* @" PROF_CALLSITE "(i32)";
-    const char entFn[] = "declare void @" PROF_ENTER "(i8*, i8*)";
-    const char extFn[] = "declare void @" PROF_EXIT "(i8*, i8*)";
+    const char retAddr[] = "declare ptr @" PROF_CALLSITE "(i32)";
+    const char entFn[] = "declare void @" PROF_ENTER "(ptr, ptr)";
+    const char extFn[] = "declare void @" PROF_EXIT "(ptr, ptr)";
     char *gname;
 
     protos_defined = true;
@@ -3208,16 +3208,8 @@ write_instructions(LL_Module *module)
         OPERAND *cc;
         cc = instrs->operands;
 
-        if (cc->ot_type == OT_CONSTVAL) {
-          print_token("\tcatch i8* ");
-          write_operand(cc, " ", FLG_OMIT_OP_TYPE);
-        } else {
-          print_token("\tcatch i8* bitcast ( ");
-          write_type(cc->ll_type);
-          print_token("* ");
-          write_operand(cc, " ", FLG_OMIT_OP_TYPE);
-          print_token(" to i8*)");
-        }
+        print_token("\tcatch ptr ");
+        write_operand(cc, " ", FLG_OMIT_OP_TYPE);
       } break;
       case I_FILTER: {
         /* "filter <array-type> [ <array-of-typeinfo-vars> ]"
@@ -3227,7 +3219,7 @@ write_instructions(LL_Module *module)
           /* A no-throw exception spec, "throw()" */
           /* LLVM documentation says that "filter [0xi8*] undef" is fine, but
              the LLVM compiler rejects it.  So we have to do it differently. */
-          print_token("\t\tfilter [0 x i8*] zeroinitializer");
+          print_token("\t\tfilter [0 x ptr] zeroinitializer");
         } else {
           OPERAND *esti;       /* One typeinfo var for the exception spec. */
           int count = 0;       /* Number of types in the exception spec. */
@@ -3235,14 +3227,11 @@ write_instructions(LL_Module *module)
           for (esti = instrs->operands; esti != NULL; esti = esti->next) {
             ++count;
           }
-          snprintf(buffer, sizeof buffer, "\tfilter [%d x i8*] [", count);
+          snprintf(buffer, sizeof buffer, "\tfilter [%d x ptr] [", count);
           print_token(buffer);
           for (esti = instrs->operands; esti != NULL; esti = esti->next) {
-            print_token("i8* bitcast ( ");
-            write_type(esti->ll_type);
-            print_token("* ");
+            print_token("ptr ");
             write_operand(esti, NULL, FLG_OMIT_OP_TYPE);
-            print_token(" to i8*)");
             if (esti->next != NULL) {
               print_token(", ");
             }
@@ -4796,7 +4785,7 @@ insert_llvm_prefetch(int ilix, OPERAND *dest_op)
   static bool prefetch_defined = false;
   if (!prefetch_defined) {
     prefetch_defined = true;
-    const char *intrinsic_decl = "declare void @llvm.prefetch(i8* nocapture, i32, i32, i32)";
+    const char *intrinsic_decl = "declare void @llvm.prefetch(ptr nocapture, i32, i32, i32)";
     char *gname = (char *)getitem(LLVM_LONGTERM_AREA, strlen(intrinsic_decl) + 1);
     strcpy(gname, intrinsic_decl);
     EXFUNC_LIST *exfunc = (EXFUNC_LIST *)getitem(LLVM_LONGTERM_AREA, sizeof(EXFUNC_LIST));
@@ -4844,7 +4833,7 @@ insert_llvm_memset(int ilix, int size, OPERAND *dest_op, int len, int value,
   if (!memset_defined) {
     memset_defined = true;
     gname = (char *)getitem(LLVM_LONGTERM_AREA, strlen(memset_name) + 45);
-    sprintf(gname, "declare void %s(i8*, i8, i%d, i32, i1)", memset_name, size);
+    sprintf(gname, "declare void %s(ptr, i8, i%d, i32, i1)", memset_name, size);
     exfunc = (EXFUNC_LIST *)getitem(LLVM_LONGTERM_AREA, sizeof(EXFUNC_LIST));
     memset(exfunc, 0, sizeof(EXFUNC_LIST));
     exfunc->func_def = gname;
@@ -4887,7 +4876,7 @@ insert_llvm_memcpy(int ilix, int size, OPERAND *dest_op, OPERAND *src_op,
   if (!memcpy_defined) {
     memcpy_defined = true;
     gname = (char *)getitem(LLVM_LONGTERM_AREA, strlen(memcpy_name) + 49);
-    sprintf(gname, "declare void %s(i8*, i8*, i%d, i32, i1)", memcpy_name,
+    sprintf(gname, "declare void %s(ptr, ptr, i%d, i32, i1)", memcpy_name,
             size);
     exfunc = (EXFUNC_LIST *)getitem(LLVM_LONGTERM_AREA, sizeof(EXFUNC_LIST));
     memset(exfunc, 0, sizeof(EXFUNC_LIST));
@@ -11405,7 +11394,7 @@ process_extern_function_sptr(SPTR sptr)
   exfunc->sptr = sptr;
   if (cgmain_init_call(sptr)) {
     gname = (char *)getitem(LLVM_LONGTERM_AREA, 34);
-    sprintf(gname, "declare void @__c_bzero(i32, i8*)");
+    sprintf(gname, "declare void @__c_bzero(i32, ptr)");
     exfunc->flags |= EXF_INTRINSIC;
   } else {
     const DTYPE dTy =
@@ -14297,25 +14286,25 @@ llvm_write_ctor_dtor_list(init_list_t *list, const char *global_name)
   print_token(int_str_buffer);
 
   if (ll_feature_three_argument_ctor_and_dtor(&current_module->ir)) {
-    print_token(" x { i32, void ()*, i8* }][");
+    print_token(" x { i32, ptr, ptr }][");
     for (node = list->head; node != NULL; node = node->next) {
-      print_token("{ i32, void ()*, i8* } { i32 ");
+      print_token("{ i32, ptr, ptr } { i32 ");
       sprintf(int_str_buffer, "%d", node->priority);
       print_token(int_str_buffer);
-      print_token(", void ()* @");
+      print_token(", ptr @");
       print_token(node->name);
-      print_token(", i8* null }");
+      print_token(", ptr null }");
       if (node->next != NULL) {
         print_token(", ");
       }
     }
   } else {
-    print_token(" x { i32, void ()* }][");
+    print_token(" x { i32, ptr }][");
     for (node = list->head; node != NULL; node = node->next) {
-      print_token("{ i32, void ()* } { i32 ");
+      print_token("{ i32, ptr } { i32 ");
       sprintf(int_str_buffer, "%d", node->priority);
       print_token(int_str_buffer);
-      print_token(", void ()* @");
+      print_token(", ptr @");
       print_token(node->name);
       print_token(" }");
       if (node->next != NULL) {

--- a/tools/flang2/flang2exe/ll_structure.cpp
+++ b/tools/flang2/flang2exe/ll_structure.cpp
@@ -1237,16 +1237,16 @@ ll_get_pointer_type(LL_Type *type)
   /* We need to assign a representation string and allocate a proper array
    * for sub_types if unique_type() actually allocated a new type. */
   if (!ret_type->str) {
-    char suffix[32] = "*";
+    char ptrstr[32] = "ptr";
     char *new_str;
     int size;
 
     if (type->addrspace) {
-      snprintf(suffix, sizeof(suffix), " addrspace(%d)*", type->addrspace);
+      snprintf(ptrstr, sizeof ptrstr, "ptr addrspace(%d)", type->addrspace);
     }
-    size = strlen(type->str) + strlen(suffix) + 1;
+    size = strlen(ptrstr) + 1;
     new_str = (char *)ll_manage_malloc(module, size);
-    sprintf(new_str, "%s%s", type->str, suffix);
+    snprintf(new_str, sizeof new_str, "%s", ptrstr);
 
     ret_type->str = new_str;
     ret_type->sub_types =

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -271,8 +271,8 @@ write_prototypes(FILE *out, LLVMModuleRef module)
   }
 
   if (text_calls) {
-    fprintf(out, "declare i64 @llvm.nvvm.texsurf.handle.p1i64(metadata, i64 "
-                 "addrspace(1)*) nounwind readnone\n");
+    fprintf(out, "declare i64 @llvm.nvvm.texsurf.handle.p1i64(metadata, "
+                 "ptr addrspace(1)) nounwind readnone\n");
   }
 
   for (int i = 0; i < module->num_refs; i++) {
@@ -832,18 +832,6 @@ ll_write_function(FILE *out, LL_Function *function, LL_Module *module, bool no_r
     block = block->next;
   }
   fputs("}\n\n", out);
-}
-
-void
-ll_write_function_signature(FILE *out, LL_Function *function)
-{
-  fprintf(out, "%s (", function->return_type->str);
-  for (unsigned int j = 0; j < function->num_args; j++) {
-    fprintf(out, "%s", function->arguments[j]->type_struct->str);
-    if (j + 1 < function->num_args)
-      fprintf(out, ", ");
-  }
-  fprintf(out, ")* @%s", function->name);
 }
 
 /*
@@ -2388,9 +2376,9 @@ void
 ll_write_global_var_signature(FILE *out, LL_Value *variable)
 {
   if (variable->mvtype == LL_GLOBAL) {
-    fprintf(out, "global [0 x double]*");
+    fprintf(out, "global ptr");
   } else {
-    fprintf(out, "%s*", variable->type_struct->str);
+    fprintf(out, "ptr");
   }
   fprintf(out, " %s", variable->data);
 }
@@ -2406,7 +2394,7 @@ ll_write_llvm_used(FILE *out, LLVMModuleRef module)
   if (!module->num_llvm_used)
     return;
 
-  fprintf(out, "@llvm.used = appending global [%u x i8*] [\n  ",
+  fprintf(out, "@llvm.used = appending global [%u x ptr] [\n  ",
           module->num_llvm_used);
   for (i = 0; i < module->num_llvm_used; i++) {
     LL_Value *ptr = module->llvm_used.values[i];

--- a/tools/flang2/flang2exe/ll_write.h
+++ b/tools/flang2/flang2exe/ll_write.h
@@ -26,11 +26,6 @@ void ll_write_function(FILE *out, LL_Function *function, LL_Module *module,
 /**
    \brief ...
  */
-void ll_write_function_signature(FILE *out, struct LL_Function_ *function);
-
-/**
-   \brief ...
- */
 void ll_write_global_objects(FILE *out, LLVMModuleRef module);
 
 /**

--- a/tools/flang2/flang2exe/llassem_common.cpp
+++ b/tools/flang2/flang2exe/llassem_common.cpp
@@ -144,16 +144,10 @@ put_skip(ISZ_T old, ISZ_T New, bool is_char)
 static void
 write_proc_pointer(SPTR sptr)
 {
-  const char *fntype = "void()";
-
   if (PTR_INITIALIZERG(sptr) && PTR_TARGETG(sptr)) {
     sptr = (SPTR) PTR_TARGETG(sptr);
   }
-  LL_ABI_Info *abi = ll_proto_get_abi(ll_proto_key(sptr));
-  if (abi) {
-    fntype = ll_abi_function_type(abi)->str;
-  }
-  fprintf(ASMFIL, "i8* bitcast(%s* @%s to i8*)", fntype, getsname(sptr));
+  fprintf(ASMFIL, "ptr @%s", getsname(sptr));
 }
 
 void
@@ -980,14 +974,14 @@ put_addr(SPTR sptr, ISZ_T off, DTYPE dtype)
         /* Text type for contansts is produced via char_type */
         if (STYPEG(sptr) == ST_CONST)
           fprintf(ASMFIL,
-                  "getelementptr(%si8* bitcast (%s* @%s to i8*), i32 %ld)",
-                  elem_type, char_type(DTYPEG(sptr), sptr), name, off);
+                  "getelementptr(%sptr @%s, i32 %ld)",
+                  elem_type, name, off);
         /* Structures have type name mirroring variable name */
         else
           fprintf(
               ASMFIL,
-              "getelementptr(%si8* bitcast (%%struct%s* @%s to i8*), i32 %ld)",
-              elem_type, name, name, off);
+              "getelementptr(%sptr @%s, i32 %ld)",
+              elem_type, name, off);
       } else {
         /* Convert to LLVM-compatible structures */
         if (!LLTYPE(sptr)) {

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -4088,7 +4088,6 @@ lldbg_function_end(LL_DebugInfo *db, int func)
       LLTYPE(i) = cache;
     } else if ((!SNAME(i)) && REFG(i)) {
       // add referenced variables not discovered as yet
-      const char *sname;
       const char *name;
       char *buff;
       LL_Type *cache = LLTYPE(i);
@@ -4097,10 +4096,8 @@ lldbg_function_end(LL_DebugInfo *db, int func)
       type = ll_get_pointer_type(make_lltype_from_dtype(dtype));
       name = get_llvm_name(i);
       // Hack: splice in the LLVM user-defined IR type name
-      sname = getsname(i); // temporary pointer
-      buff = (char *)getitem(LLVM_LONGTERM_AREA, strlen(name) + strlen(sname) +
-                                                     strlen(type->str) + 25);
-      sprintf(buff, "bitcast (%%struct%s* @%s to %s)", sname, name, type->str);
+      buff = (char *)getitem(LLVM_LONGTERM_AREA, strlen(name) + 6);
+      sprintf(buff, "ptr @%s", name);
       value = ll_create_value_from_type(db->module, type, (const char *)buff);
       lldbg_emit_global_variable(db, i, 0, 1, value);
       LLTYPE(i) = cache;


### PR DESCRIPTION
This PR is based on PR #1306 submitted by @pawosm-arm, we have reviewed PR #1306 and made some changes on the original patch. 

For typed pointers generated by functions, we modify the function in ll_structrue.cpp to uniformly use 'ptr' as the IR output string.
For some hard-coded typed pointers, we rewrite them with 'ptr', and remove some redundant cast_ops between pointers.
We also modify some test cases that use typed pointer IR.

In addition, this branch needs to be built with LLVM 15.