### PR TITLE
[workflows] Do not try to run AArch64 build job on forks

### DIFF
--- a/.github/workflows/build_flang_arm64.yml
+++ b/.github/workflows/build_flang_arm64.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build_flang:
+    if: github.repository_owner == 'flang-compiler'
     runs-on: self-hosted
     env:
       build_path: /home/github


### PR DESCRIPTION
Arm's self-hosted AArch64 runner can only be used for actions in the original flang-compiler/flang repo.