### PR TITLE
[runtime] Specify location of libomp dependency

### DIFF
--- a/runtime/flang/CMakeLists.txt
+++ b/runtime/flang/CMakeLists.txt
@@ -721,3 +721,4 @@ target_compile_options(flang_static PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreent
 
 target_compile_options(flang_shared PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreentrant>)
 
+set_target_properties(flang_shared PROPERTIES INSTALL_RPATH "$ORIGIN")

--- a/runtime/flangrti/CMakeLists.txt
+++ b/runtime/flangrti/CMakeLists.txt
@@ -155,3 +155,4 @@ target_compile_options(flangrti_static PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mre
 
 target_compile_options(flangrti_shared PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-Mreentrant>)
 
+set_target_properties(flangrti_shared PROPERTIES INSTALL_RPATH "$ORIGIN")


### PR DESCRIPTION
This patch makes it possible to run flang without setting `LD_LIBRARY_PATH` for the libomp dependency in libflang and libflangrti. This patch adds an `$ORIGIN` rpath to libflang and libflangrti so that it will search for libomp in the same directory as where these libraries are located. Typically, the libraries for a toolchain are installed in the same directory.

This patch fixes #1302.