### PR TITLE
[ArgParser] Do not zero xflags when registering command line option (legacy branch)

### DIFF
--- a/include/flang/ArgParser/arg_parser.h
+++ b/include/flang/ArgParser/arg_parser.h
@@ -136,21 +136,19 @@ void register_qflag_arg(arg_parser_t *parser, const char *arg_name, int *qflags,
 /** \brief Register X version of "x flag" argument
  *
  * "x" command line switch sets a mask in x flags (features) array that is
- * consumed by other parts of compiler. This function also fills the array with
- * zeros.
+ * consumed by other parts of compiler.
  *
  * \param parser         argument parser data structure
  * \param arg_name       name of the argument (minus the '-')
  * \param xflags         pointer to x flags
- * \param xflags_size    number of elelemts in xflags array
  */
-void register_xflag_arg(arg_parser_t *parser, const char *arg_name, int *xflags,
-                        const int xflags_size);
+void register_xflag_arg(arg_parser_t *parser, const char *arg_name,
+                        int *xflags);
 
 /** \brief Register Y version of "x flag" argument
  *
  * "y" command line switch clears a mask in features array, complementing what
- * "x" flag does. Note: this function is not initialize xflags array.
+ * "x" flag does.
  *
  * \param parser         argument parser data structure
  * \param arg_name       name of the argument (minus the '-')

--- a/lib/ArgParser/arg_parser.c
+++ b/lib/ArgParser/arg_parser.c
@@ -217,12 +217,8 @@ register_qflag_arg(arg_parser_t *parser, const char *arg_name, int *qflags,
 
 /** Register "x" flag argument */
 void
-register_xflag_arg(arg_parser_t *parser, const char *arg_name, int *xflags,
-                   const int xflags_size)
+register_xflag_arg(arg_parser_t *parser, const char *arg_name, int *xflags)
 {
-  /* Fill xflags array with zeros */
-  memset(xflags, 0, xflags_size * sizeof(int));
-
   add_generic_argument(parser, arg_name, ARG_XFlag, (void *)xflags);
 }
 

--- a/tools/flang1/flang1exe/main.c
+++ b/tools/flang1/flang1exe/main.c
@@ -622,6 +622,9 @@ init(int argc, char *argv[])
   };
   time_t now;
 
+  /* Fill xflags array with zeros */
+  memset(flg.x, 0, sizeof(flg.x));
+
   flg.freeform = -1;
   file_suffix = ".f90"; /* default suffix for source files */
   /*
@@ -726,8 +729,7 @@ init(int argc, char *argv[])
   register_string_list_arg(arg_parser, "moddir", module_dirs);
 
   /* x flags */
-  register_xflag_arg(arg_parser, "x", flg.x,
-                     (sizeof(flg.x) / sizeof(flg.x[0])));
+  register_xflag_arg(arg_parser, "x", flg.x);
   register_yflag_arg(arg_parser, "y", flg.x);
   /* Debug flags */
   register_qflag_arg(arg_parser, "q", flg.dbg,

--- a/tools/flang2/flang2exe/main.cpp
+++ b/tools/flang2/flang2exe/main.cpp
@@ -544,6 +544,10 @@ init(int argc, char *argv[])
                           * initialize error and symbol table modules in case error messages are
                           * issued:
                           */
+
+  /* Fill xflags array with zeros */
+  memset(flg.x, 0, sizeof(flg.x));
+
   errini();
   if (argc <= 1)
     errfatal((error_code_t)1);
@@ -618,8 +622,7 @@ init(int argc, char *argv[])
   register_string_arg(arg_parser, "vh", &(version.host), "");
 
   /* x flags */
-  register_xflag_arg(arg_parser, "x", flg.x,
-                     (sizeof(flg.x) / sizeof(flg.x[0])));
+  register_xflag_arg(arg_parser, "x", flg.x);
   register_yflag_arg(arg_parser, "y", flg.x);
   /* Debug flags */
   register_qflag_arg(arg_parser, "q", flg.dbg,


### PR DESCRIPTION
Certain elements in `flg.x` are set before `register_xflag_arg` is called. They should not be overwritten when the `-x` command-line option is registered. Instead `flg.x` should be cleared at the beginning of the main function.

This is the `legacy` branch version of #1317.