### PR TITLE
[workflow] Fix push workflow in build_flang_arm64.yml (legacy branch)

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -39,6 +39,10 @@ jobs:
           cmake --version
           make --version
 
+      # gcc11 and g++11 are needed to install llvm
+      - if: matrix.cc == 'gcc' && matrix.version == '11'
+        run: sudo apt install gcc-11 g++-11
+
       # Download artifacts for the classic-flang-llvm-project-related builds (all toolchains)
       - name: Download artifacts
         run: |
@@ -67,14 +71,10 @@ jobs:
           tar xzf llvm_build.tar.gz
           cd classic-flang-llvm-project/build
           sudo make install/fast
-
-      # gcc11 and g++11 are needed to install llvm
-      - if: matrix.cc == 'gcc' && matrix.version == '11'
-        run: sudo apt install gcc-11 g++-11
+          ${{ env.install_prefix }}/bin/clang --version
 
       - name: Build and install flang & libpgmath
         run: |
-          ${{ env.install_prefix }}/bin/clang --version
           ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n $(nproc) -c -s -v
 
       - name: Copy llvm-lit

--- a/.github/workflows/build_flang_arm64.yml
+++ b/.github/workflows/build_flang_arm64.yml
@@ -30,18 +30,11 @@ jobs:
         llvm_branch: [release_14x, release_15x]
 
     steps:
-      - name: Check tools
-        run: |
-          git --version
-          cmake --version
-          make --version
-          ${{ env.install_prefix }}/bin/clang --version
-
       - name: Manual checkout to build in user's home dir (push)
         if: github.ref == 'refs/heads/legacy'
         run: |
           cd ${{ env.build_path }}
-          git clone https://github.com/flang-compiler/flang.git
+          git clone -b legacy https://github.com/flang-compiler/flang.git
 
       - name: Manual checkout to build in user's home dir (pull_request)
         if: github.ref != 'refs/heads/legacy'
@@ -52,12 +45,18 @@ jobs:
           git fetch origin ${{github.ref}}:pr_branch
           git checkout pr_branch
 
+      - name: Check tools
+        run: |
+          git --version
+          cmake --version
+          make --version
+          ${{ env.install_prefix }}/bin/clang --version
+
       - name: Build and install flang & libpgmath
         run: |
           cd ${{ env.build_path }}/flang
           ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n `nproc --ignore=1` -v
 
-      # Copy llvm-lit
       - name: Copy llvm-lit
         run: |
           cd ${{ env.build_path }}/flang


### PR DESCRIPTION
`build_flang_arm64.yml` has custom code for cloning the repository, since the workflow runs in a container on a hosted runner. The workflow needs to be given an explicit branch name to check out, otherwise it would always checkout the `master` branch. This patch adds back the missing branch name to fix a push workflow issue on the `legacy` branch, and also shuffles the steps slightly (NFC) to make `build_flang.yml` and `build_flang_arm64.yml` more similar.