### PR TITLE
[win][scutil] Add support Windows Complex types for pow folding

### DIFF
--- a/include/fp-folding.h
+++ b/include/fp-folding.h
@@ -57,6 +57,39 @@ typedef float float32_t;
 typedef double float64_t;
 typedef long double float128_t; /* 128 bits in memory, format host-dependent */
 
+#if !defined(_WIN32)
+# define FLOAT_COMPLEX_TYPE float complex
+# define FLOAT_COMPLEX_CREATE(real, imag) (real + imag * I)
+# define DOUBLE_COMPLEX_TYPE double complex
+# define DOUBLE_COMPLEX_CREATE(real, imag) (real + imag * I)
+# define LONG_DOUBLE_COMPLEX_TYPE long double complex
+# define LONG_DOUBLE_COMPLEX_CREATE(real, imag) (real + imag * I)
+
+/* For type conversion */
+# define FCMPLX_TO_DCMPLX(cplx) ((double complex)cplx)
+# define DCMPLX_TO_FCMPLX(cplx) ((float complex)cplx)
+# define DCMPLX_TO_LCMPLX(cplx) ((long double complex)cplx)
+# define LCMPLX_TO_DCMPLX(cplx) ((double complex)cplx)
+#else
+# define FLOAT_COMPLEX_TYPE _Fcomplex
+# define FLOAT_COMPLEX_CREATE(real, imag) _FCbuild(real, imag)
+# define DOUBLE_COMPLEX_TYPE _Dcomplex
+# define DOUBLE_COMPLEX_CREATE(real, imag) _Cbuild(real, imag)
+# define LONG_DOUBLE_COMPLEX_TYPE _Lcomplex
+# define LONG_DOUBLE_COMPLEX_CREATE(real, imag) _LCbuild(real, imag)
+
+/*
+ * For type conversion
+ * On Windows the complex numbers aren't native type,
+ * so the standard arithmetic operators aren't defined on complex types.
+ * Implicit conversions aren't defined between complex types.
+ */
+# define FCMPLX_TO_DCMPLX(cplx) DOUBLE_COMPLEX_CREATE((double)crealf(cplx), (double)cimagf(cplx))
+# define DCMPLX_TO_FCMPLX(cplx) FLOAT_COMPLEX_CREATE((float)creal(cplx), (float)cimag(cplx))
+# define DCMPLX_TO_LCMPLX(cplx) LONG_DOUBLE_COMPLEX_CREATE((long double)creal(cplx), (long double)cimag(cplx))
+# define LCMPLX_TO_DCMPLX(cplx) DOUBLE_COMPLEX_CREATE((double)creall(cplx), (double)cimagl(cplx))
+#endif // !defined(_WIN64)
+
 void fold_sanity_check(void);
 
 /*
@@ -165,14 +198,14 @@ enum fold_status fold_real128_exp(float128_t *res, const float128_t *arg);
 enum fold_status fold_real128_log(float128_t *res, const float128_t *arg);
 enum fold_status fold_real128_log10(float128_t *res, const float128_t *arg);
 
-enum fold_status fold_complex32_pow(float complex *res, const float complex *x,
-                                    const float complex *y);
-enum fold_status fold_complex64_pow(double complex *res,
-                                    const double complex *x,
-                                    const double complex *y);
-enum fold_status fold_complex128_pow(long double complex *res,
-                                     const long double complex *x,
-                                     const long double complex *y);
+enum fold_status fold_complex32_pow(FLOAT_COMPLEX_TYPE *res, const FLOAT_COMPLEX_TYPE *x,
+                                    const FLOAT_COMPLEX_TYPE *y);
+enum fold_status fold_complex64_pow(DOUBLE_COMPLEX_TYPE *res,
+                                    const DOUBLE_COMPLEX_TYPE *x,
+                                    const DOUBLE_COMPLEX_TYPE *y);
+enum fold_status fold_complex128_pow(LONG_DOUBLE_COMPLEX_TYPE *res,
+                                     const LONG_DOUBLE_COMPLEX_TYPE *x,
+                                     const LONG_DOUBLE_COMPLEX_TYPE *y);
 
 #ifdef __cplusplus
 }

--- a/lib/scutil/host-fp-folding.c
+++ b/lib/scutil/host-fp-folding.c
@@ -909,27 +909,27 @@ fold_real128_log10(float128_t *res, const float128_t *arg)
 }
 
 enum fold_status
-fold_complex32_pow(float complex *res, const float complex *x, const float complex *y)
+fold_complex32_pow(FLOAT_COMPLEX_TYPE *res, const FLOAT_COMPLEX_TYPE *x, const FLOAT_COMPLEX_TYPE *y)
 {
   fenv_t saved_fenv;
   set_up_floating_point_environment(&saved_fenv);
   /* use 'cpow' to improve precision of result. */
-  *res = (float complex)cpow((double complex)*x, (double complex)*y);
+  *res = DCMPLX_TO_FCMPLX(cpow(FCMPLX_TO_DCMPLX(*x), FCMPLX_TO_DCMPLX(*y)));
   return check_and_restore_floating_point_environment(&saved_fenv);
 }
 
 enum fold_status
-fold_complex64_pow(double complex *res, const double complex *x, const double complex *y)
+fold_complex64_pow(DOUBLE_COMPLEX_TYPE *res, const DOUBLE_COMPLEX_TYPE *x, const DOUBLE_COMPLEX_TYPE *y)
 {
   fenv_t saved_fenv;
   set_up_floating_point_environment(&saved_fenv);
   /* use 'cpowl' to improve precision of result. */
-  *res = (double complex)cpowl((long double complex)*x, (long double complex)*y);
+  *res = LCMPLX_TO_DCMPLX(cpowl(DCMPLX_TO_LCMPLX(*x), DCMPLX_TO_LCMPLX(*y)));
   return check_and_restore_floating_point_environment(&saved_fenv);
 }
 
 enum fold_status
-fold_complex128_pow(long double complex *res, const long double complex *x, const long double complex *y)
+fold_complex128_pow(LONG_DOUBLE_COMPLEX_TYPE *res, const LONG_DOUBLE_COMPLEX_TYPE *x, const LONG_DOUBLE_COMPLEX_TYPE *y)
 {
   fenv_t saved_fenv;
   set_up_floating_point_environment(&saved_fenv);

--- a/lib/scutil/legacy-folding-api.c
+++ b/lib/scutil/legacy-folding-api.c
@@ -2436,7 +2436,7 @@ cprintf(char *buffer, const char *format, INT *val)
 void
 xcfpow(IEEE32 r1, IEEE32 i1, IEEE32 r2, IEEE32 i2, IEEE32 *rr, IEEE32 *ir)
 {
-  float complex x, y, z;
+  FLOAT_COMPLEX_TYPE x, y, z;
   float32_t rx, ix, ry, iy, rz, iz;
   unwrap_f(&rx, &r1);
   unwrap_f(&ix, &i1);
@@ -2446,8 +2446,8 @@ xcfpow(IEEE32 r1, IEEE32 i1, IEEE32 r2, IEEE32 i2, IEEE32 *rr, IEEE32 *ir)
     rz = 1.0;
     iz = 0.0;
   } else {
-    x = rx + ix * I;
-    y = ry + iy * I;
+    x = FLOAT_COMPLEX_CREATE(rx, ix);
+    y = FLOAT_COMPLEX_CREATE(ry, iy);
     check(fold_complex32_pow(&z, &x, &y));
     rz = crealf(z);
     iz = cimagf(z);
@@ -2459,7 +2459,7 @@ xcfpow(IEEE32 r1, IEEE32 i1, IEEE32 r2, IEEE32 i2, IEEE32 *rr, IEEE32 *ir)
 void
 xcdpow(IEEE64 r1, IEEE64 i1, IEEE64 r2, IEEE64 i2, IEEE64 rr, IEEE64 ir)
 {
-  double complex x, y, z;
+  DOUBLE_COMPLEX_TYPE x, y, z;
   float64_t rx, ix, ry, iy, rz, iz;
   unwrap_d(&rx, r1);
   unwrap_d(&ix, i1);
@@ -2469,8 +2469,8 @@ xcdpow(IEEE64 r1, IEEE64 i1, IEEE64 r2, IEEE64 i2, IEEE64 rr, IEEE64 ir)
     rz = 1.0;
     iz = 0.0;
   } else {
-    x = rx + ix * I;
-    y = ry + iy * I;
+    x = DOUBLE_COMPLEX_CREATE(rx, ix);
+    y = DOUBLE_COMPLEX_CREATE(ry, iy);
     check(fold_complex64_pow(&z, &x, &y));
     rz = creal(z);
     iz = cimag(z);
@@ -2482,7 +2482,7 @@ xcdpow(IEEE64 r1, IEEE64 i1, IEEE64 r2, IEEE64 i2, IEEE64 rr, IEEE64 ir)
 void
 xcqpow(IEEE128 r1, IEEE128 i1, IEEE128 r2, IEEE128 i2, IEEE128 rr, IEEE128 ir)
 {
-  long double complex x, y, z;
+  LONG_DOUBLE_COMPLEX_TYPE x, y, z;
   float128_t rx, ix, ry, iy, rz, iz;
   unwrap_q(&rx, r1);
   unwrap_q(&ix, i1);
@@ -2492,8 +2492,8 @@ xcqpow(IEEE128 r1, IEEE128 i1, IEEE128 r2, IEEE128 i2, IEEE128 rr, IEEE128 ir)
     rz = 1.0;
     iz = 0.0;
   } else {
-    x = rx + ix * I;
-    y = ry + iy * I;
+    x = LONG_DOUBLE_COMPLEX_CREATE(rx, ix);
+    y = LONG_DOUBLE_COMPLEX_CREATE(ry, iy);
     check(fold_complex128_pow(&z, &x, &y));
     rz = creall(z);
     iz = cimagl(z);


### PR DESCRIPTION
On Windows 'complex' or '_Compex' keyword doesn't supported by clang-cl.
Microsoft uses structure types for representing Complex number.
Since complex numbers aren't native type, the standard arithmetic
operators aren't defined on complex types.

Implicit conversions aren't defined between complex types.