### PR TITLE
[runtime] Only use __float128 on Linux

### DIFF
--- a/runtime/include/float128.h
+++ b/runtime/include/float128.h
@@ -8,7 +8,7 @@
 #ifndef _FLOAT128_H_
 #define _FLOAT128_H_
 
-#if defined(TARGET_POWER) || (defined(TARGET_X8664) && !defined(TARGET_WIN))
+#if defined(TARGET_LINUX_POWER) || defined(TARGET_LINUX_X8664)
 typedef __float128 float128_t;
 #else
 /* __float128 is not available on AArch64 or other generic targets;

--- a/runtime/libpgmath/lib/common/float128.h
+++ b/runtime/libpgmath/lib/common/float128.h
@@ -16,7 +16,7 @@
 #include <stdint.h>
 
 /* See https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html. */
-#if defined(LINUX8664) || (defined(TARGET_X8664) && !defined(TARGET_WIN))
+#if defined(TARGET_LINUX_X8664)
 typedef __float128 float128_t;
 typedef _Complex float __attribute__((mode(TC))) quad_complex_t;
 #elif defined(TARGET_LINUX_POWER)


### PR DESCRIPTION
Clang doesn't support `__float128` on Windows and Darwin, so for now we fall back to defining `float128_t` as `long double`. Also keep the macro usage consistent between the two versions of `float128.h`, and stop using `LINUX8664` which is duplicated by `TARGET_LINUX_X8664`, as far as I can tell.

Fixes #1343. This is just a workaround; if quad-precision FP support is desired on X86 Windows and Darwin, someone will need to figure out how to get proper support from Clang and the system libraries on those platforms.