### PR TITLE
win: Fix the build with verbose options

### DIFF
--- a/scripts/build_flang.py
+++ b/scripts/build_flang.py
@@ -74,7 +74,7 @@ def generate_buildoptions(arguments):
         base_cmake_args.extend(arguments.cmake_param)
 
     if arguments.verbose:
-        base_cmake_args.extend('-DCMAKE_VERBOSE_MAKEFILE=ON')
+        base_cmake_args.append('-DCMAKE_VERBOSE_MAKEFILE=ON')
 
     return base_cmake_args
 


### PR DESCRIPTION
The 'append' method should be used instead of extend, since the 'extend' method treats the arguments as an iterable object, so extends the current list with list of characters.