### PR TITLE
cmake: stop asking llvm-config for src-root as it is not supported since LLVM16.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,7 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
       "--bindir"
       "--libdir"
       "--includedir"
-      "--prefix"
-      "--src-root")
+      "--prefix")
     execute_process(
       COMMAND ${CONFIG_COMMAND}
       RESULT_VARIABLE HAD_ERROR
@@ -108,7 +107,6 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   list(GET CONFIG_OUTPUT 2 LIBRARY_DIR)
   list(GET CONFIG_OUTPUT 3 INCLUDE_DIR)
   list(GET CONFIG_OUTPUT 4 LLVM_OBJ_ROOT)
-  list(GET CONFIG_OUTPUT 5 MAIN_SRC_DIR)
 
   if(NOT MSVC_IDE)
     set(LLVM_ENABLE_ASSERTIONS ${ENABLE_ASSERTIONS}
@@ -121,7 +119,6 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   set(LLVM_LIBRARY_DIR ${LIBRARY_DIR} CACHE PATH "Path to llvm/lib")
   set(LLVM_MAIN_INCLUDE_DIR ${INCLUDE_DIR} CACHE PATH "Path to llvm/include")
   set(LLVM_BINARY_DIR ${LLVM_OBJ_ROOT} CACHE PATH "Path to LLVM build tree")
-  set(LLVM_MAIN_SRC_DIR ${MAIN_SRC_DIR} CACHE PATH "Path to LLVM source tree")
 
   set(LLVM_CMAKE_PATH "${LLVM_BINARY_DIR}/lib/cmake/llvm"
      CACHE PATH "Path to LLVM cmake modules")
@@ -187,28 +184,55 @@ Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
       set(LLVM_UTILS_PROVIDED ON)
     endif()
 
-    if(EXISTS ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py)
-      set(LLVM_LIT ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py)
-      if(NOT LLVM_UTILS_PROVIDED)
-        add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/FileCheck utils/FileCheck)
-        add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/count utils/count)
-        add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/not utils/not)
-        set(LLVM_UTILS_PROVIDED ON)
-        set(FLANG_TEST_DEPS FileCheck count not)
+    if(LLVM_EXTERNAL_LIT)
+      if(NOT LLVM_LIT)
+        set(LLVM_LIT ${LLVM_EXTERNAL_LIT})
       endif()
-      #set(UNITTEST_DIR ${LLVM_MAIN_SRC_DIR}/utils/unittest)
-      #if(EXISTS ${UNITTEST_DIR}/googletest/include/gtest/gtest.h
-      #    AND NOT EXISTS ${LLVM_LIBRARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}
-      #    AND EXISTS ${UNITTEST_DIR}/CMakeLists.txt)
-      #  add_subdirectory(${UNITTEST_DIR} utils/unittest)
-      #endif()
-    else()
-      # Seek installed Lit.
-      find_program(LLVM_LIT "lit.py" ${LLVM_MAIN_SRC_DIR}/utils/lit
-        DOC "Path to lit.py")
     endif()
 
-    if(LLVM_LIT)
+    if(NOT LLVM_LIT OR NOT LLVM_UTILS_PROVIDED)
+      if(NOT LLVM_MAIN_SRC_DIR)
+        if(LLVM_CONFIG)
+          # --src-root was supported before LLVM 16.0
+          execute_process(
+            COMMAND ${LLVM_CONFIG} --src-root
+            RESULT_VARIABLE HAD_ERROR
+            OUTPUT_VARIABLE CONFIG_OUTPUT
+            ERROR_QUIET
+          )
+          if(NOT HAD_ERROR)
+            string(STRIP "${CONFIG_OUTPUT}" MAIN_SRC_DIR)
+            set(LLVM_MAIN_SRC_DIR ${MAIN_SRC_DIR} CACHE PATH "Path to LLVM source tree")
+          else()
+            message(WARNING "LLVM_MAIN_SRC_DIR was not set. Since LLVM16.0 this cannot be obtained from llvm-config!")
+          endif()
+        endif()
+      endif()
+      if(LLVM_MAIN_SRC_DIR)
+        if(EXISTS ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py)
+          set(LLVM_LIT ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py)
+          if(NOT LLVM_UTILS_PROVIDED)
+            add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/FileCheck utils/FileCheck)
+            add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/count utils/count)
+            add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/not utils/not)
+            set(LLVM_UTILS_PROVIDED ON)
+            set(FLANG_TEST_DEPS FileCheck count not)
+          endif()
+          #set(UNITTEST_DIR ${LLVM_MAIN_SRC_DIR}/utils/unittest)
+          #if(EXISTS ${UNITTEST_DIR}/googletest/include/gtest/gtest.h
+          #    AND NOT EXISTS ${LLVM_LIBRARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}
+          #    AND EXISTS ${UNITTEST_DIR}/CMakeLists.txt)
+          #  add_subdirectory(${UNITTEST_DIR} utils/unittest)
+          #endif()
+        else()
+          # Seek installed Lit.
+          find_program(LLVM_LIT "lit.py" ${LLVM_MAIN_SRC_DIR}/utils/lit
+            DOC "Path to lit.py")
+        endif()
+      endif()
+    endif()
+
+    if(LLVM_LIT AND LLVM_UTILS_PROVIDED)
       # Define the default arguments to use with 'lit', and an option for the user
       # to override.
       set(LIT_ARGS_DEFAULT "-sv")
@@ -221,6 +245,7 @@ Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
       if( WIN32 AND NOT CYGWIN )
         set(LLVM_LIT_TOOLS_DIR "" CACHE PATH "Path to GnuWin32 tools")
       endif()
+      message(STATUS "Found lit as ${LLVM_LIT}")
     else()
       set(LLVM_INCLUDE_TESTS OFF)
     endif()
@@ -417,13 +442,6 @@ if(FLANG_INCLUDE_TESTS)
     umbrella_lit_testsuite_begin(check-all)
   endif()
 
-#  if(EXISTS ${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include/gtest/gtest.h)
-#    add_subdirectory(unittests)
-#    list(APPEND FLANG_TEST_DEPS FlangUnitTests)
-#    list(APPEND FLANG_TEST_PARAMS
-#      flang_unit_site_config=${CMAKE_CURRENT_BINARY_DIR}/test/Unit/lit.site.cfg
-#      )
-#  endif()
   add_subdirectory(test)
 
   if(FLANG_BUILT_STANDALONE)

--- a/build-flang.sh
+++ b/build-flang.sh
@@ -9,6 +9,8 @@ BUILD_TYPE="Release"
 BUILD_PREFIX="./build"
 INSTALL_PREFIX="/usr/local"
 NPROC=1
+USE_LLVM_SRC_ROOT=""
+USE_LLVM_CONFIG=""
 USE_CCACHE="0"
 USE_SUDO="0"
 EXTRA_CMAKE_OPTS=""
@@ -32,19 +34,23 @@ function print_usage {
     echo "  -b  Build prefix. Default: ./build";
     echo "  -p  Install prefix. Default: /usr/local";
     echo "  -n  Number of parallel jobs. Default: 1";
+    echo "  -l  Path to LLVM sources. Default: not set";
+    echo "  -o  Path to llvm-config. Default: not set";
     echo "  -c  Use ccache. Default: 0 - do not use ccache";
     echo "  -s  Use sudo to install. Default: 0 - do not use sudo";
     echo "  -x  Extra CMake options. Default: ''";
     echo "  -v  Enable verbose output";
 }
 
-while getopts "t:d:b:p:n:csx:v?" opt; do
+while getopts "t:d:b:p:n:l:o:csx:v?" opt; do
     case "$opt" in
         t) TARGET=$OPTARG;;
         d) BUILD_TYPE=$OPTARG;;
         b) BUILD_PREFIX=$OPTARG;;
         p) INSTALL_PREFIX=$OPTARG;;
         n) NPROC=$OPTARG;;
+        l) USE_LLVM_SRC_ROOT="-DLLVM_MAIN_SRC_DIR=$OPTARG";;
+        o) USE_LLVM_CONFIG="-DLLVM_CONFIG=$OPTARG";;
         c) USE_CCACHE="1";;
         s) USE_SUDO="1";;
         x) EXTRA_CMAKE_OPTS="$OPTARG";;
@@ -103,6 +109,7 @@ cmake $CMAKE_OPTIONS \
       -DFLANG_INCLUDE_DOCS=ON \
       -DFLANG_LLVM_EXTENSIONS=ON \
       -DWITH_WERROR=ON \
+      $USE_LLVM_MAIN_SRC_DIR $USE_LLVM_CONFIG \
       $TOPDIR
 set +x
 make -j$NPROC VERBOSE=$VERBOSE

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -125,17 +125,9 @@ if config.test_exec_root is None:
     if not llvm_config:
         lit_config.fatal('No site specific configuration available!')
 
-    # Get the source and object roots.
-    llvm_src_root = lit.util.capture(['llvm-config', '--src-root']).strip()
+    # Get the object root.
     llvm_obj_root = lit.util.capture(['llvm-config', '--obj-root']).strip()
-    flang_src_root = os.path.join(llvm_src_root, "tools", "flang")
     flang_obj_root = os.path.join(llvm_obj_root, "tools", "flang")
-
-    # Validate that we got a tree which points to here, using the standard
-    # tools/flang layout.
-    this_src_root = os.path.dirname(config.test_source_root)
-    if os.path.realpath(flang_src_root) != os.path.realpath(this_src_root):
-        lit_config.fatal('No site specific configuration available!')
 
     # Check that the site specific configuration exists.
     site_cfg = os.path.join(flang_obj_root, 'test', 'lit.site.cfg')


### PR DESCRIPTION
A backward-compatible solution to a problem caused by the changes introduced in the LLVM 16.0.

I've found inability to refer to the LLVM sources particularly painful for classic-flang, and I guess this will many times be a source of heavy confusion for our end-users even with my patch. I tend to agree with an alternative solution which is to revert the patch that drops `--src-root` flag from `llvm-config` in our clone of the LLVM project.
