### PR TITLE
[flang1] Fix a regression about array constructor

### DIFF
--- a/test/f90_correct/inc/acl04.mk
+++ b/test/f90_correct/inc/acl04.mk
@@ -1,0 +1,26 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test acl04  ########
+
+
+acl04: run
+
+
+build:  $(SRC)/acl04.f90
+	-$(RM) acl04.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC)  -c $(FFLAGS) $(LDFLAGS) $(SRC)/acl04.f90 -o acl04.$(OBJX)
+	-$(FC)  $(FFLAGS) $(LDFLAGS) acl04.$(OBJX) check.$(OBJX) $(LIBS) -o acl04.$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test acl04
+	acl04.$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/acl04.sh
+++ b/test/f90_correct/lit/acl04.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/acl04.f90
+++ b/test/f90_correct/src/acl04.f90
@@ -1,0 +1,27 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for array constructor whose element is array of dynamic char.
+
+program m_test_adjust_len
+  call test_adjust_len(4, 4, 6)
+  print *, "PASS"
+
+contains
+  subroutine test_adjust_len(a, b, c)
+    integer :: a, b, c
+    character(len=a) :: s1(2)
+    character(len=b) :: s2
+    character(len=c) :: s3(1)
+
+    s2 = "aaaa"
+    s3 = "bbbbbb"
+
+    s1 = [s2, s3]
+
+    if (s1(1) /= "aaaa") stop 1
+    if (s1(2) /= "bbbb") stop 2
+  end
+end

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -1972,7 +1972,11 @@ compute_size_expr(bool add_flag, ACL *aclp, DTYPE dtype)
         if (dtype2 != DT_DEFERCHAR && dtype2 != DT_DEFERNCHAR)
           dtype = SST_DTYPEG(stkp);
       } else if (DTY(dtype) == TY_ARRAY) {
-        if (!eq_dtype(DDTG(dtype), acs.eltype)) {
+        if (is_dtype_runtime_length_char(dtype) &&
+            is_dtype_runtime_length_char(acs.eltype)) {
+          // AC element could have adjusted length. The length mismatch should
+          // be checked in runtime when -fcheck=bounds is enabled.
+        } else if (!eq_dtype(DDTG(dtype), acs.eltype)) {
           errsev(95);
         }
       } else {


### PR DESCRIPTION
When the array constructor element is array of dynamic char, the length can only be checked in runtime, in which case we cannot use `eq_dtype` to check if the two dtypes are equal since the length could be two different asts containing the length info.

This bug should exist long time ago, and it was hidden by 0918a2f2d. It was exposed again in a545a61c9.