### PR TITLE
[QuadFP][runtime] Define C_LONG_DOUBLE_COMPLEX as correct type kind

### DIFF
--- a/runtime/flang/iso_c_bind.F95
+++ b/runtime/flang/iso_c_bind.F95
@@ -98,7 +98,11 @@
         integer C_DOUBLE_COMPLEX
         parameter ( C_DOUBLE_COMPLEX = 8 )
         integer C_LONG_DOUBLE_COMPLEX
+#ifdef TARGET_SUPPORTS_QUADFP
+        parameter ( C_LONG_DOUBLE_COMPLEX = 16  )
+#else
         parameter ( C_LONG_DOUBLE_COMPLEX = 8  )
+#endif
         integer C_BOOL
         parameter ( C_BOOL =  1 )
         integer C_CHAR

--- a/test/f90_correct/inc/qc45.mk
+++ b/test/f90_correct/inc/qc45.mk
@@ -1,0 +1,22 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f08
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f08 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/qc45.sh
+++ b/test/f90_correct/lit/qc45.sh
@@ -1,0 +1,10 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# REQUIRES: quadfp
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/qc45.f08
+++ b/test/f90_correct/src/qc45.f08
@@ -1,0 +1,25 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for the usage of c_long_double_complex.
+! Complex(c_long_double_complex) is equal to complex(16).
+
+program example
+  use, intrinsic :: iso_c_binding
+
+  complex(c_long_double_complex) :: res
+  complex(16) :: a, b, c
+
+  a = (44.6441301697361925144580643835703598_16, &
+       7.03794069978169795284658606936286925_16)
+  b = (0.0_16, 0.0_16)
+  res = (44.6441301697361925144580643835703598_16, &
+         7.03794069978169795284658606936286925_16)
+  c = a - res
+
+  if ((c == b) .neqv. .true.) stop 1
+  if (C_SIZEOF(res) /= 32) stop 2
+
+  print *, 'PASS'
+end


### PR DESCRIPTION
When `TARGET_SUPPORTS_QUADFP` is set, `C_LONG_DOUBLE_COMPLEX` in ISO C binding should refer to quad-precision complex numbers; otherwise, it refers to double-precision complex numbers (which is the current behaviour).