### PR TITLE
[QuadFP][flang1] Support quad complex zero in collapse_assignment

### DIFF
--- a/test/llvm_ir_correct/collapse_zero_assignment.f90
+++ b/test/llvm_ir_correct/collapse_zero_assignment.f90
@@ -1,0 +1,40 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! Test that at -O2, flang1 emits zero initialization for array assignment of
+! constant zeros, but only when the LHS has a rank of 2 or more, or if its type
+! is complex. See collapse_assignment() in tools/flang1/flang1exe/transfrm.c.
+!
+! RUN: %flang -O2 -S -emit-flang-llvm -o %t.ll %s
+! RUN: FileCheck %s < %t.ll
+
+program collapse_zero_assignment
+  implicit none
+  integer(4), dimension(2) :: i1
+  integer(4), dimension(3, 3) :: i2
+  integer(4), dimension(5, 5, 5) :: i3
+  real(4), dimension(4) :: f1
+  real(4), dimension(6, 6) :: f2
+  real(8), dimension(7) :: d1
+  real(8), dimension(8, 8) :: d2
+  complex(8), dimension(9) :: c1
+  complex(8), dimension(10, 10) :: c2
+
+! CHECK: call void{{.*}} @f90_mzero4 (ptr {{.*}}, i64 9)
+! CHECK: call void{{.*}} @f90_mzero4 (ptr {{.*}}, i64 125)
+! CHECK: call void{{.*}} @f90_mzero4 (ptr {{.*}}, i64 36)
+! CHECK: call void{{.*}} @f90_mzero8 (ptr {{.*}}, i64 64)
+! CHECK: call void{{.*}} @f90_mzeroz16 (ptr {{.*}}, i64 9)
+! CHECK: call void{{.*}} @f90_mzeroz16 (ptr {{.*}}, i64 100)
+
+  i1 = 0
+  i2 = 0
+  i3 = 0
+  f1 = 0.0_4
+  f2 = 0.0_4
+  d1 = 0.0_8
+  d2 = 0.0_8
+  c1 = (0.0, 0.0)
+  c2 = (0.0, 0.0)
+end program

--- a/test/llvm_ir_correct/collapse_zero_assignment_quadfp.f90
+++ b/test/llvm_ir_correct/collapse_zero_assignment_quadfp.f90
@@ -1,0 +1,33 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+! This is the same as collapse_zero_assignment.f90, but specialized for
+! QuadFP types.
+!
+! REQUIRES: quadfp
+! RUN: %flang -O2 -S -emit-flang-llvm -o %t.ll %s
+! RUN: FileCheck %s < %t.ll
+
+program collapse_zero_assignment_quadfp
+  implicit none
+  real(16), dimension(2) :: d1
+  real(16), dimension(3, 3) :: d2
+  real(16), dimension(4, 4, 4) :: d3
+  complex(16), dimension(5) :: c1
+  complex(16), dimension(6, 6) :: c2
+  complex(16), dimension(7, 7, 7) :: c3
+
+! CHECK: call void{{.*}} @f90_mzero16 (ptr {{.*}}, i64 9)
+! CHECK: call void{{.*}} @f90_mzero16 (ptr {{.*}}, i64 64)
+! CHECK: call void{{.*}} @f90_mzeroz32 (ptr {{.*}}, i64 5)
+! CHECK: call void{{.*}} @f90_mzeroz32 (ptr {{.*}}, i64 36)
+! CHECK: call void{{.*}} @f90_mzeroz32 (ptr {{.*}}, i64 343)
+
+  d1 = 0.0
+  d2 = 0.0
+  d3 = 0.0
+  c1 = (0.0, 0.0)
+  c2 = (0.0, 0.0)
+  c3 = (0.0, 0.0)
+end program

--- a/tools/flang1/flang1exe/transfrm.c
+++ b/tools/flang1/flang1exe/transfrm.c
@@ -1936,6 +1936,12 @@ collapse_assignment(int asn, int std)
       if (CONVAL1G(cnst) == stb.dbl0 && CONVAL2G(cnst) == stb.dbl0)
         is_zero = 1;
       break;
+#ifdef TARGET_SUPPORTS_QUADFP
+    case DT_QCMPLX:
+      if (CONVAL1G(cnst) == stb.quad0 && CONVAL2G(cnst) == stb.quad0)
+        is_zero = 1;
+      break;
+#endif
     case DT_BINT:
     case DT_SINT:
     case DT_INT4:


### PR DESCRIPTION
If an array is assigned a quad-precision complex value, and the value has a zero real part and a zero imaginary part, the array assignment can be collapsed into a `memset`.