### PR TITLE
Fix issue 1336. incorrect results with entry statements

### DIFF
--- a/test/f90_correct/inc/en06.mk
+++ b/test/f90_correct/inc/en06.mk
@@ -1,0 +1,23 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/inc/en07.mk
+++ b/test/f90_correct/inc/en07.mk
@@ -1,0 +1,23 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/inc/en08.mk
+++ b/test/f90_correct/inc/en08.mk
@@ -1,0 +1,23 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/inc/en09.mk
+++ b/test/f90_correct/inc/en09.mk
@@ -1,0 +1,23 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;
+

--- a/test/f90_correct/lit/en06.sh
+++ b/test/f90_correct/lit/en06.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/en07.sh
+++ b/test/f90_correct/lit/en07.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/en08.sh
+++ b/test/f90_correct/lit/en08.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/en09.sh
+++ b/test/f90_correct/lit/en09.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/en06.f90
+++ b/test/f90_correct/src/en06.f90
@@ -1,0 +1,38 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test the fix for introduced error, in which the entry returns adjustable
+! length character.
+module m
+contains
+function f1() bind(C)
+  complex(kind=4) :: f1
+  integer :: e1
+  f1 = (2.0, 4.0)
+  return
+entry e1() bind(C)
+  e1 = 4
+end function
+end module
+
+program test
+  use m
+  complex(kind=4) :: resc
+  integer :: resi,res2(1),exp2(1)
+  real(kind=4) :: res1(2),exp1(2)
+
+  resc=f1()
+  resi = e1()
+  print *, "hello", resc, resi
+  res1(1)= resc%re
+  res1(2)= resc%im
+  exp1(1)=2.0
+  exp1(2)=4.0
+
+  res2 = resi;
+  exp2(1)=4
+  call checkf(res1,exp1,2)
+  call check(res2,exp2,1)
+end program

--- a/test/f90_correct/src/en07.f90
+++ b/test/f90_correct/src/en07.f90
@@ -1,0 +1,38 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test the fix for introduced error, in which the entry returns adjustable
+! length character.
+module m
+contains
+function f1() 
+  complex(kind=4) :: f1
+  integer :: e1
+  f1 = (2.0, 4.0)
+  return
+entry e1()
+  e1 = 4
+end function
+end module
+
+program test
+  use m
+  complex(kind=4) :: resc
+  integer :: resi,res2(1),exp2(1)
+  real(kind=4) :: res1(2),exp1(2)
+
+  resc=f1()
+  resi = e1()
+  print *, "hello", resc, resi
+  res1(1)= resc%re
+  res1(2)= resc%im
+  exp1(1)=2.0
+  exp1(2)=4.0
+
+  res2 = resi;
+  exp2(1)=4
+  call checkf(res1,exp1,2)
+  call check(res2,exp2,1)
+end program

--- a/test/f90_correct/src/en08.f90
+++ b/test/f90_correct/src/en08.f90
@@ -1,0 +1,36 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test the fix for introduced error, in which the entry returns adjustable
+! length character.
+module m
+contains
+function f1() bind(C)
+  real (kind=4) :: f1
+  integer :: e1
+  f1 = 8.0
+  return
+entry e1() bind(C)
+  e1 = 4
+end function
+end module
+
+program test
+  use m
+  real(kind=4) :: resc
+  integer :: resi,res2(1),exp2(1)
+  real(kind=4) :: res1(1),exp1(1)
+
+  resc=f1()
+  resi = e1()
+  print *, "hello", resc, resi
+  res1(1)= resc
+  exp1(1)=8.0
+
+  res2 = resi;
+  exp2(1)=4
+  call checkf(res1,exp1,1)
+  call check(res2,exp2,1)
+end program

--- a/test/f90_correct/src/en09.f90
+++ b/test/f90_correct/src/en09.f90
@@ -1,0 +1,36 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test the fix for introduced error, in which the entry returns adjustable
+! length character.
+module m
+contains
+function f1() bind(C)
+  real (kind=8) :: f1
+  integer :: e1
+  f1 = 8.0
+  return
+entry e1() bind(C)
+  e1 = 4
+end function
+end module
+
+program test
+  use m
+  real(kind=8) :: resc
+  integer :: resi,res2(1),exp2(1)
+  real(kind=8) :: res1(1),exp1(1)
+
+  resc=f1()
+  resi = e1()
+  print *, "hello", resc, resi
+  res1(1)= resc
+  exp1(1)=8.0
+
+  res2 = resi;
+  exp2(1)=4
+  call checkf(res1,exp1,1)
+  call check(res2,exp2,1)
+end program

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -14241,42 +14241,42 @@ reset_expr_id(void)
 static void
 store_return_value_for_entry(OPERAND *p, int i_name)
 {
-  if (p->ot_type != OT_VAR || !DT_ISCMPLX(DTYPEG(p->val.sptr))) {
-    print_token("\tstore ");
-    write_type(p->ll_type);
-    print_space(1);
-    write_operand(p, "", FLG_OMIT_OP_TYPE);
-    print_token(", ");
-    write_type(make_ptr_lltype(p->ll_type));
-    print_token(" %");
-    print_token(get_entret_arg_name());
-    print_token(", align 4\n");
-  } else {
-    TMPS *loadtmp;
-    /*  %11 = load <{float, float}>, ptr %cp1_300, align 4  */
-    loadtmp = make_tmps();
+  const LL_Type *retTy;
+  TMPS *new_tmps;
+  // extract the scalar value if datatype is a pointer type
+  if (p->ll_type->data_type == LL_PTR) {
+    retTy = p->ll_type->sub_types[0];
+    assert((retTy->data_type  != LL_PTR), 
+	    "scalar type is expected : got %d ", LL_PTR, ERR_Fatal);
+    new_tmps = make_tmps();
     print_token("\t");
-    print_tmp_name(loadtmp);
-    print_token(" = load");
-    write_type(p->ll_type->sub_types[0]);
+    print_tmp_name(new_tmps);
+    print_space(1);
+    print_token("=");
+    print_space(1);
+    print_token("load ");
+    write_type(retTy);
     print_token(", ");
     write_type(p->ll_type);
-    print_space(1);
     write_operand(p, "", FLG_OMIT_OP_TYPE);
-    print_token(", align 4\n");
-
-    /*  store <{float, float}> %11, ptr %__master_entry_rslt323, align 4  */
-    print_token("\tstore ");
-    write_type(p->ll_type->sub_types[0]);
-    print_space(1);
-    print_tmp_name(loadtmp);
-    print_token(", ");
-
-    write_type(p->ll_type);
-    print_token(" %");
-    print_token(get_entret_arg_name());
     print_token(", align 4\n");
   }
+
+  print_token("\tstore ");
+  if (p->ll_type->data_type == LL_PTR) {
+    write_type(retTy);
+    print_space(1);
+    print_tmp_name(new_tmps);
+  } else {
+   write_type(p->ll_type);
+   print_space(1);
+   write_operand(p, "", FLG_OMIT_OP_TYPE);
+  }
+  print_token(", ");
+  write_type(make_ptr_lltype(p->ll_type));
+  print_token(" %");
+  print_token(get_entret_arg_name());
+  print_token(", align 4\n");
 
   print_token("\t");
   print_token(llvm_instr_names[i_name]);

--- a/tools/flang2/flang2exe/x86_64/ll_abi.cpp
+++ b/tools/flang2/flang2exe/x86_64/ll_abi.cpp
@@ -248,7 +248,12 @@ amd64_coerce(LL_Module *module, LL_ABI_ArgInfo *arg,
       break;
     case AMD64_SSE:
       /* Possibilities: float, double, <2 x float> */
-      if (size == 8 * i + 4)
+      if (dtype == DT_CMPLX) {
+        LL_Type *ftype = ll_create_basic_type(module, LL_FLOAT, 0);
+        LL_Type *pair[2] = {ftype, ftype};
+        types[i] = ll_create_anon_struct_type(module, pair, 2,  true, 0);
+      }
+      else if (size == 8 * i + 4)
         types[i] = ll_create_basic_type(module, LL_FLOAT, 0);
       else
         types[i] = ll_create_basic_type(module, LL_DOUBLE, 0);


### PR DESCRIPTION
Fixing the issue 1336.
currently the address of entry return value is stored when the entry return type is pointer. this gives incorrect result.
The fix addresses the issue by storing the scalar return value to the entry return value.