### PR TITLE
Fix for issue # 1361. Flang does not allow expression as argument for NORM2

### DIFF
--- a/test/f90_correct/inc/norm2_expr_arg.mk
+++ b/test/f90_correct/inc/norm2_expr_arg.mk
@@ -1,0 +1,23 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+EXE=norm2_expr_arg.$(EXESUFFIX)
+
+build:  $(SRC)/norm2_expr_arg.F90
+	-$(RM) norm2_expr_arg.$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	-$(RM) $(OBJ)
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	@echo ------------------------------------ building test $@
+	$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/norm2_expr_arg.F90 check.$(OBJX) -o norm2_expr_arg.$(EXESUFFIX)
+	$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/norm2_expr_arg.F90 check.$(OBJX) -r8 -o norm2_expr_argR8.$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test norm2_expr_arg
+	norm2_expr_arg.$(EXESUFFIX)
+	norm2_expr_argR8.$(EXESUFFIX)
+
+verify: ;
+
+norm2_expr_arg.run: run

--- a/test/f90_correct/lit/norm2_expr_arg.sh
+++ b/test/f90_correct/lit/norm2_expr_arg.sh
@@ -1,0 +1,10 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/norm2_expr_arg.F90
+++ b/test/f90_correct/src/norm2_expr_arg.F90
@@ -1,0 +1,23 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+program norm2_expr_arg
+
+  parameter(N=1)
+  integer :: result(N),expect(N)
+  real    :: x(10), y(10)
+  integer :: i
+
+  do i = 1, 10
+    x(i) = i * i
+    y(i) = i
+  enddo
+
+  result(1) = norm2(x-y)
+  expect(1) = 140.2426
+  call check(result,expect,N)
+
+end program

--- a/tools/flang1/flang1exe/func.c
+++ b/tools/flang1/flang1exe/func.c
@@ -3262,6 +3262,16 @@ leave_arg(int ast, int i, int *parg, int lc)
     case I_NORM2:
       if (i != 0)
         return 0;
+      // Argument with expression has to be rewritten
+      switch(A_TYPEG(arg)) {
+        default:
+          break;
+        case A_BINOP:
+        case A_UNOP:
+        case A_PAREN:
+          return 0;
+      }
+
       args = A_ARGSG(ast);
       astdim = ARGT_ARG(args, 1);
       break;


### PR DESCRIPTION
When the arguments of NORM2 are expressions they are not getting lowered and hence results in compiler internal error. This change lowers the expression arguments and handles such cases.
A testcase is also added to validate the change. 