### PR TITLE
[Flang1] Fix the string operation of file name

### DIFF
--- a/test/f90_correct/inc/import_mod_from_user.mk
+++ b/test/f90_correct/inc/import_mod_from_user.mk
@@ -1,0 +1,30 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(MKDIR) import_mod_from_user_dir1
+	-$(CD) import_mod_from_user_dir1
+	-$(CP) $(SRC)/import_mod_from_user_dir1_m2.f90 .
+	-$(FC) -c import_mod_from_user_dir1_m2.f90
+	-$(CD) ..
+	-$(MKDIR) import_mod_from_user_dir2
+	-$(CD) import_mod_from_user_dir2
+	-$(CP) $(SRC)/import_mod_from_user_dir2* .
+	-$(FC) -c import_mod_from_user_dir2_m2.f90
+	-$(FC) -c import_mod_from_user_dir2_m1.f90
+	-$(CD) ..
+	-$(FC) -c -I./import_mod_from_user_dir1 -I./import_mod_from_user_dir2 $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/import_mod_from_user.sh
+++ b/test/f90_correct/lit/import_mod_from_user.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/makefile
+++ b/test/f90_correct/makefile
@@ -24,6 +24,8 @@ COMP_CHECK=python $(HOMEQA)/../tools/check_compilation.py
 
 RM=rm -f
 CP=cp -f
+CD=cd
+MKDIR=mkdir -p
 UNAME := $(shell uname -a)
 
 INCLUDES=$(BASE_DIR)/inc

--- a/test/f90_correct/src/import_mod_from_user.f90
+++ b/test/f90_correct/src/import_mod_from_user.f90
@@ -1,0 +1,17 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for the import module from the correct path.
+
+module import_mod_from_user
+contains
+  subroutine sub()
+     use import_source2
+  end
+end
+
+program import_mod_from_user_test
+  print *, "PASS"
+end

--- a/test/f90_correct/src/import_mod_from_user_dir1_m2.f90
+++ b/test/f90_correct/src/import_mod_from_user_dir1_m2.f90
@@ -1,0 +1,20 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for the import module from the correct path. This file is in the wrong
+! path for testing.
+
+module import_source
+contains
+  subroutine sub1()
+  end
+
+  subroutine sub3()
+  end
+
+  function func() result(funit)
+    integer :: funit
+  end
+end

--- a/test/f90_correct/src/import_mod_from_user_dir2_m1.f90
+++ b/test/f90_correct/src/import_mod_from_user_dir2_m1.f90
@@ -1,0 +1,11 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for the import module from the correct path. This file is in the
+! correct path.
+
+module import_source2
+    use import_source, only : func, sub1
+end

--- a/test/f90_correct/src/import_mod_from_user_dir2_m2.f90
+++ b/test/f90_correct/src/import_mod_from_user_dir2_m2.f90
@@ -1,0 +1,21 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for the import module from the correct path. This file is in the
+! correct path.
+
+module import_source
+contains
+  subroutine sub1()
+  end
+
+  subroutine sub2(m)
+    integer, intent(out) :: m
+  end
+
+  function func() result(funit)
+    integer :: funit
+  end
+end

--- a/tools/flang1/flang1exe/interf.c
+++ b/tools/flang1/flang1exe/interf.c
@@ -845,7 +845,7 @@ get_module_file_name_from_user(TOBE_IMPORTED_LIST *il, const char *from_file_nam
     saveslash = *slash;
     *slash = '\0'; /* have a directory, terminate the string */
     if (fndpath(il->modulefilename, il->fullfilename, MAX_FNAME_LEN,
-                from_file_name) == 0) {
+                chfromdup) == 0) {
       *slash = saveslash;
       FREE(chfromdup);
       return 1;


### PR DESCRIPTION
This bug came from 0bcbadbf3f7f056b298a7724b9689ebacbdae4e9, which uses strdup to allocate non-const versions of const string, but does not change the use of the original string. The use of original string (file name) terminates the string by removing the last directory. So, we need to replace the use of original string with the allocated string.