### PR TITLE
Enable NCAR kernel tests

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Test flang
         run: |
           cd build/flang
-          make check-all
+          make check-flang-long
 
       # Archive documentation just once, for the fastest job.
       - if: matrix.cc == 'clang' && matrix.version == '11'

--- a/.github/workflows/build_flang_arm64.yml
+++ b/.github/workflows/build_flang_arm64.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Test flang
         run: |
           cd ${{ env.build_path }}/flang/build/flang
-          make check-all
+          make check-flang-long

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,15 @@ add_lit_testsuite(check-flang "Running Flang regression tests"
   )
 set_target_properties(check-flang PROPERTIES FOLDER "Flang tests")
 
+add_lit_testsuite(check-flang-long "Running time-consuming Flang regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  EXCLUDE_FROM_CHECK_ALL
+  PARAMS "${FLANG_TEST_PARAMS};run_long_tests=true"
+  DEPENDS ${FLANG_TEST_DEPS}
+  ARGS ${FLANG_TEST_EXTRA_ARGS}
+  )
+set_target_properties(check-flang-long PROPERTIES FOLDER "Flang tests")
+
 add_lit_testsuites(FLANG ${CMAKE_CURRENT_SOURCE_DIR}
   PARAMS ${FLANG_TEST_PARAMS}
   DEPENDS ${FLANG_TEST_DEPS}

--- a/test/ncar_kernels/PORT_binterp/src/kernel_binterp.F90
+++ b/test/ncar_kernels/PORT_binterp/src/kernel_binterp.F90
@@ -179,7 +179,7 @@
 
 
     ! STATE VERIFICATION
-    IF ( ALL(( abs(outstate_itab - itab) ) .LT. _TOL )) THEN
+    IF ( ALL(( abs(outstate_itab - itab) ) .LE. _TOL )) THEN
         WRITE(*,*) "itab is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_itab
         !WRITE(*,*) "KERNEL: ", itab
@@ -197,7 +197,7 @@
         WRITE(*,*) "Mean value of original outstate_itab is ", sum(outstate_itab)/real(size(outstate_itab))
         WRITE(*,*) ""
     END IF
-    IF ( ALL(( abs(outstate_refr - refr) ) .LT. _TOL )) THEN
+    IF ( ALL(( abs(outstate_refr - refr) ) .LE. _TOL )) THEN
         WRITE(*,*) "refr is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_refr
         !WRITE(*,*) "KERNEL: ", refr
@@ -215,7 +215,7 @@
         WRITE(*,*) "Mean value of original outstate_refr is ", sum(outstate_refr)/real(size(outstate_refr))
         WRITE(*,*) ""
     END IF
-    IF ( ALL(( abs(outstate_cext - cext) ) .LT. _TOL )) THEN
+    IF ( ALL(( abs(outstate_cext - cext) ) .LE. _TOL )) THEN
         WRITE(*,*) "cext is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_cext
         !WRITE(*,*) "KERNEL: ", cext
@@ -241,7 +241,7 @@
         end do
     END IF
 
-    IF ( ALL(( abs(outstate_utab -  utab) ) .LT. _TOL )) THEN
+    IF ( ALL(( abs(outstate_utab -  utab) ) .LE. _TOL )) THEN
         WRITE(*,*) "utab is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_utab
         !WRITE(*,*) "KERNEL: ", utab
@@ -259,7 +259,7 @@
         WRITE(*,*) "Mean value of original outstate_utab is ", sum(outstate_utab)/real(size(outstate_utab))
         WRITE(*,*) ""
     END IF
-    IF ( ALL(( abs(outstate_refitabsw - refitabsw) ) .LT. _TOL )) THEN
+    IF ( ALL(( abs(outstate_refitabsw - refitabsw) ) .LE. _TOL )) THEN
         WRITE(*,*) "refitabsw is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_refitabsw
         !WRITE(*,*) "KERNEL: ", refitabsw
@@ -277,7 +277,7 @@
         WRITE(*,*) "Mean value of original outstate_refitabsw is ", sum(outstate_refitabsw)/real(size(outstate_refitabsw))
         WRITE(*,*) ""
     END IF
-    IF ( ALL(( abs(outstate_refrtabsw - refrtabsw) ) .LT. _TOL )) THEN
+    IF ( ALL(( abs(outstate_refrtabsw - refrtabsw) ) .LE. _TOL )) THEN
         WRITE(*,*) "refrtabsw is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_refrtabsw
         !WRITE(*,*) "KERNEL: ", refrtabsw
@@ -295,7 +295,7 @@
         WRITE(*,*) "Mean value of original outstate_refrtabsw is ", sum(outstate_refrtabsw)/real(size(outstate_refrtabsw))
         WRITE(*,*) ""
     END IF
-    IF ( ALL(( abs(outstate_ttab - ttab) ) .LT. _TOL )) THEN
+    IF ( ALL(( abs(outstate_ttab - ttab) ) .LE. _TOL )) THEN
         WRITE(*,*) "ttab is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_ttab
         !WRITE(*,*) "KERNEL: ", ttab
@@ -313,7 +313,7 @@
         WRITE(*,*) "Mean value of original outstate_ttab is ", sum(outstate_ttab)/real(size(outstate_ttab))
         WRITE(*,*) ""
     END IF
-    IF ( ALL(( abs(outstate_refi - refi )) .LT. _TOL)) THEN
+    IF ( ALL(( abs(outstate_refi - refi )) .LE. _TOL)) THEN
         WRITE(*,*) "refi is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_refi
         !WRITE(*,*) "KERNEL: ", refi
@@ -331,7 +331,7 @@
         WRITE(*,*) "Mean value of original outstate_refi is ", sum(outstate_refi)/real(size(outstate_refi))
         WRITE(*,*) ""
     END IF
-    IF ( (abs(outstate_ncol - ncol) ) .LT. _TOL ) THEN
+    IF ( (abs(outstate_ncol - ncol) ) .LE. _TOL ) THEN
         WRITE(*,*) "ncol is IDENTICAL."
         WRITE(*,*) "STATE : ", outstate_ncol
         WRITE(*,*) "KERNEL: ", ncol
@@ -341,7 +341,7 @@
         WRITE(*,*) "STATE : ", outstate_ncol
         WRITE(*,*) "KERNEL: ", ncol
     END IF
-    IF ( ALL(( abs(outstate_jtab - jtab) ) .LT. _TOL )) THEN
+    IF ( ALL(( abs(outstate_jtab - jtab) ) .LE. _TOL )) THEN
         WRITE(*,*) "jtab is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_jtab
         !WRITE(*,*) "KERNEL: ", jtab
@@ -359,7 +359,7 @@
         WRITE(*,*) "Mean value of original outstate_jtab is ", sum(outstate_jtab)/real(size(outstate_jtab))
         WRITE(*,*) ""
     END IF
-    IF ( ALL(( abs(outstate_extpsw - extpsw) ) .LT. _TOL )) THEN
+    IF ( ALL(( abs(outstate_extpsw - extpsw) ) .LE. _TOL )) THEN
         WRITE(*,*) "extpsw is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_extpsw
         !WRITE(*,*) "KERNEL: ", extpsw

--- a/test/ncar_kernels/PORT_reftra_sw/src/kernel_reftra_sw.F90
+++ b/test/ncar_kernels/PORT_reftra_sw/src/kernel_reftra_sw.F90
@@ -132,7 +132,7 @@
    
 
     ! STATE VERIFICATION
-    IF ( ALL(( abs(outstate_ztradc - ztradc) ) .LT. _TOL) ) THEN
+    IF ( ALL(( abs(outstate_ztradc - ztradc) ) .LE. _TOL) ) THEN
         WRITE(*,*) "ztradc is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_ztradc
         !WRITE(*,*) "KERNEL: ", ztradc
@@ -150,7 +150,7 @@
         WRITE(*,*) "Mean value of original outstate_ztradc is ", sum(outstate_ztradc)/real(size(outstate_ztradc))
         WRITE(*,*) ""
     END IF
-    IF ( ALL(( abs(outstate_zrefdc - zrefdc) ) .LT. _TOL)) THEN
+    IF ( ALL(( abs(outstate_zrefdc - zrefdc) ) .LE. _TOL)) THEN
         WRITE(*,*) "zrefdc is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_zrefdc
         !WRITE(*,*) "KERNEL: ", zrefdc
@@ -168,7 +168,7 @@
         WRITE(*,*) "Mean value of original outstate_zrefdc is ", sum(outstate_zrefdc)/real(size(outstate_zrefdc))
         WRITE(*,*) ""
     END IF
-    IF ( ALL(( abs(outstate_ztrac - ztrac) ) .LT. _TOL)) THEN
+    IF ( ALL(( abs(outstate_ztrac - ztrac) ) .LE. _TOL)) THEN
         WRITE(*,*) "ztrac is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_ztrac
         !WRITE(*,*) "KERNEL: ", ztrac
@@ -186,7 +186,7 @@
         WRITE(*,*) "Mean value of original outstate_ztrac is ", sum(outstate_ztrac)/real(size(outstate_ztrac))
         WRITE(*,*) ""
     END IF
-    IF ( ALL(( abs(outstate_zrefc - zrefc) ) .LT. _TOL) ) THEN
+    IF ( ALL(( abs(outstate_zrefc - zrefc) ) .LE. _TOL) ) THEN
         WRITE(*,*) "zrefc is IDENTICAL."
         !WRITE(*,*) "STATE : ", outstate_zrefc
         !WRITE(*,*) "KERNEL: ", zrefc


### PR DESCRIPTION
This PR fixes a couple of failures in the NCAR tests on X86, adds a new Makefile goal named `check-flang-long`, and updates the GitHub CI workflow to run that instead of `check-all`.  `check-all` remains synonymous to `check-flang`, which skips the NCAR kernel tests as `UNSUPPORTED`.