### PR TITLE
[LLVM16][llvm_ir_correct] Expect `memory(none)` as replacements for `readnone`

### DIFF
--- a/test/llvm_ir_correct/sincos.f90
+++ b/test/llvm_ir_correct/sincos.f90
@@ -46,4 +46,4 @@ end subroutine
 ! CHECK: declare float @__ps_sin_1(float) #[[ATTR_ID]]
 ! CHECK: declare float @__ps_cos_1(float) #[[ATTR_ID]]
 
-! CHECK: attributes #[[ATTR_ID]] = { nounwind readnone willreturn
+! CHECK: attributes #[[ATTR_ID]] = { nounwind {{willreturn memory\(none\)|readnone willreturn}}


### PR DESCRIPTION
The `readnone` function attribute has been replaced with `memory(none)`, at least in some cases. This patch updates test/llvm_ir_correct/sincos.f90 to be compatible with both LLVM 15 and LLVM 16. See the Discourse link below for details:

https://discourse.llvm.org/t/rfc-unify-memory-effect-attributes/65579