### PR TITLE
[LLVM16][flang1] Suppress -Wsingle-bit-bitfield-constant-conversion warnings

### DIFF
--- a/tools/flang1/flang1exe/commopt.h
+++ b/tools/flang1/flang1exe/commopt.h
@@ -162,8 +162,8 @@ typedef union {
     int barr1;
     int barr2;
     int fg; /* fg node */
-    int ignore : 1;
-    int fused : 1;
+    unsigned ignore : 1;
+    unsigned fused : 1;
   } forall;
 } FTABLE;
 

--- a/tools/flang1/flang1exe/hlvect.h
+++ b/tools/flang1/flang1exe/hlvect.h
@@ -18,13 +18,13 @@
 #define MAX_LOOPS 14
 
 typedef struct {
-  int depchk : 1;   /* [no]depchk */
-  int assoc : 1;    /* [no]assoc */
-  int eqvchk : 1;   /* [no]eqvchk */
-  int lstval : 1;   /* [no]lastval */
-  int recog : 1;    /* [no]recog */
-  int trans : 1;    /* [no]transform */
-  int safecall : 1; /* permit calls in loops */
+  unsigned depchk : 1;   /* [no]depchk */
+  unsigned assoc : 1;    /* [no]assoc */
+  unsigned eqvchk : 1;   /* [no]eqvchk */
+  unsigned lstval : 1;   /* [no]lastval */
+  unsigned recog : 1;    /* [no]recog */
+  unsigned trans : 1;    /* [no]transform */
+  unsigned safecall : 1; /* permit calls in loops */
   int shortloop;    /* a.k.a. smallvect */
   int mincnt;       /* flg.x[30] = min lp count for vectorization */
   int ldstsplit;    /* flg.x[40] = load/store threshhold for splitting */


### PR DESCRIPTION
Some single-bit bitfields are declared as `int`, and Clang 16 now emits warnings for such uses, e.g.

    .../flang1exe/commopt.c:389:23: error: implicit truncation from 'int' to a one-bit wide bit-field changes value from 1 to -1

Such bitfields should be declared `unsigned` instead.