### PR TITLE
Fix sprintf overflow

### DIFF
--- a/runtime/flang/ftnmiscsup.c
+++ b/runtime/flang/ftnmiscsup.c
@@ -35,7 +35,7 @@ void
 Ftn_date(char *buf,     /* date buffer */
          INT buf_len)   /* length of date buffer */
 {
-  char loc_buf[9];
+  char loc_buf[10];
   INT idx1;
   time_t ltime;
   struct tm *lt;


### PR DESCRIPTION
Give sprintf one extra byte to write the null character in the end of string and resolve the overflow warning