### PR TITLE
fix missing local lit config file in ili_correct test folder

### DIFF
--- a/test/ili_correct/lit.local.cfg
+++ b/test/ili_correct/lit.local.cfg
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+config.suffixes = ['.f', '.FOR', '.for', '.f77', '.f90', '.f95', '.F', '.fpp',
+ '.FPP']
+


### PR DESCRIPTION
related issue: #1363 