### PR TITLE
fix sema tests on Windows

### DIFF
--- a/test/sema/aconst_with_null_subict.f90
+++ b/test/sema/aconst_with_null_subict.f90
@@ -8,7 +8,7 @@
 ! Ensure that flang1 successfully produces correct symbol table entries for the
 ! empty derived type S, the array A, as well as the array constructor [S()].
 
-! RUN: %flang1 %s -opt 0 -q 0 1 -q 47 1 | FileCheck %s
+! RUN: flang1 %s -opt 0 -q 0 1 -q 47 1 | FileCheck %s
 ! CHECK: datatype:[[STYPE:[0-9]+]] Derived member:1 size:0
 ! CHECK: datatype:[[ATYPE:[0-9]+]] Array type:[[STYPE]] dims:1
 ! CHECK: datatype:[[CTYPE:[0-9]+]] Array type:[[STYPE]] dims:1

--- a/test/sema/implied_do.f90
+++ b/test/sema/implied_do.f90
@@ -4,7 +4,7 @@
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
 
-! RUN: %flang1 %s | FileCheck %s
+! RUN: flang1 %s | FileCheck %s
 ! CHECK: procedure:Program
 ! CHECK-DAG: s:[[FUNC:[0-9]+]] {{.*}}:func
 ! CHECK-DAG: s:[[REALLOC:[0-9]+]] {{.*}}:f90_realloc_arr_in_impiled_do

--- a/test/sema/sconst_with_null_subc.f90
+++ b/test/sema/sconst_with_null_subc.f90
@@ -8,7 +8,7 @@
 ! Ensure that flang1 generates a flag for empty derived type to mark null subc
 ! when exporting typedef initialization to MOD file.
 
-! RUN: %flang1 %s
+! RUN: flang1 %s
 ! RUN: FileCheck %s --input-file=./sconst_with_null_subc.mod
 ! RUN: rm -f ./sconst_with_null_subc.mod
 module sconst_with_null_subc


### PR DESCRIPTION
On Windows `%flang1` is interpreted incorrectly as `flang.exe1`. This change assumes that flang1 executable is in the user's path.

related issue: #1363 