### PR TITLE
Fix flang2 tests on Windows

### DIFF
--- a/test/flang2/invocation.ilm
+++ b/test/flang2/invocation.ilm
@@ -5,17 +5,17 @@
 !
 
 ! flang2 should not crash when invoked with no command line argument.
-! RUN: not %flang2 > %t 2>&1
+! RUN: not flang2 > %t 2>&1
 ! RUN: FileCheck --check-prefix=CHECK-NO-CMDLINE-ARG %s < %t
 
 ! CHECK-NO-CMDLINE-ARG: F90-F-0001-Source input file name not specified
 
 ! flang2 should print a warning for a blank .ilm file.
-! RUN: %flang2 %S/Inputs/blank.ilm > %t 2>&1
+! RUN: flang2 %S/Inputs/blank.ilm > %t 2>&1
 ! RUN: FileCheck --check-prefix=CHECK-BLANK-INPUT %s < %t
 
 ! flang2 should print a warning for a blank .stb file.
-! RUN: %flang2 %S/Inputs/nop.ilm -stbfile %S/Inputs/blank.stb > %t 2>&1
+! RUN: flang2 %S/Inputs/nop.ilm -stbfile %S/Inputs/blank.stb > %t 2>&1
 ! RUN: FileCheck --check-prefix=CHECK-BLANK-INPUT %s < %t
 
 ! CHECK-BLANK-INPUT: F90-W-0006-Input file empty


### PR DESCRIPTION
On Windows '%flang2' is interpreted incorrectly as 'flang.exe2'. This change assumes that flang2 executable is in the user's path.

related issue: #1363 