### PR TITLE
Fix llvm_ir_correct tests on Windows

### DIFF
--- a/test/llvm_ir_correct/iso_fortran_env_functions.f90
+++ b/test/llvm_ir_correct/iso_fortran_env_functions.f90
@@ -5,7 +5,7 @@
 !
 ! Simply check the file compiles with no error.
 !
-! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -I%flags -S -emit-llvm %s -o - | FileCheck %s
 ! CHECK: version_var
 ! CHECK: options_var
 

--- a/test/llvm_ir_correct/omp_atomic_load_logical.f90
+++ b/test/llvm_ir_correct/omp_atomic_load_logical.f90
@@ -2,8 +2,8 @@
 !* See https://llvm.org/LICENSE.txt for license information.
 !* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-! RUN: %flang -O0 -fopenmp -Hy,69,0x1000 -S -emit-llvm %s -o - | FileCheck %s
-! RUN: %flang -i8 -O0 -fopenmp -Hy,69,0x1000 -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -I%flags -O0 -fopenmp -Hy,69,0x1000 -S -emit-llvm %s -o - | FileCheck %s
+! RUN: %flang -I%flags -i8 -O0 -fopenmp -Hy,69,0x1000 -S -emit-llvm %s -o - | FileCheck %s
 
 module omp_atomic_load_logical
   use, intrinsic :: iso_fortran_env, &


### PR DESCRIPTION
On Windows some tests are unable to open iso_fortran_env.mod unless we include it explicitly.

related issue: #1363 