### PR TITLE
Fix executable names in lit.cfg

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -263,9 +263,11 @@ config.substitutions.append( ('%test_debuginfo', ' ' + config.llvm_src_root + '/
 config.substitutions.append( ('%itanium_abi_triple', makeItaniumABITriple(config.target_triple)) )
 config.substitutions.append( ('%ms_abi_triple', makeMSABITriple(config.target_triple)) )
 
-config.substitutions.append( ('%flang1', ' ' + config.flang + '1 ') )
-config.substitutions.append( ('%flang2', ' ' + config.flang + '2 ') )
-config.substitutions.append( ('%flang', ' ' + config.flang + ' ') )
+flang_root = os.path.splitext(config.flang)[0]
+flang_suffix = os.path.splitext(config.flang)[1]
+config.substitutions.append( ('%flang1', ' {}1{} '.format(flang_root, flang_suffix)) )
+config.substitutions.append( ('%flang2', ' {}2{} '.format(flang_root, flang_suffix)) )
+config.substitutions.append( ('%flang', ' {} '.format(config.flang)) )
 
 # The host triple might not be set, at least if we're compiling flang from
 # an already installed llvm.


### PR DESCRIPTION
On Windows concatenating strings for variables`%flang1` and `%flang2`  are incorrect (config.flang + '1' or '2') e.g.: `path\to\flang.exe1` instead of `path\to\flang1.exe`. 

related issue: #1363