### PR TITLE
Fix for handling absolute include paths

### DIFF
--- a/test/llvm_ir_correct/include-self.f90
+++ b/test/llvm_ir_correct/include-self.f90
@@ -1,0 +1,18 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+
+! RUN: %flang -cpp %s -DSELF=\"`realpath "%s"`\" -S -emit-llvm -o - | FileCheck %s
+
+#ifndef __SELF_INCLUDED
+#define __SELF_INCLUDED
+
+#include SELF
+
+subroutine foo
+! CHECK: foo
+end subroutine
+
+#endif

--- a/tools/flang1/flang1exe/accpp.c
+++ b/tools/flang1/flang1exe/accpp.c
@@ -2103,6 +2103,7 @@ add_to_incllist(char *fullname)
 static void
 _doincl(char *name, int type, LOGICAL include_next)
 {
+  FILE *tmpfp;
   char fullname[MAX_PATHNAME_LEN];
   int i;
 
@@ -2129,6 +2130,16 @@ _doincl(char *name, int type, LOGICAL include_next)
       idir.last = i;
       goto found;
     }
+
+  if (type == 0) { /* could be absolute path, check where it leads to */
+    tmpfp = fopen(name, "r");
+    if (tmpfp) {
+      snprintf(fullname, MAX_PATHNAME_LEN, "%s", name);
+      idir.last = 0;
+      if (fclose(tmpfp) == 0)
+        goto found;
+    }
+  }
 
   pperror(206, name, 4); /* cpp just continues, but why?? */
   return;

--- a/tools/flang1/flang1exe/fpp.c
+++ b/tools/flang1/flang1exe/fpp.c
@@ -1115,6 +1115,7 @@ dodef(void)
 static void
 doincl(LOGICAL include_next)
 {
+  FILE *tmpfp;
   int toktyp;
   char buff[MAX_FNAME_LEN];
   char fullname[MAX_FNAME_LEN];
@@ -1177,6 +1178,16 @@ doincl(LOGICAL include_next)
       idir.last = i;
       goto found;
     }
+
+  if (type == 0) { /* could be absolute path, check where it leads to */
+    tmpfp = fopen(buff, "r");
+    if (tmpfp) {
+      snprintf(fullname, MAX_FNAME_LEN, "%s", buff);
+      idir.last = 0;
+      if (fclose(tmpfp) == 0)
+        goto found;
+    }
+  }
 
   pperror(226, buff, 4); /* cpp just continues, but why?? */
   return;


### PR DESCRIPTION
A silly bug that prevented building OpenMPI OOT.
