### PR TITLE
[runtime] Fix infinite loop in `__fort_bcopysl`

### DIFF
--- a/runtime/flang/bcopys.c
+++ b/runtime/flang/bcopys.c
@@ -168,9 +168,12 @@ __fort_bcopysl(char *to, char *fr, size_t cnt, size_t tostr, size_t frstr,
     i *= len;
     j *= len;
     for (; cnt > 0; cnt--, i -= tostr, j -= frstr) {
-      for (k = len - 1; k >= 0; k--) {
+      // Since k is unsigned, stop the loop when k == 0, then
+      // copy the last element after the loop.
+      for (k = len - 1; k > 0; k--) {
         to[i + k] = fr[j + k];
       }
+      to[i] = fr[j];
     }
   }
 }

--- a/test/f90_correct/inc/issue1406.mk
+++ b/test/f90_correct/inc/issue1406.mk
@@ -1,0 +1,25 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+########## Make rule for test issue1406  ########
+
+
+$(TEST): run
+
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(CC) -c $(CFLAGS) $(SRC)/check.c -o check.$(OBJX)
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) check.$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/issue1406.sh
+++ b/test/f90_correct/lit/issue1406.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/issue1406.f90
+++ b/test/f90_correct/src/issue1406.f90
@@ -1,0 +1,25 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+program issue1406
+  integer, parameter :: n = 4 * 8
+  integer, parameter :: expect(n) = (/ &
+     5,  5,  5,  5,  5,  5,  5,  5, &
+    10, 10, 10, 10, 10, 10, 10, 10, &
+    15, 15, 15, 15, 15, 15, 15, 15, &
+    20, 20, 20, 20, 20, 20, 20, 20  &
+  /)
+  type t
+    integer :: a(8)
+  end type
+  type(t) :: stdm1(4, 5)
+  integer, dimension (1:2) :: rowmajor = (/ 2, 1 /)
+  type(t) :: array1(20)
+  integer :: i
+  do i = 1, 20
+    array1(i)%a = i
+  end do
+  stdm1 = reshape(array1, (/ 4, 5 /), order = rowmajor)
+  call check(stdm1(:, 5), expect, n)
+end


### PR DESCRIPTION
Fix a downward-counting loop with an unsigned loop counter to exit when the counter reaches 0 (instead of -1, which never happens).

Closes #1406.