### PR TITLE
Fix failures for imports with LLVM-17

### DIFF
--- a/test/debug_info/use_only_test.f90
+++ b/test/debug_info/use_only_test.f90
@@ -1,11 +1,16 @@
+! REQUIRES: llvm-17
+
 !RUN: %flang -g -S -emit-llvm %s_mod.f90 %s
 !RUN: cat use_only_test.ll | FileCheck %s
 
 !CHECK: [[MOD_VAR:![0-9]+]] = distinct !DIGlobalVariable(name: "mod_var1"
 !CHECK: distinct !DICompileUnit
 !CHECK-SAME: imports: [[IMPLIST:![0-9]+]]
-!CHECK: [[IMPLIST]] = !{[[IMPORT:![0-9]+]]
-!CHECK: [[IMPORT]] = !DIImportedEntity(tag: DW_TAG_imported_declaration
+!CHECK: [[IMPLIST]] = !{}
+!CHECK: !DISubprogram(name: "main"
+!CHECK-SAME: retainedNodes: [[RETAINED:![0-9]+]]
+!CHECK: [[RETAINED]] = !{[[RETAIN1:![0-9]+]]}
+!CHECK: [[RETAIN1]] = !DIImportedEntity(tag: DW_TAG_imported_declaration
 !CHECK-SAME: entity: [[MOD_VAR]]
 !CHECK-NOT: !DIImportedEntity(tag: DW_TAG_imported_module
 

--- a/test/debug_info/usemodule.f90
+++ b/test/debug_info/usemodule.f90
@@ -1,24 +1,29 @@
+! REQUIRES: llvm-17
+
 !RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
-!CHECK: [[VAR1:![0-9]+]] = distinct !DIGlobalVariable(name: "var1"
-!CHECK: [[MYMOD:![0-9]+]] = !DIModule(scope: {{![0-9]+}}, name: "mymod"
-!CHECK: [[VAR2:![0-9]+]] = distinct !DIGlobalVariable(name: "var2"
-!CHECK: [[VAR3:![0-9]+]] = distinct !DIGlobalVariable(name: "var3"
 
-!CHECK: !DIImportedEntity(tag: DW_TAG_imported_module, scope: [[USE_ALL:![0-9]+]], entity: [[MYMOD]]
-!CHECK: [[USE_ALL]] = distinct !DISubprogram(name: "use_all"
+!CHECK-DAG: [[VAR1:![0-9]+]] = distinct !DIGlobalVariable(name: "var1"
+!CHECK-DAG: [[MYMOD:![0-9]+]] = !DIModule(scope: {{![0-9]+}}, name: "mymod"
+!CHECK-DAG: [[VAR2:![0-9]+]] = distinct !DIGlobalVariable(name: "var2"
+!CHECK-DAG: [[VAR3:![0-9]+]] = distinct !DIGlobalVariable(name: "var3"
 
-!CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: [[USE_RESTRICTED:![0-9]+]], entity: [[VAR1]]
-!CHECK: [[USE_RESTRICTED]] = distinct !DISubprogram(name: "use_restricted"
+!CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: [[USE_ALL:![0-9]+]], entity: [[MYMOD]]
+!CHECK-DAG: [[USE_ALL]] = distinct !DISubprogram(name: "use_all"
 
-!CHECK: !DIImportedEntity(tag: DW_TAG_imported_module, scope: [[USE_RENAMED:![0-9]+]], entity: [[MYMOD]]
+!CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: [[USE_RESTRICTED:![0-9]+]], entity: [[VAR1]]
+!CHECK-DAG: [[USE_RESTRICTED]] = distinct !DISubprogram(name: "use_restricted"
+
+!CHECK: [[USE_RENAMED:![0-9]+]] = distinct !DISubprogram(name: "use_renamed"
+!CHECK-SAME: retainedNodes: [[RETAINED:![0-9]+]]
+!CHECK: [[RETAINED]] = !{[[RETAIN1:![0-9]+]]
+!CHECK: [[RETAIN1]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: [[USE_RENAMED]], entity: [[MYMOD]]
 !CHECK-SAME: elements: [[RENAMES:![0-9]+]]
-!CHECK: [[USE_RENAMED]] = distinct !DISubprogram(name: "use_renamed"
 !CHECK: [[RENAMES]] = !{[[RENAME1:![0-9]+]]}
-!CHECK: [[RENAME1]] = !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4", scope: [[USE_RENAMED]], entity: [[VAR1]]
+!CHECK: [[RENAME1]] = !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4", scope: [[USE_RENAMED:![0-9]+]], entity: [[VAR1]]
 
-!CHECK: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4", scope: [[USE_RESTRICTED_RENAMED:![0-9]+]], entity: [[VAR1]]
-!CHECK: [[USE_RESTRICTED_RENAMED]] = distinct !DISubprogram(name: "use_restricted_renamed"
+!CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "var4", scope: [[USE_RESTRICTED_RENAMED:![0-9]+]], entity: [[VAR1]]
+!CHECK-DAG: [[USE_RESTRICTED_RENAMED]] = distinct !DISubprogram(name: "use_restricted_renamed"
 
 module mymod
   integer :: var1 = 11

--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -149,6 +149,7 @@ typedef enum LL_IRVersion {
   LL_Version_11_0 = 110,
   LL_Version_12_0 = 120,
   LL_Version_13_0 = 130,
+  LL_Version_17_0 = 170,
   LL_Version_trunk = 1023
 } LL_IRVersion;
 
@@ -414,6 +415,13 @@ ll_feature_debug_info_ver13(const LL_IRFeatures *feature)
 }
 
 /**
+   \brief Version 17.0 debug metadata
+ */
+INLINE static bool ll_feature_debug_info_ver17(const LL_IRFeatures *feature)
+{
+  return feature->version >= LL_Version_17_0;
+}
+/**
    \brief Version 9.0 onwards uses 3 field syntax for constructors
    and destructors
  */
@@ -515,6 +523,7 @@ ll_feature_no_file_in_namespace(const LL_IRFeatures *feature)
 #define ll_feature_debug_info_ver11(f) ((f)->version >= LL_Version_11_0)
 #define ll_feature_debug_info_ver12(f) ((f)->version >= LL_Version_12_0)
 #define ll_feature_debug_info_ver13(f) ((f)->version >= LL_Version_13_0)
+#define ll_feature_debug_info_ver17(f) ((f)->version >= LL_Version_17_0)
 #define ll_feature_three_argument_ctor_and_dtor(f) \
   ((f)->version >= LL_Version_9_0)
 #define ll_feature_use_distinct_metadata(f) ((f)->version >= LL_Version_3_8)

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -4115,7 +4115,7 @@ lldbg_function_end(LL_DebugInfo *db, int func)
 static LL_MDRef
 lldbg_create_imported_entity(LL_DebugInfo *db, SPTR entity_sptr, SPTR func_sptr,
                              IMPORT_TYPE entity_type, LL_MDRef elements_mdnode,
-                            LL_MDRef imported_list)
+                             LL_MDRef imported_list)
 {
   LLMD_Builder mdb;
   LL_MDRef entity_mdnode, scope_mdnode = 0, file_mdnode, cur_mdnode;

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -188,10 +188,11 @@ static LL_MDRef lldbg_fwd_local_variable(LL_DebugInfo *db, int sptr, int findex,
 static LL_MDRef lldbg_create_imported_entity(LL_DebugInfo *db, SPTR entity_sptr,
                                              SPTR func_sptr,
                                              IMPORT_TYPE entity_type,
-                                             LL_MDRef elements_mdnode);
+                                             LL_MDRef elements_mdnode,
+                                             LL_MDRef imported_list);
 static void lldbg_emit_imported_entity(LL_DebugInfo *db, SPTR entity_sptr,
                                        SPTR func_sptr, IMPORT_TYPE entity_type,
-                                       LL_MDRef elements);
+                                       LL_MDRef elements, LL_MDRef imported_list);
 static LL_MDRef lldbg_create_subrange_mdnode(LL_DebugInfo *db, LL_MDRef count,
                                              LL_MDRef lb, LL_MDRef ub,
                                              LL_MDRef st);
@@ -530,6 +531,7 @@ lldbg_create_subprogram_mdnode(
       llmd_add_md(mdb, lv_list_mdnode);
   } else if (ll_feature_debug_info_ver13(&db->module->ir))
     llmd_add_md(mdb, lv_list_mdnode);
+
   llmd_add_i32(mdb, scope);
 
   /* Request a distinct mdnode so that it can be updated with a function pointer
@@ -2417,6 +2419,7 @@ lldbg_emit_subprogram(LL_DebugInfo *db, SPTR sptr, DTYPE ret_dtype, int findex,
   LL_MDRef lv_list_mdnode;
   LL_MDRef context_mdnode;
   LL_MDRef scope;
+  LL_MDRef imported_list;
   const char *mips_linkage_name = "";
   const char *func_name;
   int virtuality = 0;
@@ -2471,6 +2474,8 @@ lldbg_emit_subprogram(LL_DebugInfo *db, SPTR sptr, DTYPE ret_dtype, int findex,
                                  ll_get_md_null(), lv_list_mdnode, lineno);
   if (!db->subroutine_mdnodes)
     db->subroutine_mdnodes = hashmap_alloc(hash_functions_direct);
+  imported_list = ll_feature_debug_info_ver17(&db->module->ir) ?
+                 lv_list_mdnode : db->llvm_dbg_imported;
   scopeData = (hash_data_t)(unsigned long)db->cur_subprogram_mdnode;
   hashmap_replace(db->subroutine_mdnodes, INT2HKEY(sptr), &scopeData);
   while (db->import_entity_list) {
@@ -2480,10 +2485,12 @@ lldbg_emit_subprogram(LL_DebugInfo *db, SPTR sptr, DTYPE ret_dtype, int findex,
     /* There are pending entities to be imported into this func */
     lldbg_emit_imported_entity(db, db->import_entity_list->entity, sptr,
                                db->import_entity_list->entity_type,
-                               elements_mdnode);
+                               elements_mdnode, imported_list);
     while (child) {
       LL_MDRef element = lldbg_create_imported_entity(db, child->entity, sptr,
-                                                      child->entity_type, (LL_MDRef) NULL);
+                                                      child->entity_type,
+                                                      (LL_MDRef) NULL,
+                                                      (LL_MDRef) NULL);
       ll_extend_md_node(db->module, elements_mdnode, element);
       child = child->next;
     }
@@ -4107,7 +4114,8 @@ lldbg_function_end(LL_DebugInfo *db, int func)
 
 static LL_MDRef
 lldbg_create_imported_entity(LL_DebugInfo *db, SPTR entity_sptr, SPTR func_sptr,
-                             IMPORT_TYPE entity_type, LL_MDRef elements_mdnode)
+                             IMPORT_TYPE entity_type, LL_MDRef elements_mdnode,
+                            LL_MDRef imported_list)
 {
   LLMD_Builder mdb;
   LL_MDRef entity_mdnode, scope_mdnode = 0, file_mdnode, cur_mdnode;
@@ -4164,14 +4172,16 @@ lldbg_create_imported_entity(LL_DebugInfo *db, SPTR entity_sptr, SPTR func_sptr,
   llmd_add_md(mdb, elements_mdnode); // elements
 
   cur_mdnode = llmd_finish(mdb);
-  ll_extend_md_node(db->module, db->llvm_dbg_imported, cur_mdnode);
+  if (imported_list)
+    ll_extend_md_node(db->module, imported_list, cur_mdnode);
   return cur_mdnode;
 }
 
 static void
 lldbg_emit_imported_entity(LL_DebugInfo *db, SPTR entity_sptr,
                            SPTR func_sptr, IMPORT_TYPE entity_type,
-                           LL_MDRef elements_mdnode)
+                           LL_MDRef elements_mdnode,
+                           LL_MDRef imported_list)
 {
   static hashset_t entity_func_added;
   const char *entity_func;
@@ -4185,7 +4195,7 @@ lldbg_emit_imported_entity(LL_DebugInfo *db, SPTR entity_sptr,
     return;
   hashset_insert(entity_func_added, entity_func);
   lldbg_create_imported_entity(db, entity_sptr, func_sptr, entity_type,
-                               elements_mdnode);
+                               elements_mdnode, imported_list);
 }
 
 void


### PR DESCRIPTION
Symptom: Compilation of any Fortran program with imports (USE statement) fails with assert in compiler backend.

Diagnosis: LLVM-17 expects imports list in retainedNode field of DISubprogram wihch while Flang is still generating it as imports field of DICompilationUnit.

Fix: Flang is now updated to new IR as expected by LLVM-17.