### PR TITLE
Supplement to fix failures for imports with LLVM-17

### DIFF
--- a/test/debug_info/debug_metadata_dwarf_01.f90
+++ b/test/debug_info/debug_metadata_dwarf_01.f90
@@ -1,0 +1,17 @@
+! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s
+! CHECK-NOT: distinct !DICompileUnit({{.*}}, imports: ![[DBG_IMPORTS:[0-9]+]], nameTableKind: None
+
+module mymod
+  integer :: var1 = 11
+  integer :: var2 = 12
+  integer :: var3 = 13
+end module mymod
+
+Program test
+  call use_renamed()
+  contains
+    subroutine use_renamed()
+      use mymod, var4 => var1
+      print *, var4
+    end subroutine use_renamed
+end program test

--- a/test/debug_info/debug_module_import.f90
+++ b/test/debug_info/debug_module_import.f90
@@ -25,11 +25,7 @@ print *, var2
 end program hello
 
 ! CHECK-DAG: ![[DBG_MOD1:[0-9]+]] = !DIModule({{.*}}, name: "first"
-! CHECK-DAG: ![[DBG_DIC:[0-9]+]] = distinct !DICompileUnit({{.*}}, imports: ![[DBG_IMPORTS:[0-9]+]], nameTableKind: None
+! CHECK-DAG: ![[DBG_DIC:[0-9]+]] = distinct !DICompileUnit({{.*}}, nameTableKind: None
 ! CHECK-DAG: ![[DBG_MOD2:[0-9]+]] = !DIModule({{.*}}, name: "second"
-! CHECK-DAG: ![[DBG_IMPORTS]] = !{![[DBG_IE1:[0-9]+]], ![[DBG_IE2:[0-9]+]], ![[DBG_IE3:[0-9]+]]}
-! CHECK-DAG: ![[DBG_IE1]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP1:[0-9]+]], entity: ![[DBG_MOD1]],
-! CHECK-DAG: ![[DBG_SP1]] = distinct !DISubprogram(name: "init", scope: ![[DBG_MOD2]]
-! CHECK-DAG: ![[DBG_IE2]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP2:[0-9]+]], entity: ![[DBG_MOD1]],
-! CHECK-DAG: ![[DBG_SP2]] = distinct !DISubprogram(name: "hello", scope: ![[DBG_DIC]]
-! CHECK-DAG: ![[DBG_IE3]] = !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[DBG_SP2]], entity: ![[DBG_MOD2]],
+! CHECK-DAG: ![[DBG_SP1:[0-9]+]] = distinct !DISubprogram(name: "init", scope: ![[DBG_MOD2]]
+! CHECK-DAG: ![[DBG_SP2:[0-9]+]] = distinct !DISubprogram(name: "hello", scope: ![[DBG_DIC]]

--- a/test/debug_info/module.f90
+++ b/test/debug_info/module.f90
@@ -3,7 +3,7 @@
 !CHECK-DAG: DIModule(scope: !{{.*}}, name: "dummy", file: !{{.*}}, line: 9)
 !CHECK-DAG: ![[FOO_NODE:.*]] = {{.*}} !DIGlobalVariable(name: "foo", {{.*}}
 !CHECK-DAG: ![[BAR_NODE:.*]] = {{.*}} !DIGlobalVariable(name: "bar", {{.*}}
-!CHECK-DAG: DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !{{.*}}, entity: ![[FOO_NODE]], file: !{{.*}}, line: 14)
+!CHECK-NOT: DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !{{.*}}, entity: ![[FOO_NODE]], file: !{{.*}}, line: 14)
 !CHECK-NOT: DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !{{.*}}, entity: ![[BAR_NODE]], file: !{{.*}}, line: 14)
 
 MODULE dummy !line no. 9

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -935,7 +935,6 @@ static const MDTemplate Tmpl_DICompileUnit_ver39[] = {
   { "retainedTypes",            NodeField,               0 },
   { "globals",                  NodeField,               0 },
   { "emissionKind",             DWEmissionField,         0 },
-  { "imports",                  NodeField,               0 },
   { "splitDebugFilename",       StringField,             0 },
   { "nameTableKind",            DebugNameTableKindField, 0 }
 };

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -313,8 +313,7 @@ lldbg_create_compile_unit_mdnode(LL_DebugInfo *db, int lang_tag,
                                  const char *compflags, int vruntime,
                                  LL_MDRef *enum_types_list,
                                  LL_MDRef *retained_types_list,
-                                 LL_MDRef *subprograms_list, LL_MDRef *gv_list,
-                                 LL_MDRef *imported_entity_list)
+                                 LL_MDRef *subprograms_list, LL_MDRef *gv_list)
 {
   LLMD_Builder mdb = llmd_init(db->module);
   LL_MDRef cur_mdnode;
@@ -347,7 +346,6 @@ lldbg_create_compile_unit_mdnode(LL_DebugInfo *db, int lang_tag,
   *retained_types_list = ll_create_flexible_md_node(db->module);
   *subprograms_list = ll_create_flexible_md_node(db->module);
   *gv_list = ll_create_flexible_md_node(db->module);
-  *imported_entity_list = ll_create_flexible_md_node(db->module);
 
   if (ll_feature_debug_info_pre34(&db->module->ir)) {
     llmd_add_md(mdb,
@@ -365,7 +363,6 @@ lldbg_create_compile_unit_mdnode(LL_DebugInfo *db, int lang_tag,
     llmd_add_md(mdb, *gv_list);
     if (ll_feature_subprogram_not_in_cu(&db->module->ir))
       llmd_add_i32(mdb, 1); /* emissionMode: FullDebug */
-    llmd_add_md(mdb, *imported_entity_list);
     llmd_add_string(mdb, "");
     if (!XBIT(120, 0x40000000))
       llmd_add_i32(mdb, 2); /* nameTableKind: None */
@@ -1852,7 +1849,7 @@ lldbg_emit_compile_unit(LL_DebugInfo *db)
         db, lang_tag, get_filename(1), get_currentdir(), db->producer, 1,
         flg.opt >= 1/*isOptimized Flag*/, flg.cmdline,
         0, &db->llvm_dbg_enum, &db->llvm_dbg_retained, &db->llvm_dbg_sp,
-        &db->llvm_dbg_gv, &db->llvm_dbg_imported);
+        &db->llvm_dbg_gv);
   }
   return db->comp_unit_mdnode;
 }


### PR DESCRIPTION
LLVM-17 expects imports list in retainedNode field of DISubprogram, and flang has completed this step but it's still generating imports list as imports field of DICompilationUnit.

Flang is now updated to new IR as expected by LLVM-17.