### PR TITLE
Fix a sret attribute bug

### DIFF
--- a/test/llvm_ir_correct/test-sret-01.f90
+++ b/test/llvm_ir_correct/test-sret-01.f90
@@ -1,0 +1,39 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM
+! Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for the scenario that when Fortran case calls the function of
+! C with a struct as the return value.
+
+! RUN: %flang -S -emit-flang-llvm %s -o %t
+! cat %t | FileCheck %s -check-prefix=CHECK-SRET
+
+! CHECK-SRET: call void @c_function (ptr sret([[TYPENAME:%.*]]) {{%.*}}, ptr byval([[TYPENAME]]) {{%.*}})
+! CHECK-SRET: declare void @c_function(ptr sret([[TYPENAME]]), ptr byval([[TYPENAME]]))
+module c_interface
+  use, intrinsic :: iso_c_binding
+  type, bind(c) :: c_type
+     real(kind = c_double) :: year = 0, month = 0, day = 0, hour = 0, minute = 0
+  end type
+  interface
+    type(c_type) function c_function(dur) bind(c)
+      use iso_c_binding
+      import :: c_type
+      type(c_type), value :: dur
+    end function
+  end interface
+end module
+
+module test
+  use c_interface
+contains
+  function ss(dur) result(res)
+  use c_interface, only : c_type
+    implicit none
+    type(c_type), intent(in) :: dur
+    type(c_type) :: res
+    res = c_function(dur)
+  END FUNCTION
+END MODULE
+

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -7279,6 +7279,8 @@ gen_arg_operand(LL_ABI_Info *abi, unsigned abi_arg, int arg_ili)
     operand = gen_llvm_expr(value_ili, arg_type);
   if (arg->kind == LL_ARG_BYVAL && !missing)
     operand->flags |= OPF_SRARG_TYPE;
+  if (arg->kind == LL_ARG_INDIRECT && !missing && (abi_arg == 0))
+    operand->flags |= OPF_SRET_TYPE;
   return operand;
 
   arg_type = make_lltype_from_abi_arg(arg);
@@ -13760,7 +13762,9 @@ print_function_signature(int func_sptr, const char *fn_name, LL_ABI_Info *abi,
   /* Hidden sret argument for struct returns. */
   if (LL_ABI_HAS_SRET(abi)) {
     print_token(abi->arg[0].type->str);
-    print_token(" sret");
+    print_token(" sret(");
+    print_token(abi->arg[0].type->sub_types[0]->str);
+    print_token(")");
     if (print_arg_names) {
       print_space(1);
       print_token(SNAME(ret_info.sret_sptr));

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -2349,8 +2349,11 @@ write_operand(OPERAND *p, const char *punc_string, int flags)
 #endif
     if (!(flags & FLG_OMIT_OP_TYPE))
       write_type(pllt);
-    if (p->flags & OPF_SRET_TYPE)
+    if (p->flags & OPF_SRET_TYPE) {
       print_token(" sret");
+      print_token(p->ll_type->sub_types[0]->str);
+      print_token(")");
+    }
     if (p->flags & OPF_SRARG_TYPE)
       print_token(" byval");
     print_space(1);


### PR DESCRIPTION
When the return value of the function is a structure, sometimes the compiler will use the structure as an input argument and add the sret attribute in IR generation stage. At this case, the IR generated by flang will lack the actual structure type.