### PR TITLE
Fix an entry statement debuginfo bug

### DIFF
--- a/test/debug_info/entry_argument_1.f90
+++ b/test/debug_info/entry_argument_1.f90
@@ -1,0 +1,20 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: [[N1:![0-9]+]] = distinct !DISubprogram
+!CHECK: !DILocalVariable(arg: 1, scope: [[N1]]
+!CHECK: !DILocalVariable(arg: 2, scope: [[N1]]
+!CHECK: !DILocalVariable(name: "a", arg: 3, scope: [[N1]]
+
+module test
+contains
+  subroutine sub(a)
+    implicit none
+    integer(kind = 4) :: m
+    real(kind = 8), intent(inout) :: a(:,:)
+    m = size(a, 1)
+    entry subsub(a)
+    m = size(a, 1) + 1
+    entry subsub1(a)
+    m = size(a, 1) + 2
+  end subroutine sub
+end module

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -275,6 +275,7 @@ typedef struct ComplexResultList_t {
   unsigned entries;
 } ComplexResultList_t;
 static ComplexResultList_t complexResultList;
+LL_ABI_Info *entry_abi;
 
 /* ---  static prototypes (exported prototypes belong in cgllvm.h) --- */
 
@@ -1613,11 +1614,12 @@ restartConcur:
 
   /* Build up the additional items/dummys needed for the master sptr if there
      are entries, and call process_formal_arguments on that information. */
-  if (has_multiple_entries(gbl.currsub) && get_entries_argnum())
-    process_formal_arguments(
-        process_ll_abi_func_ftn_mod(current_module, get_master_sptr(), 1));
-  else
+  if (has_multiple_entries(gbl.currsub) && get_entries_argnum()) {
+    entry_abi = process_ll_abi_func_ftn_mod(current_module, get_master_sptr(), 1);
+    process_formal_arguments(entry_abi);
+  } else {
     process_formal_arguments(llvm_info.abi_info);
+  }
   made_return = false;
 
   get_local_overlap_size();
@@ -14562,6 +14564,18 @@ get_parnum(SPTR sptr)
 {
   for (unsigned parnum = 1; parnum <= llvm_info.abi_info->nargs; parnum++) {
     if (llvm_info.abi_info->arg[parnum].sptr == sptr) {
+      return parnum;
+    }
+  }
+
+  return 0;
+}
+
+int
+get_entry_parnum(SPTR sptr)
+{
+  for (unsigned parnum = 1; parnum <= entry_abi->nargs; parnum++) {
+    if (entry_abi->arg[parnum].sptr == sptr) {
       return parnum;
     }
   }

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -303,4 +303,6 @@ void insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode, SPTR sptr,
 bool pointer_scalar_need_debug_info(SPTR sptr);
 
 int get_parnum(SPTR sptr);
+
+int get_entry_parnum(SPTR sptr);
 #endif

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -3253,10 +3253,15 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
               if (SCG(data_sptr) == SC_DUMMY) {
                 LL_MDRef type_mdnode = lldbg_emit_type(
                     db, __POINT_T, data_sptr, findex, false, false, false);
+                int parnum_lldbg = 0;
+                if (has_multiple_entries(gbl.currsub))
+                  parnum_lldbg = get_entry_parnum(data_sptr);
+                else
+                  parnum_lldbg = get_parnum(data_sptr);
                 dataloc = lldbg_create_local_variable_mdnode(
                     db, DW_TAG_arg_variable, db->cur_subprogram_mdnode, NULL,
                     file_mdnode, db->cur_subprogram_lineno,
-                    get_parnum(data_sptr), type_mdnode,
+                    parnum_lldbg, type_mdnode,
                     set_dilocalvariable_flags(data_sptr), ll_get_md_null());
                 lldbg_register_param_mdnode(db, dataloc, data_sptr);
 
@@ -3317,10 +3322,15 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
                   if (SCG(datasptr) == SC_DUMMY) {
                     LL_MDRef type_mdnode = lldbg_emit_type(
                         db, __POINT_T, datasptr, findex, false, false, false);
+                    int parnum_lldbg = 0;
+                    if (has_multiple_entries(gbl.currsub))
+                      parnum_lldbg = get_entry_parnum(data_sptr);
+                    else
+                      parnum_lldbg = get_parnum(data_sptr);
                     dataloc = lldbg_create_local_variable_mdnode(
                         db, DW_TAG_arg_variable, db->cur_subprogram_mdnode,
                         NULL, file_mdnode, db->cur_subprogram_lineno,
-                        get_parnum(sptr), type_mdnode,
+                        parnum_lldbg, type_mdnode,
                         set_dilocalvariable_flags(datasptr), ll_get_md_null());
                     lldbg_register_param_mdnode(db, dataloc, datasptr);
                   } else
@@ -3975,12 +3985,18 @@ lldbg_emit_param_variable(LL_DebugInfo *db, SPTR sptr, int findex, int parnum,
     if ((ASSUMRANKG(sptr) || ASSUMSHPG(sptr)) && SDSCG(sptr)) {
       type_mdnode = lldbg_emit_type(db, dtype, SDSCG(sptr), findex,
                                     is_reference, true, false, sptr);
-      parnum = get_parnum(SDSCG(sptr));
+      if (has_multiple_entries(gbl.currsub))
+        parnum = get_entry_parnum(SDSCG(sptr));
+      else
+        parnum = get_parnum(SDSCG(sptr));
     } else if (STYPEG(sptr) == ST_ARRAY &&
                (ALLOCATTRG(sptr) || POINTERG(sptr)) && SDSCG(sptr)) {
       type_mdnode = lldbg_emit_type(db, dtype, sptr, findex, is_reference, true,
                                     false, MIDNUMG(sptr));
-      parnum = get_parnum(SDSCG(sptr));
+      if (has_multiple_entries(gbl.currsub))
+        parnum = get_entry_parnum(SDSCG(sptr));
+      else
+        parnum = get_parnum(SDSCG(sptr));
     } else {
       type_mdnode =
           lldbg_emit_type(db, dtype, sptr, findex, is_reference, true, false);


### PR DESCRIPTION
When the compiler generates debuginfo, it does not consider that when there is an entry, the number of arguments will increase by one.
We can fix this problem by getting the returned information by process_ll_abi_func_ftn_mod function, and using the new number of arguments.