### PR TITLE
Fix semantic analysis failures of LBOUND/UBOUND in type specification

### DIFF
--- a/test/f90_correct/inc/bound1.mk
+++ b/test/f90_correct/inc/bound1.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound10.mk
+++ b/test/f90_correct/inc/bound10.mk
@@ -1,0 +1,14 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build: $(SRC)/$(TEST).f90
+	@echo ------------------------------------ building test $(TEST)
+	-$(FC) -c $(SRC)/$(TEST).f90 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ nothing to run for test $(TEST)
+
+verify: $(TEST).rslt
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f90 $(TEST).rslt $(FC)

--- a/test/f90_correct/inc/bound11.mk
+++ b/test/f90_correct/inc/bound11.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound12.mk
+++ b/test/f90_correct/inc/bound12.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound13.mk
+++ b/test/f90_correct/inc/bound13.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound14.mk
+++ b/test/f90_correct/inc/bound14.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).F90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).F90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound15.mk
+++ b/test/f90_correct/inc/bound15.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound16.mk
+++ b/test/f90_correct/inc/bound16.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound2.mk
+++ b/test/f90_correct/inc/bound2.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound3.mk
+++ b/test/f90_correct/inc/bound3.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound4.mk
+++ b/test/f90_correct/inc/bound4.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound5.mk
+++ b/test/f90_correct/inc/bound5.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -Hy,68,1 -My,68,1 -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound6.mk
+++ b/test/f90_correct/inc/bound6.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound7.mk
+++ b/test/f90_correct/inc/bound7.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -Hy,68,1 -My,68,1 -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound8.mk
+++ b/test/f90_correct/inc/bound8.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) -c $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/inc/bound9.mk
+++ b/test/f90_correct/inc/bound9.mk
@@ -1,0 +1,14 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build: $(SRC)/$(TEST).f90
+	@echo ------------------------------------ building test $(TEST)
+	-$(FC) -c $(SRC)/$(TEST).f90 > $(TEST).rslt 2>&1
+
+run:
+	@echo ------------------------------------ nothing to run for test $(TEST)
+
+verify: $(TEST).rslt
+	@echo ------------------------------------ verifying test $(TEST)
+	$(COMP_CHECK) $(SRC)/$(TEST).f90 $(TEST).rslt $(FC)

--- a/test/f90_correct/lit/bound1.sh
+++ b/test/f90_correct/lit/bound1.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound10.sh
+++ b/test/f90_correct/lit/bound10.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound11.sh
+++ b/test/f90_correct/lit/bound11.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound12.sh
+++ b/test/f90_correct/lit/bound12.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound13.sh
+++ b/test/f90_correct/lit/bound13.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound14.sh
+++ b/test/f90_correct/lit/bound14.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound15.sh
+++ b/test/f90_correct/lit/bound15.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound16.sh
+++ b/test/f90_correct/lit/bound16.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound2.sh
+++ b/test/f90_correct/lit/bound2.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound3.sh
+++ b/test/f90_correct/lit/bound3.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound4.sh
+++ b/test/f90_correct/lit/bound4.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound5.sh
+++ b/test/f90_correct/lit/bound5.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound6.sh
+++ b/test/f90_correct/lit/bound6.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound7.sh
+++ b/test/f90_correct/lit/bound7.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound8.sh
+++ b/test/f90_correct/lit/bound8.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/lit/bound9.sh
+++ b/test/f90_correct/lit/bound9.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/bound1.f90
+++ b/test/f90_correct/src/bound1.f90
@@ -1,0 +1,31 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND in type specification.
+
+program test
+  implicit none
+  integer :: x(2,3,4)
+  integer, allocatable :: y(:)
+  integer :: i
+
+  y = foo(x)
+  if (size(y) /= 24 .or. any(y /= 1)) STOP 1
+  y = bar(x)
+  if (size(y) /= 3 .or. any(y /= 2)) STOP 2
+  print *, "PASS"
+contains
+  function foo(a)
+    integer :: a(:, :, :)
+    integer :: foo(1:product(ubound(a)))
+    foo = 1
+  end function
+
+  function bar(a)
+    integer :: a(:, :, :)
+    integer :: bar(1:sum(lbound(a)))
+    bar = 2
+  end function
+end program

--- a/test/f90_correct/src/bound10.f90
+++ b/test/f90_correct/src/bound10.f90
@@ -1,0 +1,22 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for restrictions about LBOUND and UBOUND.
+
+program test
+  implicit none
+  integer, allocatable :: x(:, :, :)
+
+  allocate(x(2, 3, 4))
+contains
+  subroutine test_assumed_size(a)
+    integer :: a(4:7, 9:*)
+    !{error "PGF90-S-0084-Illegal use of symbol a - ubound of assumed size array is unknown"}
+    print *, ubound(a)
+    !{error "PGF90-S-0084-Illegal use of symbol a - ubound of assumed size array is unknown"}
+    print *, ubound(a, 2)
+  end subroutine
+end program
+

--- a/test/f90_correct/src/bound11.f90
+++ b/test/f90_correct/src/bound11.f90
@@ -1,0 +1,69 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND of assumed-shape formal in type specification.
+
+program test
+  implicit none
+  integer :: x(2,3,4)
+  integer, allocatable :: x_alloc(:, :, :)
+  integer, pointer :: x_ptr(:, :, :)
+  integer, allocatable :: arr_res(:)
+  character(len=:), allocatable :: char_res
+  integer :: i
+
+  allocate(x_alloc(2:3, 3:5, 4:7))
+  allocate(x_ptr(2:3, 3:5, 4:7))
+
+  arr_res = array_test_specified_lb(1, 0, -1, x)
+  if (size(arr_res) /= 8 .or. any(arr_res /= 1)) STOP 1
+  arr_res = array_test_specified_lb(2, 1, 0, x(2:, 3:, 2:))
+  if (size(arr_res) /= 4 .or. any(arr_res /= 1)) STOP 2
+  arr_res = array_test_missing_lb(x_alloc)
+  if (size(arr_res) /= 3 .or. any(arr_res /= 2)) STOP 3
+  arr_res = array_test_specified_lb(1, 0, -1, x_alloc)
+  if (size(arr_res) /= 8 .or. any(arr_res /= 1)) STOP 4
+  arr_res = array_test_missing_lb(x_ptr)
+  if (size(arr_res) /= 3 .or. any(arr_res /= 2)) STOP 5
+
+  char_res = char_test_specified_lb(1, 0, -1, x)
+  if (len(char_res) /= 8 .or. char_res /= 'aaaaaaaa') STOP 6
+  char_res = char_test_specified_lb(2, 1, 0, x(2:, 3:, 2:))
+  if (len(char_res) /= 4 .or. char_res /= 'aaaa') STOP 7
+  char_res = char_test_missing_lb(x_alloc)
+  if (len(char_res) /= 3 .or. char_res /= 'bbb') STOP 8
+  char_res = char_test_specified_lb(1, 0, -1, x_alloc)
+  if (len(char_res) /= 8 .or. char_res /= 'aaaaaaaa') STOP 9
+  char_res = char_test_missing_lb(x_ptr)
+  if (len(char_res) /= 3 .or. char_res /= 'bbb') STOP 10
+
+  print *, "PASS"
+contains
+  function array_test_specified_lb(l1, l2, l3, a) result(res)
+    integer :: l1, l2, l3
+    integer :: a(l1:, l2:, l3:)
+    integer :: res(1:product(ubound(a)))
+    res = 1
+  end function
+
+  function array_test_missing_lb(a) result(res)
+    integer :: a(:, :, :)
+    integer :: res(1:sum(lbound(a)))
+    res = 2
+  end function
+
+  function char_test_specified_lb(l1, l2, l3, a) result(res)
+    integer :: l1, l2, l3
+    integer :: a(l1:, l2:, l3:)
+    character(len=product(ubound(a))) :: res
+    res = repeat('a', product(ubound(a)))
+  end function
+
+  function char_test_missing_lb(a) result(res)
+    integer :: a(:, :, :)
+    character(len=sum(lbound(a))) :: res
+    res = repeat('b', sum(lbound(a)))
+  end function
+end program

--- a/test/f90_correct/src/bound12.f90
+++ b/test/f90_correct/src/bound12.f90
@@ -1,0 +1,81 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND of assumed-shape formal in type specification when
+! DIM is present.
+
+program test
+  implicit none
+  integer :: x(2,3,4)
+  integer, allocatable :: x_alloc(:, :, :)
+  integer, pointer :: x_ptr(:, :, :)
+  integer, allocatable :: arr_res(:)
+  character(len=:), allocatable :: char_res
+  integer :: i
+
+  allocate(x_alloc(2:3, 3:5, 4:7))
+  allocate(x_ptr(2:3, 3:5, 4:7))
+
+  arr_res = array_test_specified_lb(1, 0, -1, x)
+  if (size(arr_res) /= 8 .or. any(arr_res /= 1)) STOP 1
+  arr_res = array_test_specified_lb(2, 1, 0, x(2:, 3:, 2:))
+  if (size(arr_res) /= 4 .or. any(arr_res /= 1)) STOP 2
+  arr_res = array_test_missing_lb(x_alloc)
+  if (size(arr_res) /= 3 .or. any(arr_res /= 2)) STOP 3
+  arr_res = array_test_specified_lb(1, 0, -1, x_alloc)
+  if (size(arr_res) /= 8 .or. any(arr_res /= 1)) STOP 4
+  arr_res = array_test_missing_lb(x_ptr)
+  if (size(arr_res) /= 3 .or. any(arr_res /= 2)) STOP 5
+
+  char_res = char_test_specified_lb(1, 0, -1, x)
+  if (len(char_res) /= 8 .or. char_res /= 'aaaaaaaa') STOP 6
+  char_res = char_test_specified_lb(2, 1, 0, x(2:, 3:, 2:))
+  if (len(char_res) /= 4 .or. char_res /= 'aaaa') STOP 7
+  char_res = char_test_missing_lb(x_alloc)
+  if (len(char_res) /= 3 .or. char_res /= 'bbb') STOP 8
+  char_res = char_test_specified_lb(1, 0, -1, x_alloc)
+  if (len(char_res) /= 8 .or. char_res /= 'aaaaaaaa') STOP 9
+  char_res = char_test_missing_lb(x_ptr)
+  if (len(char_res) /= 3 .or. char_res /= 'bbb') STOP 10
+
+  arr_res = test_noncnst_dim(1, 0, -1, x, 1, 2, 3)
+  if (size(arr_res) /= 8 .or. any(arr_res /= 1)) STOP 11
+
+  print *, "PASS"
+contains
+  function array_test_specified_lb(l1, l2, l3, a) result(res)
+    integer :: l1, l2, l3
+    integer :: a(l1:, l2:, l3:)
+    integer :: res(1:ubound(a, 1) * ubound(a, 2) * ubound(a, 3))
+    res = 1
+  end function
+
+  function array_test_missing_lb(a) result(res)
+    integer :: a(:, :, :)
+    integer :: res(1:lbound(a, 1) + lbound(a, 2) + lbound(a, 3))
+    res = 2
+  end function
+
+  function char_test_specified_lb(l1, l2, l3, a) result(res)
+    integer :: l1, l2, l3
+    integer :: a(l1:, l2:, l3:)
+    character(len=ubound(a, 1) * ubound(a, 2) * ubound(a, 3)) :: res
+    res = repeat('a', ubound(a, 1) * ubound(a, 2) * ubound(a, 3))
+  end function
+
+  function char_test_missing_lb(a) result(res)
+    integer :: a(:, :, :)
+    character(len=lbound(a, 1) + lbound(a, 2) + lbound(a, 3)) :: res
+    res = repeat('b', lbound(a, 1) + lbound(a, 2) + lbound(a, 3))
+  end function
+
+  function test_noncnst_dim(l1, l2, l3, a, d1, d2, d3) result(res)
+    integer :: l1, l2, l3
+    integer :: a(l1:, l2:, l3:)
+    integer :: d1, d2, d3
+    integer :: res(1:ubound(a, d1) * ubound(a, d2) * ubound(a, d3))
+    res = 1
+  end function
+end program

--- a/test/f90_correct/src/bound13.f90
+++ b/test/f90_correct/src/bound13.f90
@@ -1,0 +1,51 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND of assumed-shape formal in type specification.
+
+program test
+  implicit none
+  integer :: x(2,3,4)
+  integer, allocatable :: y(:)
+  type t
+    integer, allocatable :: arr(:)
+  end type
+  type(t) :: z(8)
+  integer :: i
+
+  y = test_binary_expr(3, 4, 5, x)
+  if (size(y) /= 910 .or. any(y /= 1)) STOP 1
+  y = test_unary_expr(1, 2, 3, x)
+  if (size(y) /= 288 .or. any(y /= 2)) STOP 2
+
+  do i = 1, 8
+    z(i)%arr = i * [1, 2, 3, 4, 5, 6, 7, 8, 9]
+  enddo
+  y = test_subscript_expr(1, 2, -2, x, z)
+  if (size(y) /= 8 .or. any(y /= 3)) STOP 3
+  print *, "PASS"
+contains
+  function test_binary_expr(l1, l2, l3, a) result(res)
+    integer :: l1, l2, l3
+    integer :: a(l1:, l2:, l3:)
+    integer :: res(1:product(ubound(a) + lbound(a)))
+    res = 1
+  end function
+
+  function test_unary_expr(l1, l2, l3, a) result(res)
+    integer :: l1, l2, l3
+    integer :: a(l1:, l2:, l3:)
+    integer :: res(1:product(-ubound(a)) * sum(-lbound(a)))
+    res = 2
+  end function
+
+  function test_subscript_expr(l1, l2, l3, a, b) result(res)
+    integer :: l1, l2, l3
+    integer :: a(l1:, l2:, l3:)
+    type(t) :: b(:)
+    integer :: res(1: b(product(ubound(a)))%arr(sum(lbound(a))))
+    res = 3
+  end function
+end program

--- a/test/f90_correct/src/bound14.F90
+++ b/test/f90_correct/src/bound14.F90
@@ -1,0 +1,29 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND in data initialization when DIM is present.
+
+program test
+  use iso_fortran_env
+  implicit none
+
+  integer, parameter :: sp1 = real_kinds(lbound(real_kinds,dim=1))
+  integer, parameter :: dp1 = real_kinds(lbound(real_kinds,dim=1)+1)
+#ifdef __flang_quadfp__
+  integer, parameter :: qp1 = real_kinds(lbound(real_kinds,dim=1)+2)
+#endif
+  integer, parameter :: sp2 = real_kinds(ubound(real_kinds,dim=1)-2)
+  integer, parameter :: dp2 = real_kinds(ubound(real_kinds,dim=1)-1)
+#ifdef __flang_quadfp__
+  integer, parameter :: qp2 = real_kinds(ubound(real_kinds,dim=1))
+#endif
+
+  if (sp1 /= 4 .or. sp2 /= 4) STOP 1
+  if (dp1 /= 8 .or. dp2 /= 8) STOP 2
+#ifdef __flang_quadfp__
+  if (qp1 /= 16 .or. qp2 /= 16) STOP 3
+#endif
+  print *, "PASS"
+end program

--- a/test/f90_correct/src/bound15.f90
+++ b/test/f90_correct/src/bound15.f90
@@ -1,0 +1,25 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test the fix for the LBOUND/UBOUND regression, where the subscript expression
+! as the ARRAY argument has a scalar index in some dimension.
+
+program test
+  implicit none
+  integer :: arr1(2:4, 3:8)
+  integer, pointer :: arr2(:, :, :)
+  integer, allocatable :: res(:)
+
+  res = ubound(arr1(3, 4:7))
+  if (size(res) /= 1 .or. res(1) /= 4) STOP 1
+  res = lbound(arr1(3, 4:7))
+  if (size(res) /= 1 .or. res(1) /= 1) STOP 2
+  allocate(arr2(2:4, 3:8, 4:10))
+  res = ubound(arr2(3, 4:7, 5))
+  if (size(res) /= 1 .or. res(1) /= 4) STOP 3
+  res = lbound(arr2(3, 4:7, 5))
+  if (size(res) /= 1 .or. res(1) /= 1) STOP 4
+  print *, "PASS"
+end program

--- a/test/f90_correct/src/bound16.f90
+++ b/test/f90_correct/src/bound16.f90
@@ -1,0 +1,71 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test the fix for the LBOUND/UBOUND regression, where the LBOUND/UBOUND call
+! nested within the SIZE call has a defer-shape ARRAY parameter and a DIM
+! parameter.
+
+module m
+  implicit none
+  type t1
+    character, pointer :: arr1(:)
+  end type
+  type t2
+    type(t1), pointer :: arr2(:)
+    integer, pointer :: arr3(:)
+  end type
+contains
+  function test_default(a) result(ret)
+    type(t2) :: a
+    character(len=size(a%arr2(ubound(a%arr3, 1))%arr1)) :: ret
+    ret = repeat('a', len(ret))
+  end function
+
+  function test_kind1(a) result(ret)
+    type(t2) :: a
+    character(len=size(a%arr2(ubound(a%arr3, 1, kind=1))%arr1)) :: ret
+    ret = repeat('b', len(ret))
+  end function
+
+  function test_kind2(a) result(ret)
+    type(t2) :: a
+    character(len=size(a%arr2(ubound(a%arr3, 1, kind=2))%arr1)) :: ret
+    ret = repeat('c', len(ret))
+  end function
+
+  function test_kind4(a) result(ret)
+    type(t2) :: a
+    character(len=size(a%arr2(ubound(a%arr3, 1, kind=4))%arr1)) :: ret
+    ret = repeat('d', len(ret))
+  end function
+
+  function test_kind8(a) result(ret)
+    type(t2) :: a
+    character(len=size(a%arr2(ubound(a%arr3, 1, kind=8))%arr1)) :: ret
+    ret = repeat('e', len(ret))
+  end function
+end module
+
+program test
+  use m
+  implicit none
+  type(t2) :: x
+  character(len=:), allocatable :: y
+
+  allocate(x%arr2(5))
+  allocate(x%arr3(2:4))
+  allocate(x%arr2(4)%arr1(2:10))
+  y = test_default(x)
+  if (len(y) /= 9 .or. y /= 'aaaaaaaaa') STOP 1
+  y = test_kind1(x)
+  if (len(y) /= 9 .or. y /= 'bbbbbbbbb') STOP 2
+  y = test_kind2(x)
+  if (len(y) /= 9 .or. y /= 'ccccccccc') STOP 3
+  y = test_kind4(x)
+  if (len(y) /= 9 .or. y /= 'ddddddddd') STOP 4
+  y = test_kind8(x)
+  if (len(y) /= 9 .or. y /= 'eeeeeeeee') STOP 5
+  print *, "PASS"
+end program

--- a/test/f90_correct/src/bound2.f90
+++ b/test/f90_correct/src/bound2.f90
@@ -1,0 +1,19 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND when the array is assumed-rank.
+
+program test
+  implicit none
+  integer :: x(2,3,4)
+  call test_assumed_rank(x)
+  print *, "PASS"
+contains
+  subroutine test_assumed_rank(a)
+    integer :: a(..)
+    if (size(lbound(a)) /= 3 .or. any(lbound(a) /= 1)) STOP 1
+    if (size(ubound(a)) /= 3 .or. any(ubound(a) /= [2, 3, 4])) STOP 2
+  end subroutine
+end program

--- a/test/f90_correct/src/bound3.f90
+++ b/test/f90_correct/src/bound3.f90
@@ -1,0 +1,20 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND when the array is assumed-size.
+
+program test
+  implicit none
+  integer :: x(2,3,4)
+  call test_assumed_size(x)
+  print *, "PASS"
+contains
+  subroutine test_assumed_size(a)
+    integer :: a(2:5, 4:*)
+    if (size(lbound(a)) /= 2 .or. any(lbound(a) /= [2, 4])) STOP 1
+    if (any([lbound(a, 1), lbound(a, 2)] /= [2, 4])) STOP 2
+    if (ubound(a, 1) /= 5) STOP 3
+  end subroutine
+end program

--- a/test/f90_correct/src/bound4.f90
+++ b/test/f90_correct/src/bound4.f90
@@ -1,0 +1,78 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND when the array is deferred-shape.
+
+program test
+  implicit none
+  integer, allocatable :: x(:, :, :, :)
+  integer, pointer :: y(:, :, :, :)
+  integer :: i
+  integer :: n
+  integer, parameter :: default_kind = kind(i)
+
+  n = 2
+  x = reshape([(i, i=1,120)], [2, 3, 4, 5])
+  allocate(y(1:2, 2:4, 3:6, 4:8))
+
+  call test_dim_present(x, y)
+  call test_dim_missing(x, y)
+  call test_component()
+  print *, "PASS"
+contains
+  subroutine test_dim_present(a, b)
+    integer, allocatable :: a(:, :, :, :)
+    integer, pointer :: b(:, :, :, :)
+    if (kind(ubound(a, 1)) /= default_kind .or. ubound(a, 1) /= 2) STOP 1
+    if (kind(ubound(a, 1, 1)) /= 1 .or. ubound(a, 1, 1) /= 2) STOP 2
+    if (kind(ubound(a, n, 2)) /= 2 .or. ubound(a, n, 2) /= 3) STOP 3
+    if (kind(ubound(a, n+1, 4)) /= 4 .or. ubound(a, n+1, 4) /= 4) STOP 4
+    if (kind(ubound(a, 4, 8)) /= 8 .or. ubound(a, 4, 8) /= 5) STOP 5
+    if (kind(lbound(b, 1)) /= default_kind .or. lbound(b, 1) /= 1) STOP 6
+    if (kind(lbound(b, 1, 1)) /= 1 .or. lbound(b, 1, 1) /= 1) STOP 7
+    if (kind(lbound(b, n, 2)) /= 2 .or. lbound(b, n, 2) /= 2) STOP 8
+    if (kind(lbound(b, n+1, 4)) /= 4 .or. lbound(b, n+1, 4) /= 3) STOP 9
+    if (kind(lbound(b, 4, 8)) /= 8 .or. lbound(b, 4, 8) /= 4) STOP 10
+  end subroutine
+
+  subroutine test_dim_missing (a, b)
+    integer, allocatable :: a(:, :, :, :)
+    integer, pointer :: b(:, :, :, :)
+    if (kind(ubound(a)) /= default_kind .or. size(ubound(a)) /= 4 .or. &
+        any(ubound(a) /= [2, 3, 4, 5])) STOP 11
+    if (kind(ubound(a, kind=1)) /= 1 .or. size(ubound(a, kind=1)) /= 4 .or. &
+        any(ubound(a, kind=1) /= [2, 3, 4, 5])) STOP 12
+    if (kind(ubound(a, kind=2)) /= 2 .or. size(ubound(a, kind=2)) /= 4 .or. &
+        any(ubound(a, kind=2) /= [2, 3, 4, 5])) STOP 13
+    if (kind(ubound(a, kind=4)) /= 4 .or. size(ubound(a, kind=4)) /= 4 .or. &
+        any(ubound(a, kind=4) /= [2, 3, 4, 5])) STOP 14
+    if (kind(ubound(a, kind=8)) /= 8 .or. size(ubound(a, kind=8)) /= 4 .or. &
+        any(ubound(a, kind=8) /= [2, 3, 4, 5])) STOP 15
+    if (kind(lbound(b)) /= default_kind .or. size(lbound(b)) /= 4 .or. &
+        any(lbound(b) /= [1, 2, 3, 4])) STOP 16
+    if (kind(lbound(b, kind=1)) /= 1 .or. size(lbound(b, kind=1)) /= 4 .or. &
+        any(lbound(b, kind=1) /= [1, 2, 3, 4])) STOP 17
+    if (kind(lbound(b, kind=2)) /= 2 .or. size(lbound(b, kind=2)) /= 4 .or. &
+        any(lbound(b, kind=2) /= [1, 2, 3, 4])) STOP 18
+    if (kind(lbound(b, kind=4)) /= 4 .or. size(lbound(b, kind=4)) /= 4 .or. &
+        any(lbound(b, kind=4) /= [1, 2, 3, 4])) STOP 19
+    if (kind(lbound(b, kind=8)) /= 8 .or. size(lbound(b, kind=8)) /= 4 .or. &
+        any(lbound(b, kind=8) /= [1, 2, 3, 4])) STOP 20
+  end subroutine
+
+  subroutine test_component()
+    type t
+      integer, allocatable :: x(:, :, :, :)
+      integer, pointer :: y(:, :, :, :)
+    end type
+    type(t) :: a
+    a%x = reshape([(i, i=1,120)], [2, 3, 4, 5])
+    allocate(a%y(1:2, 2:4, 3:6, 4:8))
+    if (any(lbound(a%x) /= 1)) STOP 21
+    if (any(ubound(a%x) /= [2, 3, 4, 5])) STOP 22
+    if (any(lbound(a%y) /= [1, 2, 3, 4])) STOP 23
+    if (any(ubound(a%y) /= [2, 4, 6, 8])) STOP 24
+  end subroutine
+end program

--- a/test/f90_correct/src/bound5.f90
+++ b/test/f90_correct/src/bound5.f90
@@ -1,0 +1,79 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND when the array is deferred-shape.
+! The options -Hy,68,1 and -My,68,1 are required.
+
+program test
+  implicit none
+  integer, allocatable :: x(:, :, :, :)
+  integer, pointer :: y(:, :, :, :)
+  integer :: i
+  integer :: n
+  integer, parameter :: default_kind = kind(i)
+
+  n = 2
+  x = reshape([(i, i=1,120)], [2, 3, 4, 5])
+  allocate(y(1:2, 2:4, 3:6, 4:8))
+
+  call test_dim_present(x, y)
+  call test_dim_missing(x, y)
+  call test_component()
+  print *, "PASS"
+contains
+  subroutine test_dim_present(a, b)
+    integer, allocatable :: a(:, :, :, :)
+    integer, pointer :: b(:, :, :, :)
+    if (kind(ubound(a, 1)) /= default_kind .or. ubound(a, 1) /= 2) STOP 1
+    if (kind(ubound(a, 1, 1)) /= 1 .or. ubound(a, 1, 1) /= 2) STOP 2
+    if (kind(ubound(a, n, 2)) /= 2 .or. ubound(a, n, 2) /= 3) STOP 3
+    if (kind(ubound(a, n+1, 4)) /= 4 .or. ubound(a, n+1, 4) /= 4) STOP 4
+    if (kind(ubound(a, 4, 8)) /= 8 .or. ubound(a, 4, 8) /= 5) STOP 5
+    if (kind(lbound(b, 1)) /= default_kind .or. lbound(b, 1) /= 1) STOP 6
+    if (kind(lbound(b, 1, 1)) /= 1 .or. lbound(b, 1, 1) /= 1) STOP 7
+    if (kind(lbound(b, n, 2)) /= 2 .or. lbound(b, n, 2) /= 2) STOP 8
+    if (kind(lbound(b, n+1, 4)) /= 4 .or. lbound(b, n+1, 4) /= 3) STOP 9
+    if (kind(lbound(b, 4, 8)) /= 8 .or. lbound(b, 4, 8) /= 4) STOP 10
+  end subroutine
+
+  subroutine test_dim_missing (a, b)
+    integer, allocatable :: a(:, :, :, :)
+    integer, pointer :: b(:, :, :, :)
+    if (kind(ubound(a)) /= default_kind .or. size(ubound(a)) /= 4 .or. &
+        any(ubound(a) /= [2, 3, 4, 5])) STOP 11
+    if (kind(ubound(a, kind=1)) /= 1 .or. size(ubound(a, kind=1)) /= 4 .or. &
+        any(ubound(a, kind=1) /= [2, 3, 4, 5])) STOP 12
+    if (kind(ubound(a, kind=2)) /= 2 .or. size(ubound(a, kind=2)) /= 4 .or. &
+        any(ubound(a, kind=2) /= [2, 3, 4, 5])) STOP 13
+    if (kind(ubound(a, kind=4)) /= 4 .or. size(ubound(a, kind=4)) /= 4 .or. &
+        any(ubound(a, kind=4) /= [2, 3, 4, 5])) STOP 14
+    if (kind(ubound(a, kind=8)) /= 8 .or. size(ubound(a, kind=8)) /= 4 .or. &
+        any(ubound(a, kind=8) /= [2, 3, 4, 5])) STOP 15
+    if (kind(lbound(b)) /= default_kind .or. size(lbound(b)) /= 4 .or. &
+        any(lbound(b) /= [1, 2, 3, 4])) STOP 16
+    if (kind(lbound(b, kind=1)) /= 1 .or. size(lbound(b, kind=1)) /= 4 .or. &
+        any(lbound(b, kind=1) /= [1, 2, 3, 4])) STOP 17
+    if (kind(lbound(b, kind=2)) /= 2 .or. size(lbound(b, kind=2)) /= 4 .or. &
+        any(lbound(b, kind=2) /= [1, 2, 3, 4])) STOP 18
+    if (kind(lbound(b, kind=4)) /= 4 .or. size(lbound(b, kind=4)) /= 4 .or. &
+        any(lbound(b, kind=4) /= [1, 2, 3, 4])) STOP 19
+    if (kind(lbound(b, kind=8)) /= 8 .or. size(lbound(b, kind=8)) /= 4 .or. &
+        any(lbound(b, kind=8) /= [1, 2, 3, 4])) STOP 20
+  end subroutine
+
+  subroutine test_component()
+    type t
+      integer, allocatable :: x(:, :, :, :)
+      integer, pointer :: y(:, :, :, :)
+    end type
+    type(t) :: a
+    a%x = reshape([(i, i=1,120)], [2, 3, 4, 5])
+    allocate(a%y(1:2, 2:4, 3:6, 4:8))
+    if (any(lbound(a%x) /= 1)) STOP 21
+    if (any(ubound(a%x) /= [2, 3, 4, 5])) STOP 22
+    if (any(lbound(a%y) /= [1, 2, 3, 4])) STOP 23
+    if (any(ubound(a%y) /= [2, 4, 6, 8])) STOP 24
+  end subroutine
+end program

--- a/test/f90_correct/src/bound6.f90
+++ b/test/f90_correct/src/bound6.f90
@@ -1,0 +1,140 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND when the array is assumed-shape.
+
+program test
+  implicit none
+  integer, allocatable :: x(:, :, :, :)
+  integer, parameter :: default_kind = kind(x)
+
+  allocate(x(1:2, 2:4, 3:6, 4:8))
+  call test_assumed_shape(x)
+  call test_assumed_shape_with_lower_bound(1, 3, 2, 4, x)
+  print *, "PASS"
+contains
+  subroutine test_assumed_shape(a)
+    integer :: a(:, :, :, :)
+    integer :: l_exp(4), u_exp(4), i
+
+    l_exp = [1, 1, 1, 1]
+    u_exp = [2, 3, 4, 5]
+    ! DIM is constant
+    if (any([lbound(a, 1), lbound(a, 2), lbound(a, 3), lbound(a, 4)] /= &
+        l_exp)) STOP 1
+    if (any([ubound(a, 1), ubound(a, 2), ubound(a, 3), ubound(a, 4)] /= &
+        u_exp)) STOP 2
+
+    ! DIM is variable
+    do i = 1, 4
+      if (kind(lbound(a, i)) /= default_kind .or. lbound(a, i) /= &
+          l_exp(i)) STOP 3
+      if (kind(lbound(a, i, kind=1)) /= 1 .or. lbound(a, i, kind=1) /= &
+          l_exp(i)) STOP 4
+      if (kind(lbound(a, i, kind=2)) /= 2 .or. lbound(a, i, kind=2) /= &
+          l_exp(i)) STOP 5
+      if (kind(lbound(a, i, kind=4)) /= 4 .or. lbound(a, i, kind=4) /= &
+          l_exp(i)) STOP 6
+      if (kind(lbound(a, i, kind=8)) /= 8 .or. lbound(a, i, kind=8) /= &
+          l_exp(i)) STOP 7
+
+      if (kind(ubound(a, i)) /= default_kind .or. ubound(a, i) /= &
+          u_exp(i)) STOP 9
+      if (kind(ubound(a, i, kind=1)) /= 1 .or. ubound(a, i, kind=1) /= &
+          u_exp(i)) STOP 10
+      if (kind(ubound(a, i, kind=2)) /= 2 .or. ubound(a, i, kind=2) /= &
+          u_exp(i)) STOP 11
+      if (kind(ubound(a, i, kind=4)) /= 4 .or. ubound(a, i, kind=4) /= &
+          u_exp(i)) STOP 12
+      if (kind(ubound(a, i, kind=8)) /= 8 .or. ubound(a, i, kind=8) /= &
+          u_exp(i)) STOP 13
+    enddo
+
+    ! DIM is missing
+    if (kind(lbound(a)) /= default_kind .or. size(lbound(a)) /= 4 .or. &
+        any(lbound(a) /= l_exp)) STOP 15
+    if (kind(lbound(a, kind=1)) /= 1 .or. size(lbound(a, kind=1)) /= 4 .or. &
+        any(lbound(a, kind=1) /= l_exp)) STOP 16
+    if (kind(lbound(a, kind=2)) /= 2 .or. size(lbound(a, kind=2)) /= 4 .or. &
+        any(lbound(a, kind=2) /= l_exp)) STOP 17
+    if (kind(lbound(a, kind=4)) /= 4 .or. size(lbound(a, kind=4)) /= 4 .or. &
+        any(lbound(a, kind=4) /= l_exp)) STOP 18
+    if (kind(lbound(a, kind=8)) /= 8 .or. size(lbound(a, kind=8)) /= 4 .or. &
+        any(lbound(a, kind=8) /= l_exp)) STOP 19
+
+    if (kind(ubound(a)) /= default_kind .or. size(ubound(a)) /= 4 .or. &
+        any(ubound(a) /= u_exp)) STOP 21
+    if (kind(ubound(a, kind=1)) /= 1 .or. size(ubound(a, kind=1)) /= 4 .or. &
+        any(ubound(a, kind=1) /= u_exp)) STOP 22
+    if (kind(ubound(a, kind=2)) /= 2 .or. size(ubound(a, kind=2)) /= 4 .or. &
+        any(ubound(a, kind=2) /= u_exp)) STOP 23
+    if (kind(ubound(a, kind=4)) /= 4 .or. size(ubound(a, kind=4)) /= 4 .or. &
+        any(ubound(a, kind=4) /= u_exp)) STOP 24
+    if (kind(ubound(a, kind=8)) /= 8 .or. size(ubound(a, kind=8)) /= 4 .or. &
+        any(ubound(a, kind=8) /= u_exp)) STOP 25
+  end subroutine test_assumed_shape
+
+  subroutine test_assumed_shape_with_lower_bound(l1, l2, l3, l4, a)
+    integer :: l1, l2, l3, l4
+    integer :: a(l1:, l2:, l3:, l4:)
+    integer :: l_exp(4), u_exp(4), i
+
+    l_exp = [l1, l2, l3, l4]
+    u_exp = [l1 + 1, l2 + 2, l3 + 3, l4 + 4]
+    ! DIM is constant
+    if (any([lbound(a, 1), lbound(a, 2), lbound(a, 3), lbound(a, 4)] /= &
+        l_exp)) STOP 27
+    if (any([ubound(a, 1), ubound(a, 2), ubound(a, 3), ubound(a, 4)] /= &
+        u_exp)) STOP 28
+
+    ! DIM is variable
+    do i = 1, 4
+      if (kind(lbound(a, i)) /= default_kind .or. lbound(a, i) /= &
+          l_exp(i)) STOP 29
+      if (kind(lbound(a, i, kind=1)) /= 1 .or. lbound(a, i, kind=1) /= &
+          l_exp(i)) STOP 30
+      if (kind(lbound(a, i, kind=2)) /= 2 .or. lbound(a, i, kind=2) /= &
+          l_exp(i)) STOP 31
+      if (kind(lbound(a, i, kind=4)) /= 4 .or. lbound(a, i, kind=4) /= &
+          l_exp(i)) STOP 32
+      if (kind(lbound(a, i, kind=8)) /= 8 .or. lbound(a, i, kind=8) /= &
+          l_exp(i)) STOP 33
+
+      if (kind(ubound(a, i)) /= default_kind .or. ubound(a, i) /= &
+          u_exp(i)) STOP 35
+      if (kind(ubound(a, i, kind=1)) /= 1 .or. ubound(a, i, kind=1) /= &
+          u_exp(i)) STOP 36
+      if (kind(ubound(a, i, kind=2)) /= 2 .or. ubound(a, i, kind=2) /= &
+          u_exp(i)) STOP 37
+      if (kind(ubound(a, i, kind=4)) /= 4 .or. ubound(a, i, kind=4) /= &
+          u_exp(i)) STOP 38
+      if (kind(ubound(a, i, kind=8)) /= 8 .or. ubound(a, i, kind=8) /= &
+          u_exp(i)) STOP 39
+    enddo
+
+    ! DIM is missing
+    if (kind(lbound(a)) /= default_kind .or. size(lbound(a)) /= 4 .or. &
+        any(lbound(a) /= l_exp)) STOP 41
+    if (kind(lbound(a, kind=1)) /= 1 .or. size(lbound(a, kind=1)) /= 4 .or. &
+        any(lbound(a, kind=1) /= l_exp)) STOP 42
+    if (kind(lbound(a, kind=2)) /= 2 .or. size(lbound(a, kind=2)) /= 4 .or. &
+        any(lbound(a, kind=2) /= l_exp)) STOP 43
+    if (kind(lbound(a, kind=4)) /= 4 .or. size(lbound(a, kind=4)) /= 4 .or. &
+        any(lbound(a, kind=4) /= l_exp)) STOP 44
+    if (kind(lbound(a, kind=8)) /= 8 .or. size(lbound(a, kind=8)) /= 4 .or. &
+        any(lbound(a, kind=8) /= l_exp)) STOP 45
+
+    if (kind(ubound(a)) /= default_kind .or. size(ubound(a)) /= 4 .or. &
+        any(ubound(a) /= u_exp)) STOP 47
+    if (kind(ubound(a, kind=1)) /= 1 .or. size(ubound(a, kind=1)) /= 4 .or. &
+        any(ubound(a, kind=1) /= u_exp)) STOP 48
+    if (kind(ubound(a, kind=2)) /= 2 .or. size(ubound(a, kind=2)) /= 4 .or. &
+        any(ubound(a, kind=2) /= u_exp)) STOP 49
+    if (kind(ubound(a, kind=4)) /= 4 .or. size(ubound(a, kind=4)) /= 4 .or. &
+        any(ubound(a, kind=4) /= u_exp)) STOP 50
+    if (kind(ubound(a, kind=8)) /= 8 .or. size(ubound(a, kind=8)) /= 4 .or. &
+        any(ubound(a, kind=8) /= u_exp)) STOP 51
+  end subroutine test_assumed_shape_with_lower_bound
+end program

--- a/test/f90_correct/src/bound7.f90
+++ b/test/f90_correct/src/bound7.f90
@@ -1,0 +1,141 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND when the array is assumed-shape.
+! The options -Hy,68,1 and -My,68,1 are required.
+
+program test
+  implicit none
+  integer, allocatable :: x(:, :, :, :)
+  integer, parameter :: default_kind = kind(x)
+
+  allocate(x(1:2, 2:4, 3:6, 4:8))
+  call test_assumed_shape(x)
+  call test_assumed_shape_with_lower_bound(1, 3, 2, 4, x)
+  print *, "PASS"
+contains
+  subroutine test_assumed_shape(a)
+    integer :: a(:, :, :, :)
+    integer :: l_exp(4), u_exp(4), i
+
+    l_exp = [1, 1, 1, 1]
+    u_exp = [2, 3, 4, 5]
+    ! DIM is constant
+    if (any([lbound(a, 1), lbound(a, 2), lbound(a, 3), lbound(a, 4)] /= &
+        l_exp)) STOP 1
+    if (any([ubound(a, 1), ubound(a, 2), ubound(a, 3), ubound(a, 4)] /= &
+        u_exp)) STOP 2
+
+    ! DIM is variable
+    do i = 1, 4
+      if (kind(lbound(a, i)) /= default_kind .or. lbound(a, i) /= &
+          l_exp(i)) STOP 3
+      if (kind(lbound(a, i, kind=1)) /= 1 .or. lbound(a, i, kind=1) /= &
+          l_exp(i)) STOP 4
+      if (kind(lbound(a, i, kind=2)) /= 2 .or. lbound(a, i, kind=2) /= &
+          l_exp(i)) STOP 5
+      if (kind(lbound(a, i, kind=4)) /= 4 .or. lbound(a, i, kind=4) /= &
+          l_exp(i)) STOP 6
+      if (kind(lbound(a, i, kind=8)) /= 8 .or. lbound(a, i, kind=8) /= &
+          l_exp(i)) STOP 7
+
+      if (kind(ubound(a, i)) /= default_kind .or. ubound(a, i) /= &
+          u_exp(i)) STOP 9
+      if (kind(ubound(a, i, kind=1)) /= 1 .or. ubound(a, i, kind=1) /= &
+          u_exp(i)) STOP 10
+      if (kind(ubound(a, i, kind=2)) /= 2 .or. ubound(a, i, kind=2) /= &
+          u_exp(i)) STOP 11
+      if (kind(ubound(a, i, kind=4)) /= 4 .or. ubound(a, i, kind=4) /= &
+          u_exp(i)) STOP 12
+      if (kind(ubound(a, i, kind=8)) /= 8 .or. ubound(a, i, kind=8) /= &
+          u_exp(i)) STOP 13
+    enddo
+
+    ! DIM is missing
+    if (kind(lbound(a)) /= default_kind .or. size(lbound(a)) /= 4 .or. &
+        any(lbound(a) /= l_exp)) STOP 15
+    if (kind(lbound(a, kind=1)) /= 1 .or. size(lbound(a, kind=1)) /= 4 .or. &
+        any(lbound(a, kind=1) /= l_exp)) STOP 16
+    if (kind(lbound(a, kind=2)) /= 2 .or. size(lbound(a, kind=2)) /= 4 .or. &
+        any(lbound(a, kind=2) /= l_exp)) STOP 17
+    if (kind(lbound(a, kind=4)) /= 4 .or. size(lbound(a, kind=4)) /= 4 .or. &
+        any(lbound(a, kind=4) /= l_exp)) STOP 18
+    if (kind(lbound(a, kind=8)) /= 8 .or. size(lbound(a, kind=8)) /= 4 .or. &
+        any(lbound(a, kind=8) /= l_exp)) STOP 19
+
+    if (kind(ubound(a)) /= default_kind .or. size(ubound(a)) /= 4 .or. &
+        any(ubound(a) /= u_exp)) STOP 21
+    if (kind(ubound(a, kind=1)) /= 1 .or. size(ubound(a, kind=1)) /= 4 .or. &
+        any(ubound(a, kind=1) /= u_exp)) STOP 22
+    if (kind(ubound(a, kind=2)) /= 2 .or. size(ubound(a, kind=2)) /= 4 .or. &
+        any(ubound(a, kind=2) /= u_exp)) STOP 23
+    if (kind(ubound(a, kind=4)) /= 4 .or. size(ubound(a, kind=4)) /= 4 .or. &
+        any(ubound(a, kind=4) /= u_exp)) STOP 24
+    if (kind(ubound(a, kind=8)) /= 8 .or. size(ubound(a, kind=8)) /= 4 .or. &
+        any(ubound(a, kind=8) /= u_exp)) STOP 25
+  end subroutine test_assumed_shape
+
+  subroutine test_assumed_shape_with_lower_bound(l1, l2, l3, l4, a)
+    integer :: l1, l2, l3, l4
+    integer :: a(l1:, l2:, l3:, l4:)
+    integer :: l_exp(4), u_exp(4), i
+
+    l_exp = [l1, l2, l3, l4]
+    u_exp = [l1 + 1, l2 + 2, l3 + 3, l4 + 4]
+    ! DIM is constant
+    if (any([lbound(a, 1), lbound(a, 2), lbound(a, 3), lbound(a, 4)] /= &
+        l_exp)) STOP 27
+    if (any([ubound(a, 1), ubound(a, 2), ubound(a, 3), ubound(a, 4)] /= &
+        u_exp)) STOP 28
+
+    ! DIM is variable
+    do i = 1, 4
+      if (kind(lbound(a, i)) /= default_kind .or. lbound(a, i) /= &
+          l_exp(i)) STOP 29
+      if (kind(lbound(a, i, kind=1)) /= 1 .or. lbound(a, i, kind=1) /= &
+          l_exp(i)) STOP 30
+      if (kind(lbound(a, i, kind=2)) /= 2 .or. lbound(a, i, kind=2) /= &
+          l_exp(i)) STOP 31
+      if (kind(lbound(a, i, kind=4)) /= 4 .or. lbound(a, i, kind=4) /= &
+          l_exp(i)) STOP 32
+      if (kind(lbound(a, i, kind=8)) /= 8 .or. lbound(a, i, kind=8) /= &
+          l_exp(i)) STOP 33
+
+      if (kind(ubound(a, i)) /= default_kind .or. ubound(a, i) /= &
+          u_exp(i)) STOP 35
+      if (kind(ubound(a, i, kind=1)) /= 1 .or. ubound(a, i, kind=1) /= &
+          u_exp(i)) STOP 36
+      if (kind(ubound(a, i, kind=2)) /= 2 .or. ubound(a, i, kind=2) /= &
+          u_exp(i)) STOP 37
+      if (kind(ubound(a, i, kind=4)) /= 4 .or. ubound(a, i, kind=4) /= &
+          u_exp(i)) STOP 38
+      if (kind(ubound(a, i, kind=8)) /= 8 .or. ubound(a, i, kind=8) /= &
+          u_exp(i)) STOP 39
+    enddo
+
+    ! DIM is missing
+    if (kind(lbound(a)) /= default_kind .or. size(lbound(a)) /= 4 .or. &
+        any(lbound(a) /= l_exp)) STOP 41
+    if (kind(lbound(a, kind=1)) /= 1 .or. size(lbound(a, kind=1)) /= 4 .or. &
+        any(lbound(a, kind=1) /= l_exp)) STOP 42
+    if (kind(lbound(a, kind=2)) /= 2 .or. size(lbound(a, kind=2)) /= 4 .or. &
+        any(lbound(a, kind=2) /= l_exp)) STOP 43
+    if (kind(lbound(a, kind=4)) /= 4 .or. size(lbound(a, kind=4)) /= 4 .or. &
+        any(lbound(a, kind=4) /= l_exp)) STOP 44
+    if (kind(lbound(a, kind=8)) /= 8 .or. size(lbound(a, kind=8)) /= 4 .or. &
+        any(lbound(a, kind=8) /= l_exp)) STOP 45
+
+    if (kind(ubound(a)) /= default_kind .or. size(ubound(a)) /= 4 .or. &
+        any(ubound(a) /= u_exp)) STOP 47
+    if (kind(ubound(a, kind=1)) /= 1 .or. size(ubound(a, kind=1)) /= 4 .or. &
+        any(ubound(a, kind=1) /= u_exp)) STOP 48
+    if (kind(ubound(a, kind=2)) /= 2 .or. size(ubound(a, kind=2)) /= 4 .or. &
+        any(ubound(a, kind=2) /= u_exp)) STOP 49
+    if (kind(ubound(a, kind=4)) /= 4 .or. size(ubound(a, kind=4)) /= 4 .or. &
+        any(ubound(a, kind=4) /= u_exp)) STOP 50
+    if (kind(ubound(a, kind=8)) /= 8 .or. size(ubound(a, kind=8)) /= 4 .or. &
+        any(ubound(a, kind=8) /= u_exp)) STOP 51
+  end subroutine test_assumed_shape_with_lower_bound
+end program

--- a/test/f90_correct/src/bound8.f90
+++ b/test/f90_correct/src/bound8.f90
@@ -1,0 +1,57 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for LBOUND and UBOUND when the array is explicit-shape.
+
+program test
+  implicit none
+  integer :: x(2,3,4)
+  call test_explicit_shape(4, 3, 2, x)
+  call test_explicit_shape_with_lower_bound(3, 5, 9, 12, 1, 5, x)
+  call test_subobject()
+  call test_array_func()
+  print *, "PASS"
+contains
+  subroutine test_explicit_shape(n1, n2, n3, a)
+    integer :: n1, n2, n3
+    integer :: a(n1, n2, n3)
+    if (any(lbound(a) /= 1)) STOP 1
+    if (any(ubound(a) /= [n1, n2, n3])) STOP 2
+  end subroutine
+
+  subroutine test_explicit_shape_with_lower_bound(l1, u1, l2, u2, l3, u3, a)
+    integer :: l1, u1, l2, u2, l3, u3
+    integer :: a(l1:u1, l2:u2, l3:u3)
+    if (any(lbound(a) /= [l1, l2, l3])) STOP 3
+    if (any(ubound(a) /= [u1, u2, u3])) STOP 4
+  end subroutine
+
+  subroutine test_subobject()
+    integer :: y(10, 10, 10)
+    type t
+      integer, allocatable :: y(:, :, :)
+      integer :: i
+    end type
+    type(t) :: z, zz(2, 3, 4)
+    if (any(lbound(y(3:4, 5:9, 1:5)) /= [1, 1, 1])) STOP 5
+    if (any(ubound(y(3:4, 5:9, 1:5)) /= [2, 5, 5])) STOP 6
+
+    allocate(z%y(10:20, 20:30, 30:40))
+    if (any(lbound(z%y(13:14, 25:29, 31:35)) /= [1, 1, 1])) STOP 7
+    if (any(ubound(z%y(13:14, 25:29, 31:35)) /= [2, 5, 5])) STOP 8
+
+    if (any(lbound(zz%i) /= [1, 1, 1])) STOP 9
+    if (any(ubound(zz%i) /= [2, 3, 4])) STOP 10
+  end subroutine
+
+  subroutine test_array_func()
+    integer, allocatable :: y(:, :, :)
+    allocate(y(-1:1, -2:2, -3:3))
+    if (lbound(shape(y), 1) /= 1) STOP 11
+    if (any(lbound(shape(y)) /= 1)) STOP 12
+    if (ubound(shape(y), 1) /= 3) STOP 13
+    if (any(ubound(shape(y)) /= 3)) STOP 14
+  end subroutine
+end program

--- a/test/f90_correct/src/bound9.f90
+++ b/test/f90_correct/src/bound9.f90
@@ -1,0 +1,30 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for restrictions about LBOUND and UBOUND.
+
+program test
+  implicit none
+  integer :: x(2,3,4)
+  type t
+    integer :: y
+  end type
+  type(t) :: a = t(1)
+  !{error "PGF90-S-0423-Constant DIM= argument is out of range"}
+  print *, ubound(x, 4)
+  !{error "PGF90-S-0423-Constant DIM= argument is out of range"}
+  print *, lbound(x, 0)
+  !{error "PGF90-S-0074-Illegal number or type of arguments to ubound - keyword argument *dim"}
+  print *, ubound(x, a)
+  !{error "PGF90-S-0074-Illegal number or type of arguments to lbound - keyword argument *kind"}
+  print *, lbound(x, a%y, a)
+contains
+  subroutine test_assumed_rank(a)
+    integer :: a(..)
+    !{error "PGF90-S-0423-Constant DIM= argument is out of range"}
+    print *, ubound(a, DIM=200)
+  end subroutine
+end program
+

--- a/test/f90_correct/src/submod32.f90
+++ b/test/f90_correct/src/submod32.f90
@@ -32,10 +32,11 @@ program prog
     print *, "kind: ", kind(x)
     print *, "maxval: ", maxval(x)
     call check_arr(x)
-    if ( a .EQ. lbound(x, DIM=1) .AND. b .EQ. size(x) .AND. maxval(x) .EQ. m) then 
+    if ( a .EQ. 1 .AND. lbound(x, DIM=1) .EQ. 7 .AND. b .EQ. size(x) .AND. maxval(x) .EQ. m) then
         print *, " PASS "
     else 
-        print *, "FAILED: lbound of arr in submod is ", a, " and lbound of x is ", lbound(x, DIM=1)
+        print *, "FAILED: lbound of arr in submod is ", a, " and the expection is 1"
+        print *, "FAILED: lbound of x is is ", lbound(x, DIM=1), "and the expection is 7"
         print *, "FAILED: size of arr in submod is ", b, " and size of x is ", size(x)
         print *, "FAILED: maxval of arr in submod is", m, " and maxval of x is", maxval(x)
     end if

--- a/test/mp_correct/inc/bound1.mk
+++ b/test/mp_correct/inc/bound1.mk
@@ -1,0 +1,17 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) $(FFLAGS) $(SRC)/$(TEST).f90
+	-$(FC) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	-$(RUN4) $(TEST).$(EXESUFFIX)

--- a/test/mp_correct/lit/bound1.sh
+++ b/test/mp_correct/lit/bound1.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/mp_correct/src/bound1.f90
+++ b/test/mp_correct/src/bound1.f90
@@ -1,0 +1,25 @@
+!
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for the fix for LBOUND/UBOUND regression where the calling is in the
+! parallel region.
+
+program test
+  implicit none
+  integer :: x(7)
+  call test_assumed_shp(10, 1, x)
+  print *, "PASS"
+contains
+  subroutine test_assumed_shp(n, m, a)
+    integer :: n, m
+    integer :: a(n:)
+    !$omp parallel
+      if (lbound(a, 1) /= 10) STOP 1
+      if (ubound(a, 1) /= 16) STOP 2
+      if (lbound(a, m) /= 10) STOP 3
+      if (ubound(a, m) /= 16) STOP 4
+    !$omp end parallel
+  end subroutine
+end program

--- a/tools/flang1/flang1exe/ast.c
+++ b/tools/flang1/flang1exe/ast.c
@@ -4470,7 +4470,6 @@ ast_rewrite(int ast)
 {
   int atype;
   int astnew;
-  int l;
   int parent, mem, left, right, lop, rop, l1, l2, l3, sub, lbd, upbd, stride,
       dest, src, ifexpr, ifstmt, dolab, dovar, m1, m2, m3, itriple, otriple,
       otriple1, dim, bvect, ddesc, sdesc, mdesc, vsub, chunk, npar, start,
@@ -4689,26 +4688,6 @@ ast_rewrite(int ast)
             astnew = mk_binop(OP_DIV, astnew, stride, astb.bnd.dtype);
           }
         }
-      }
-      break;
-    case I_LBOUND:
-      /* is dim a constant ? */
-      if ((i = A_ALIASG(ARGT_ARG(argtnew, 1)))) {
-        shape = A_SHAPEG(ARGT_ARG(argtnew, 0));
-        i = CONVAL2G(A_SPTRG(i)) - 1;
-        l = lbound_of_shape(shape, i);
-        if (l)
-          astnew = l;
-      }
-      break;
-    case I_UBOUND:
-      /* is dim a constant ? */
-      if ((i = A_ALIASG(ARGT_ARG(argtnew, 1)))) {
-        shape = A_SHAPEG(ARGT_ARG(argtnew, 0));
-        i = CONVAL2G(A_SPTRG(i)) - 1;
-        l = ubound_of_shape(shape, i);
-        if (l)
-          astnew = l;
       }
       break;
     default:
@@ -10181,4 +10160,16 @@ add_shapely_subscripts(int to_ast, int from_ast, DTYPE arr_dtype,
   int extent_asts[MAXRANK];
   int rank = get_ast_extents(extent_asts, from_ast, arr_dtype);
   return add_extent_subscripts(to_ast, rank, extent_asts, elt_dtype);
+}
+
+/* If an array AST is a whole array, return the SPTR of the array or the
+ * structure component. */
+SPTR
+get_whole_array_sym(int arr_ast)
+{
+  if (A_TYPEG(arr_ast) == A_ID)
+    return A_SPTRG(arr_ast);
+  if (A_TYPEG(arr_ast) == A_MEM && !A_SHAPEG(A_PARENTG(arr_ast)))
+    return A_SPTRG(A_MEMG(arr_ast));
+  return SPTR_NULL;
 }

--- a/tools/flang1/flang1exe/dpm_out.c
+++ b/tools/flang1/flang1exe/dpm_out.c
@@ -1535,10 +1535,22 @@ transform_wrapup(void)
     finish_fl();
     open_entry_guard(this_entry);
     if (ENTSTDG(this_entry) != EntryStd) {
+      int s;
+      /* Rewrite any assignments added at the entry point. */
+      for (s = STD_NEXT(ENTSTDG(this_entry)); s != EntryStd; s = STD_NEXT(s)) {
+        int ast;
+        arg_gbl.std = s;
+        arg_gbl.lhs = 0;
+        arg_gbl.used = FALSE;
+        arg_gbl.inforall = FALSE;
+        gbl.lineno = STD_LINENO(s);
+        ast = STD_AST(s);
+        if (A_TYPEG(ast) == A_ASN)
+          rewrite_asn(ast, s, TRUE, 0);
+      }
       /* reset LINENO for any statements added at the entry point.
        * this allows the debugger to set its breakpoints at the proper
        * point, which is after the prologue code */
-      int s;
       for (s = STD_NEXT(ENTSTDG(this_entry)); s != EntryStd; s = STD_NEXT(s)) {
         STD_LINENO(s) = 0;
       }

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -6800,10 +6800,11 @@ const_eval(int ast)
       return sz;
     }
     case I_LBOUND: {
-      int lwb;
+      int lwb, dim;
       val = A_ARGSG(ast);
       ast = ARGT_ARG(val, 0);
-      ast = ADD_LWAST(A_DTYPEG(ast), val - 1);
+      dim = get_const_from_ast(ARGT_ARG(val, 1));
+      ast = ADD_LWAST(A_DTYPEG(ast), dim - 1);
       lwb = get_const_from_ast(ast);
       if (XBIT(68, 0x1) && A_ALIASG(ast) && !DT_ISWORD(A_DTYPEG(ast))) {
         lwb = get_int_cval(lwb);
@@ -6811,10 +6812,11 @@ const_eval(int ast)
       return lwb;
     }
     case I_UBOUND: {
-      int upb;
+      int upb, dim;
       val = A_ARGSG(ast);
       ast = ARGT_ARG(val, 0);
-      ast = ADD_UPAST(A_DTYPEG(ast), val - 1);
+      dim = get_const_from_ast(ARGT_ARG(val, 1));
+      ast = ADD_UPAST(A_DTYPEG(ast), dim - 1);
       upb = get_const_from_ast(ast);
       if (XBIT(68, 0x1) && A_ALIASG(ast) && !DT_ISWORD(A_DTYPEG(ast))) {
         upb = get_int_cval(upb);

--- a/tools/flang1/flang1exe/symutl.h
+++ b/tools/flang1/flang1exe/symutl.h
@@ -70,6 +70,7 @@ void fixup_srcalloc_bounds(int *, int *, int);
 
 void check_alloc_ptr_type(int, int, DTYPE, int, int, int, int); /* func.c */
 LOGICAL contiguous_section(int arr_ast);                        /* func.c */
+int rewrite_lbound_ubound(int func_ast, int actual, int nextstd); /* func.c */
 
 int gen_set_len_ast(int ast, SPTR ddesc, int sz); /* outconv.c */
 LOGICAL inline_RTE_set_type(int, int, int, int, DTYPE, int); /* outconv.c */

--- a/tools/flang1/utils/ast/ast.in.h
+++ b/tools/flang1/utils/ast/ast.in.h
@@ -498,3 +498,4 @@ int add_bounds_subscripts(int to_ast, int rank, const int lower_bound_asts[],
                           const int upper_bound_asts[], DTYPE elt_dtype);
 int add_shapely_subscripts(int to_ast, int from_ast, DTYPE arr_dtype, DTYPE elt_dtype);
 LOGICAL ast_is_sym(int ast);
+SPTR get_whole_array_sym(int arr_ast);


### PR DESCRIPTION
An issue occurs when LBOUND/UBOUND appears in the type specification
of a function result and the DIM argument is missing.

The root cause of this issue is that LBOUND/UBOUND is converted to
runtime call in semantic phase, which is too early for type-spec of
a function result. On the calling side of the function, we have no
way of knowing whether LBOUND/UBOUND exists or its reference to the
function's dummy arguments.

We fix the issue by delaying the conversion to the tranform phase.
In particular, we perform the conversion in dummy-actual argument
replacement if the array argument of LBOUND/UBOUND is an assumed-shape
array dummy.

In addition, we fix an ICE that occurs when LBOUND/UBOUND appears in
subscript expressions in type-spec, fix the link error that occurs
when both DIM and KIND arguments are present, fix an issue with LBOUND
on the last dimension of an assumed-size array, and add support for
LBOUND/UBOUND on an assumed-rank array.