### PR TITLE
Add align pragma for scalar data types (integer, logical, real, complex)

### DIFF
--- a/test/directives/align_function_var.f90
+++ b/test/directives/align_function_var.f90
@@ -1,0 +1,46 @@
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK: %struct.[[BLOCK1:STATICS[0-9]+]] = type <{ [132 x i8] }>
+! CHECK: @.[[BLOCK1]] = internal global %struct.[[BLOCK1]] <{ [132 x i8] {{[^,]+}} }>, align 128
+integer(kind=4) function function_init()
+   !dir$ align 128
+   integer(kind=4) :: a128 = 10
+   !dir$ align 128
+   integer(kind=4) :: b128 = 20
+! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 128
+   a128 = a128 + 1
+! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 128
+   b128 = b128 + 2
+! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 128
+   function_init = a128 + b128
+end function function_init
+
+
+integer(kind=4) function function_no_init()
+! CHECK: {{[^=]+}} = alloca i32, align 128
+   !dir$ align 128
+   integer(kind=4) :: a128
+! CHECK: {{[^=]+}} = alloca i32, align 128
+   !dir$ align 128
+   integer(kind=4) :: b128
+
+   a128 = 1
+   b128 = 2
+
+   function_no_init = a128 + b128
+end function function_no_init
+
+
+program MainProgram
+   implicit none
+
+
+   integer(kind=4) :: res
+   integer(kind=4) :: function_init
+   integer(kind=4) :: function_no_init
+
+   res = function_init()
+   res = function_no_init()
+
+end program MainProgram
+

--- a/test/directives/align_local_var_init.f90
+++ b/test/directives/align_local_var_init.f90
@@ -1,0 +1,14 @@
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s
+! CHECK: %struct.[[BLOCK1:STATICS[0-9]+]] = type <{ [1028 x i8] }>
+! CHECK: @.[[BLOCK1]] = internal global %struct.[[BLOCK1]] <{ [1028 x i8] {{[^,]+}} }>, align 1024
+program MainProgram
+   implicit none
+! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 1024
+! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 1024
+   !dir$ align 1024
+   integer(kind=4) :: a1024 =30
+   !dir$ align 1024
+   integer(kind=4) :: b1024 =40
+   a1024 = a1024 + b1024
+
+end program MainProgram

--- a/test/directives/align_local_var_no_init.f90
+++ b/test/directives/align_local_var_no_init.f90
@@ -1,0 +1,12 @@
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s
+program main
+   implicit none
+! CHECK: {{[^=]+}} = alloca i64, align 256
+! CHECK: {{[^=]+}} = alloca i64, align 256
+
+   !dir$ align 256
+   integer(kind=8) :: d,e
+
+   d=e
+
+end program main

--- a/test/directives/align_module_var_init.f90
+++ b/test/directives/align_module_var_init.f90
@@ -1,0 +1,50 @@
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK: %struct.[[BLOCK1:STATICS[0-9]+]] = type <{ [260 x i8] }>
+! CHECK: %struct[[STRUCT1:[^=]+]] = type <{ [516 x i8] }>
+
+! CHECK: @.[[BLOCK1]] = internal global %struct.[[BLOCK1]] <{ [260 x i8] {{[^,]+}} }>, align 256
+! CHECK: @[[STRUCT1]] = global %struct[[STRUCT1]] <{ [516 x i8] {{[^,]+}} }>, align 512
+module module_align
+   implicit none
+
+   !dir$ align 128
+   integer :: a128 = 123
+
+   !dir$ align 512
+   integer :: b512 = 234
+
+   interface
+      module subroutine module_interface_subroutine()
+      end subroutine module_interface_subroutine
+   end interface
+
+end module module_align
+
+submodule (module_align) submodule_align
+
+contains
+   module subroutine module_interface_subroutine()
+
+
+      !dir$ align 256
+      integer :: a256 = 12
+
+      !dir$ align 128
+      integer :: b128 = 14
+
+! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 256
+! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 512
+      a128 = 12 + a256
+      b512 = 23 + b128
+
+
+   end subroutine module_interface_subroutine
+end submodule submodule_align
+
+program MainProgram
+
+   use module_align
+   call module_interface_subroutine()
+
+end program MainProgram

--- a/test/directives/align_module_var_no_init.f90
+++ b/test/directives/align_module_var_no_init.f90
@@ -1,0 +1,52 @@
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s
+! CHECK: %struct[[STRUCT1:[^=]+]] = type <{ [2052 x i8] }>
+! CHECK: @[[STRUCT1]] = common global %struct[[STRUCT1]] zeroinitializer, align 1024
+module MyModule
+   implicit none
+
+   !dir$ align 512
+   integer(kind=4) :: a512
+   !dir$ align 512
+   integer(kind=4) :: b512
+   !dir$ align 512
+   integer, dimension (5,5) :: c
+
+   !dir$ align 128
+   integer(kind=4) :: d128
+
+   integer(kind=4) :: e4
+
+   !dir$ align 1024
+   integer(kind=4) :: f1024
+
+   interface
+      module subroutine module_interface_subroutine()
+      end subroutine module_interface_subroutine
+   end interface
+
+end module MyModule
+
+submodule (MyModule) submodule_align
+
+contains
+   module subroutine module_interface_subroutine()
+
+      a512 = 11
+      ! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 512
+      b512 = 12
+      ! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 1072
+      c(3, 3) = 13
+      ! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 1152
+      d128 = 14
+      ! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 1156
+      e4 = 15
+      ! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 2048
+      f1024 = 16
+   end subroutine module_interface_subroutine
+end submodule submodule_align
+
+
+program MainProgram
+   use MyModule
+   call module_interface_subroutine()
+end program MainProgram

--- a/test/directives/align_subroutine_var.f90
+++ b/test/directives/align_subroutine_var.f90
@@ -1,0 +1,36 @@
+! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s
+
+program MainProgram
+   implicit none
+
+   call subroutine_init()
+   call subroutine_no_init()
+
+end program MainProgram
+
+
+! CHECK: %struct.[[BLOCK1:STATICS[0-9]+]] = type <{ [2052 x i8] }>
+! CHECK: @.[[BLOCK1]] = internal global %struct.[[BLOCK1]] <{ [2052 x i8] {{[^,]+}} }>, align 2048
+subroutine subroutine_init()
+   !dir$ align 2048
+   integer(kind=4) :: a2048 = 10
+   !dir$ align 2048
+   integer(kind=4) :: b2048 = 20
+   ! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 2048
+   ! CHECK: {{[^g]+}}getelementptr {{[^,]+}}, {{[^,]+}}, i64 2048
+   a2048 = a2048 + 1
+   b2048 = b2048 + 2
+
+end subroutine subroutine_init
+
+subroutine subroutine_no_init()
+   ! CHECK: {{[^=]+}} = alloca i32, align 1024
+   !dir$ align 1024
+   integer(kind=4) :: a1024
+   ! CHECK: {{[^=]+}} = alloca i32, align 1024
+   !dir$ align 1024
+   integer(kind=4) :: b1024
+   a1024 = 1
+   b1024 = 2
+
+end subroutine subroutine_no_init


### PR DESCRIPTION
Add support for aligning the first address of scalar data types (integer, logical, real, complex) with align pragma like "!dir$ align n".

For example: 

```fortran
!dir$ align 128
integer(kind=4) :: a
```

The align pragma enables the first address of variable "a" to be an integer multiple of 128.

The overall idea for this patch is as follows:

* flang1:
  1. recognize the align pragma in the source code in `do_sw()`
  2. add a field to the `ST_VAR` symbol table to store the align value
  3. add `ALIGN_PRAGMA *align_pragma_base` to store all the align pragmas info parsed in the first pass
  4. match all the align pragmas and corresponding variables and  set the variable's align value at the end of parse
  5. print the variable's align value in `lower_symbol()`
* flang2:
  1. add a field to the `ST_VAR` symbol table to store the align value
  2. read and set the variable's align value in `read_symbol()`
  3. set the `LL_Object::align_bytes` field with the symbol's align field when creating an LLVM variable object
  4. adjust the size and align of common block according to the align value of variables in it, set the first address of a variable in the common block an integer multiple of the variable's align value.

This patch can be combined with https://github.com/flang-compiler/flang/pull/1360, which adds align pragma support for derived types and fixed shape array/character types. These two patches enable flang to support align pragma for most common data types.

I test locally through `make check-flang-long`, and also pass some custom tests and add them to the test folder. 