### PR TITLE
[flang1] Fix a parallel do bug

### DIFF
--- a/test/mp_correct/inc/do20.mk
+++ b/test/mp_correct/inc/do20.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) $(FFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	-$(RUN4) $(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/mp_correct/lit/do20.sh
+++ b/test/mp_correct/lit/do20.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%s MAKE_FILE_DIR=%S/.. bash %S/runmake | tee %t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/mp_correct/src/do20.f90
+++ b/test/mp_correct/src/do20.f90
@@ -1,0 +1,21 @@
+!* Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+!* See https://llvm.org/LICENSE.txt for license information.
+!* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+!       simple parallel do, negative stride
+
+program main
+  call mmm(10, 1, -2)
+contains
+
+subroutine mmm (m1, m2, m3)
+  integer :: m, m1, m2, m3
+!$OMP PARALLEL DO
+  do m = m1, m2, m3
+    print *, "PASS"
+  enddo
+!$OMP END PARALLEL DO
+end subroutine
+
+end program
+

--- a/tools/flang1/flang1exe/lowerilm.c
+++ b/tools/flang1/flang1exe/lowerilm.c
@@ -1883,11 +1883,13 @@ llvm_omp_sched(int std, int ast, int dtype, int dotop, int dobottom, int dovar,
     ilm = lower_sptr(odovar, VarBase);
     lower_typestore(dtype, ilm, doinitilm);
 
-    plower("oL", "LABEL", dotop);
-    if (schedtype == 0x000 || chunkone) {
-      check_loop_bound(odovar, o_ub, o_ub, dost, dobottom, 0, incr_loop);
-    } else {
-      check_loop_bound(odovar, newend, o_ub, dost, dobottom, 1, incr_loop);
+    if (schedtype != 0) { 
+      plower("oL", "LABEL", dotop);
+      if (chunkone) {
+        check_loop_bound(odovar, o_ub, o_ub, dost, dobottom, 0, incr_loop);
+      } else {
+        check_loop_bound(odovar, newend, o_ub, dost, dobottom, 1, incr_loop);
+      }
     }
 
     /* dovar = odovar */


### PR DESCRIPTION
When the stride of parallel do is negative, flang will always exit loop.
It is because check_loop_bound function always check the incr of a loop
to avoid out of loop bound. It is not necessary since __kmp_for_static_init
in openmp have do the same thing, and will change the stride to match
the actual number of iterations. The function is only needed when SCHEDULE
is enabled.