### PR TITLE
NFC: With LLVM18 a loop preheader is being exposed, hence the preds must be more liberal

### DIFF
--- a/test/directives/nounroll.f90
+++ b/test/directives/nounroll.f90
@@ -6,7 +6,7 @@
 !
 ! RUN: %flang -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK
 !
-! CHECK:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]]{{.*}}, %L.LB
 ! CHECK:      store float
 ! CHECK-NOT:  store float
 ! CHECK:      br i1 {{.*}}, label %[[LOOP]], label %L.LB

--- a/test/directives/nounroll2.f90
+++ b/test/directives/nounroll2.f90
@@ -7,7 +7,7 @@
 !
 ! RUN: %flang -O0 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK-O0
 !
-! CHECK-O0:     [[LOOP:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-O0:     [[LOOP:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[LOOP]]{{.*}}, %L.LB
 ! CHECK-O0:     store float
 ! CHECK-O0-NOT: store float
 ! CHECK-O0:     br i1 {{.*}}, label %[[LOOP]], label %L.LB

--- a/test/directives/unroll.f90
+++ b/test/directives/unroll.f90
@@ -29,7 +29,7 @@ subroutine func1(a, b)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-  ! CHECK-O0:           [[BB1:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB1]],
+  ! CHECK-O0:           [[BB1:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB1]]
   ! CHECK-O0:           br i1 {{.*}}, label %[[BB1]]
   ! CHECK-O0-SAME:      !llvm.loop [[MD_LOOP1:![0-9]+]]
   ! CHECK-O1-COUNT-10:  store i32
@@ -37,7 +37,7 @@ subroutine func1(a, b)
   ! CHECK-O1-NOT:       br i1 {{.*}}, label %{{L.LB[0-9]_[0-9]+}}
   ! CHECK-O1-NOT:       !llvm.loop !{{[0-9]+}}
   ! CHECK-O1:           ret void
-  ! CHECK-DISABLED:     [[BB1:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB1]],
+  ! CHECK-DISABLED:     [[BB1:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB1]]
   ! CHECK-DISABLED:     br i1 {{.*}}, label %[[BB1]]
 end subroutine func1
 
@@ -49,7 +49,7 @@ subroutine func2(m, a, b)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-  ! CHECK:              [[BB2:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB2]],
+  ! CHECK:              [[BB2:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB2]]
   ! CHECK-O1-COUNT-4:   store i32
   ! CHECK-O1-NOT:       store i32
   ! CHECK:              br i1 {{.*}}, label %[[BB2]]
@@ -66,7 +66,7 @@ subroutine func3(m, a, b)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-  ! CHECK:              [[BB3:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB3]],
+  ! CHECK:              [[BB3:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB3]]
   ! CHECK-O1-COUNT-7:   store i32
   ! CHECK-O1-NOT:       store i32
   ! CHECK:              br i1 {{.*}}, label %[[BB3]]

--- a/test/directives/unroll_override.f90
+++ b/test/directives/unroll_override.f90
@@ -17,7 +17,7 @@ subroutine func1(m, a, b)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-  ! CHECK:       [[BB1:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB1]],
+  ! CHECK:       [[BB1:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB1]]
   ! CHECK:       br i1 {{.*}}, label %[[BB1]]
   ! CHECK-SAME:  !llvm.loop [[MD_LOOP1:![0-9]+]]
 end subroutine func1
@@ -32,7 +32,7 @@ subroutine func2(m, a, b)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-  ! CHECK:       [[BB2:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB2]],
+  ! CHECK:       [[BB2:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB2]]
   ! CHECK:       br i1 {{.*}}, label %[[BB2]]
   ! CHECK-SAME:  !llvm.loop [[MD_LOOP2:![0-9]+]]
 end subroutine func2
@@ -47,7 +47,7 @@ subroutine func3(m, a, b)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-  ! CHECK:       [[BB3:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB3]],
+  ! CHECK:       [[BB3:L.LB[0-9]_[0-9]+]]:{{[ \t]+}}; preds = %[[BB3]]
   ! CHECK:       br i1 {{.*}}, label %[[BB3]]
   ! CHECK-SAME:  !llvm.loop [[MD_LOOP3:![0-9]+]]
 end subroutine func3

--- a/test/directives/vector_vectorlength_integer.f90
+++ b/test/directives/vector_vectorlength_integer.f90
@@ -15,7 +15,7 @@ subroutine func1(a, b, m)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-! CHECK-00:      [[LOOP:L.LB1_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-00:      [[LOOP:L.LB1_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]]{{.*}}, %L.LB
 ! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD:![0-9]+]]
 end subroutine func1
 
@@ -26,7 +26,7 @@ subroutine func2(a, b, m)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-! CHECK-00:      [[LOOP:L.LB2_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-00:      [[LOOP:L.LB2_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]]{{.*}}, %L.LB
 ! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD2:![0-9]+]]
 end subroutine func2
 

--- a/test/directives/vector_vectorlength_num_fixed.f90
+++ b/test/directives/vector_vectorlength_num_fixed.f90
@@ -15,7 +15,7 @@ subroutine func1(a, b, m)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-! CHECK-00:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-00:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]]{{.*}}, %L.LB
 ! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD:![0-9]+]]
 end subroutine func1
 

--- a/test/directives/vector_vectorlength_num_scalable.f90
+++ b/test/directives/vector_vectorlength_num_scalable.f90
@@ -15,7 +15,7 @@ subroutine func1(a, b, m)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-! CHECK-00:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-00:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]]{{.*}}, %L.LB
 ! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD:![0-9]+]]
 end subroutine func1
 

--- a/test/directives/vector_vectorlength_scalable.f90
+++ b/test/directives/vector_vectorlength_scalable.f90
@@ -16,7 +16,7 @@ subroutine func1(a, b, m)
   do i = 1, m
     b(i) = a(i) + 1
   end do
-! CHECK-00:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]], %L.LB
+! CHECK-00:      [[LOOP:L.LB[0-9]_[0-9]+]]:{{[' ',\t]+}}; preds = %[[LOOP]]{{.*}}, %L.LB
 ! CHECK-00:      br i1 {{.*}}, label %[[LOOP]], {{.*}} !llvm.loop [[LOOP_LATCH_MD:![0-9]+]]
 end subroutine func1
 


### PR DESCRIPTION
This is a preparation patch for ensuring LLVM18 compatibility.
