### PR TITLE
NFC: The checks for AArch64 target features must be more flexible after Oliver Stannard's LLVM commit

### DIFF
--- a/test/llvm_ir_correct/attr.f90
+++ b/test/llvm_ir_correct/attr.f90
@@ -16,5 +16,6 @@
        end do
        print *, acc(100)
       end program
-! ATTRS-NOSVE: attributes{{.*}}"target-features"="+neon{{(,\+v8a)*}}"
-! ATTRS-SVE: attributes{{.*}}"target-features"="+neon{{(,\+v8a)*}},+sve"
+! ATTRS-NOSVE-NOT: attributes{{.*}}"target-features"="{{.*}}+sve{{.*}}"
+! ATTRS-NOSVE: attributes{{.*}}"target-features"="{{.*}}+neon{{.*}}"
+! ATTRS-SVE: attributes{{.*}}"target-features"="{{.*}}+sve{{.*}}"

--- a/test/llvm_ir_correct/vscale-mbits.f90
+++ b/test/llvm_ir_correct/vscale-mbits.f90
@@ -24,29 +24,29 @@
        print *, acc(100)
       end program
 ! ATTRS-SVE-128: attributes #{{[0-9]+}}
-! ATTRS-SVE-128-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
+! ATTRS-SVE-128-DAG: "target-features"="{{.*}}+sve{{.*}}"
 ! ATTRS-SVE-128-DAG: vscale_range(1,1)
 ! ATTRS-SVE-128PLUS: attributes #{{[0-9]+}}
-! ATTRS-SVE-128PLUS-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
+! ATTRS-SVE-128PLUS-DAG: "target-features"="{{.*}}+sve{{.*}}"
 ! ATTRS-SVE-128PLUS-DAG: vscale_range(1,0)
 ! ATTRS-SVE-256: attributes #{{[0-9]+}}
-! ATTRS-SVE-256-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
+! ATTRS-SVE-256-DAG: "target-features"="{{.*}}+sve{{.*}}"
 ! ATTRS-SVE-256-DAG: vscale_range(2,2)
 ! ATTRS-SVE-256PLUS: attributes #{{[0-9]+}}
-! ATTRS-SVE-256PLUS-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
+! ATTRS-SVE-256PLUS-DAG: "target-features"="{{.*}}+sve{{.*}}"
 ! ATTRS-SVE-256PLUS-DAG: vscale_range(2,0)
 ! ATTRS-SVE2-512: attributes #{{[0-9]+}}
-! ATTRS-SVE2-512-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve"
+! ATTRS-SVE2-512-DAG: "target-features"="{{.*}}+sve2{{.*}}"
 ! ATTRS-SVE2-512-DAG: vscale_range(4,4)
 ! ATTRS-SVE2-512PLUS: attributes #{{[0-9]+}}
-! ATTRS-SVE2-512PLUS-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve"
+! ATTRS-SVE2-512PLUS-DAG: "target-features"="{{.*}}+sve2{{.*}}"
 ! ATTRS-SVE2-512PLUS-DAG: vscale_range(4,0)
 ! ATTRS-SVE2SHA3-2048: attributes #{{[0-9]+}}
-! ATTRS-SVE2SHA3-2048-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2-sha3,+sve,+sve2"
+! ATTRS-SVE2SHA3-2048-DAG: "target-features"="{{.*}}+sve2-sha3{{.*}}"
 ! ATTRS-SVE2SHA3-2048-DAG: vscale_range(16,16)
 ! ATTRS-SVE2SHA3-2048PLUS: attributes #{{[0-9]+}}
-! ATTRS-SVE2SHA3-2048PLUS-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2-sha3,+sve,+sve2"
+! ATTRS-SVE2SHA3-2048PLUS-DAG: "target-features"="{{.*}}+sve2-sha3{{.*}}"
 ! ATTRS-SVE2SHA3-2048PLUS-DAG: vscale_range(16,0)
 ! ATTRS-SVE2-SCALABLE: attributes #{{[0-9]+}}
-! ATTRS-SVE2-SCALABLE-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve"
+! ATTRS-SVE2-SCALABLE-DAG: "target-features"="{{.*}}+sve2{{.*}}"
 ! ATTRS-SVE2-SCALABLE-DAG: vscale_range(1,16)

--- a/test/llvm_ir_correct/vscale.f90
+++ b/test/llvm_ir_correct/vscale.f90
@@ -23,23 +23,28 @@
        print *, acc(100)
       end program
 ! ATTRS-NEON-NOT: vscale_range
-! ATTRS-NEON: attributes{{.*}}"target-features"="+neon{{(,\+v8a)*}}"
+! ATTRS-NEON: attributes{{.*}}"target-features"="{{.*}}+neon{{.*}}"
 ! ATTRS-SVE: attributes #{{[0-9]+}}
-! ATTRS-SVE-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
+! ATTRS-SVE-NOT: "target-features"="{{.*}}+sve2{{.*}}"
+! ATTRS-SVE-DAG: "target-features"="{{.*}}+sve{{.*}}"
 ! ATTRS-SVE-DAG: vscale_range(1,16)
 ! ATTRS-SVE2: attributes #{{[0-9]+}}
-! ATTRS-SVE2-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve"
+! ATTRS-SVE2-DAG: "target-features"="{{.*}}+sve2{{.*}}"
 ! ATTRS-SVE2-DAG: vscale_range(1,16)
 ! ATTRS-SVE2SHA3: attributes #{{[0-9]+}}
-! ATTRS-SVE2SHA3-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2-sha3,+sve,+sve2"
+! ATTRS-SVE2SHA3-DAG: "target-features"="{{.*}}+sve2-sha3{{.*}}"
 ! ATTRS-SVE2SHA3-DAG: vscale_range(1,16)
 ! ATTRS-SVE-NOSVE-NOT: vscale_range
-! ATTRS-SVE-NOSVE: attributes{{.*}}"target-features"="+neon{{(,\+v8a)*}},-sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
+! ATTRS-SVE-NOSVE-NOT: attributes{{.*}}"target-features"{{.*}}+sve{{.*}}"
+! ATTRS-SVE-NOSVE-DAG: attributes{{.*}}"target-features"{{.*}}+neon{{.*}}"
 ! ATTRS-SVE2-NOSVE2SHA3: attributes #{{[0-9]+}}
-! ATTRS-SVE2-NOSVE2SHA3-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve,-sve2-sha3"
+! ATTRS-SVE2-NOSVE2SHA3-NOT: "target-features"="{{.*}}+sve2-sha3{{.*}}"
+! ATTRS-SVE2-NOSVE2SHA3-DAG: "target-features"="{{.*}}+sve2{{.*}}"
 ! ATTRS-SVE2-NOSVE2SHA3-DAG: vscale_range(1,16)
 ! ATTRS-SVE2SHA3-NOSVE2: attributes #{{[0-9]+}}
-! ATTRS-SVE2SHA3-NOSVE2-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
+! ATTRS-SVE2SHA3-NOSVE2-NOT: "target-features"="{{.*}}+sve2{{.*}}"
+! ATTRS-SVE2SHA3-NOSVE2-NOT: "target-features"="{{.*}}+sve2-sha3{{.*}}"
+! ATTRS-SVE2SHA3-NOSVE2-DAG: "target-features"="{{.*}}+sve{{.*}}"
 ! ATTRS-SVE2SHA3-NOSVE2-DAG: vscale_range(1,16)
 ! ATTRS-SVE2SHA3-NOSVE-NOT: vscale_range
-! ATTRS-SVE2SHA3-NOSVE: attributes{{.*}}"target-features"="+neon{{(,\+v8a)*}},-sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
+! ATTRS-SVE2SHA3-NOSVE: attributes{{.*}}"target-features"="{{.*}}-sve2-sha3{{.*}}"


### PR DESCRIPTION
This is a preparation patch for ensuring LLVM18 compatibility.