### PR TITLE
[workflows] Update CI to test release_18x, and stop testing release_16x

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -22,16 +22,16 @@ jobs:
         target: [X86]
         cc: [clang]
         version: [14, 15]
-        llvm_branch: [release_16x, release_17x]
+        llvm_branch: [release_17x, release_18x]
         include:
           - target: X86
             cc: gcc
             version: 12
-            llvm_branch: release_16x
+            llvm_branch: release_17x
           - target: X86
             cc: gcc
             version: 12
-            llvm_branch: release_17x
+            llvm_branch: release_18x
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it

--- a/.github/workflows/build_flang_arm64.yml
+++ b/.github/workflows/build_flang_arm64.yml
@@ -20,13 +20,13 @@ jobs:
       build_path: /home/github
       install_prefix: /home/github/usr/local
     container:
-      image: ghcr.io/${{ github.repository_owner}}/ubuntu20-flang-${{ matrix.llvm_branch }}:latest
+      image: ghcr.io/${{ github.repository_owner}}/ubuntu-flang-${{ matrix.llvm_branch }}:latest
       credentials:
         username: github
     strategy:
       matrix:
         target: [AArch64]
-        llvm_branch: [release_16x, release_17x]
+        llvm_branch: [release_17x, release_18x]
 
     steps:
       - name: Check tools

--- a/.github/workflows/build_flang_windows.yml
+++ b/.github/workflows/build_flang_windows.yml
@@ -20,7 +20,7 @@ jobs:
         os:
           - windows-latest
           # - self-hosted
-        llvm_branch: [release_16x, release_17x]
+        llvm_branch: [release_17x, release_18x]
         include:
           - os: windows-latest
             arch: amd64


### PR DESCRIPTION
`release_16x` test jobs are now failing because the prebuilt `classic-flang-llvm-project` binaries on GitHub have expired.

Also, we have renamed the Ubuntu container image generated by the `classic-flang-llvm-project` workflow; it needs to be renamed in the workflow for this repository as well.