### PR TITLE
[NFC] modifying the testcase by adding Mbackslash and Mnobackslash options together

### DIFF
--- a/test/lex/backslash.f90
+++ b/test/lex/backslash.f90
@@ -8,6 +8,12 @@
 ! RUN: %flang -c -fno-backslash %s
 ! RUN: not %flang -c -Mnobackslash %s 2>&1 | FileCheck %s
 ! RUN: not %flang -c -fbackslash %s 2>&1 | FileCheck %s
+! RUN: %flang -c -Mnobackslash -Mbackslash %s
+! RUN: %flang -c -fbackslash -fno-backslash %s
+! RUN: not %flang -c -Mbackslash -Mnobackslash %s 2>&1 | FileCheck %s
+! RUN: not %flang -c -fno-backslash -fbackslash %s 2>&1 | FileCheck %s
+! RUN: not %flang -c -Mnobackslash -Mbackslash -Mnobackslash %s 2>&1 | FileCheck %s
+! RUN: not %flang -c -fbackslash -fno-backslash -fbackslash %s 2>&1 | FileCheck %s
 
 write (*,*) "\" ! CHECK: Unmatched quote
 end


### PR DESCRIPTION


flang should use the last specified option when both these options are used. e.g Mbaskslash should be used when "-Mnobackslash -Mbackslash <filename>" arguments are specified. 