### PR TITLE
[workflows] Update CI to use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -107,7 +107,7 @@ jobs:
 
       # Upload docs just once, for the fastest job.
       - if: matrix.cc == 'clang' && matrix.version == '15'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: html_docs_flang
           path: html


### PR DESCRIPTION
This fixes a workflow failure caused by the deprecation of older versions of the action:

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/