### PR TITLE
Fix build failures when using Clang 19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,8 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
       "--bindir"
       "--libdir"
       "--includedir"
-      "--prefix")
+      "--prefix"
+      "--host-target")
     execute_process(
       COMMAND ${CONFIG_COMMAND}
       RESULT_VARIABLE HAD_ERROR
@@ -107,6 +108,7 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   list(GET CONFIG_OUTPUT 2 LIBRARY_DIR)
   list(GET CONFIG_OUTPUT 3 INCLUDE_DIR)
   list(GET CONFIG_OUTPUT 4 LLVM_OBJ_ROOT)
+  list(GET CONFIG_OUTPUT 5 LLVM_HOST_TARGET)
 
   if(NOT MSVC_IDE)
     set(LLVM_ENABLE_ASSERTIONS ${ENABLE_ASSERTIONS}
@@ -158,7 +160,7 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   endif()
 
   include_directories("${LLVM_BINARY_DIR}/include" "${LLVM_MAIN_INCLUDE_DIR}")
-  link_directories("${LLVM_LIBRARY_DIR}")
+  link_directories("${LLVM_LIBRARY_DIR}/${LLVM_HOST_TARGET}")
 
   set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
   set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )

--- a/runtime/flang/gather.c
+++ b/runtime/flang/gather.c
@@ -191,5 +191,5 @@ static gatherfn_t __fort_local_gather[__NTYPES] = {
 void
 local_gather_WRAPPER(int n, void *dst, void *src, int *gv, __INT_T kind)
 {
-  __fort_local_gather[kind](n, dst, src, gv);
+  __fort_local_gather[kind](n, dst, src, gv, /* optional */ 0);
 }

--- a/runtime/flang/gathscat.c
+++ b/runtime/flang/gathscat.c
@@ -191,7 +191,7 @@ static scatterfn_t __fort_local_scatter[__NTYPES] = {
 void
 local_scatter_WRAPPER(int n, void *dst, int *sv, void *src, __INT_T kind)
 {
-  __fort_local_scatter[kind](n, dst, sv, src);
+  __fort_local_scatter[kind](n, dst, sv, src, /* optional */ 0);
 }
 
 /* local gather-scatter functions */
@@ -377,5 +377,5 @@ void
 local_gathscat_WRAPPER(int n, void *dst, int *sv, void *src, int *gv,
                        __INT_T kind)
 {
-  __fort_local_gathscat[kind](n, dst, sv, src, gv);
+  __fort_local_gathscat[kind](n, dst, sv, src, gv, /* optional */ 0);
 }

--- a/runtime/flang/red_count.c
+++ b/runtime/flang/red_count.c
@@ -84,11 +84,13 @@ COUNTFNLKN(count_int8, __INT8_T, 8)
 
 static void (*l_count[4][__NTYPES])() = TYPELIST2LK(l_count_);
 
-static void I8(g_count)(__INT_T n, __INT_T *lr, __INT_T *rr, void *lv, void *rv)
+static void I8(g_count)(__INT_T n, void *lr, void *rr, void *lv, void *rv, __INT_T unused)
 {
   __INT_T i;
+  __INT_T *lr_i = (__INT_T *)lr;
+  __INT_T *rr_i = (__INT_T *)rr;
   for (i = 0; i < n; i++) {
-    lr[i] = lr[i] + rr[i];
+    lr_i[i] = lr_i[i] + rr_i[i];
   }
 }
 
@@ -110,8 +112,7 @@ void ENTFTN(COUNTS, counts)(char *rb, char *mb, DECL_HDR_PTRS(rs), F90_Desc *ms)
     z.lk_shift = GET_DIST_SHIFTS(F90_KIND_G(ms));
   }
   z.l_fn = l_count[z.lk_shift][ms->kind];
-  z.g_fn =
-      (void (*)(__INT_T, void *, void *, void *, void *, __INT_T))I8(g_count);
+  z.g_fn = I8(g_count);
   z.zb = GET_DIST_ZED;
   *(__INT_T *)rb = 0;
   I8(__fort_red_scalar)(&z, rb, mb, (char *)GET_DIST_TRUE_LOG_ADDR,
@@ -137,8 +138,7 @@ void ENTFTN(COUNT, count)(char *rb, char *mb, char *db, DECL_HDR_PTRS(rs),
     z.lk_shift = GET_DIST_SHIFTS(F90_KIND_G(ms));
   }
   z.l_fn = l_count[z.lk_shift][ms->kind];
-  z.g_fn =
-      (void (*)(__INT_T, void *, void *, void *, void *, __INT_T))I8(g_count);
+  z.g_fn = I8(g_count);
   z.zb = GET_DIST_ZED;
   I8(__fort_red_array)(&z, rb, mb, (char *)GET_DIST_TRUE_LOG_ADDR, db,
 		        rs, ms, (F90_Desc *)&mask_desc, ds, __COUNT);

--- a/runtime/flang/scatter.c
+++ b/runtime/flang/scatter.c
@@ -99,21 +99,11 @@ static void I8(gathscat_start)(void *skp, char *rb, char *sb, F90_Desc *rd,
 
   j = k = sk->lclcnt;
   if (k > 0) {
-
     /* 
      * make sure base type of object hasn't changed for local gather...
      * This can occur when we share schedules across objects ...
      */
-    /* Couldn't find where gathscatfn is set to local_gathscat_WRAPPER.
-       Possible dead code? Work around the compiler warning with an
-       explicit cast for now. */
-    if (sk->gathscatfn == (gathscatfn_t)local_gathscat_WRAPPER) {
-
-      local_gathscat_WRAPPER(k, rp, sk->soff, sp, sk->goff, F90_KIND_G(rd));
-
-    } else {
-      sk->gathscatfn(k, rp, sk->soff, sp, sk->goff);
-    }
+    sk->gathscatfn(k, rp, sk->soff, sp, sk->goff, F90_KIND_G(rd));
   }
   /* now non-local elements */
 
@@ -160,20 +150,12 @@ static void I8(gathscat_start)(void *skp, char *rb, char *sb, F90_Desc *rd,
       }
 
       if (nr > 0) {
-
         /* 
          * Added call to wrapper routine for local scatter
          * in order to handle cases where the schedule is
          * shared between objects of different types...
          */
-        /* Couldn't find where gathscatfn is set to local_gathscat_WRAPPER.
-           Possible dead code? Work around the compiler warning with an
-           explicit cast for now. */
-        if (sk->scatterfn == (scatterfn_t)local_scatter_WRAPPER) {
-          local_scatter_WRAPPER(nr, rp, sk->soff + k, bufr, F90_KIND_G(rd));
-        } else {
-          sk->scatterfn(nr, rp, sk->soff + k, bufr);
-        }
+        sk->scatterfn(nr, rp, sk->soff + k, bufr, F90_KIND_G(rd));
       }
 
       j += ns;

--- a/runtime/flang/scatter.h
+++ b/runtime/flang/scatter.h
@@ -42,9 +42,12 @@ struct gathscat_dim {
   __INT_T *xmap;     /* map index axis -> unvectored axis */
 };
 
-typedef void (*gatherfn_t)(int, void *, void *, int *);
-typedef void (*gathscatfn_t)(int, void *, int *, void *, int *);
-typedef void (*scatterfn_t)(int, void *, int *, void *);
+typedef void (*gatherfn_t)(int n, void *dst, void *src, int *gv,
+                           __INT_T optional_kind);
+typedef void (*gathscatfn_t)(int n, void *dst, int *sv, void *src, int *gv,
+                             __INT_T optional_kind);
+typedef void (*scatterfn_t)(int n, void *dst, int *sv, void *src,
+                            __INT_T optional_kind);
 
 struct gathscat_parm {
   const char *what;           /* "GATHER"/"XXX_SCATTER" */

--- a/runtime/flangrti/CMakeLists.txt
+++ b/runtime/flangrti/CMakeLists.txt
@@ -108,7 +108,7 @@ if (NOT DEFINED LIBOMP_EXPORT_DIR)
   find_library(
     FLANG_LIBOMP
     NAMES omp libomp
-    HINTS ${CMAKE_BINARY_DIR}/lib)
+    HINTS "${LLVM_LIBRARY_DIR}/${LLVM_HOST_TARGET}")
   target_link_libraries(flangrti_shared PUBLIC ${FLANG_LIBOMP})
 endif()
 

--- a/runtime/flangrti/trace_lin.c
+++ b/runtime/flangrti/trace_lin.c
@@ -215,9 +215,8 @@ __abort_sig_hand(int sig, siginfo_t *in, FLANGRTI_UCONTEXT_T *u)
   struct sigaction new;
   struct sigaction old;
 
-  new.sa_sigaction = (void (*)(int, siginfo_t *, void *))SIG_DFL;
+  new.sa_handler = SIG_DFL;
   sigemptyset(&new.sa_mask);
-  new.sa_flags = SA_SIGINFO;
   n = 0;
   while (sigs[n].sig != 0) {
     sigaction(sigs[n].sig, &new, &old);

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -86,7 +86,11 @@ if flang_obj_root is not None:
     llvm_libs_dir = getattr(config, 'llvm_libs_dir', None)
     if not llvm_libs_dir:
         lit_config.fatal('No LLVM libs dir set!')
+    host_triple = getattr(config, 'host_triple', None)
+    if not host_triple:
+        lit_config.fatal('No LLVM host triple set!')
     path = os.path.pathsep.join((llvm_libs_dir,
+                                 os.path.sep.join((llvm_libs_dir, host_triple)),
                                  config.environment.get('LD_LIBRARY_PATH','')))
     config.environment['LD_LIBRARY_PATH'] = path
 

--- a/tools/flang1/flang1exe/semutil2.c
+++ b/tools/flang1/flang1exe/semutil2.c
@@ -13799,7 +13799,7 @@ save_host_state(int wherefrom)
       }
     }
   }
-  rw_host_state(wherefrom, (int (*)())fwrite, state_file);
+  rw_host_state(wherefrom, fwrite, state_file);
   saved_symavl = stb.stg_avail;
   saved_astavl = astb.stg_avail;
   saved_dtyavl = stb.dt.stg_avail;
@@ -13906,7 +13906,7 @@ restore_host_state(int whichpass)
 
   if (whichpass == 2) {
     fseek(state_file, 0L, 0);
-    rw_host_state(0x13, (int (*)())fread, state_file);
+    rw_host_state(0x13, fread, state_file);
     /*astb.firstuast = astb.stg_avail;*/
     /* ### don't reset firstusym for main program */
     stb.firstusym = stb.stg_avail;
@@ -13914,7 +13914,7 @@ restore_host_state(int whichpass)
     fix_symtab();
   } else if (whichpass == 4) { /* for ipa import */
     fseek(state_file, 0L, 0);
-    rw_host_state(0x2, (int (*)())fread, state_file);
+    rw_host_state(0x2, fread, state_file);
     /*astb.firstuast = astb.stg_avail;*/
     /* ### don't reset firstusym for main program */
     stb.firstusym = stb.stg_avail;
@@ -13993,7 +13993,7 @@ restore_host_state(int whichpass)
     saved_labels[saved_labels_avail] = ';';
 
     fseek(state_file, 0L, 0);
-    rw_host_state(0x3, (int (*)())fread, state_file);
+    rw_host_state(0x3, fread, state_file);
     /*astb.firstuast = astb.stg_avail;*/
 
     fseek(state_append_file, state_file_position, 0);
@@ -14124,13 +14124,13 @@ save_module_state1()
     if (modstate_file == NULL)
       errfatal(5);
   }
-  rw_host_state(0x1, (int (*)())fwrite, modstate_file);
+  rw_host_state(0x1, fwrite, modstate_file);
 } /* save_module_state1 */
 
 void
 save_module_state2()
 {
-  rw_host_state(0x16, (int (*)())fwrite, modstate_file);
+  rw_host_state(0x16, fwrite, modstate_file);
   modsaved_symavl = stb.stg_avail;
   modsaved_astavl = astb.stg_avail;
   modsaved_dtyavl = stb.dt.stg_avail;
@@ -14151,14 +14151,14 @@ save_imported_modules_state()
     if (modsave_file == NULL)
       errfatal(5);
   }
-  rw_host_state(0x20, (int (*)())fwrite, modsave_file);
+  rw_host_state(0x20, fwrite, modsave_file);
 } /* save_imported_modules_state */
 
 void
 restore_imported_modules_state()
 {
   fseek(modsave_file, 0L, 0);
-  rw_host_state(0x20, (int (*)())fread, modsave_file);
+  rw_host_state(0x20, fread, modsave_file);
 } /* restore_imported_modules_state */
 
 /*
@@ -14193,7 +14193,7 @@ restore_module_state()
     errfatal(5);
   /* First, read the binary-saved information */
   fseek(modstate_file, 0L, 0);
-  rw_host_state(0x17, (int (*)())fread, modstate_file);
+  rw_host_state(0x17, fread, modstate_file);
   /* for TPR 1654, if we need to set NEEDMOD for internal
    * subprograms, this is the place to set it
    * NEEDMODP( stb.curr_scope, 1 );
@@ -14221,7 +14221,7 @@ restore_module_state()
     mod_clear_init = 0;
     /* Lastly, rewrite the module state file */
     fseek(modstate_file, 0L, 0);
-    rw_host_state(0x17, (int (*)())fwrite, modstate_file);
+    rw_host_state(0x17, fwrite, modstate_file);
     modsaved_symavl = stb.stg_avail;
     modsaved_astavl = astb.stg_avail;
     modsaved_dtyavl = stb.dt.stg_avail;
@@ -14239,7 +14239,7 @@ reset_module_state()
     interr("no module state file to restore", 0, 4);
   if (sem.which_pass == 1) {
     fseek(modstate_file, 0L, 0);
-    rw_host_state(0x17, (int (*)())fread, modstate_file);
+    rw_host_state(0x17, fread, modstate_file);
   } else {
     /* export the module-contained subprogram */
     if (!modstate_append_file) {

--- a/tools/flang1/flang1exe/state.h
+++ b/tools/flang1/flang1exe/state.h
@@ -32,9 +32,9 @@
  * this declares the proper names for the rw_routine and file
  * used in the RW_ macros
  */
-#define RW_ROUTINE int (*p_rw)(void *, size_t, size_t, FILE *)
+#define RW_ROUTINE size_t (*p_rw)(void *, size_t, size_t, FILE *)
 #define RW_FILE FILE *fd
-#define RW_ROUTINE_TYPE int (*)(void *, size_t, size_t, FILE *)
+#define RW_ROUTINE_TYPE size_t (*)(void *, size_t, size_t, FILE *)
 
 /*
  * sometimes special action is taken on read or write.
@@ -47,8 +47,7 @@ extern void rw_dpmout_state(RW_ROUTINE, RW_FILE);
 extern void rw_semant_state(RW_ROUTINE, RW_FILE); /* semfin.c */
 extern void rw_gnr_state(RW_ROUTINE, RW_FILE);    /* semgnr.c */
 extern void rw_sym_state(RW_ROUTINE, RW_FILE);    /* symtab.c */
-extern void rw_dtype_state(int (*p_rw)(void *, size_t, size_t, FILE *),
-                           FILE *fd);             /* dtypeutl.c */
+extern void rw_dtype_state(RW_ROUTINE, RW_FILE);  /* dtypeutl.c */
 extern void rw_ast_state(RW_ROUTINE, RW_FILE);    /* ast.c */
 extern void rw_dinit_state(RW_ROUTINE, RW_FILE);  /* dinit.c */
 extern void rw_import_state(RW_ROUTINE, RW_FILE); /* interf.c */


### PR DESCRIPTION
When building Classic Flang with Clang 19, the compiler produces numerous `-Wcast-function-type-mismatch` warnings. Also, `libflangrti.so` fails to link and tests fail to run, since the OpenMP library `libomp.so` is now installed in a different location by default. This PR fixes these issues, in a way that should be compatible with the `release_18x` branch.