### PR TITLE
[DebugInfo][test] Fix tests for LLVM 19 compatibility

### DIFF
--- a/test/debug_info/allocatable_arr_param.f90
+++ b/test/debug_info/allocatable_arr_param.f90
@@ -1,14 +1,19 @@
-!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!CHECK-LABEL: define void @callee_
-!CHECK: call void @llvm.dbg.declare(metadata ptr %"array$p", metadata [[DLOC:![0-9]+]]
-!CHECK-NEXT: call void @llvm.dbg.declare(metadata ptr %"array$p", metadata [[ALLOCATED:![0-9]+]]
-!CHECK-NEXT: call void @llvm.dbg.declare(metadata ptr %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
-!CHECK: [[ARRAY]] = !DILocalVariable(name: "array",
-!CHECK-SAME: arg: 2,
-!CHECK-SAME: type: [[TYPE:![0-9]+]]
-!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type,
-!CHECK-SAME: dataLocation: [[DLOC]], allocated: [[ALLOCATED]]
+! REQUIRES: llvm-19
+! RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK-LABEL: define void @callee_
+! CHECK: #dbg_declare(ptr %"array$p", [[DLOC:![0-9]+]]
+! CHECK-NEXT: #dbg_declare(ptr %"array$p", [[ALLOCATED:![0-9]+]]
+! CHECK-NEXT: #dbg_declare(ptr %"array$sd", [[ARRAY:![0-9]+]], !DIExpression()
+! CHECK: [[ARRAY]] = !DILocalVariable(name: "array",
+! CHECK-SAME: arg: 2,
+! CHECK-SAME: type: [[TYPE:![0-9]+]]
+! CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type,
+! CHECK-SAME: dataLocation: [[DLOC]], allocated: [[ALLOCATED]]
 
 subroutine callee (array)
   integer, allocatable :: array(:, :)

--- a/test/debug_info/assumed_rank.f90
+++ b/test/debug_info/assumed_rank.f90
@@ -1,30 +1,41 @@
-!Check debug info generation for assumed rank arrays with DWARF5 and lower.
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=DWARF4
-!RUN: %flang -gdwarf-5 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=DWARF5
+! REQUIRES: llvm-19
+! RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=DWARF4
+! RUN: %flang -gdwarf-5 -S -emit-llvm %s -o - | FileCheck %s --check-prefix=DWARF5
 
-!DWARF4: call void @llvm.dbg.value(metadata ptr %ararray, metadata [[DLOC:![0-9]+]], metadata !DIExpression())
-!DWARF4: !DILocalVariable(name: "ararray"
-!DWARF4-SAME: arg: 2
-!DWARF4-SAME: type: [[ARTYPE:![0-9]+]])
-!DWARF4: [[ARTYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: !{{[0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[ELEMS:![0-9]+]], dataLocation: [[DLOC:![0-9]+]])
-!DWARF4: [[ELEMS]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]], [[ELEM3:![0-9]+]], [[ELEM4:![0-9]+]], [[ELEM5:![0-9]+]], [[ELEM6:![0-9]+]], [[ELEM7:![0-9]+]]}
-!DWARF4: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
-!DWARF4: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
-!DWARF4: [[ELEM3]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 176, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 216, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 208, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
-!DWARF4: [[ELEM4]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 224, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 264, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 256, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
-!DWARF4: [[ELEM5]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 272, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 312, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 304, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
-!DWARF4: [[ELEM6]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 320, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 360, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 352, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
-!DWARF4: [[ELEM7]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 368, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 408, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 400, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+! Check debug info generation for assumed rank arrays with DWARF5 and lower.
 
 
-!DWARF5: call void @llvm.dbg.value(metadata ptr %ararray, metadata [[DLOC:![0-9]+]], metadata !DIExpression())
-!DWARF5: !DILocalVariable(name: "ararray"
-!DWARF5-SAME: arg: 2
-!DWARF5-SAME: type: [[ARTYPE:![0-9]+]])
-!DWARF5: [[ARTYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: !{{[0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[ELEMS:![0-9]+]], dataLocation: [[DLOC:![0-9]+]], rank: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 8, DW_OP_deref, DW_OP_constu, 7, DW_OP_and))
-!DWARF5: [[ELEMS]] = !{[[ELEM1:![0-9]+]]}
-!DWARF5: [[ELEM1]] = !DIGenericSubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 80, DW_OP_plus, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 120, DW_OP_plus, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 112, DW_OP_plus, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+! DWARF4: #dbg_value(ptr %ararray, [[DLOC:![0-9]+]], !DIExpression()
+! DWARF4: distinct !DISubprogram(name: "sub"
+! DWARF4-SAME: retainedNodes: [[RETAINS:![0-9]+]]
+! DWARF4: [[RETAINS]] = !{{{![0-9]+}}, [[DLOC:![0-9]+]]}
+! DWARF4: [[DLOC]] = !DILocalVariable(name: "ararray",
+! DWARF4-SAME: arg: 2,
+! DWARF4-SAME: type: [[ARTYPE:![0-9]+]])
+! DWARF4: [[ARTYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: !{{[0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[ELEMS:![0-9]+]], dataLocation: [[DLOC:![0-9]+]])
+! DWARF4: [[ELEMS]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]], [[ELEM3:![0-9]+]], [[ELEM4:![0-9]+]], [[ELEM5:![0-9]+]], [[ELEM6:![0-9]+]], [[ELEM7:![0-9]+]]}
+! DWARF4: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+! DWARF4: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+! DWARF4: [[ELEM3]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 176, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 216, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 208, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+! DWARF4: [[ELEM4]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 224, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 264, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 256, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+! DWARF4: [[ELEM5]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 272, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 312, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 304, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+! DWARF4: [[ELEM6]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 320, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 360, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 352, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+! DWARF4: [[ELEM7]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 368, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 408, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 400, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+
+! DWARF5: #dbg_value(ptr %ararray, [[DLOC:![0-9]+]], !DIExpression()
+! DWARF5: distinct !DISubprogram(name: "sub"
+! DWARF5-SAME: retainedNodes: [[RETAINS:![0-9]+]]
+! DWARF5: [[RETAINS]] = !{{{![0-9]+}}, [[DLOC:![0-9]+]]}
+! DWARF5: [[DLOC]] = !DILocalVariable(name: "ararray",
+! DWARF5-SAME: arg: 2,
+! DWARF5-SAME: type: [[ARTYPE:![0-9]+]])
+! DWARF5: [[ARTYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: !{{[0-9]+}}, size: {{[0-9]+}}, align: {{[0-9]+}}, elements: [[ELEMS:![0-9]+]], dataLocation: [[DLOC:![0-9]+]], rank: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 8, DW_OP_deref, DW_OP_constu, 7, DW_OP_and))
+! DWARF5: [[ELEMS]] = !{[[ELEM1:![0-9]+]]}
+! DWARF5: [[ELEM1]] = !DIGenericSubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 80, DW_OP_plus, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 120, DW_OP_plus, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_over, DW_OP_constu, 48, DW_OP_mul, DW_OP_plus_uconst, 112, DW_OP_plus, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 
 subroutine sub(ararray)
   real :: ararray(..)

--- a/test/debug_info/assumed_shape.f90
+++ b/test/debug_info/assumed_shape.f90
@@ -1,16 +1,21 @@
-!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!CHECK: call void @llvm.dbg.declare(metadata ptr %assume, metadata [[ASSUME:![0-9]+]], metadata !DIExpression())
-!CHECK: [[TYPE:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEMS:![0-9]+]])
-!CHECK: [[ELEMS]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]], [[ELEM3:![0-9]+]], [[ELEM4:![0-9]+]]
-!CHECK: [[ELEM1]] = !DISubrange(lowerBound: 1, upperBound: 5)
-!CHECK: [[ELEM2]] = !DISubrange(lowerBound: 1, upperBound: [[N1:![0-9]+]])
-!CHECK: [[N1]] = distinct !DILocalVariable
-!CHECK: [[ELEM3]] = !DISubrange(lowerBound: [[N2:![0-9]+]], upperBound: 9)
-!CHECK: [[N2]] = distinct !DILocalVariable
-!CHECK: [[ELEM4]] = !DISubrange(lowerBound: [[N3:![0-9]+]], upperBound: [[N4:![0-9]+]])
-!CHECK: [[N3]] = distinct !DILocalVariable
-!CHECK: [[N4]] = distinct !DILocalVariable
+! REQUIRES: llvm-19
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK: #dbg_declare(ptr %assume, [[ASSUME:![0-9]+]], !DIExpression()
+! CHECK: [[TYPE:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEMS:![0-9]+]])
+! CHECK: [[ELEMS]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]], [[ELEM3:![0-9]+]], [[ELEM4:![0-9]+]]
+! CHECK: [[ELEM1]] = !DISubrange(lowerBound: 1, upperBound: 5)
+! CHECK: [[ELEM2]] = !DISubrange(lowerBound: 1, upperBound: [[N1:![0-9]+]])
+! CHECK: [[N1]] = distinct !DILocalVariable
+! CHECK: [[ELEM3]] = !DISubrange(lowerBound: [[N2:![0-9]+]], upperBound: 9)
+! CHECK: [[N2]] = distinct !DILocalVariable
+! CHECK: [[ELEM4]] = !DISubrange(lowerBound: [[N3:![0-9]+]], upperBound: [[N4:![0-9]+]])
+! CHECK: [[N3]] = distinct !DILocalVariable
+! CHECK: [[N4]] = distinct !DILocalVariable
 subroutine sub(assume,n1,n2,n3,n4)
   integer(kind=4) :: assume(5,n1,n2:9,n3:n4)
   assume(1,1,1,1) = 7

--- a/test/debug_info/assumed_shape_non_contiguous.f90
+++ b/test/debug_info/assumed_shape_non_contiguous.f90
@@ -1,15 +1,20 @@
-!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!CHECK: call void @llvm.dbg.value(metadata ptr %array, metadata [[ARRAYDL:![0-9]+]], metadata !DIExpression())
-!CHECK: call void @llvm.dbg.declare(metadata ptr %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
-!CHECK-LABEL: distinct !DICompileUnit(language: DW_LANG_Fortran90,
-!CHECK: [[ARRAY]] = !DILocalVariable(name: "array"
-!CHECK-SAME: arg: 3
-!CHECK-SAME: type: [[TYPE:![0-9]+]])
-!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: [[ARRAYDL]])
-!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
-!CHECK: [[ELEM1]] = !DISubrange(count: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 88, DW_OP_deref), lowerBound: 1, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
-!CHECK: [[ELEM2]] = !DISubrange(count: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 136, DW_OP_deref), lowerBound: 1, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+! REQUIRES: llvm-19
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK: #dbg_value(ptr %array, [[ARRAYDL:![0-9]+]], !DIExpression()
+! CHECK: #dbg_declare(ptr %"array$sd", [[ARRAY:![0-9]+]], !DIExpression()
+! CHECK-LABEL: distinct !DICompileUnit(language: DW_LANG_Fortran90,
+! CHECK: [[ARRAY]] = !DILocalVariable(name: "array"
+! CHECK-SAME: arg: 3
+! CHECK-SAME: type: [[TYPE:![0-9]+]])
+! CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: [[ARRAYDL]])
+! CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
+! CHECK: [[ELEM1]] = !DISubrange(count: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 88, DW_OP_deref), lowerBound: 1, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+! CHECK: [[ELEM2]] = !DISubrange(count: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 136, DW_OP_deref), lowerBound: 1, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 
 subroutine show (message, array)
   character (len=*) :: message

--- a/test/debug_info/assumed_size_array.f90
+++ b/test/debug_info/assumed_size_array.f90
@@ -1,18 +1,23 @@
-!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!CHECK: call void @llvm.dbg.declare(metadata ptr %array1, metadata [[ARRAY1:![0-9]+]], metadata !DIExpression())
-!CHECK: call void @llvm.dbg.declare(metadata ptr %array2, metadata [[ARRAY2:![0-9]+]], metadata !DIExpression())
-!CHECK: [[TYPE1:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, align: 32, elements: [[ELEMS1:![0-9]+]])
-!CHECK: [[ELEMS1]] = !{[[ELEM11:![0-9]+]]}
-!CHECK: [[ELEM11]] = !DISubrange(lowerBound: 1)
-!CHECK: [[TYPE2:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, align: 32, elements: [[ELEMS2:![0-9]+]])
-!CHECK: [[ELEMS2]] = !{[[ELEM21:![0-9]+]], [[ELEM22:![0-9]+]]}
-!CHECK: [[ELEM21]] = !DISubrange(lowerBound: 4, upperBound: 9)
-!CHECK: [[ELEM22]] = !DISubrange(lowerBound: 10)
-!CHECK: [[ARRAY1]] = !DILocalVariable(name: "array1"
-!CHECK-SAME: type: [[TYPE1]]
-!CHECK: [[ARRAY2]] = !DILocalVariable(name: "array2"
-!CHECK-SAME: type: [[TYPE2]]
+! REQUIRES: llvm-19
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK: #dbg_declare(ptr %array1, [[ARRAY1:![0-9]+]], !DIExpression()
+! CHECK: #dbg_declare(ptr %array2, [[ARRAY2:![0-9]+]], !DIExpression()
+! CHECK: [[TYPE1:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, align: 32, elements: [[ELEMS1:![0-9]+]])
+! CHECK: [[ELEMS1]] = !{[[ELEM11:![0-9]+]]}
+! CHECK: [[ELEM11]] = !DISubrange(lowerBound: 1)
+! CHECK: [[TYPE2:![0-9]+]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, align: 32, elements: [[ELEMS2:![0-9]+]])
+! CHECK: [[ELEMS2]] = !{[[ELEM21:![0-9]+]], [[ELEM22:![0-9]+]]}
+! CHECK: [[ELEM21]] = !DISubrange(lowerBound: 4, upperBound: 9)
+! CHECK: [[ELEM22]] = !DISubrange(lowerBound: 10)
+! CHECK: [[ARRAY1]] = !DILocalVariable(name: "array1"
+! CHECK-SAME: type: [[TYPE1]]
+! CHECK: [[ARRAY2]] = !DILocalVariable(name: "array2"
+! CHECK-SAME: type: [[TYPE2]]
 subroutine sub (array1, array2)
   integer :: array1 (*)
   integer :: array2 (4:9, 10:*)

--- a/test/debug_info/byval-name.f90
+++ b/test/debug_info/byval-name.f90
@@ -1,19 +1,27 @@
-!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!Verify the IR contains _V_ (flang)convention naming and the
-! operation using them are well formed.
-!CHECK: sub_(i32 [[PREFIXED_ARG_NAME:%_V_arg_abc.arg]])
-!CHECK: [[PREFIXED_LOCAL_NAME:%_V_arg_abc.addr]] = alloca i32, align 4
-!CHECK: call void @llvm.dbg.declare(metadata ptr [[PREFIXED_LOCAL_NAME]]
-!CHECK: store i32 [[PREFIXED_ARG_NAME]], ptr [[PREFIXED_LOCAL_NAME]], align 4
+! REQUIRES: llvm-19
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
-!Verify the DebugInfo metadata contains prefix _V_ truncated names.
-!CHECK: DILocalVariable(name: "arg_abc"
-!CHECK-NOT: DILocalVariable(name: "_V_arg_abc"
+! Verify that the IR contains "_V_" (Flang's naming convention for byval
+! parameters) and that the operation using them are well-formed.
+
+! CHECK: sub_(i32 [[PREFIXED_ARG_NAME:%_V_arg_abc.arg]])
+! CHECK: [[PREFIXED_LOCAL_NAME:%_V_arg_abc.addr]] = alloca i32, align 4
+! CHECK: #dbg_declare(ptr [[PREFIXED_LOCAL_NAME]]
+! CHECK: store i32 [[PREFIXED_ARG_NAME]], ptr [[PREFIXED_LOCAL_NAME]], align 4
+
+! Verify that the names in the DebugInfo metadata have dropped the "_V_" prefix.
+
+! CHECK-NOT: DILocalVariable(name: "_V_arg_abc"
+! CHECK-COUNT-2: DILocalVariable(name: "arg_abc"
+! CHECK-NOT: DILocalVariable(name: "_V_arg_abc"
 
 subroutine sub(arg_abc)
-      integer,value :: arg_abc
-      integer :: abc_local
-      abc_local = arg_abc
-      print*, arg_abc
+    integer, value :: arg_abc
+    integer :: abc_local
+    abc_local = arg_abc
+    print *, arg_abc
 end subroutine

--- a/test/debug_info/conststring.f90
+++ b/test/debug_info/conststring.f90
@@ -1,16 +1,21 @@
-!! This should be enabled only after #888
-!! check if conststrings are stored correctly for special characters
-!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!! \0 = 0 , " = 34 = 0x22
-!CHECK: call void @llvm.dbg.value(metadata [10 x i8] c"a\00d\22g     ", metadata [[CONSTR1:![0-9a-f]+]], metadata !DIExpression())
-!CHECK: call void @llvm.dbg.value(metadata [10 x i8] c"h i~j     ", metadata [[CONSTR2:![0-9a-f]+]], metadata !DIExpression())
-!! \n = 10 \r = 13
-!CHECK: call void @llvm.dbg.value(metadata [10 x i8] c"k\0Al\0Dm     ", metadata [[CONSTR3:![0-9a-f]+]], metadata !DIExpression())
-!CHECK-LABEL: distinct !DISubprogram(name: "main"
-!CHECK: [[CONSTR1]] = !DILocalVariable(name: "constr1",
-!CHECK: [[CONSTR2]] = !DILocalVariable(name: "constr2",
-!CHECK: [[CONSTR3]] = !DILocalVariable(name: "constr3",
+! REQUIRES: llvm-19
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! Check if string constants are stored correctly for special characters.
+
+! \0 = 0 , " = 34 = 0x22, \n = 10, \r = 13
+! CHECK-LABEL: define void @MAIN_
+! CHECK: #dbg_value([10 x i8] c"a\00d\22g     ", [[CONSTR1:![0-9a-f]+]], !DIExpression()
+! CHECK: #dbg_value([10 x i8] c"h i~j     ",     [[CONSTR2:![0-9a-f]+]], !DIExpression()
+! CHECK: #dbg_value([10 x i8] c"k\0Al\0Dm     ", [[CONSTR3:![0-9a-f]+]], !DIExpression()
+! CHECK-LABEL: distinct !DISubprogram(name: "main"
+! CHECK: [[CONSTR1]] = !DILocalVariable(name: "constr1",
+! CHECK: [[CONSTR2]] = !DILocalVariable(name: "constr2",
+! CHECK: [[CONSTR3]] = !DILocalVariable(name: "constr3",
 
 program main
   character(10),parameter :: constr1 = "a"//achar(0)//"d"//achar(34)//"g"

--- a/test/debug_info/cray_ptr_param.f90
+++ b/test/debug_info/cray_ptr_param.f90
@@ -1,9 +1,14 @@
-!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!CHECK-LABEL: define internal void @main_callee
-!CHECK: call void @llvm.dbg.declare(metadata ptr %callee_ptr, metadata [[CALLEE_PTR:![0-9]+]]
-!CHECK: [[CALLEE_PTR]] = !DILocalVariable(name: "callee_ptr"
-!CHECK-SAME: arg: 1
+! REQUIRES: llvm-19
+! RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK-LABEL: define internal void @main_callee
+! CHECK: #dbg_declare(ptr %callee_ptr, [[CALLEE_PTR:![0-9]+]]
+! CHECK: [[CALLEE_PTR]] = !DILocalVariable(name: "callee_ptr"
+! CHECK-SAME: arg: 1,
 
 program main
   pointer (ptr, b)

--- a/test/debug_info/enum.f90
+++ b/test/debug_info/enum.f90
@@ -1,13 +1,18 @@
-!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!CHECK: call void @llvm.dbg.value(metadata i32 1, metadata [[ENM1:![0-9]+]], metadata !DIExpression())
-!CHECK: call void @llvm.dbg.value(metadata i32 2, metadata [[ENM2:![0-9]+]], metadata !DIExpression())
-!CHECK: call void @llvm.dbg.value(metadata i32 5, metadata [[ENM3:![0-9]+]], metadata !DIExpression())
-!CHECK: call void @llvm.dbg.value(metadata i32 6, metadata [[ENM4:![0-9]+]], metadata !DIExpression())
-!CHECK: [[ENM1]] = !DILocalVariable(name: "red"
-!CHECK: [[ENM2]] = !DILocalVariable(name: "blue"
-!CHECK: [[ENM3]] = !DILocalVariable(name: "black"
-!CHECK: [[ENM4]] = !DILocalVariable(name: "pink"
+! REQUIRES: llvm-19
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK: #dbg_value(i32 1, [[ENM1:![0-9]+]], !DIExpression()
+! CHECK: #dbg_value(i32 2, [[ENM2:![0-9]+]], !DIExpression()
+! CHECK: #dbg_value(i32 5, [[ENM3:![0-9]+]], !DIExpression()
+! CHECK: #dbg_value(i32 6, [[ENM4:![0-9]+]], !DIExpression()
+! CHECK: [[ENM1]] = !DILocalVariable(name: "red"
+! CHECK: [[ENM2]] = !DILocalVariable(name: "blue"
+! CHECK: [[ENM3]] = !DILocalVariable(name: "black"
+! CHECK: [[ENM4]] = !DILocalVariable(name: "pink"
 
 program main
   enum, bind(c)

--- a/test/debug_info/parameter.f90
+++ b/test/debug_info/parameter.f90
@@ -1,8 +1,13 @@
-!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!CHECK: call void @llvm.dbg.value(metadata i64 99, metadata [[SPAR:![0-9]+]], metadata !DIExpression())
-!CHECK: distinct !DIGlobalVariable(name: "apar"
-!CHECK: [[SPAR]] = !DILocalVariable(name: "spar"
+! REQUIRES: llvm-19
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK: #dbg_value(i64 99, [[SPAR:![0-9]+]], !DIExpression()
+! CHECK: distinct !DIGlobalVariable(name: "apar"
+! CHECK: [[SPAR]] = !DILocalVariable(name: "spar"
 
 program main
   integer (kind=8) :: svar

--- a/test/debug_info/pointer_arr_param.f90
+++ b/test/debug_info/pointer_arr_param.f90
@@ -1,14 +1,19 @@
-!RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!CHECK-LABEL: define void @callee_
-!CHECK: call void @llvm.dbg.declare(metadata ptr %"array$p", metadata [[DLOC:![0-9]+]]
-!CHECK-NEXT: call void @llvm.dbg.declare(metadata ptr %"array$p", metadata [[ASSOCIATED:![0-9]+]]
-!CHECK-NEXT: call void @llvm.dbg.declare(metadata ptr %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
-!CHECK: [[ARRAY]] = !DILocalVariable(name: "array"
-!CHECK-SAME: arg: 2
-!CHECK-SAME: type: [[TYPE:![0-9]+]]
-!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type,
-!CHECK-SAME: dataLocation: [[DLOC]], associated: [[ASSOCIATED]]
+! REQUIRES: llvm-19
+! RUN: %flang -gdwarf-4 -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK-LABEL: define void @callee_
+! CHECK: #dbg_declare(ptr %"array$p", [[DLOC:![0-9]+]]
+! CHECK-NEXT: #dbg_declare(ptr %"array$p", [[ASSOCIATED:![0-9]+]]
+! CHECK-NEXT: #dbg_declare(ptr %"array$sd", [[ARRAY:![0-9]+]], !DIExpression()
+! CHECK: [[ARRAY]] = !DILocalVariable(name: "array"
+! CHECK-SAME: arg: 2,
+! CHECK-SAME: type: [[TYPE:![0-9]+]])
+! CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type,
+! CHECK-SAME: dataLocation: [[DLOC]], associated: [[ASSOCIATED]]
 
 subroutine callee (array)
   integer, pointer :: array(:, :)

--- a/test/debug_info/pointer_array_openmp.f90
+++ b/test/debug_info/pointer_array_openmp.f90
@@ -1,10 +1,15 @@
-!RUN: %flang -g -fopenmp -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!CHECK: define internal void @main_sub
-!CHECK: define internal void @__nv_main_sub_
-!CHECK:  call void @llvm.dbg.declare(metadata ptr %"res$p
-!CHECK-NEXT:  call void @llvm.dbg.declare(metadata ptr %"res$p
-!CHECK-NEXT:  call void @llvm.dbg.declare(metadata ptr %"res$sd
+! REQUIRES: llvm-19
+! RUN: %flang -g -fopenmp -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK: define internal void @main_sub
+! CHECK: define internal void @__nv_main_sub_
+! CHECK:      #dbg_declare(ptr %"res$p
+! CHECK-NEXT: #dbg_declare(ptr %"res$p
+! CHECK-NEXT: #dbg_declare(ptr %"res$sd
 
 program main
   type :: dtype

--- a/test/debug_info/prolog.f90
+++ b/test/debug_info/prolog.f90
@@ -1,34 +1,38 @@
-!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-! check non debug instructions should not have debug location
-!CHECK: define void @show_
-!CHECK: call void @llvm.dbg.declare
-!CHECK-SAME: , !dbg {{![0-9]+}}
-!CHECK-NOT: bitcast ptr %"array$sd" to ptr, !dbg
-!CHECK: store i64 {{%[0-9]+}}, ptr %z_b_3_{{[0-9]+}}, align 8
-!CHECK: br label
-!CHECK: ret void, !dbg {{![0-9]+}}
+! REQUIRES: llvm-19
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! Check that non-debug instructions should not have debug location.
+
+! CHECK: define void @show_
+! CHECK:      #dbg_declare(ptr %message, {{.*}}, [[DLOC:![0-9]+]])
+! CHECK-NEXT: #dbg_value(ptr %array, {{.*}}, [[DLOC]])
+! CHECK-NEXT: #dbg_declare(ptr %"array$sd", {{.*}}, [[DLOC]])
+! CHECK-NOT: getelementptr {{.*}}, !dbg
+! CHECK: store i64 {{%[0-9]+}}, ptr %z_b_3_{{[0-9]+}}, align 8
+! CHECK: br label
+! CHECK: ret void, !dbg {{![0-9]+}}
 subroutine show (message, array)
   character (len=*) :: message
   integer :: array(:)
 
   print *, message
   print *, array
-
 end subroutine show
 
-!CHECK: define void @MAIN_
-!CHECK-NOT: bitcast ptr @fort_init to ptr, !dbg {{![0-9]+}}
-!CHECK: call void @llvm.dbg.declare
-!CHECK-SAME: , !dbg {{![0-9]+}}
-!CHECK: ret void, !dbg
+! CHECK: define void @MAIN_
+! CHECK: #dbg_declare(ptr %"array$sd{{.*}}, [[DLOC:![0-9]+]]
+! CHECK-NOT: br label {{.*}}, !dbg
+! CHECK: ret void, !dbg
 program prolog
-
   interface
-     subroutine show (message, array)
-       character (len=*) :: message
-       integer :: array(:)
-     end subroutine show
+    subroutine show (message, array)
+      character (len=*) :: message
+      integer :: array(:)
+    end subroutine show
   end interface
 
   integer :: array(10) = (/1,2,3,4,5,6,7,8,9,10/)

--- a/test/debug_info/result_var.f90
+++ b/test/debug_info/result_var.f90
@@ -1,7 +1,12 @@
-!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!CHECK: call void @llvm.dbg.declare(metadata ptr %rvar_{{[0-9]+}}, metadata [[RESULT:![0-9]+]], metadata !DIExpression())
-!CHECK: [[RESULT]] = !DILocalVariable(name: "rvar"
+! REQUIRES: llvm-19
+! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! CHECK: #dbg_declare(ptr %rvar_{{[0-9]+}}, [[RESULT:![0-9]+]], !DIExpression()
+! CHECK: [[RESULT]] = !DILocalVariable(name: "rvar"
 
 function func(arg) result(rvar)
   integer, intent(in) :: arg ! input

--- a/test/debug_info/retained-nodes.f90
+++ b/test/debug_info/retained-nodes.f90
@@ -1,24 +1,21 @@
-!
 ! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-!
 
-! REQUIRES: llvm-13
-
+! REQUIRES: llvm-19
 ! RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
 
 subroutine addf(a, b, c, d, e, f, g, h, i)
   integer :: a, b, c, d, e, f, g, h, i
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %a, metadata [[A:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %b, metadata [[B:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %c, metadata [[C:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %d, metadata [[D:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %e, metadata [[E:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %f, metadata [[F:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %g, metadata [[G:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %h, metadata [[H:![0-9]+]]
-! CHECK: call void @llvm.dbg.declare{{.*}}({{.*}}metadata ptr %i, metadata [[I:![0-9]+]]
+! CHECK: #dbg_declare(ptr %a, [[A:![0-9]+]]
+! CHECK: #dbg_declare(ptr %b, [[B:![0-9]+]]
+! CHECK: #dbg_declare(ptr %c, [[C:![0-9]+]]
+! CHECK: #dbg_declare(ptr %d, [[D:![0-9]+]]
+! CHECK: #dbg_declare(ptr %e, [[E:![0-9]+]]
+! CHECK: #dbg_declare(ptr %f, [[F:![0-9]+]]
+! CHECK: #dbg_declare(ptr %g, [[G:![0-9]+]]
+! CHECK: #dbg_declare(ptr %h, [[H:![0-9]+]]
+! CHECK: #dbg_declare(ptr %i, [[I:![0-9]+]]
 end subroutine
 
 ! CHECK-DAG: [[NODES:![0-9]+]] = !{{{.*}}[[A]], [[B]], [[C]], [[D]], [[E]], [[F]], [[G]], [[H]], [[I]]{{.*}}}

--- a/test/debug_info/scalar_allocatable.f90
+++ b/test/debug_info/scalar_allocatable.f90
@@ -1,12 +1,18 @@
-!RUN: %flang %s -g -S -emit-llvm -o - | FileCheck %s
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!Ensure that for an allocatable variable, we're taking the type of
-!allocatable variable as DW_TAG_pointer_type.
-!CHECK: call void @llvm.dbg.declare(metadata ptr %{{.*}}, metadata ![[DILocalVariable:[0-9]+]], metadata !DIExpression())
-!CHECK: ![[DILocalVariable]] = !DILocalVariable(name: "alcvar"
-!CHECK-SAME: type: ![[PTRTYPE:[0-9]+]]
-!CHECK: ![[PTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[TYPE:[0-9]+]]
-!CHECK: ![[TYPE]] = !DIBasicType(name: "double precision",{{.*}}
+! REQUIRES: llvm-19
+! RUN: %flang %s -g -S -emit-llvm -o - | FileCheck %s
+
+! Ensure that for an allocatable variable, we're recording the type of
+! allocatable variable as DW_TAG_pointer_type.
+
+! CHECK: #dbg_declare(ptr %{{.*}}, ![[DILocalVariable:[0-9]+]], !DIExpression()
+! CHECK: ![[DILocalVariable]] = !DILocalVariable(name: "alcvar"
+! CHECK-SAME: type: ![[PTRTYPE:[0-9]+]]
+! CHECK: ![[PTRTYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[TYPE:[0-9]+]]
+! CHECK: ![[TYPE]] = !DIBasicType(name: "double precision",{{.*}}
 
 program main
   real(kind=8), allocatable :: alcvar

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -466,6 +466,9 @@ if config.llvm_version_major >= "13":
 if config.llvm_version_major >= "17":
     config.available_features.add('llvm-17')
 
+if config.llvm_version_major >= "19":
+    config.available_features.add('llvm-19')
+
 if config.enable_backtrace == "1":
     config.available_features.add("backtrace")
 


### PR DESCRIPTION
Upstream LLVM has eliminated debug intrinsics like `@llvm.dbg.value()` and `@llvm.dbg.declare()`, and replaced them with `DPValue` objects that are printed as `#dbg_value()` and `#dbg_declare()`. This patch modifies the FileCheck patterns in the tests to match, and make them require the `llvm-19` feature.