### PR TITLE
[workflows] Disable intermittently failing build/test job

### DIFF
--- a/.github/workflows/build_flang.yml
+++ b/.github/workflows/build_flang.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         target: [X86]
         cc: [clang]
-        version: [14, 15]
+        version: [14]
         llvm_branch: [release_17x, release_18x]
         include:
           - target: X86
@@ -100,13 +100,13 @@ jobs:
           make check-flang-long
 
       # Archive documentation just once, for the fastest job.
-      - if: matrix.cc == 'clang' && matrix.version == '15'
+      - if: matrix.cc == 'clang' && matrix.version == '14'
         run: |
           cd build/flang/docs/web
           cp -r html/ ../../.. # copy to a place where Upload can find it.
 
       # Upload docs just once, for the fastest job.
-      - if: matrix.cc == 'clang' && matrix.version == '15'
+      - if: matrix.cc == 'clang' && matrix.version == '14'
         uses: actions/upload-artifact@v4
         with:
           name: html_docs_flang


### PR DESCRIPTION
The test case mp_correct/lit/pv01.sh has been failing intermittently in the GitHub workflows (see issue #1453). It seems that it only happens when classic-flang-llvm-project is built with Clang 15. This patch disables the job temporarily, until we can determine the root cause of the problem.