### PR TITLE
[flang1][openmp] Add missing check for statement function var

### DIFF
--- a/test/mp_correct/inc/stfunc_derived.mk
+++ b/test/mp_correct/inc/stfunc_derived.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) $(FFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	-$(RUN4) $(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/mp_correct/inc/stfunc_intent.mk
+++ b/test/mp_correct/inc/stfunc_intent.mk
@@ -1,0 +1,19 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build:  $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) $(FFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(OBJX)
+	-$(FC) $(LDFLAGS) $(TEST).$(OBJX) $(LIBS) -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	-$(RUN4) $(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/mp_correct/lit/stfunc_derived.sh
+++ b/test/mp_correct/lit/stfunc_derived.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: env KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%/s MAKE_FILE_DIR=%/S/.. bash %/S/runmake | tee %/t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/mp_correct/lit/stfunc_intent.sh
+++ b/test/mp_correct/lit/stfunc_intent.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: env KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%/s MAKE_FILE_DIR=%/S/.. bash %/S/runmake | tee %/t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/mp_correct/src/stfunc_derived.f90
+++ b/test/mp_correct/src/stfunc_derived.f90
@@ -1,0 +1,19 @@
+program main
+    print *, "PASS"
+end
+
+subroutine test_stfunc
+    implicit none
+    type test
+        integer :: c
+    end type
+    type(test) :: a
+    integer :: b, i
+    integer :: func1
+    integer :: arr(10)
+    func1(b) = a%c
+!$omp parallel do
+    do i = 1, 10
+        arr(i) = func1(b)
+    end do
+end subroutine

--- a/test/mp_correct/src/stfunc_intent.f90
+++ b/test/mp_correct/src/stfunc_intent.f90
@@ -1,0 +1,19 @@
+program main
+    integer :: a
+    a = 10
+    call test_stfunc(a)
+    print *, "PASS"
+contains
+subroutine test_stfunc(a)
+    implicit none
+    integer, intent(in) :: a
+    integer :: b, c, i
+    integer :: func1
+    integer :: arr(10)
+    func1(b, c) = a
+!$omp parallel do
+    do i = 1, 10
+        arr(i) = func1(b, c)
+    end do
+end subroutine
+end

--- a/tools/flang1/flang1exe/semfunc2.c
+++ b/tools/flang1/flang1exe/semfunc2.c
@@ -84,6 +84,11 @@ static ITEM *stfunc_argl;
 static int pass_position = 0;
 static int pass_object_dummy = 0;
 
+/** \brief current statement function argument information used in AST traversal
+ *  to exclude dummy argument in statement function.
+ */
+static ARGINFO *cur_stfunc_arginfo;
+
 /** \brief Set position of type-bound procedure passed object location. */
 void
 set_pass_objects(int pos, int pod)
@@ -270,6 +275,21 @@ dump_stfunc(int sptr)
   fprintf(gbl.dbgfil, "\n");
 }
 
+static void
+chk_stfunc_shared_var(int ast, int *unused)
+{
+  if (ast && A_TYPEG(ast) == A_ID) {
+    for (ARGINFO* arginfo = cur_stfunc_arginfo; arginfo != NULL;
+         arginfo = arginfo->next)
+      if (ast == arginfo->formal)
+        return;
+    int sptr = A_SPTRG(ast);
+    // exclude structure member
+    if (STYPEG(sptr) != ST_MEMBER)
+      sem_check_scope(sptr, sptr);
+  }
+}
+
 /*---------------------------------------------------------------------*/
 
 int
@@ -423,6 +443,12 @@ ref_stfunc(SST *stktop, ITEM *args)
    * of the statement function.
    */
   asn_sfuse(sfdsc->l_use);
+
+  if (sem.parallel || sem.task || sem.target || sem.teams || sem.orph) {
+    cur_stfunc_arginfo = sfdsc->args;
+    ast_traverse(sfdsc->rhs, NULL, chk_stfunc_shared_var, NULL);
+    cur_stfunc_arginfo = NULL;
+  }
 
   ast = ast_rewrite(sfdsc->rhs);
   ast_unvisit();


### PR DESCRIPTION
When statement function used in an openmp block, some variables used in stfunc does not added in openmp shared list which will create undefined value in flang2 and cause error in llvm. This commit add a traverse for statement function variables and add rvalue to openmp shared list by sem_check_scope like what ref_object do.