### PR TITLE
Fix RESHAPE for assumed length character arrays

### DIFF
--- a/test/f90_correct/inc/reshape_asschar.mk
+++ b/test/f90_correct/inc/reshape_asschar.mk
@@ -1,0 +1,18 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+$(TEST): run
+
+build: $(SRC)/$(TEST).f90
+	-$(RM) $(TEST).$(EXESUFFIX) core *.d *.mod FOR*.DAT FTN* ftn* fort.*
+	@echo ------------------------------------ building test $@
+	-$(FC) $(FFLAGS) $(LDFLAGS) $(SRC)/$(TEST).f90 -o $(TEST).$(EXESUFFIX)
+
+run:
+	@echo ------------------------------------ executing test $(TEST)
+	$(TEST).$(EXESUFFIX)
+
+verify: ;

--- a/test/f90_correct/lit/reshape_asschar.sh
+++ b/test/f90_correct/lit/reshape_asschar.sh
@@ -1,0 +1,9 @@
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Shared lit script for each tests. Run bash commands that run tests with make.
+
+# RUN: env KEEP_FILES=%keep FLAGS=%flags TEST_SRC=%/s MAKE_FILE_DIR=%/S/.. bash %/S/runmake | tee %/t
+# RUN: cat %t | FileCheck %S/runmake

--- a/test/f90_correct/src/reshape_asschar.f90
+++ b/test/f90_correct/src/reshape_asschar.f90
@@ -1,0 +1,63 @@
+! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+! See https://llvm.org/LICENSE.txt for license information.
+! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+!
+! Test for the reshape function calls when the array element of the source is
+! an assumed length character varivable.
+
+program test
+  call check_alloc('1', '2', '3', '4')
+  call check_auto('12', '34', '56', '78', 4)
+  call check_cp('123', '345', '567', '789')
+  call check_fixed('abcd', 'efgh', 'ijkl', 'mnop')
+  call check_p('12', '34', '56', '78')
+  print *, "PASS"
+contains
+  subroutine check_alloc(w, x, y, z)
+    character(*), intent(in) :: w, x, y, z
+    character(1), allocatable :: a(:), b(:)
+
+    a = [w, x, y, z]
+    b = reshape([w, x, y, z], [4])
+    if (any(a /= b)) stop 1
+  end subroutine
+
+  subroutine check_auto(w, x, y, z, n)
+    character(*), intent(in) :: w, x, y, z
+    integer, intent(in) :: n
+    character(2) :: a(n), b(n)
+
+    a = [w, x, y, z]
+    b = reshape([w, x, y, z], [4])
+    if (any(a /= b)) stop 2
+  end subroutine
+
+  subroutine check_cp(w, x, y, z)
+    character(*), intent(in) :: w, x, y, z
+    character(3), contiguous, pointer :: a(:), b(:)
+
+    allocate(a(4), b(4))
+    a = [w, x, y, z]
+    b = reshape([w, x, y, z], [4])
+    if (any(a /= b)) stop 3
+  end subroutine
+  
+  subroutine check_fixed(w, x, y, z)
+    character(*), intent(in) :: w, x, y, z
+    character(4) :: a(4), b(4)
+
+    a = [w, x, y, z]
+    b = reshape([w, x, y, z], [4])
+    if (any(a /= b)) stop 4
+  end subroutine
+
+  subroutine check_p(w, x, y, z)
+    character(*), intent(in) :: w, x, y, z
+    character(2), pointer :: a(:), b(:)
+
+    allocate(a(4), b(4))
+    a = [w, x, y, z]
+    b = reshape([w, x, y, z], [4])
+    if (any(a /= b)) stop 5
+  end subroutine
+end program

--- a/tools/flang1/flang1exe/func.c
+++ b/tools/flang1/flang1exe/func.c
@@ -7359,8 +7359,11 @@ _reshape(int func_args, DTYPE dtype, int lhs)
     /* pad and order must not be present */
     return 0;
   if (DTYG(dtype) == TY_CHAR) {
+    /* character must have constant length */
+    int length_ast = DTY(DDTG(dtype) + 1);
     if (DDTG(dtype) == DT_ASSCHAR || DDTG(dtype) == DT_ASSNCHAR ||
-        DDTG(dtype) == DT_DEFERCHAR || DDTG(dtype) == DT_DEFERNCHAR) {
+        DDTG(dtype) == DT_DEFERCHAR || DDTG(dtype) == DT_DEFERNCHAR ||
+        !length_ast || A_TYPEG(length_ast) != A_CNST) {
       return 0;
     }
   }


### PR DESCRIPTION
Fix a bug in the lowering of the RESHAPE intrinsic, when the element
type of the source parameter is assumed length character.

The problem is that flang1 calls the function _reshape() to optimize
RESHAPE by representing the result of RESHAPE as a (Cray) pointer of
the source argument, but the above-mentioned argument element type is
not supported according to the description of _reshape(). This patch
adds a check for the character length in _reshape(), so that it can
bail out when it sees an assumed length character array.

*(Edited to remove a second commit.)*