### PR TITLE
Fix compile-time warnings; NFC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.9.0)
 
 # If we are not building as a part of LLVM, build Flang as a
 # standalone project, using LLVM as an external library:

--- a/include/universal.h
+++ b/include/universal.h
@@ -35,6 +35,14 @@
 #define FLANG_FALLTHROUGH
 #endif
 
+/* FLANG_NONSTRING - Mark char[] declarations that intentionally omit
+   terminating NULLs. */
+#if __has_attribute(nonstring)
+#define FLANG_NONSTRING __attribute__((nonstring))
+#else
+#define FLANG_NONSTRING
+#endif
+
 #ifdef __cplusplus
 
 #ifdef SHADOW_BUILD

--- a/runtime/flang/format-double.c
+++ b/runtime/flang/format-double.c
@@ -11,12 +11,12 @@
  */
 
 #include "format-double.h"
+#include "universal.h"
+
 #include <string.h>
 #ifndef TARGET_WIN
-#include <stdbool.h>
 #include <stdint.h>
 #else
-typedef enum bool { false, true } bool;
 typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
 #endif
@@ -111,6 +111,7 @@ nan_or_infinite(char *out, int width, uint64_t raw, int sign_char)
   }
 }
 
+FLANG_NONSTRING
 static char base100[100][2] = {
   "00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
   "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",

--- a/tools/flang1/flang1exe/semant2.c
+++ b/tools/flang1/flang1exe/semant2.c
@@ -2813,7 +2813,7 @@ rewrite_cmplxpart_rval(SST *e)
 {
   int ast;
   ITEM *list;
-  const char *intrnm;
+  const char *intrnm = NULL;
   SST *arg;
   int sptr;
   int part; /* 1==> real, 2==>imag */
@@ -2843,7 +2843,7 @@ rewrite_cmplxpart_rval(SST *e)
       break;
 #endif
     default:
-      interr("rewrite_cmplxpart_rval: unexpected type", DTY(dtype), 3);
+      interr("rewrite_cmplxpart_rval: unexpected type", DTY(dtype), ERR_Severe);
     }
     sptr = getsymbol(intrnm);
     if (IS_INTRINSIC(STYPEG(sptr))) {

--- a/tools/flang1/utils/prstab/prstab1.c
+++ b/tools/flang1/utils/prstab/prstab1.c
@@ -11,6 +11,7 @@
 
 #include "lrutils.h"
 #include "prstab.h"
+#include "universal.h"
 
 INT xargc;
 char **xargv;
@@ -922,7 +923,7 @@ INT
 fndnul(void)
 {
   static struct {
-    char e_1[128];
+    FLANG_NONSTRING char e_1[128];
     INT e_2;
   } equiv_128 = {"1       p   o   t   e   n   t   i   a   l   l   y  "
                  "     n   u   l   l       n   o   n   -   t   e   r   m   i  "

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -6315,6 +6315,7 @@ gen_binary_expr(int ilix, int itype)
       vcon1_sptr = get_vcon_scalar(constant, vdt);
       break;
     default:
+      bit_type = make_int_lltype(32); /* silence -Wsometimes-uninitialized */
       assert(0, "Unexpected dtype for VNOT", DTySeqTyElement(vect_dtype),
              ERR_Fatal);
     }
@@ -8309,7 +8310,7 @@ gen_llvm_expr(int ilix, LL_Type *expected_type)
   OPERAND *operand, *args, *call_op;
   OPERAND *cc_op1, *cc_op2, *c1, *cse1;
   INT tmp[2];
-  const char *intrinsic_name;
+  const char *intrinsic_name = NULL;
   float f;
   union {
     double d;


### PR DESCRIPTION
Clang 21 produces new warnings when compiling Classic Flang.
This NFC PR suppress the warnings.